### PR TITLE
add pagination

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/export.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/export.py
@@ -201,6 +201,11 @@ async def export_detections(
         le=100_000,
         description="Maximum number of rows to export in a single call",
     ),
+    offset: int = Query(
+        0,
+        ge=0,
+        description="Number of rows to skip before starting to return results",
+    ),
     session: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user),
 ) -> List[DetectionExportRow]:
@@ -351,7 +356,7 @@ async def export_detections(
     )
     stmt = stmt.order_by(desc(order_column) if order_desc else asc(order_column))
 
-    stmt = stmt.limit(limit)
+    stmt = stmt.offset(offset).limit(limit)
 
     result = await session.execute(stmt)
     rows = result.mappings().all()


### PR DESCRIPTION
This PR updates the dataset export script to support **pagination on `/export/detections`** using `limit` + `offset`.
We can now export large datasets (50k+ detections) reliably without hitting memory or timeout limits.

#### Key changes

* Add `offset` parameter when calling the export endpoint
* Loop through pages until no more rows (or `--max-rows` reached)
* New CLI flag `--max-rows` to optionally cap the total number of detections
* Existing logic for dataset structure, image download and YOLO label generation remains unchanged

#### Result

* Dataset export now works for large batches safely and continuously
* Sequence grouping remains consistent across pages since ordering and grouping happens after merge
