### PR TITLE
Export route

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/platform/export_dataset.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/export_dataset.py
@@ -1,0 +1,527 @@
+"""
+Export a YOLO style dataset from the local annotation API.
+
+For each detection, this script:
+- Calls the /export/detections endpoint
+- Downloads the image from image_url
+- Uses sequence level annotations (sequences_bbox) to create YOLO labels
+- Organizes data as:
+    dataset_exported_{timestamp}/
+        <seq_type>/                # smoke type, false positive type or "no_label"
+            <sequence_folder>/     # named after first image basename for this sequence and type
+                images/
+                    pyronear-{organisation_name}-{camera_name}-{azimuth}-{recorded_at}.jpg
+                labels/
+                    pyronear-{organisation_name}-{camera_name}-{azimuth}-{recorded_at}.txt  # empty if no bbox
+
+YOLO format per line:
+    class_id x_center y_center width height
+
+Example:
+uv run python -m scripts.data_transfer.ingestion.platform.export_dataset \
+  --api-base http://localhost:5050/api/v1 \
+  --username admin --password admin12345 \
+  --limit 5000 \
+  --annotation-created-gte 2025-01-01T00:00:00Z \
+  --annotation-created-lte 2025-01-31T23:59:59Z \
+  --output-dir outputs/datasets \
+  --loglevel info
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import unicodedata
+import re
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+
+# ---------------------------------------------------------------------------
+# CLI and utilities
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export YOLO style dataset from annotation API")
+    parser.add_argument("--api-base", default="http://localhost:5050/api/v1", help="Base URL of the API")
+    parser.add_argument("--username", default="admin", help="API username")
+    parser.add_argument("--password", default="admin12345", help="API password")
+    parser.add_argument("--timeout", type=int, default=30, help="HTTP request timeout in seconds")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=10000,
+        help="Maximum number of detections to export in a single call to /export/detections",
+    )
+    parser.add_argument(
+        "--annotation-created-gte",
+        default="",
+        help="Filter sequences with annotation created_at greater or equal to this ISO datetime",
+    )
+    parser.add_argument(
+        "--annotation-created-lte",
+        default="",
+        help="Filter sequences with annotation created_at less or equal to this ISO datetime",
+    )
+    parser.add_argument(
+        "--source-api",
+        default="",
+        help="Optional filter by source API, for example pyronear_french, alert_wildfire, api_cenia",
+    )
+    parser.add_argument(
+        "--organisation-name",
+        default="",
+        help="Optional filter by organisation name exact match",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="",
+        help=(
+            "Base directory where the dataset root will be created, "
+            "defaults to outputs/datasets/dataset_exported_YYYYMMDD_HHMMSS"
+        ),
+    )
+    parser.add_argument(
+        "--loglevel",
+        default="info",
+        choices=["debug", "info", "warning", "error"],
+        help="Logging level",
+    )
+    parser.add_argument(
+        "--verify-ssl",
+        action="store_true",
+        help="Verify TLS certificates when connecting to the API and image URLs",
+    )
+    return parser.parse_args()
+
+
+def setup_logging(level: str) -> None:
+    logging.basicConfig(level=getattr(logging, level.upper()), format="[%(levelname)s] %(message)s")
+
+
+def default_dataset_root(base_output_dir: Optional[str] = None) -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    if base_output_dir:
+        base = Path(base_output_dir)
+    else:
+        base = Path("outputs") / "datasets"
+    root = base / f"dataset_exported_{timestamp}"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def get_token(api_base: str, username: str, password: str, timeout: int, verify_ssl: bool) -> str:
+    login_url = f"{api_base}/auth/login"
+    payload = {"username": username, "password": password}
+    resp = requests.post(login_url, json=payload, timeout=timeout, verify=verify_ssl)
+    resp.raise_for_status()
+    data = resp.json()
+    token = data.get("access_token")
+    if not token:
+        raise RuntimeError("Login response did not include access_token")
+    logging.info("Token generated successfully")
+    return token
+
+
+# ---------------------------------------------------------------------------
+# Dataset specific helpers
+# ---------------------------------------------------------------------------
+
+# SmokeType and FalsePositiveType values from the API enums
+SMOKE_TYPES: List[str] = ["wildfire", "industrial", "other"]
+
+FALSE_POSITIVE_TYPES: List[str] = [
+    "antenna",
+    "building",
+    "cliff",
+    "dark",
+    "dust",
+    "high_cloud",
+    "low_cloud",
+    "lens_flare",
+    "lens_droplet",
+    "light",
+    "rain",
+    "trail",
+    "road",
+    "sky",
+    "tree",
+    "water_body",
+    "other",
+]
+
+ALL_CLASSES: List[str] = SMOKE_TYPES + FALSE_POSITIVE_TYPES
+CLASS_ID: Dict[str, int] = {name: idx for idx, name in enumerate(ALL_CLASSES)}
+
+
+def format_recorded_at(raw: Any) -> str:
+    """
+    Convert recorded_at field to string YYYY-MM-DDTHH-MM-SS.
+    Accepts ISO strings with optional timezone or datetime objects.
+    """
+    if isinstance(raw, datetime):
+        dt = raw
+    elif isinstance(raw, str):
+        text = raw
+        if text.endswith("Z"):
+            text = text.replace("Z", "+00:00")
+        try:
+            dt = datetime.fromisoformat(text)
+        except ValueError:
+            text = text[:19]
+            dt = datetime.fromisoformat(text)
+    else:
+        raise ValueError(f"Unsupported recorded_at value {raw!r}")
+
+    dt = dt.replace(tzinfo=None, microsecond=0)
+    return dt.strftime("%Y-%m-%dT%H-%M-%S")
+
+
+def normalize_slug(s: str) -> str:
+    """
+    Convert arbitrary text into a filename friendly slug without underscores.
+    lower case, remove accents, replace non alnum characters with dash,
+    collapse repeated dashes, strip leading and trailing dashes.
+    """
+    s = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode("ascii")
+    s = s.lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    s = re.sub(r"-+", "-", s)
+    return s.strip("-")
+
+
+def build_file_basename(row: Dict[str, Any]) -> str:
+    """
+    Build base filename:
+        pyronear-{organisation_name}-{camera_name}-{azimuth}-{recorded_at}
+    where recorded_at is formatted as YYYY-MM-DDTHH-MM-SS.
+    If azimuth is missing use 000.
+    """
+    org_raw = row.get("organisation_name", "unknown_org")
+    cam_raw = row.get("camera_name", "unknown_camera")
+
+    org = normalize_slug(str(org_raw))
+    cam = normalize_slug(str(cam_raw))
+
+    az = row.get("azimuth", None)
+    az_str = f"{az:03d}" if isinstance(az, int) else "000"
+
+    recorded_at_raw = row.get("recorded_at")
+    if recorded_at_raw is None:
+        raise ValueError("Missing recorded_at in export row")
+    recorded_at_str = format_recorded_at(recorded_at_raw)
+
+    return f"pyronear-{org}-{cam}-{az_str}-{recorded_at_str}"
+
+
+def recorded_at_sort_key(row: Dict[str, Any]) -> Tuple[int, str]:
+    """
+    Sort key: (sequence_id, recorded_at_string)
+    Uses format_recorded_at so ordering is chronological.
+    """
+    seq_id = row.get("sequence_id") or 0
+    raw = row.get("recorded_at") or "1970-01-01T00:00:00"
+    try:
+        rec_str = format_recorded_at(raw)
+    except Exception:
+        rec_str = "1970-01-01T00-00-00"
+    return int(seq_id), rec_str
+
+
+def compute_sequence_types(rows: List[Dict[str, Any]]) -> Dict[int, List[str]]:
+    """
+    For each sequence, compute the set of seq_types present in sequences_bbox.
+    seq_type is smoke_type if is_smoke is true,
+    otherwise the first false_positive_type if present.
+    """
+    seq_types: Dict[int, set] = defaultdict(set)
+    for row in rows:
+        seq_id = row.get("sequence_id")
+        if seq_id is None:
+            continue
+        seq_ann = row.get("sequence_annotation") or {}
+        groups = seq_ann.get("sequences_bbox") or []
+        for group in groups:
+            is_smoke = group.get("is_smoke", False)
+            smoke_type = group.get("smoke_type")
+            fp_types = group.get("false_positive_types") or []
+
+            if is_smoke and smoke_type:
+                seq_type = smoke_type
+            elif fp_types:
+                seq_type = fp_types[0]
+            else:
+                continue
+
+            if seq_type not in CLASS_ID:
+                seq_type = "other"
+            seq_types[int(seq_id)].add(seq_type)
+
+    return {seq_id: sorted(types) for seq_id, types in seq_types.items()}
+
+
+def extract_labels_for_detection(row: Dict[str, Any]) -> Dict[str, List[str]]:
+    """
+    From one export row, build:
+      { seq_type: [ 'class_id x_center y_center width height', ... ] }
+
+    seq_type is smoke_type if is_smoke is true,
+    otherwise the first false_positive_type if present,
+    otherwise "other".
+
+    Only boxes whose detection_id matches row["detection_id"] are used.
+
+    Boxes use normalized xyxyn coordinates [x1, y1, x2, y2].
+    """
+    detection_id = row.get("detection_id")
+    seq_ann = row.get("sequence_annotation") or {}
+    sequences_bbox = seq_ann.get("sequences_bbox") or []
+
+    labels_by_type: Dict[str, List[str]] = {}
+
+    for group in sequences_bbox:
+        is_smoke = group.get("is_smoke", False)
+        smoke_type = group.get("smoke_type")
+        fp_types = group.get("false_positive_types") or []
+
+        if is_smoke and smoke_type:
+            seq_type = smoke_type
+        elif fp_types:
+            seq_type = fp_types[0]
+        else:
+            seq_type = "other"
+
+        if seq_type not in CLASS_ID:
+            seq_type = "other"
+
+        class_id = CLASS_ID[seq_type]
+
+        for bbox in group.get("bboxes", []):
+            if bbox.get("detection_id") != detection_id:
+                continue
+
+            xyxyn = bbox.get("xyxyn")
+            if not xyxyn or len(xyxyn) != 4:
+                continue
+
+            x1, y1, x2, y2 = xyxyn
+            x_center = (x1 + x2) / 2.0
+            y_center = (y1 + y2) / 2.0
+            width = x2 - x1
+            height = y2 - y1
+
+            line = f"{class_id} {x_center:.6f} {y_center:.6f} {width:.6f} {height:.6f}"
+            labels_by_type.setdefault(seq_type, []).append(line)
+
+    return labels_by_type
+
+
+def fetch_detections(
+    api_base: str,
+    headers: Dict[str, str],
+    timeout: int,
+    verify_ssl: bool,
+    limit: int,
+    annotation_created_gte: str,
+    annotation_created_lte: str,
+    source_api: str,
+    organisation_name: str,
+) -> List[Dict[str, Any]]:
+    """
+    Call /export/detections once with the given filters.
+    """
+    url = f"{api_base}/export/detections"
+    params: Dict[str, Any] = {
+        "limit": limit,
+    }
+
+    if annotation_created_gte:
+        params["sequence_annotation_created_gte"] = annotation_created_gte
+    if annotation_created_lte:
+        params["sequence_annotation_created_lte"] = annotation_created_lte
+    if source_api:
+        params["source_api"] = source_api
+    if organisation_name:
+        params["organisation_name"] = organisation_name
+
+    logging.info("Requesting detections export with params: %s", params)
+    resp = requests.get(url, headers=headers, params=params, timeout=timeout, verify=verify_ssl)
+    resp.raise_for_status()
+    data = resp.json()
+
+    if not isinstance(data, list):
+        raise RuntimeError("Expected a list from /export/detections")
+
+    logging.info("Received %s detections from export endpoint", len(data))
+    return data
+
+
+def build_dataset(
+    rows: List[Dict[str, Any]],
+    root_dir: Path,
+    timeout: int,
+    verify_ssl: bool,
+    headers: Dict[str, str],
+) -> None:
+    """
+    Build the dataset folder structure from the exported rows.
+
+    All detections are included:
+      images are always saved,
+      labels are written from bboxes,
+      if no bbox is present for a given type an empty txt file is created.
+
+    For each sequence and seq_type, all images of the sequence are copied
+    in that seq_type folder. Label content depends on the annotation
+    for that detection and type.
+    """
+    session = requests.Session()
+    session.verify = verify_ssl
+    session.headers.update(headers)
+
+    # sort rows by (sequence_id, recorded_at)
+    rows_sorted = sorted(rows, key=recorded_at_sort_key)
+
+    # compute sequence -> list of seq_types present in annotation
+    seq_types_map = compute_sequence_types(rows_sorted)
+
+    num_images = 0
+    num_labels = 0
+    total_rows = len(rows_sorted)
+
+    # map (seq_type, sequence_id) -> folder name (first file_base)
+    folder_name_map: Dict[Tuple[str, int], str] = {}
+
+    for idx, row in enumerate(rows_sorted, start=1):
+        if idx % 100 == 0 or idx == total_rows:
+            logging.info("Processing detection %s/%s", idx, total_rows)
+
+        image_url = row.get("image_url")
+        if not image_url:
+            continue
+
+        seq_id = row.get("sequence_id")
+        detection_id = row.get("detection_id")
+        if seq_id is None or detection_id is None:
+            continue
+        seq_id_int = int(seq_id)
+
+        # for this sequence, which seq_types do we have
+        types_for_seq = seq_types_map.get(seq_id_int)
+        if not types_for_seq:
+            # no annotated bbox at sequence level, put everything under "no_label"
+            types_for_seq = ["no_label"]
+
+        # base filename for this detection
+        try:
+            file_base = build_file_basename(row)
+        except Exception as exc:
+            logging.warning("Could not build filename for detection %s: %s", detection_id, exc)
+            continue
+
+        # labels of this detection per type
+        labels_by_type = extract_labels_for_detection(row)
+
+        # download image once for this detection
+        try:
+            resp_img = session.get(image_url, timeout=timeout, stream=True)
+            resp_img.raise_for_status()
+            img_bytes = resp_img.content
+        except Exception as exc:
+            logging.warning("Failed to download %s: %s", image_url, exc)
+            continue
+
+        img_filename = f"{file_base}.jpg"
+        label_filename = f"{file_base}.txt"
+
+        for seq_type in types_for_seq:
+            # get lines for this detection and this type (can be empty)
+            lines = labels_by_type.get(seq_type, [])
+
+            key = (seq_type, seq_id_int)
+            if key not in folder_name_map:
+                folder_name_map[key] = file_base
+
+            seq_folder_name = folder_name_map[key]
+
+            base = root_dir / seq_type / seq_folder_name
+            img_dir = base / "images"
+            label_dir = base / "labels"
+            img_dir.mkdir(parents=True, exist_ok=True)
+            label_dir.mkdir(parents=True, exist_ok=True)
+
+            img_path = img_dir / img_filename
+            label_path = label_dir / label_filename
+
+            if not img_path.exists():
+                with open(img_path, "wb") as f:
+                    f.write(img_bytes)
+                num_images += 1
+
+            # always create label file, possibly empty
+            with open(label_path, "w", encoding="utf-8") as f:
+                if lines:
+                    f.write("\n".join(lines) + "\n")
+            if lines:
+                num_labels += 1
+
+    logging.info("Dataset build complete")
+    logging.info("Root directory: %s", root_dir)
+    logging.info("Images saved: %s", num_images)
+    logging.info("Label files written (non empty): %s", num_labels)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    args = parse_args()
+    setup_logging(args.loglevel)
+
+    root_dir = default_dataset_root(args.output_dir)
+    logging.info("Dataset root directory: %s", root_dir)
+
+    token = get_token(
+        api_base=args.api_base,
+        username=args.username,
+        password=args.password,
+        timeout=args.timeout,
+        verify_ssl=args.verify_ssl,
+    )
+    headers = {"accept": "application/json", "Authorization": f"Bearer {token}"}
+
+    rows = fetch_detections(
+        api_base=args.api_base,
+        headers=headers,
+        timeout=args.timeout,
+        verify_ssl=args.verify_ssl,
+        limit=args.limit,
+        annotation_created_gte=args.annotation_created_gte,
+        annotation_created_lte=args.annotation_created_lte,
+        source_api=args.source_api,
+        organisation_name=args.organisation_name,
+    )
+
+    if not rows:
+        logging.warning("No detections returned by export endpoint, nothing to do")
+        return
+
+    build_dataset(
+        rows=rows,
+        root_dir=root_dir,
+        timeout=args.timeout,
+        verify_ssl=args.verify_ssl,
+        headers=headers,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/annotation_api/src/app/api/api_v1/endpoints/export.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/export.py
@@ -1,0 +1,375 @@
+# app/api/api_v1/endpoints/export.py
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy import (
+    and_,
+    asc,
+    desc,
+    select,
+    cast,
+    ARRAY,
+    String,
+)
+from sqlalchemy.sql import ColumnElement
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.api.dependencies import get_current_user
+from app.db import get_session
+from app.models import (
+    Detection,
+    DetectionAnnotation,
+    DetectionAnnotationProcessingStage,
+    Sequence,
+    SequenceAnnotation,
+    SequenceAnnotationProcessingStage,
+    User,
+    AnnotationType,
+    FalsePositiveType,
+    SmokeType,
+)
+from app.services.storage import s3_service
+
+router = APIRouter()
+
+
+class DetectionExportOrderBy(str, Enum):
+    recorded_at = "recorded_at"
+    created_at = "created_at"
+
+
+class DetectionExportRow(BaseModel):
+    # Detection core
+    detection_id: int
+    sequence_id: Optional[int]
+    alert_api_id: int
+    source_api: str
+    recorded_at: datetime
+    created_at: datetime
+
+    # Sequence metadata
+    sequence_recorded_at: Optional[datetime] = None
+    sequence_last_seen_at: Optional[datetime] = None
+    camera_id: int
+    camera_name: str
+    organisation_id: int
+    organisation_name: str
+    lat: float
+    lon: float
+    azimuth: Optional[int] = None
+    is_wildfire_alertapi: Optional[AnnotationType] = None
+
+    # Storage and image
+    bucket_key: str
+    image_url: Optional[str] = None
+
+    # Model predictions
+    algo_predictions_raw: Optional[Dict[str, Any]] = None
+
+    # Sequence annotation
+    sequence_has_smoke: Optional[bool] = None
+    sequence_has_false_positives: Optional[bool] = None
+    sequence_false_positive_types: Optional[List[str]] = None
+    sequence_smoke_types: Optional[List[str]] = None
+    sequence_has_missed_smoke: Optional[bool] = None
+    sequence_is_unsure: Optional[bool] = None
+    sequence_processing_stage: Optional[SequenceAnnotationProcessingStage] = None
+    sequence_annotation: Optional[Dict[str, Any]] = None
+    sequence_annotation_created_at: Optional[datetime] = None
+    sequence_annotation_updated_at: Optional[datetime] = None
+
+    # Detection annotation
+    detection_processing_stage: Optional[DetectionAnnotationProcessingStage] = None
+    detection_annotation: Optional[Dict[str, Any]] = None
+    detection_annotation_created_at: Optional[datetime] = None
+    detection_annotation_updated_at: Optional[datetime] = None
+
+
+@router.get(
+    "/detections",
+    response_model=List[DetectionExportRow],
+    summary="Export annotated detections",
+    description=(
+        "Export detection centric rows with joined sequence metadata "
+        "and annotations for external processing. "
+        "By default only sequences with sequence level annotation at stage annotated are exported."
+    ),
+)
+async def export_detections(
+    # Basic filters
+    source_api: Optional[str] = Query(
+        None,
+        description=(
+            "Filter by source API, for example pyronear_french, "
+            "alert_wildfire, api_cenia"
+        ),
+    ),
+    organisation_id: Optional[int] = Query(
+        None, description="Filter by organisation identifier"
+    ),
+    organisation_name: Optional[str] = Query(
+        None, description="Filter by organisation name exact match"
+    ),
+    camera_id: Optional[int] = Query(
+        None, description="Filter by camera identifier"
+    ),
+    camera_name: Optional[str] = Query(
+        None, description="Filter by camera name exact match"
+    ),
+    # External API wildfire label
+    is_wildfire_alertapi: Optional[str] = Query(
+        None,
+        description=(
+            "Filter by wildfire classification from external API "
+            "wildfire_smoke, other_smoke, other, "
+            "or null for unclassified"
+        ),
+    ),
+    # Sequence annotation filters
+    has_smoke: Optional[bool] = Query(
+        None, description="Filter by sequence annotation has_smoke flag"
+    ),
+    has_false_positives: Optional[bool] = Query(
+        None, description="Filter by sequence annotation has_false_positives flag"
+    ),
+    has_missed_smoke: Optional[bool] = Query(
+        None, description="Filter by sequence annotation has_missed_smoke flag"
+    ),
+    is_unsure: Optional[bool] = Query(
+        None, description="Filter by sequence annotation is_unsure flag"
+    ),
+    sequence_processing_stage: Optional[str] = Query(
+        "annotated",
+        description=(
+            "Filter by sequence annotation processing stage, "
+            "imported, ready_to_annotate, annotated. "
+            "Default is annotated."
+        ),
+    ),
+    false_positive_types: Optional[List[FalsePositiveType]] = Query(
+        None,
+        description=(
+            "Filter by specific false positive types OR logic, "
+            "sequences containing any of the specified types are kept"
+        ),
+    ),
+    smoke_types: Optional[List[SmokeType]] = Query(
+        None,
+        description=(
+            "Filter by specific smoke types OR logic, "
+            "sequences containing any of the specified types are kept"
+        ),
+    ),
+    # Date filters at detection level
+    recorded_at_gte: Optional[datetime] = Query(
+        None,
+        description="Filter detections with recorded_at greater or equal to this date",
+    ),
+    recorded_at_lte: Optional[datetime] = Query(
+        None,
+        description="Filter detections with recorded_at less or equal to this date",
+    ),
+    # Date filters at sequence annotation level
+    sequence_annotation_created_gte: Optional[datetime] = Query(
+        None,
+        description=(
+            "Filter sequences with annotation created_at greater or equal to this date"
+        ),
+    ),
+    sequence_annotation_created_lte: Optional[datetime] = Query(
+        None,
+        description=(
+            "Filter sequences with annotation created_at less or equal to this date"
+        ),
+    ),
+    # Ordering and limit
+    order_by: DetectionExportOrderBy = Query(
+        DetectionExportOrderBy.recorded_at,
+        description="Order results by detection recorded_at or created_at",
+    ),
+    order_desc: bool = Query(
+        True,
+        description="If true order in descending order, if false order in ascending order",
+    ),
+    limit: int = Query(
+        10_000,
+        ge=1,
+        le=100_000,
+        description="Maximum number of rows to export in a single call",
+    ),
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> List[DetectionExportRow]:
+    """
+    Export detection centric rows with joined sequence metadata and annotations.
+    """
+
+    stmt = (
+        select(
+            Detection.id.label("detection_id"),
+            Detection.sequence_id.label("sequence_id"),
+            Detection.alert_api_id.label("alert_api_id"),
+            Detection.recorded_at.label("recorded_at"),
+            Detection.created_at.label("created_at"),
+            Detection.bucket_key.label("bucket_key"),
+            Detection.algo_predictions.label("algo_predictions_raw"),
+            Sequence.source_api.label("source_api"),
+            Sequence.recorded_at.label("sequence_recorded_at"),
+            Sequence.last_seen_at.label("sequence_last_seen_at"),
+            Sequence.camera_id.label("camera_id"),
+            Sequence.camera_name.label("camera_name"),
+            Sequence.organisation_id.label("organisation_id"),
+            Sequence.organisation_name.label("organisation_name"),
+            Sequence.lat.label("lat"),
+            Sequence.lon.label("lon"),
+            Sequence.azimuth.label("azimuth"),
+            Sequence.is_wildfire_alertapi.label("is_wildfire_alertapi"),
+            SequenceAnnotation.has_smoke.label("sequence_has_smoke"),
+            SequenceAnnotation.has_false_positives.label(
+                "sequence_has_false_positives"
+            ),
+            SequenceAnnotation.false_positive_types.label(
+                "sequence_false_positive_types"
+            ),
+            SequenceAnnotation.smoke_types.label("sequence_smoke_types"),
+            SequenceAnnotation.has_missed_smoke.label("sequence_has_missed_smoke"),
+            SequenceAnnotation.is_unsure.label("sequence_is_unsure"),
+            SequenceAnnotation.processing_stage.label("sequence_processing_stage"),
+            SequenceAnnotation.annotation.label("sequence_annotation"),
+            SequenceAnnotation.created_at.label("sequence_annotation_created_at"),
+            SequenceAnnotation.updated_at.label("sequence_annotation_updated_at"),
+            DetectionAnnotation.processing_stage.label("detection_processing_stage"),
+            DetectionAnnotation.annotation.label("detection_annotation"),
+            DetectionAnnotation.created_at.label("detection_annotation_created_at"),
+            DetectionAnnotation.updated_at.label("detection_annotation_updated_at"),
+        )
+        .select_from(Detection)
+        .join(Sequence, Detection.sequence_id == Sequence.id)
+        .outerjoin(
+            SequenceAnnotation,
+            SequenceAnnotation.sequence_id == Sequence.id,
+        )
+        .outerjoin(
+            DetectionAnnotation,
+            DetectionAnnotation.detection_id == Detection.id,
+        )
+    )
+
+    conditions: List[ColumnElement[bool]] = []
+
+    if source_api is not None:
+        conditions.append(Sequence.source_api == source_api)
+
+    if organisation_id is not None:
+        conditions.append(Sequence.organisation_id == organisation_id)
+
+    if organisation_name is not None:
+        conditions.append(Sequence.organisation_name == organisation_name)
+
+    if camera_id is not None:
+        conditions.append(Sequence.camera_id == camera_id)
+
+    if camera_name is not None:
+        conditions.append(Sequence.camera_name == camera_name)
+
+    if is_wildfire_alertapi is not None:
+        if is_wildfire_alertapi == "null":
+            conditions.append(Sequence.is_wildfire_alertapi.is_(None))
+        else:
+            try:
+                enum_value = AnnotationType(is_wildfire_alertapi)
+                conditions.append(Sequence.is_wildfire_alertapi == enum_value)
+            except ValueError:
+                pass
+
+    if has_smoke is not None:
+        conditions.append(SequenceAnnotation.has_smoke == has_smoke)
+
+    if has_false_positives is not None:
+        conditions.append(
+            SequenceAnnotation.has_false_positives == has_false_positives
+        )
+
+    if has_missed_smoke is not None:
+        conditions.append(SequenceAnnotation.has_missed_smoke == has_missed_smoke)
+
+    if is_unsure is not None:
+        conditions.append(SequenceAnnotation.is_unsure == is_unsure)
+
+    # default filter on processing stage annotated unless user overrides
+    if sequence_processing_stage is not None:
+        try:
+            stage_enum = SequenceAnnotationProcessingStage(sequence_processing_stage)
+            conditions.append(SequenceAnnotation.processing_stage == stage_enum)
+        except ValueError:
+            pass
+
+    if false_positive_types:
+        fp_values = [fp.value for fp in false_positive_types]
+        conditions.append(
+            SequenceAnnotation.false_positive_types.op("?|")(
+                cast(fp_values, ARRAY(String))
+            )
+        )
+
+    if smoke_types:
+        smoke_values = [st.value for st in smoke_types]
+        conditions.append(
+            SequenceAnnotation.smoke_types.op("?|")(
+                cast(smoke_values, ARRAY(String))
+            )
+        )
+
+    if recorded_at_gte is not None:
+        conditions.append(Detection.recorded_at >= recorded_at_gte)
+
+    if recorded_at_lte is not None:
+        conditions.append(Detection.recorded_at <= recorded_at_lte)
+
+    # annotation date window
+    if sequence_annotation_created_gte is not None:
+        conditions.append(
+            SequenceAnnotation.created_at >= sequence_annotation_created_gte
+        )
+
+    if sequence_annotation_created_lte is not None:
+        conditions.append(
+            SequenceAnnotation.created_at <= sequence_annotation_created_lte
+        )
+
+    if conditions:
+        stmt = stmt.where(and_(*conditions))
+
+    order_column = (
+        Detection.recorded_at
+        if order_by == DetectionExportOrderBy.recorded_at
+        else Detection.created_at
+    )
+    stmt = stmt.order_by(desc(order_column) if order_desc else asc(order_column))
+
+    stmt = stmt.limit(limit)
+
+    result = await session.execute(stmt)
+    rows = result.mappings().all()
+
+    bucket = s3_service.get_bucket(s3_service.resolve_bucket_name())
+
+    export_rows: List[DetectionExportRow] = []
+
+    for row in rows:
+        data = dict(row)
+
+        bucket_key = data.get("bucket_key")
+        image_url: Optional[str] = None
+        if bucket_key:
+            image_url = bucket.get_public_url(bucket_key)
+
+        data["image_url"] = image_url
+
+        export_rows.append(DetectionExportRow(**data))
+
+    return export_rows

--- a/annotation_api/src/app/api/api_v1/router.py
+++ b/annotation_api/src/app/api/api_v1/router.py
@@ -14,6 +14,7 @@ from app.api.api_v1.endpoints import (
     sequences,
     source_apis,
     users,
+    export
 )
 from app.auth import endpoints as auth
 
@@ -43,4 +44,10 @@ api_router.include_router(
 )
 api_router.include_router(
     source_apis.router, prefix="/source-apis", tags=["source apis"]
+)
+
+api_router.include_router(
+    export.router,
+    prefix="/export",
+    tags=["export"]
 )

--- a/annotation_api/src/tests/endpoints/test_export.py
+++ b/annotation_api/src/tests/endpoints/test_export.py
@@ -64,7 +64,15 @@ async def test_export_detections_empty_without_annotated_sequence(
         "alert_api_id": "8001",
         "recorded_at": now.isoformat(),
         "algo_predictions": json.dumps(
-            {"predictions": [{"xyxyn": [0.1, 0.1, 0.2, 0.2], "confidence": 0.9}]}
+            {
+                "predictions": [
+                    {
+                        "class_name": "smoke",
+                        "xyxyn": [0.1, 0.1, 0.2, 0.2],
+                        "confidence": 0.9,
+                    }
+                ]
+            }
         ),
     }
 
@@ -112,7 +120,15 @@ async def test_export_detections_basic_row_and_image_url(
         "alert_api_id": "8101",
         "recorded_at": now.isoformat(),
         "algo_predictions": json.dumps(
-            {"predictions": [{"xyxyn": [0.1, 0.1, 0.3, 0.3], "confidence": 0.95}]}
+            {
+                "predictions": [
+                    {
+                        "class_name": "smoke",
+                        "xyxyn": [0.1, 0.1, 0.3, 0.3],
+                        "confidence": 0.95,
+                    }
+                ]
+            }
         ),
     }
 
@@ -249,7 +265,15 @@ async def test_export_detections_filters_by_organisation_and_source(
             "alert_api_id": f"83{seq_id}",
             "recorded_at": now.isoformat(),
             "algo_predictions": json.dumps(
-                {"predictions": [{"xyxyn": [0.1, 0.1, 0.2, 0.2], "confidence": 0.9}]}
+                {
+                    "predictions": [
+                        {
+                            "class_name": "smoke",
+                            "xyxyn": [0.1, 0.1, 0.2, 0.2],
+                            "confidence": 0.9,
+                        }
+                    ]
+                }
             ),
         }
         img = Image.new("RGB", (64, 64), color="green")
@@ -349,7 +373,15 @@ async def test_export_detections_filters_by_sequence_annotation_created_window(
             "alert_api_id": f"840{idx}",
             "recorded_at": created_at.isoformat(),
             "algo_predictions": json.dumps(
-                {"predictions": [{"xyxyn": [0.1, 0.1, 0.2, 0.2], "confidence": 0.9}]}
+                {
+                    "predictions": [
+                        {
+                            "class_name": "smoke",
+                            "xyxyn": [0.1, 0.1, 0.2, 0.2],
+                            "confidence": 0.9,
+                        }
+                    ]
+                }
             ),
         }
         img = Image.new("RGB", (64, 64), color="yellow")
@@ -378,8 +410,14 @@ async def test_export_detections_filters_by_sequence_annotation_created_window(
                     "smoke_type": "wildfire",
                     "false_positive_types": [],
                     "bboxes": [
-                        {"detection_id": detection_ids[0], "xyxyn": [0.1, 0.1, 0.2, 0.2]},
-                        {"detection_id": detection_ids[1], "xyxyn": [0.3, 0.3, 0.4, 0.4]},
+                        {
+                            "detection_id": detection_ids[0],
+                            "xyxyn": [0.1, 0.1, 0.2, 0.2],
+                        },
+                        {
+                            "detection_id": detection_ids[1],
+                            "xyxyn": [0.3, 0.3, 0.4, 0.4],
+                        },
                     ],
                 }
             ]
@@ -481,7 +519,15 @@ async def test_export_detections_ordering_and_limit(
             "alert_api_id": f"850{idx}",
             "recorded_at": rec.isoformat(),
             "algo_predictions": json.dumps(
-                {"predictions": [{"xyxyn": [0.1, 0.1, 0.2, 0.2], "confidence": 0.8}]}
+                {
+                    "predictions": [
+                        {
+                            "class_name": "smoke",
+                            "xyxyn": [0.1, 0.1, 0.2, 0.2],
+                            "confidence": 0.8,
+                        }
+                    ]
+                }
             ),
         }
         img = Image.new("RGB", (64, 64), color="pink")
@@ -596,7 +642,15 @@ async def test_export_detections_filters_by_false_positive_and_smoke_types(
             "alert_api_id": f"869{idx}",
             "recorded_at": now.isoformat(),
             "algo_predictions": json.dumps(
-                {"predictions": [{"xyxyn": [0.1, 0.1, 0.2, 0.2], "confidence": 0.9}]}
+                {
+                    "predictions": [
+                        {
+                            "class_name": "smoke",
+                            "xyxyn": [0.1, 0.1, 0.2, 0.2],
+                            "confidence": 0.9,
+                        }
+                    ]
+                }
             ),
         }
         img = Image.new("RGB", (64, 64), color="cyan")

--- a/annotation_api/src/tests/endpoints/test_export.py
+++ b/annotation_api/src/tests/endpoints/test_export.py
@@ -1,0 +1,710 @@
+from datetime import datetime, timedelta, UTC
+import io
+import json
+
+import pytest
+from httpx import AsyncClient
+from PIL import Image
+
+from app import models
+from app.services import storage as storage_module
+
+now = datetime.now(UTC)
+
+
+class DummyBucket:
+    def __init__(self) -> None:
+        self.public_urls = {}
+
+    def get_public_url(self, key: str) -> str:
+        url = f"https://example.com/{key}"
+        self.public_urls[key] = url
+        return url
+
+
+@pytest.mark.asyncio
+async def test_export_detections_empty_without_annotated_sequence(
+    authenticated_client: AsyncClient,
+    sequence_session,
+    detection_session,
+    monkeypatch,
+):
+    """
+    Default filter is sequence_processing_stage=annotated,
+    so sequences without an annotated sequence annotation should not be exported.
+    """
+    # Monkeypatch S3 bucket lookup to avoid real S3 usage
+    dummy_bucket = DummyBucket()
+
+    def fake_get_bucket(_bucket_name: str) -> DummyBucket:
+        return dummy_bucket
+
+    monkeypatch.setattr(storage_module.s3_service, "get_bucket", fake_get_bucket)
+
+    # Create a sequence without annotation
+    seq_payload = {
+        "source_api": "pyronear_french",
+        "alert_api_id": "8000",
+        "camera_name": "Export Test Camera",
+        "camera_id": "800",
+        "organisation_name": "Test Org No Annotation",
+        "organisation_id": "80",
+        "lat": "43.0",
+        "lon": "1.0",
+        "recorded_at": now.isoformat(),
+        "last_seen_at": now.isoformat(),
+    }
+    seq_resp = await authenticated_client.post("/sequences", data=seq_payload)
+    assert seq_resp.status_code == 201
+    seq_id = seq_resp.json()["id"]
+
+    # Create a detection for that sequence
+    det_payload = {
+        "sequence_id": str(seq_id),
+        "alert_api_id": "8001",
+        "recorded_at": now.isoformat(),
+        "algo_predictions": json.dumps(
+            {"predictions": [{"xyxyn": [0.1, 0.1, 0.2, 0.2], "confidence": 0.9}]}
+        ),
+    }
+
+    img = Image.new("RGB", (64, 64), color="red")
+    img_bytes = io.BytesIO()
+    img.save(img_bytes, format="JPEG")
+    img_bytes.seek(0)
+    files = {"file": ("test.jpg", img_bytes, "image/jpeg")}
+
+    det_resp = await authenticated_client.post(
+        "/detections", data=det_payload, files=files
+    )
+    assert det_resp.status_code == 201
+
+    # No sequence annotation created, default sequence_processing_stage=annotated must exclude this sequence
+    resp = await authenticated_client.get("/export/detections")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert data == []
+
+
+@pytest.mark.asyncio
+async def test_export_detections_basic_row_and_image_url(
+    authenticated_client: AsyncClient,
+    sequence_session,
+    detection_session,
+    monkeypatch,
+):
+    """
+    When a sequence has an annotated sequence annotation,
+    export_detections should return detection rows with image_url
+    resolved through s3_service.get_bucket().get_public_url().
+    """
+    dummy_bucket = DummyBucket()
+
+    def fake_get_bucket(_bucket_name: str) -> DummyBucket:
+        return dummy_bucket
+
+    monkeypatch.setattr(storage_module.s3_service, "get_bucket", fake_get_bucket)
+
+    # Use existing sequence 1 from fixtures, create a detection on it
+    det_payload = {
+        "sequence_id": "1",
+        "alert_api_id": "8101",
+        "recorded_at": now.isoformat(),
+        "algo_predictions": json.dumps(
+            {"predictions": [{"xyxyn": [0.1, 0.1, 0.3, 0.3], "confidence": 0.95}]}
+        ),
+    }
+
+    img = Image.new("RGB", (64, 64), color="blue")
+    img_bytes = io.BytesIO()
+    img.save(img_bytes, format="JPEG")
+    img_bytes.seek(0)
+    files = {"file": ("test.jpg", img_bytes, "image/jpeg")}
+
+    det_resp = await authenticated_client.post(
+        "/detections", data=det_payload, files=files
+    )
+    assert det_resp.status_code == 201
+    detection = det_resp.json()
+    detection_id = detection["id"]
+
+    # Create a sequence annotation in annotated stage so export route sees it
+    seq_ann_payload = {
+        "sequence_id": 1,
+        "has_missed_smoke": False,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": True,
+                    "smoke_type": "wildfire",
+                    "false_positive_types": [],
+                    "bboxes": [
+                        {"detection_id": detection_id, "xyxyn": [0.1, 0.1, 0.2, 0.2]}
+                    ],
+                }
+            ]
+        },
+        "processing_stage": models.SequenceAnnotationProcessingStage.ANNOTATED.value,
+        "created_at": now.isoformat(),
+    }
+    seq_ann_resp = await authenticated_client.post(
+        "/annotations/sequences/", json=seq_ann_payload
+    )
+    assert seq_ann_resp.status_code == 201
+
+    # Call export endpoint
+    resp = await authenticated_client.get("/export/detections")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert isinstance(rows, list)
+    assert len(rows) >= 1
+
+    # Look for our detection id
+    row = next(r for r in rows if r["detection_id"] == detection_id)
+
+    # Basic structure
+    for key in [
+        "detection_id",
+        "sequence_id",
+        "alert_api_id",
+        "source_api",
+        "recorded_at",
+        "created_at",
+        "camera_name",
+        "organisation_name",
+        "lat",
+        "lon",
+        "bucket_key",
+    ]:
+        assert key in row
+
+    # image_url must be non null and built through dummy bucket
+    assert row["image_url"] is not None
+    assert row["bucket_key"] in dummy_bucket.public_urls
+    assert row["image_url"] == dummy_bucket.public_urls[row["bucket_key"]]
+
+    # Sequence annotation metadata must be present
+    assert row["sequence_has_smoke"] is True
+    assert row["sequence_processing_stage"] == "annotated"
+    assert row["sequence_annotation"] is not None
+    assert row["sequence_annotation_created_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_export_detections_filters_by_organisation_and_source(
+    authenticated_client: AsyncClient,
+    sequence_session,
+    detection_session,
+    monkeypatch,
+):
+    """
+    Filters organisation_name and source_api should restrict results to matching sequences.
+    """
+    dummy_bucket = DummyBucket()
+
+    def fake_get_bucket(_bucket_name: str) -> DummyBucket:
+        return dummy_bucket
+
+    monkeypatch.setattr(storage_module.s3_service, "get_bucket", fake_get_bucket)
+
+    # Create two sequences with different organisation and source api
+    seq_specs = [
+        {
+            "source_api": "pyronear_french",
+            "alert_api_id": "8201",
+            "camera_name": "Export Cam A",
+            "camera_id": "821",
+            "organisation_name": "Org A",
+            "organisation_id": "821",
+        },
+        {
+            "source_api": "alert_wildfire",
+            "alert_api_id": "8202",
+            "camera_name": "Export Cam B",
+            "camera_id": "822",
+            "organisation_name": "Org B",
+            "organisation_id": "822",
+        },
+    ]
+
+    seq_ids = []
+    for spec in seq_specs:
+        payload = {
+            **spec,
+            "lat": "43.0",
+            "lon": "1.0",
+            "recorded_at": (now - timedelta(minutes=5)).isoformat(),
+            "last_seen_at": now.isoformat(),
+        }
+        resp = await authenticated_client.post("/sequences", data=payload)
+        assert resp.status_code == 201
+        seq_ids.append(resp.json()["id"])
+
+    # Create one detection and annotation per sequence in annotated stage
+    created = []
+    for seq_id, spec in zip(seq_ids, seq_specs):
+        det_payload = {
+            "sequence_id": str(seq_id),
+            "alert_api_id": f"83{seq_id}",
+            "recorded_at": now.isoformat(),
+            "algo_predictions": json.dumps(
+                {"predictions": [{"xyxyn": [0.1, 0.1, 0.2, 0.2], "confidence": 0.9}]}
+            ),
+        }
+        img = Image.new("RGB", (64, 64), color="green")
+        img_bytes = io.BytesIO()
+        img.save(img_bytes, format="JPEG")
+        img_bytes.seek(0)
+        files = {"file": ("test.jpg", img_bytes, "image/jpeg")}
+        det_resp = await authenticated_client.post(
+            "/detections", data=det_payload, files=files
+        )
+        assert det_resp.status_code == 201
+        det_id = det_resp.json()["id"]
+
+        seq_ann_payload = {
+            "sequence_id": seq_id,
+            "has_missed_smoke": False,
+            "annotation": {
+                "sequences_bbox": [
+                    {
+                        "is_smoke": True,
+                        "smoke_type": "wildfire",
+                        "false_positive_types": [],
+                        "bboxes": [
+                            {"detection_id": det_id, "xyxyn": [0.1, 0.1, 0.2, 0.2]}
+                        ],
+                    }
+                ]
+            },
+            "processing_stage": models.SequenceAnnotationProcessingStage.ANNOTATED.value,
+            "created_at": now.isoformat(),
+        }
+        ann_resp = await authenticated_client.post(
+            "/annotations/sequences/", json=seq_ann_payload
+        )
+        assert ann_resp.status_code == 201
+        created.append((seq_id, det_id, spec))
+
+    # Filter for Org A and pyronear_french only
+    resp = await authenticated_client.get(
+        "/export/detections",
+        params={
+            "organisation_name": "Org A",
+            "source_api": "pyronear_french",
+        },
+    )
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) >= 1
+    # All rows must match the filter
+    for row in rows:
+        assert row["organisation_name"] == "Org A"
+        assert row["source_api"] == "pyronear_french"
+
+    # Filtering on Org B and alert_wildfire returns only that one
+    resp_b = await authenticated_client.get(
+        "/export/detections",
+        params={
+            "organisation_name": "Org B",
+            "source_api": "alert_wildfire",
+        },
+    )
+    assert resp_b.status_code == 200
+    rows_b = resp_b.json()
+    assert len(rows_b) >= 1
+    for row in rows_b:
+        assert row["organisation_name"] == "Org B"
+        assert row["source_api"] == "alert_wildfire"
+
+
+@pytest.mark.asyncio
+async def test_export_detections_filters_by_sequence_annotation_created_window(
+    authenticated_client: AsyncClient,
+    sequence_session,
+    detection_session,
+    monkeypatch,
+):
+    """
+    sequence_annotation_created_gte and sequence_annotation_created_lte
+    should filter detections based on the underlying sequence annotation dates.
+    """
+    dummy_bucket = DummyBucket()
+
+    def fake_get_bucket(_bucket_name: str) -> DummyBucket:
+        return dummy_bucket
+
+    monkeypatch.setattr(storage_module.s3_service, "get_bucket", fake_get_bucket)
+
+    # Use sequence 1 from fixtures, create two detections to share same sequence
+    base_time = now - timedelta(days=10)
+
+    detection_ids = []
+    created_times = [base_time, base_time + timedelta(days=5)]
+
+    for idx, created_at in enumerate(created_times, start=1):
+        det_payload = {
+            "sequence_id": "1",
+            "alert_api_id": f"840{idx}",
+            "recorded_at": created_at.isoformat(),
+            "algo_predictions": json.dumps(
+                {"predictions": [{"xyxyn": [0.1, 0.1, 0.2, 0.2], "confidence": 0.9}]}
+            ),
+        }
+        img = Image.new("RGB", (64, 64), color="yellow")
+        img_bytes = io.BytesIO()
+        img.save(img_bytes, format="JPEG")
+        img_bytes.seek(0)
+        files = {"file": ("test.jpg", img_bytes, "image/jpeg")}
+        det_resp = await authenticated_client.post(
+            "/detections", data=det_payload, files=files
+        )
+        assert det_resp.status_code == 201
+        detection_ids.append(det_resp.json()["id"])
+
+    # One sequence annotation older, one newer, we overwrite since there is unique constraint
+    # So instead we use created_at field itself as filter on a single annotation
+    # Create annotation at a known created_at timestamp
+    annotation_created_at = base_time + timedelta(days=3)
+
+    seq_ann_payload = {
+        "sequence_id": 1,
+        "has_missed_smoke": False,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": True,
+                    "smoke_type": "wildfire",
+                    "false_positive_types": [],
+                    "bboxes": [
+                        {"detection_id": detection_ids[0], "xyxyn": [0.1, 0.1, 0.2, 0.2]},
+                        {"detection_id": detection_ids[1], "xyxyn": [0.3, 0.3, 0.4, 0.4]},
+                    ],
+                }
+            ]
+        },
+        "processing_stage": models.SequenceAnnotationProcessingStage.ANNOTATED.value,
+        "created_at": annotation_created_at.isoformat(),
+    }
+
+    seq_ann_resp = await authenticated_client.post(
+        "/annotations/sequences/", json=seq_ann_payload
+    )
+    assert seq_ann_resp.status_code == 201
+
+    # Window that includes annotation_created_at should return both detections
+    resp = await authenticated_client.get(
+        "/export/detections",
+        params={
+            "sequence_annotation_created_gte": (
+                annotation_created_at - timedelta(hours=1)
+            ).isoformat(),
+            "sequence_annotation_created_lte": (
+                annotation_created_at + timedelta(hours=1)
+            ).isoformat(),
+        },
+    )
+    assert resp.status_code == 200
+    rows = resp.json()
+    ids = {row["detection_id"] for row in rows}
+    assert detection_ids[0] in ids
+    assert detection_ids[1] in ids
+
+    # Window that is strictly before annotation_created_at should return no rows
+    resp_before = await authenticated_client.get(
+        "/export/detections",
+        params={
+            "sequence_annotation_created_gte": (
+                annotation_created_at - timedelta(days=5)
+            ).isoformat(),
+            "sequence_annotation_created_lte": (
+                annotation_created_at - timedelta(days=1)
+            ).isoformat(),
+        },
+    )
+    assert resp_before.status_code == 200
+    assert resp_before.json() == []
+
+
+@pytest.mark.asyncio
+async def test_export_detections_ordering_and_limit(
+    authenticated_client: AsyncClient,
+    sequence_session,
+    detection_session,
+    monkeypatch,
+):
+    """
+    order_by and order_desc, combined with limit,
+    should control which detections are returned and in which order.
+    """
+    dummy_bucket = DummyBucket()
+
+    def fake_get_bucket(_bucket_name: str) -> DummyBucket:
+        return dummy_bucket
+
+    monkeypatch.setattr(storage_module.s3_service, "get_bucket", fake_get_bucket)
+
+    # Create a sequence annotation for sequence 1 so exports are allowed
+    seq_ann_payload = {
+        "sequence_id": 1,
+        "has_missed_smoke": False,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": True,
+                    "smoke_type": "wildfire",
+                    "false_positive_types": [],
+                    "bboxes": [],
+                }
+            ]
+        },
+        "processing_stage": models.SequenceAnnotationProcessingStage.ANNOTATED.value,
+        "created_at": now.isoformat(),
+    }
+    seq_ann_resp = await authenticated_client.post(
+        "/annotations/sequences/", json=seq_ann_payload
+    )
+    assert seq_ann_resp.status_code == 201
+
+    # Create three detections with distinct recorded_at timestamps
+    detection_ids = []
+    recorded_times = [
+        now - timedelta(minutes=30),
+        now - timedelta(minutes=20),
+        now - timedelta(minutes=10),
+    ]
+
+    for idx, rec in enumerate(recorded_times, start=1):
+        det_payload = {
+            "sequence_id": "1",
+            "alert_api_id": f"850{idx}",
+            "recorded_at": rec.isoformat(),
+            "algo_predictions": json.dumps(
+                {"predictions": [{"xyxyn": [0.1, 0.1, 0.2, 0.2], "confidence": 0.8}]}
+            ),
+        }
+        img = Image.new("RGB", (64, 64), color="pink")
+        img_bytes = io.BytesIO()
+        img.save(img_bytes, format="JPEG")
+        img_bytes.seek(0)
+        files = {"file": ("test.jpg", img_bytes, "image/jpeg")}
+        det_resp = await authenticated_client.post(
+            "/detections", data=det_payload, files=files
+        )
+        assert det_resp.status_code == 201
+        detection_ids.append(det_resp.json()["id"])
+
+    # Export with order_by=recorded_at, desc, limit=2
+    resp = await authenticated_client.get(
+        "/export/detections",
+        params={
+            "order_by": "recorded_at",
+            "order_desc": "true",
+            "limit": 2,
+        },
+    )
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 2
+
+    # Recorded_at must be descending
+    rec0 = datetime.fromisoformat(rows[0]["recorded_at"])
+    rec1 = datetime.fromisoformat(rows[1]["recorded_at"])
+    assert rec0 >= rec1
+
+    # When ordering ascending, first row should be oldest
+    resp_asc = await authenticated_client.get(
+        "/export/detections",
+        params={
+            "order_by": "recorded_at",
+            "order_desc": "false",
+            "limit": 1,
+        },
+    )
+    assert resp_asc.status_code == 200
+    rows_asc = resp_asc.json()
+    assert len(rows_asc) == 1
+    oldest_rec = min(recorded_times)
+    assert datetime.fromisoformat(rows_asc[0]["recorded_at"]) == oldest_rec
+
+
+@pytest.mark.asyncio
+async def test_export_detections_filters_by_false_positive_and_smoke_types(
+    authenticated_client: AsyncClient,
+    sequence_session,
+    detection_session,
+    monkeypatch,
+):
+    """
+    false_positive_types and smoke_types filters should use OR logic on sequence level
+    and restrict exported detections accordingly.
+    """
+    dummy_bucket = DummyBucket()
+
+    def fake_get_bucket(_bucket_name: str) -> DummyBucket:
+        return dummy_bucket
+
+    monkeypatch.setattr(storage_module.s3_service, "get_bucket", fake_get_bucket)
+
+    # Create three sequences for different type configurations
+    seq_payloads = [
+        {
+            "source_api": "pyronear_french",
+            "alert_api_id": "8601",
+            "camera_name": "FP Smoke Cam 1",
+            "camera_id": "861",
+            "organisation_name": "Org Types",
+            "organisation_id": "861",
+        },
+        {
+            "source_api": "pyronear_french",
+            "alert_api_id": "8602",
+            "camera_name": "FP Smoke Cam 2",
+            "camera_id": "862",
+            "organisation_name": "Org Types",
+            "organisation_id": "861",
+        },
+        {
+            "source_api": "pyronear_french",
+            "alert_api_id": "8603",
+            "camera_name": "FP Smoke Cam 3",
+            "camera_id": "863",
+            "organisation_name": "Org Types",
+            "organisation_id": "861",
+        },
+    ]
+
+    seq_ids = []
+    for payload in seq_payloads:
+        data = {
+            **payload,
+            "lat": "43.0",
+            "lon": "1.0",
+            "recorded_at": now.isoformat(),
+            "last_seen_at": now.isoformat(),
+        }
+        resp = await authenticated_client.post("/sequences", data=data)
+        assert resp.status_code == 201
+        seq_ids.append(resp.json()["id"])
+
+    # Create detections for each sequence
+    det_ids = []
+    for idx, seq_id in enumerate(seq_ids, start=1):
+        det_payload = {
+            "sequence_id": str(seq_id),
+            "alert_api_id": f"869{idx}",
+            "recorded_at": now.isoformat(),
+            "algo_predictions": json.dumps(
+                {"predictions": [{"xyxyn": [0.1, 0.1, 0.2, 0.2], "confidence": 0.9}]}
+            ),
+        }
+        img = Image.new("RGB", (64, 64), color="cyan")
+        img_bytes = io.BytesIO()
+        img.save(img_bytes, format="JPEG")
+        img_bytes.seek(0)
+        files = {"file": ("test.jpg", img_bytes, "image/jpeg")}
+        det_resp = await authenticated_client.post(
+            "/detections", data=det_payload, files=files
+        )
+        assert det_resp.status_code == 201
+        det_ids.append(det_resp.json()["id"])
+
+    # Create sequence annotations with different smoke and false positive types
+    annotations = [
+        {
+            "sequence_id": seq_ids[0],
+            "annotation": {
+                "sequences_bbox": [
+                    {
+                        "is_smoke": False,
+                        "false_positive_types": ["antenna", "building"],
+                        "bboxes": [
+                            {"detection_id": det_ids[0], "xyxyn": [0.1, 0.1, 0.2, 0.2]}
+                        ],
+                    }
+                ]
+            },
+        },
+        {
+            "sequence_id": seq_ids[1],
+            "annotation": {
+                "sequences_bbox": [
+                    {
+                        "is_smoke": True,
+                        "smoke_type": "wildfire",
+                        "false_positive_types": [],
+                        "bboxes": [
+                            {"detection_id": det_ids[1], "xyxyn": [0.1, 0.1, 0.2, 0.2]}
+                        ],
+                    }
+                ]
+            },
+        },
+        {
+            "sequence_id": seq_ids[2],
+            "annotation": {
+                "sequences_bbox": [
+                    {
+                        "is_smoke": True,
+                        "smoke_type": "industrial",
+                        "false_positive_types": ["high_cloud"],
+                        "bboxes": [
+                            {"detection_id": det_ids[2], "xyxyn": [0.1, 0.1, 0.2, 0.2]}
+                        ],
+                    }
+                ]
+            },
+        },
+    ]
+
+    for ann in annotations:
+        payload = {
+            "sequence_id": ann["sequence_id"],
+            "has_missed_smoke": False,
+            "annotation": ann["annotation"],
+            "processing_stage": models.SequenceAnnotationProcessingStage.ANNOTATED.value,
+            "created_at": now.isoformat(),
+        }
+        resp = await authenticated_client.post(
+            "/annotations/sequences/", json=payload
+        )
+        assert resp.status_code == 201
+
+    # Filter by false_positive_types=antenna, should match only first sequence
+    resp_fp = await authenticated_client.get(
+        "/export/detections",
+        params={"false_positive_types": models.FalsePositiveType.ANTENNA.value},
+    )
+    assert resp_fp.status_code == 200
+    rows_fp = resp_fp.json()
+    assert len(rows_fp) >= 1
+    seq_ids_fp = {row["sequence_id"] for row in rows_fp}
+    assert seq_ids[0] in seq_ids_fp
+    assert seq_ids[1] not in seq_ids_fp
+    assert seq_ids[2] not in seq_ids_fp
+
+    # Filter by smoke_types=wildfire, should match second sequence
+    resp_smoke = await authenticated_client.get(
+        "/export/detections",
+        params={"smoke_types": models.SmokeType.WILDFIRE.value},
+    )
+    assert resp_smoke.status_code == 200
+    rows_smoke = resp_smoke.json()
+    seq_ids_smoke = {row["sequence_id"] for row in rows_smoke}
+    assert seq_ids[1] in seq_ids_smoke
+    assert seq_ids[0] not in seq_ids_smoke
+
+    # Filter by smoke_types=industrial and false_positive_types=high_cloud,
+    # should match third sequence
+    resp_mixed = await authenticated_client.get(
+        "/export/detections",
+        params={
+            "smoke_types": models.SmokeType.INDUSTRIAL.value,
+            "false_positive_types": models.FalsePositiveType.HIGH_CLOUD.value,
+        },
+    )
+    assert resp_mixed.status_code == 200
+    rows_mixed = resp_mixed.json()
+    seq_ids_mixed = {row["sequence_id"] for row in rows_mixed}
+    assert seq_ids[2] in seq_ids_mixed


### PR DESCRIPTION

## Summary

This pull request adds a detection centric export route to the annotation API and a companion script that turns the export into a YOLO style dataset ready for training.

The goal is to go from validated annotations in the platform to a structured on disk dataset with images and labels, with minimal glue code needed downstream.

## API changes

### New endpoint

New route in `app/api/api_v1/endpoints/export.py`

* `GET /api/v1/export/detections`

It returns a list of rows with the following information for each detection

* Detection metadata

  * `detection_id`
  * `sequence_id`
  * `alert_api_id`
  * `recorded_at` and `created_at`
  * `bucket_key` and raw `algo_predictions`

* Sequence metadata

  * `source_api`
  * `camera_id` and `camera_name`
  * `organisation_id` and `organisation_name`
  * `lat`, `lon`, `azimuth`
  * `is_wildfire_alertapi`
  * sequence level annotation flags
  * full `sequence_annotation` object

* Detection annotation

  * `detection_processing_stage`
  * full `detection_annotation` object

* Storage helper

  * public `image_url` generated from `bucket_key` using the existing S3 helper

The endpoint joins `detections`, `sequences`, `sequences_annotations` and `detections_annotations` and exposes a flat view that is convenient for dataset export and analysis.

### Filters and defaults

Supported query parameters include

* Basic filters

  * `source_api`
  * `organisation_id` and `organisation_name`
  * `camera_id` and `camera_name`

* External wildfire label

  * `is_wildfire_alertapi` with values `wildfire_smoke`, `other_smoke`, `other` or `null` for unclassified

* Sequence annotation filters

  * `has_smoke`, `has_false_positives`, `has_missed_smoke`, `is_unsure`
  * `sequence_processing_stage` with values `imported`, `ready_to_annotate`, `annotated`
  * `false_positive_types` and `smoke_types` with OR logic based on the JSONB arrays

* Detection level date filters

  * `recorded_at_gte` and `recorded_at_lte`

* Export controls

  * `order_by` on `recorded_at` or `created_at`
  * `order_desc` toggle
  * `limit` with a hard cap to avoid exporting unbounded result sets

In addition, the endpoint applies by default a restriction on sequence processing stage equal to `annotated`, so that exports focus on fully validated sequences unless the caller explicitly changes this behavior.

## Dataset export script

A new script is added under `scripts/data_transfer/ingestion/platform/export_dataset.py`.

High level behavior

* Authenticates against the annotation API
* Calls `/export/detections` with the provided filters and limit
* Builds a YOLO style dataset on disk with the following layout

```text
dataset_exported_{timestamp}/
    <seq_type>/                 # smoke type, false positive type or "no_label"
        <sequence_folder>/      # named after first image basename for this sequence and type
            images/
                pyronear-{organisation_name}-{camera_name}-{azimuth}-{recorded_at}.jpg
            labels/
                pyronear-{organisation_name}-{camera_name}-{azimuth}-{recorded_at}.txt
```

### Class mapping

The script uses the existing semantic types from the API enums and maps them to integer class identifiers:

```python
SMOKE_TYPES = ["wildfire", "industrial", "other"]

FALSE_POSITIVE_TYPES = [
    "antenna",
    "building",
    "cliff",
    "dark",
    "dust",
    "high_cloud",
    "low_cloud",
    "lens_flare",
    "lens_droplet",
    "light",
    "rain",
    "trail",
    "road",
    "sky",
    "tree",
    "water_body",
    "other",
]

ALL_CLASSES = SMOKE_TYPES + FALSE_POSITIVE_TYPES
CLASS_ID = {name: idx for idx, name in enumerate(ALL_CLASSES)}
```

Each YOLO label line uses the format

```text
class_id x_center y_center width height
```

with coordinates coming from normalized `xyxyn` boxes stored in `sequence_annotation.annotation["sequences_bbox"]`.

### Image naming and sequence folders

For each detection row, the script builds a stable base filename

```text
pyronear-{organisation_name}-{camera_name}-{azimuth}-{recorded_at}
```

* `organisation_name` and `camera_name` are normalized into a slug

  * lower case
  * accents removed
  * non alphanumeric characters replaced by a single dash
* `azimuth` is formatted on three digits, falls back to `000` when missing
* `recorded_at` is parsed as ISO datetime and formatted as `YYYY-MM-DDTHH-MM-SS`

This produces filenames such as

```text
pyronear-sdis-07-marguerite-185-2024-01-26T13-19-24.jpg
```

For the directory structure

* For each sequence, the script inspects `sequences_bbox` and collects the list of `seq_type` values present

  * `smoke_type` when `is_smoke` is true
  * otherwise the first `false_positive_type` when available
* For each `(seq_type, sequence_id)` pair, a sequence folder is created and named after the first image basename seen for this pair

  * this gives compact and human readable sequence folders inside each type directory

### Handling of multiple types and missing boxes

The script follows these rules

* For each detection, it always downloads and saves the image
* It always writes a label file, even when no bounding box is present for that detection and type

  * the txt file is then empty
* For a given sequence

  * all images of the sequence are copied into every relevant `seq_type` folder
  * label content is type specific and detection specific

    * for example a sequence where some frames are annotated as `high_cloud` and others as `antenna` will produce

      * one folder under `high_cloud` with all images of the sequence and labels only where `high_cloud` boxes exist
      * one folder under `antenna` with all images of the sequence and labels only where `antenna` boxes exist
* When a sequence has no `sequences_bbox` at all, exported detections go to a dedicated `no_label` type, still with images and empty txt files

This design keeps full temporal context for each sequence in each semantic group while keeping label semantics unambiguous for training.

### Script options

The script exposes a CLI similar to the existing export utilities

* `--api-base`
* `--username` and `--password`
* `--timeout`
* `--limit` forwarded to `/export/detections`
* `--annotation-created-gte` and `--annotation-created-lte` to filter on `sequence_annotation.created_at`
* `--source-api` and `--organisation-name` mirrors the route filters
* `--output-dir` base directory for the dataset, default is `outputs/datasets/dataset_exported_{timestamp}`
* `--loglevel` and `--verify-ssl`

Example usage

```bash
uv run python -m scripts.data_transfer.ingestion.platform.export_dataset \
  --api-base http://localhost:5050/api/v1 \
  --username admin --password admin12345 \
  --limit 5000 \
  --annotation-created-gte 2025-01-01T00:00:00Z \
  --annotation-created-lte 2025-01-31T23:59:59Z \
  --output-dir outputs/datasets \
  --loglevel info
```

## Notes and limitations

* Export is currently done in a single call to `/export/detections` and controlled by `limit`

  * if we need very large datasets we might later add pagination support in the export route
* Class mapping is hard coded in the script to make the generated datasets reproducible and stable across runs
* The route and the script are both opinionated toward sequence level annotation in `sequences_bbox` and may need adjustments if we extend the annotation schema in the future
