### PR TITLE
upload seq annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ uv run python -m scripts.data_transfer.ingestion.platform.import \
   --source-annotation-url https://annotationdev.pyronear.org \
   --url-api-annotation http://localhost:5050 \
   --max-sequences 10 \
+  --clone-processing-stage ready_to_annotate \
+  --sequence-list "1234,5678"  # optional alert_api_id filter
 ```
 
 - `--max-sequences` caps how many sequences you pull.
@@ -72,6 +74,17 @@ uv run python -m scripts.data_transfer.ingestion.platform.import \
 - `--sequence-list` lets you restrict by alert_api_id (comma/space-separated or a file path).
 
 Then open http://localhost:3000 to annotate locally.
+
+When you're done annotating locally, push your sequence annotations back to the remote API:
+
+```bash
+MAIN_ANNOTATION_LOGIN=<remote_user> MAIN_ANNOTATION_PASSWORD=<remote_pass> \
+uv run python -m scripts.data_transfer.ingestion.platform.push_sequence_annotations \
+  --local-api http://localhost:5050 \
+  --remote-api https://annotationdev.pyronear.org \
+  --max-sequences 10 \
+  --sequence-list "1234,5678"  # optional alert_api_id filter
+```
 
 ### Admins (populate main from platform)
 

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import.py
@@ -61,6 +61,8 @@ import time
 from datetime import datetime
 from typing import List, Optional
 
+from dotenv import load_dotenv
+
 from rich.console import Console
 from rich.panel import Panel
 from rich.progress import (
@@ -81,6 +83,9 @@ from .annotation_management import (
 )
 from . import shared
 from app.clients import annotation_api
+
+# Load environment variables from .env automatically
+load_dotenv()
 
 # Import platform functionality
 from . import client as platform_client

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import.py
@@ -62,7 +62,6 @@ from datetime import datetime
 from typing import List, Optional
 
 from dotenv import load_dotenv
-
 from rich.console import Console
 from rich.panel import Panel
 from rich.progress import (
@@ -77,18 +76,13 @@ from rich.progress import (
 from .progress_management import ErrorCollector, StepManager, LogSuppressor
 from .worker_config import WorkerConfig
 from .sequence_fetching import fetch_all_sequences_within
-from .annotation_management import (
-    valid_date,
-    create_simple_sequence_annotation,
-)
+from .annotation_management import valid_date, create_simple_sequence_annotation
 from . import shared
+from . import client as platform_client
 from app.clients import annotation_api
 
-# Load environment variables from .env automatically
 load_dotenv()
 
-# Import platform functionality
-from . import client as platform_client
 
 
 def make_cli_parser() -> argparse.ArgumentParser:

--- a/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
@@ -1,0 +1,262 @@
+"""
+Sync local sequence annotations to a remote annotation API.
+
+Workflow:
+1. List annotated sequences on the local API (optionally filter by alert_api_id and limit).
+2. For each, find the corresponding sequence on the remote API by alert_api_id.
+3. Create or update the sequence annotation on the remote API.
+"""
+
+import argparse
+import logging
+from typing import List, Optional, Dict, Any
+
+from dotenv import load_dotenv
+
+from app.clients import annotation_api
+from . import shared
+
+# Load environment variables from .env automatically
+load_dotenv()
+
+
+def parse_sequence_selection(sequence_arg: str) -> List[int]:
+    """Parse comma/space separated alert_api_id list."""
+    tokens = [t.strip() for t in sequence_arg.replace(",", " ").split() if t.strip()]
+    ids: List[int] = []
+    for tok in tokens:
+        try:
+            ids.append(int(tok))
+        except ValueError as exc:
+            raise ValueError(f"Invalid sequence id '{tok}' in sequence list") from exc
+    return ids
+
+
+def fetch_local_annotated_sequences(
+    base_url: str,
+    token: str,
+    sequence_filter: Optional[List[int]],
+    max_sequences: Optional[int],
+) -> List[Dict[str, Any]]:
+    """Fetch annotated sequences from local API with optional filtering/limit."""
+    page = 1
+    size = 100
+    results: List[Dict[str, Any]] = []
+    targets = set(sequence_filter) if sequence_filter else None
+
+    while True:
+        params = {
+            "page": page,
+            "size": size,
+            "processing_stage": "annotated",
+        }
+        resp = annotation_api.list_sequences(base_url, token, **params)
+        items = resp.get("items", [])
+        for seq in items:
+            if targets and seq.get("alert_api_id") not in targets:
+                continue
+            results.append(seq)
+            if max_sequences and len(results) >= max_sequences:
+                return results
+        if page >= resp.get("pages", 1):
+            break
+        page += 1
+    return results
+
+
+def get_sequence_annotation_single(
+    base_url: str, token: str, sequence_id: int
+) -> Optional[Dict[str, Any]]:
+    """Return the first annotation for a sequence, if any."""
+    resp = annotation_api.list_sequence_annotations(
+        base_url, token, sequence_id=sequence_id, page=1, size=1
+    )
+    items = resp.get("items", []) if isinstance(resp, dict) else resp
+    if items:
+        return items[0]
+    return None
+
+
+def find_remote_sequence_by_alert_id(
+    base_url: str,
+    token: str,
+    alert_api_id: int,
+    source_api: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Lookup a remote sequence by alert_api_id (and optional source_api) via pagination."""
+    page = 1
+    size = 100
+    while True:
+        params = {"page": page, "size": size}
+        if source_api:
+            params["source_api"] = source_api
+        resp = annotation_api.list_sequences(base_url, token, **params)
+        items = resp.get("items", [])
+        for seq in items:
+            if seq.get("alert_api_id") == alert_api_id:
+                return seq
+        if page >= resp.get("pages", 1):
+            break
+        page += 1
+    return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Push local sequence annotations to a remote annotation API"
+    )
+    parser.add_argument(
+        "--local-api",
+        type=str,
+        default="http://localhost:5050",
+        help="Local annotation API base URL",
+    )
+    parser.add_argument(
+        "--remote-api",
+        type=str,
+        default="https://annotationdev.pyronear.org",
+        help="Remote (main) annotation API base URL",
+    )
+    parser.add_argument(
+        "--sequence-list",
+        type=str,
+        help="Optional comma/space-separated alert_api_id list to restrict syncing",
+    )
+    parser.add_argument(
+        "--max-sequences",
+        type=int,
+        default=None,
+        help="Maximum number of sequences to sync",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be synced without modifying the remote API",
+    )
+    parser.add_argument(
+        "--loglevel",
+        type=str,
+        default="info",
+        choices=["debug", "info", "warning", "error"],
+        help="Logging level",
+    )
+
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=args.loglevel.upper(), format="%(asctime)s - %(levelname)s - %(message)s"
+    )
+
+    sequence_filter = (
+        parse_sequence_selection(args.sequence_list) if args.sequence_list else None
+    )
+
+    # Auth tokens
+    local_login, local_password = shared.get_annotation_credentials(args.local_api)
+    remote_login, remote_password = shared.get_annotation_credentials(args.remote_api)
+
+    local_token = annotation_api.get_auth_token(
+        args.local_api, username=local_login, password=local_password
+    )
+    remote_token = annotation_api.get_auth_token(
+        args.remote_api, username=remote_login, password=remote_password
+    )
+
+    logging.info(
+        f"Fetching annotated sequences from local API {args.local_api} "
+        f"(filter={sequence_filter or 'none'}, max={args.max_sequences or 'all'})"
+    )
+    local_sequences = fetch_local_annotated_sequences(
+        args.local_api, local_token, sequence_filter, args.max_sequences
+    )
+    logging.info(f"Found {len(local_sequences)} annotated sequence(s) locally")
+
+    stats = {
+        "attempted": 0,
+        "synced_new": 0,
+        "synced_updated": 0,
+        "skipped_no_annotation": 0,
+        "missing_remote": 0,
+        "errors": 0,
+    }
+
+    for seq in local_sequences:
+        stats["attempted"] += 1
+        alert_id = seq.get("alert_api_id")
+        source_api = seq.get("source_api")
+
+        # Fetch local annotation
+        local_ann = get_sequence_annotation_single(args.local_api, local_token, seq["id"])
+        if not local_ann:
+            logging.warning(f"Skipping alert_api_id={alert_id}: no local annotation")
+            stats["skipped_no_annotation"] += 1
+            continue
+
+        # Find matching remote sequence by alert_api_id (and source_api if available)
+        remote_seq = find_remote_sequence_by_alert_id(
+            args.remote_api, remote_token, alert_id, source_api=source_api
+        )
+        if not remote_seq:
+            logging.warning(
+                f"Skipping alert_api_id={alert_id}: not found on remote API"
+            )
+            stats["missing_remote"] += 1
+            continue
+        remote_seq_id = remote_seq["id"]
+
+        # Check if remote already has an annotation
+        remote_ann = get_sequence_annotation_single(
+            args.remote_api, remote_token, remote_seq_id
+        )
+
+        # Build payload from local annotation
+        payload = {
+            "sequence_id": remote_seq_id,
+            "annotation": local_ann.get("annotation", {}),
+            "processing_stage": local_ann.get("processing_stage", "annotated"),
+            "has_missed_smoke": local_ann.get("has_missed_smoke", False),
+        }
+
+        try:
+            if args.dry_run:
+                action = "update" if remote_ann else "create"
+                logging.info(
+                    f"DRY RUN: would {action} annotation for alert_api_id={alert_id} "
+                    f"(remote_seq_id={remote_seq_id})"
+                )
+                continue
+
+            if remote_ann:
+                annotation_api.update_sequence_annotation(
+                    args.remote_api, remote_token, remote_ann["id"], payload
+                )
+                stats["synced_updated"] += 1
+                logging.info(
+                    f"Updated remote annotation for alert_api_id={alert_id} "
+                    f"(remote_seq_id={remote_seq_id})"
+                )
+            else:
+                annotation_api.create_sequence_annotation(
+                    args.remote_api, remote_token, payload
+                )
+                stats["synced_new"] += 1
+                logging.info(
+                    f"Created remote annotation for alert_api_id={alert_id} "
+                    f"(remote_seq_id={remote_seq_id})"
+                )
+        except Exception as exc:
+            logging.error(
+                f"Failed to sync annotation for alert_api_id={alert_id}: {exc}"
+            )
+            stats["errors"] += 1
+
+    logging.info(
+        f"Done. Attempted={stats['attempted']}, "
+        f"created={stats['synced_new']}, updated={stats['synced_updated']}, "
+        f"missing_remote={stats['missing_remote']}, "
+        f"no_local_annotation={stats['skipped_no_annotation']}, "
+        f"errors={stats['errors']}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary

Added a new sync script to push local sequence annotations to a remote annotation API (match on alert_api_id, create/update annotations, optional filters/limits, dry-run mode).
Enhanced import/clone scripts with dotenv loading for creds, proper credential selection, max-sequence capping, duplicate handling, and bbox sanitization; added cleanup utility for removing unwanted sequences



```
uv run --active python -m scripts.data_transfer.ingestion.platform.push_sequence_annotations
--local-api http://localhost:5050/
--remote-api https://annotationdev.pyronear.org/
--loglevel info
```