### PR TITLE
fix: configure VITE_API_BASE_URL at build time in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,15 +67,15 @@ services:
     build:
       context: ./frontend
       dockerfile: ./Dockerfile
+      args:
+        - VITE_API_BASE_URL=http://localhost:5050
+        # - VITE_API_BASE_URL=https://apidev.pyronear.org
+        - VITE_ENVIRONMENT=production
     depends_on:
       annotation_api:
         condition: service_healthy
     ports:
       - "3000:80"
-    environment:
-      # Configure API base URL for backend communication within Docker network
-      - VITE_API_BASE_URL=http://annotation_api:5050
-      - VITE_ENVIRONMENT=production
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,14 @@
 # Build stage
 FROM node:18-alpine AS builder
 
+# Accept build arguments
+ARG VITE_API_BASE_URL=http://localhost:5050
+ARG VITE_ENVIRONMENT=development
+
+# Set environment variables from build args
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+ENV VITE_ENVIRONMENT=$VITE_ENVIRONMENT
+
 WORKDIR /app
 
 # Copy package files


### PR DESCRIPTION
## Summary
- Fix Docker Compose configuration to set VITE_API_BASE_URL at build time instead of runtime
- Update frontend Dockerfile to accept build arguments for environment variables  
- Enable easy switching between localhost and production API URLs

## Problem
The frontend was hardcoded to use `localhost:5050` because Vite environment variables must be available at **build time**, but the Docker Compose configuration was setting them as **runtime** environment variables. This caused the API URL to not be properly configured when targeting external APIs like `https://apidev.pyronear.org`.

## Solution
1. **Move environment variables from `environment` to `build.args`** in docker-compose.yml
2. **Add ARG and ENV statements** to frontend/Dockerfile to accept build arguments
3. **Provide default values** and easy configuration switching via commented line

## Changes Made
- `docker-compose.yml`: Move `VITE_API_BASE_URL` from runtime `environment` to `build.args`
- `frontend/Dockerfile`: Add build argument acceptance and environment variable setup
- Added commented line for easy switching to production API URL

## Test plan
- [x] Build frontend container with new configuration
- [x] Verify API URL is embedded in built JavaScript bundle  
- [x] Confirm Docker Compose builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)