### PR TITLE
fix: include logo.png in Docker build

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -4,6 +4,7 @@ import { Menu, X, BarChart3, ChevronRight, ChevronDown, Layers, Target } from 'l
 import { clsx } from 'clsx';
 import { useAnnotationCounts } from '@/hooks/useAnnotationCounts';
 import NotificationBadge from '@/components/ui/NotificationBadge';
+import logoImg from '/public/logo.png';
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -174,7 +175,7 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
       <div className="flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
         <div className="flex items-center flex-shrink-0 px-4">
           <div className="flex items-center">
-            <img src="/logo.png" alt="PyroAnnotator Logo" className="w-8 h-8" />
+            <img src={logoImg} alt="PyroAnnotator Logo" className="w-8 h-8" />
             <h1 className="ml-2 text-xl font-bold text-gray-900">
               PyroAnnotator
             </h1>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { useAnnotationStats } from '@/hooks/useAnnotationStats';
 import ProgressBar, { MultiStageProgressBar } from '@/components/ProgressBar';
+import logoImg from '/public/logo.png';
 
 export default function DashboardPage() {
   const { 
@@ -32,7 +33,7 @@ export default function DashboardPage() {
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-4">
             <img 
-              src="/logo.png" 
+              src={logoImg} 
               alt="PyroAnnotator Logo" 
               className="w-16 h-16 object-contain"
             />


### PR DESCRIPTION
## Summary
- Fix logo.png not being included in the final Docker image
- Convert static `/logo.png` references to ES module imports

## Problem
The logo file existed in `public/logo.png` but wasn't being copied to the final Docker image because Vite's build process only includes files from the `public/` directory when they are explicitly imported as ES modules.

## Solution
- Added `import logoImg from '/public/logo.png'` to both components using the logo
- Updated `src="/logo.png"` to `src={logoImg}` in AppLayout and DashboardPage
- Verified the fix by running `npm run build` - logo now appears in `dist/assets/`

## Test plan
- [x] Run `npm run build` and verify logo appears in `dist/assets/` directory
- [x] Build Docker image and confirm logo is included in final image
- [x] Test that logo displays correctly in both sidebar and dashboard