### PR TITLE
fix: prioritize false negatives in model accuracy classification

### DIFF
--- a/frontend/src/utils/modelAccuracy.ts
+++ b/frontend/src/utils/modelAccuracy.ts
@@ -25,12 +25,14 @@ export function getModelAccuracyType(
   // If we don't have annotation data, we can't determine accuracy
   if (hasSmoke === null) return 'unknown';
   
+  // FALSE NEGATIVES TAKE PRECEDENCE: If there's any missed smoke, it's a false negative
+  if (hasMissedSmoke) {
+    return 'false_negative';
+  }
+  
   if (hasSmoke) {
     // Model detected something, human confirmed smoke → Model correct
     return 'true_positive';
-  } else if (hasMissedSmoke) {
-    // Model detected something, but human found different smoke that model missed
-    return 'false_negative';
   } else {
     // Model detected something, human found no smoke → Model wrong
     return 'false_positive';


### PR DESCRIPTION
## Summary
• Fixed false negative classification logic to take precedence over true/false positives
• Updated `getModelAccuracyType()` to check for missed smoke first
• Now sequences with annotated missed smoke will immediately show as false negatives (blue background)

## Changes
- Modified logic order in `/frontend/src/utils/modelAccuracy.ts`
- False negatives now take precedence when both `has_smoke` and `has_missed_smoke` are true

## Test Plan
- [x] TypeScript compilation passes
- [x] Test sequences with missed smoke annotations show as false negative
- [x] Verify blue background appears in sequences/review, detections/annotate, and detections/review pages
- [x] Confirm model accuracy filtering works correctly for false negatives

## Impact
Affects all pages using model accuracy classification:
- Sequences review page
- Detection annotation page  
- Detection review page