### PR TITLE
Remote api

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,50 @@ npm run dev  # Vite dev server on port 5173
 
 The project includes a comprehensive data import script that fetches sequences and detections from the Pyronear platform API and automatically generates annotations ready for human review.
 
+## Working with Remote Data
+
+There are two workflows depending on your role:
+
+### Annotators (duplicate from remote API, no platform access)
+
+If you only need to annotate Pyronear data locally:
+
+1) Ask an admin for credentials to the remote annotation API.
+2) Duplicate a subset into your local API (no platform creds needed):
+
+```bash
+MAIN_ANNOTATION_LOGIN=<remote_user> MAIN_ANNOTATION_PASSWORD=<remote_pass> \
+uv run python -m scripts.data_transfer.ingestion.platform.import \
+  --source-annotation-url https://annotationdev.pyronear.org \
+  --url-api-annotation http://localhost:5050 \
+  --max-sequences 10 \
+  --clone-processing-stage ready_to_annotate \
+  --sequence-list "1234,5678"  # optional alert_api_id filter
+```
+
+- `--max-sequences` caps how many sequences you pull.
+- `--clone-processing-stage` defaults to `no_annotation`; set to `ready_to_annotate` to grab ready items.
+- `--sequence-list` lets you restrict by alert_api_id (comma/space-separated or a file path).
+
+Then open http://localhost:3000 to annotate locally.
+
+### Admins (populate main from platform)
+
+If you manage the main dataset and have platform credentials, import directly from the platform into the target annotation API:
+
+```bash
+MAIN_ANNOTATION_LOGIN=<target_user> MAIN_ANNOTATION_PASSWORD=<target_pass> \
+PLATFORM_LOGIN=<platform_user> PLATFORM_PASSWORD=<platform_pass> \
+PLATFORM_ADMIN_LOGIN=<platform_admin_user> PLATFORM_ADMIN_PASSWORD=<platform_admin_pass> \
+uv run python -m scripts.data_transfer.ingestion.platform.import \
+  --date-from 2025-03-04 --date-end 2025-03-04 \
+  --url-api-annotation https://annotationdev.pyronear.org \
+  --max-sequences 10 \
+  --sequence-list "1234,5678"  # optional alert_api_id filter
+```
+
+Use `--loglevel debug` if you need more detail during imports.
+
 ### Prerequisites
 
 **Services must be running first:**

--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ uv run python -m scripts.data_transfer.ingestion.platform.import \
   --source-annotation-url https://annotationdev.pyronear.org \
   --url-api-annotation http://localhost:5050 \
   --max-sequences 10 \
-  --clone-processing-stage ready_to_annotate \
-  --sequence-list "1234,5678"  # optional alert_api_id filter
 ```
 
 - `--max-sequences` caps how many sequences you pull.
@@ -87,7 +85,7 @@ uv run python -m scripts.data_transfer.ingestion.platform.import \
   --date-from 2025-03-04 --date-end 2025-03-04 \
   --url-api-annotation https://annotationdev.pyronear.org \
   --max-sequences 10 \
-  --sequence-list "1234,5678"  # optional alert_api_id filter
+  --sequence-list alerts_id_list.txt  # optional alert_api_id filter
 ```
 
 Use `--loglevel debug` if you need more detail during imports.

--- a/annotation_api/scripts/data_transfer/ingestion/platform/annotation_management.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/annotation_management.py
@@ -34,6 +34,7 @@ import logging
 from datetime import date, datetime
 from typing import Dict, Any, Optional
 
+from . import shared
 from app.clients.annotation_api import (
     get_auth_token,
     list_sequence_annotations,
@@ -93,11 +94,8 @@ def check_existing_annotation(base_url: str, sequence_id: int) -> Optional[int]:
     """
     try:
         # Get authentication token
-        auth_token = get_auth_token(
-            base_url,
-            os.environ.get("ANNOTATOR_LOGIN", "admin"),
-            os.environ.get("ANNOTATOR_PASSWORD", "admin12345"),
-        )
+        login, password = shared.get_annotation_credentials(base_url)
+        auth_token = get_auth_token(base_url, login, password)
         response = list_sequence_annotations(
             base_url, auth_token, sequence_id=sequence_id
         )
@@ -168,11 +166,8 @@ def create_annotation_from_data(
     """
     try:
         # Get authentication token
-        auth_token = get_auth_token(
-            base_url,
-            os.environ.get("ANNOTATOR_LOGIN", "admin"),
-            os.environ.get("ANNOTATOR_PASSWORD", "admin12345"),
-        )
+        login, password = shared.get_annotation_credentials(base_url)
+        auth_token = get_auth_token(base_url, login, password)
 
         if existing_annotation_id:
             # Update existing annotation (PATCH)

--- a/annotation_api/scripts/data_transfer/ingestion/platform/annotation_management.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/annotation_management.py
@@ -41,7 +41,6 @@ from app.clients.annotation_api import (
     create_sequence_annotation,
     update_sequence_annotation,
 )
-import os
 from app.models import SequenceAnnotationProcessingStage
 from app.schemas.annotation_validation import SequenceAnnotationData
 

--- a/annotation_api/scripts/data_transfer/ingestion/platform/cleanup_sequences.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/cleanup_sequences.py
@@ -1,0 +1,116 @@
+"""
+Utility script to delete sequences from an annotation API.
+
+Use this to clean up partial/duplicate sequences (e.g., those without annotations)
+before re-running imports.
+"""
+
+import argparse
+import logging
+from typing import List, Optional
+
+from app.clients import annotation_api
+
+from . import shared
+
+
+def parse_sequence_selection(sequence_arg: str) -> List[int]:
+    """Parse comma/whitespace separated alert_api_id list."""
+    tokens = [t.strip() for t in sequence_arg.replace(",", " ").split() if t.strip()]
+    ids: List[int] = []
+    for tok in tokens:
+        try:
+            ids.append(int(tok))
+        except ValueError as exc:
+            raise ValueError(f"Invalid sequence id '{tok}' in sequence list") from exc
+    return ids
+
+
+def fetch_sequences(
+    base_url: str,
+    auth_token: str,
+    processing_stage: str,
+    alert_ids: Optional[List[int]],
+) -> List[dict]:
+    """Fetch sequences from annotation API matching filters."""
+    page = 1
+    size = 100
+    results: List[dict] = []
+    while True:
+        params = {"page": page, "size": size}
+        if processing_stage != "all":
+            params["processing_stage"] = processing_stage
+        resp = annotation_api.list_sequences(base_url, auth_token, **params)
+        items = resp.get("items", [])
+        for seq in items:
+            if alert_ids and seq.get("alert_api_id") not in alert_ids:
+                continue
+            results.append(seq)
+        if page >= resp.get("pages", 1):
+            break
+        page += 1
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Delete sequences from annotation API (use with care!)"
+    )
+    parser.add_argument(
+        "--url-api-annotation",
+        type=str,
+        default="http://localhost:5050",
+        help="Annotation API base URL",
+    )
+    parser.add_argument(
+        "--processing-stage",
+        type=str,
+        choices=["no_annotation", "imported", "ready_to_annotate", "annotated", "all"],
+        default="no_annotation",
+        help="Filter sequences by processing stage (default: no_annotation)",
+    )
+    parser.add_argument(
+        "--sequence-list",
+        type=str,
+        help="Optional comma/space-separated alert_api_id list to restrict deletions",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List matching sequences without deleting them",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    alert_ids = parse_sequence_selection(args.sequence_list) if args.sequence_list else None
+
+    login, password = shared.get_annotation_credentials(args.url_api_annotation)
+    token = annotation_api.get_auth_token(args.url_api_annotation, login, password)
+
+    sequences = fetch_sequences(
+        args.url_api_annotation, token, args.processing_stage, alert_ids
+    )
+
+    logging.info(
+        f"Found {len(sequences)} sequence(s) matching processing_stage={args.processing_stage}"
+        + (f" and alert_ids filter ({len(alert_ids)} provided)" if alert_ids else "")
+    )
+
+    if args.dry_run or not sequences:
+        logging.info("Dry run enabled or no sequences found; exiting without deletion.")
+        return
+
+    for seq in sequences:
+        seq_id = seq["id"]
+        alert_id = seq.get("alert_api_id")
+        try:
+            annotation_api.delete_sequence(args.url_api_annotation, token, seq_id)
+            logging.info(f"Deleted sequence id={seq_id} alert_api_id={alert_id}")
+        except Exception as exc:
+            logging.error(f"Failed to delete sequence id={seq_id} alert_api_id={alert_id}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/annotation_api/scripts/data_transfer/ingestion/platform/sequence_fetching.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/sequence_fetching.py
@@ -199,6 +199,7 @@ def fetch_all_sequences_within(
     access_token_admin: str,
     worker_config: WorkerConfig,
     selected_sequence_list: Optional[List[int]] = None,
+    max_sequences: Optional[int] = None,
     suppress_logs: bool = True,
     console: Optional[Console] = None,
     error_collector: Optional[ErrorCollector] = None,
@@ -223,6 +224,7 @@ def fetch_all_sequences_within(
         access_token_admin: Admin access token (for organization access)
         worker_config: WorkerConfig instance for intelligent scaling
         selected_sequence_list: Optional list of alert_api_id to restrict processing
+        max_sequences: Optional maximum number of sequences to process after filtering
         suppress_logs: Whether to suppress log output during progress display
         console: Rich console for enhanced output (created if None)
         error_collector: Error collector for clean error reporting (created if None)
@@ -337,12 +339,20 @@ def fetch_all_sequences_within(
         sequences = [
             sequence
             for sequence in sequences
-            if sequence.get("id") in selected_sequence_list
+            if sequence.get("alert_api_id") in selected_sequence_list
         ]
         filtered_out = pre_filter_count - len(sequences)
         console.print(
             f"[blue]🔍 Filtered sequences by alert_api_id[/] "
             f"[dim]({filtered_out} skipped, {len(sequences)} remaining)[/]"
+        )
+
+    # Optionally cap total sequences
+    if max_sequences is not None and max_sequences > 0 and len(sequences) > max_sequences:
+        sequences = sequences[:max_sequences]
+        console.print(
+            f"[blue]🔍 Applying max_sequences cap[/] "
+            f"[dim](processing first {max_sequences} sequences)[/]"
         )
 
     console.print(f"[green]✅ Found {len(sequences)} sequences[/]")


### PR DESCRIPTION
* Documented remote data workflows for annotators to clone sequences locally from a remote annotation API without platform access, using `--max-sequences`, `--clone-processing-stage`, and `--sequence-list`.
* Improved import flow with clearer credential selection for local vs main targets, early auth checks, capped remote fetches, better duplicate handling, and automatic cleanup of invalid bbox predictions.
* Added a cleanup utility to remove sequences from an annotation API, with optional count-only mode for dry filtering.

### Why

Simplify local annotation workflows and ensure platform imports are reliable with proper auth, filtering, and deduplication. Reduce failures caused by invalid predictions and avoid re-processing already imported data.

### Usage examples

**Clone sequences locally (annotator workflow):**

```
uv run python -m scripts.data_transfer.ingestion.platform.import \
  --source-annotation-url https://annotationdev.pyronear.org \
  --url-api-annotation http://localhost:5050 \
  --max-sequences 10 \
  --clone-processing-stage ready_to_annotate 
```

**Import from platform into a target annotation API (admin workflow):**

```
uv run python -m scripts.data_transfer.ingestion.platform.import \
  --date-from 2025-03-04 --date-end 2025-03-04 \
  --url-api-annotation https://annotationdev.pyronear.org \
  --max-sequences 10 \
  --sequence-list alerts_id_list.txt 
```

