### PR TITLE
New stages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 docker-build-production:
-	@VITE_API_BASE_URL=https://annotationdev.pyronear.org docker compose build
+	@VITE_API_BASE_URL=https://annotationapi.pyronear.org docker compose build
 
 docker-build-local:
 	@VITE_API_BASE_URL=http://localhost:5050 docker compose build

--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ uv run python -m scripts.data_transfer.ingestion.platform.import \
   --source-annotation-url https://annotationdev.pyronear.org \
   --url-api-annotation http://localhost:5050 \
   --max-sequences 10 \
-  --clone-processing-stage ready_to_annotate \
-  --sequence-list "1234,5678"  # optional alert_api_id filter
+  --clone-processing-stage ready_to_annotate
 ```
 
 - `--max-sequences` caps how many sequences you pull.
@@ -82,8 +81,7 @@ MAIN_ANNOTATION_LOGIN=<remote_user> MAIN_ANNOTATION_PASSWORD=<remote_pass> \
 uv run python -m scripts.data_transfer.ingestion.platform.push_sequence_annotations \
   --local-api http://localhost:5050 \
   --remote-api https://annotationdev.pyronear.org \
-  --max-sequences 10 \
-  --sequence-list "1234,5678"  # optional alert_api_id filter
+  --max-sequences 10
 ```
 
 ### Admins (populate main from platform)

--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ If you only need to annotate Pyronear data locally:
 ```bash
 MAIN_ANNOTATION_LOGIN=<remote_user> MAIN_ANNOTATION_PASSWORD=<remote_pass> \
 uv run python -m scripts.data_transfer.ingestion.platform.import \
-  --source-annotation-url https://annotationdev.pyronear.org \
+  --source-annotation-url https://annotationapi.pyronear.org \
   --url-api-annotation http://localhost:5050 \
   --max-sequences 10 \
-  --clone-processing-stage ready_to_annotate
+  --clone-processing-stage ready_to_annotate \
+  --loglevel info
 ```
 
 - `--max-sequences` caps how many sequences you pull.
@@ -80,8 +81,9 @@ When you're done annotating locally, push your sequence annotations back to the 
 MAIN_ANNOTATION_LOGIN=<remote_user> MAIN_ANNOTATION_PASSWORD=<remote_pass> \
 uv run python -m scripts.data_transfer.ingestion.platform.push_sequence_annotations \
   --local-api http://localhost:5050 \
-  --remote-api https://annotationdev.pyronear.org \
-  --max-sequences 10
+  --remote-api https://annotationapi.pyronear.org \
+  --max-sequences 10 \
+  --loglevel info
 ```
 
 ### Admins (populate main from platform)
@@ -94,7 +96,7 @@ PLATFORM_LOGIN=<platform_user> PLATFORM_PASSWORD=<platform_pass> \
 PLATFORM_ADMIN_LOGIN=<platform_admin_user> PLATFORM_ADMIN_PASSWORD=<platform_admin_pass> \
 uv run python -m scripts.data_transfer.ingestion.platform.import \
   --date-from 2025-03-04 --date-end 2025-03-04 \
-  --url-api-annotation https://annotationdev.pyronear.org \
+  --url-api-annotation https://annotationapi.pyronear.org \
   --max-sequences 10 \
   --sequence-list alerts_id_list.txt  # optional alert_api_id filter
 ```
@@ -171,21 +173,21 @@ uv run python -m scripts.data_transfer.ingestion.platform.import \
 # Import to deployed annotation API
 uv run python -m scripts.data_transfer.ingestion.platform.import \
   --date-from 2024-01-01 --date-end 2024-01-02 \
-  --url-api-annotation https://annotationdev.pyronear.org \
+  --url-api-annotation https://annotationapi.pyronear.org \
   --loglevel info
 
 # Mixed environment: production platform + staging annotation API
 uv run python -m scripts.data_transfer.ingestion.platform.import \
   --date-from 2024-01-01 \
   --url-api-platform https://alertapi.pyronear.org \
-  --url-api-annotation https://annotationdev.pyronear.org \
+  --url-api-annotation https://annotationapi.pyronear.org \
   --loglevel info
 
 # CENIA platform to deployed annotation API
 uv run python -m scripts.data_transfer.ingestion.platform.import \
   --date-from 2024-01-01 \
   --url-api-platform https://apicenia.pyronear.org \
-  --url-api-annotation https://annotationdev.pyronear.org \
+  --url-api-annotation https://annotationapi.pyronear.org \
   --loglevel info
 ```
 
@@ -197,7 +199,7 @@ uv run python -m scripts.data_transfer.ingestion.platform.import \
 - **Authentication**: Uses local admin credentials (`admin`/`admin12345`)
 
 **Deployed/Staging Annotation API:**
-- **Annotation API**: `https://annotationdev.pyronear.org`
+- **Annotation API**: `https://annotationapi.pyronear.org`
 - **Platform API**: Any platform API endpoint
 - **Authentication**: Requires proper credentials for the deployed annotation API
 - **Network**: Ensure firewall/network access to deployed services
@@ -205,8 +207,8 @@ uv run python -m scripts.data_transfer.ingestion.platform.import \
 **Authentication Notes:**
 - Platform API credentials are always required via environment variables
 - Deployed annotation APIs may have different authentication requirements
-- Test connectivity: `curl https://annotationdev.pyronear.org/docs`
-- Check API health: `curl https://annotationdev.pyronear.org/status`
+- Test connectivity: `curl https://annotationapi.pyronear.org/docs`
+- Check API health: `curl https://annotationapi.pyronear.org/status`
 
 For detailed documentation, parameter reference, and troubleshooting, see [Data Ingestion Guide](annotation_api/docs/data-ingestion-guide.md).
 
@@ -223,7 +225,7 @@ For detailed documentation, parameter reference, and troubleshooting, see [Data 
 - Ensure database and S3 services are running
 
 **Remote annotation API connection issues:**
-- Test API connectivity: `curl https://annotationdev.pyronear.org/status`
+- Test API connectivity: `curl https://annotationapi.pyronear.org/status`
 - Check network access and firewall settings
 - Verify authentication credentials for deployed services
 - Review import script logs for connection timeouts or SSL errors

--- a/annotation_api/scripts/data_transfer/ingestion/platform/export_dataset.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/export_dataset.py
@@ -19,7 +19,7 @@ YOLO format per line:
 
 Example:
 uv run python -m scripts.data_transfer.ingestion.platform.export_dataset \
-  --api-base https://annotationdev.pyronear.org/api/v1 \
+  --api-base https://annotationapi.pyronear.org/api/v1 \
   --limit 500 \
   --max-rows 2000 \
   --timeout 120 \

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import.py
@@ -388,6 +388,52 @@ def count_sequences_from_annotation_api(
     return total
 
 
+def update_source_annotations_stage(
+    source_annotation_url: str,
+    source_sequence_ids: List[int],
+    target_stage: str,
+    console: Console,
+) -> None:
+    """
+    Update processing_stage for annotations on the source annotation API.
+    """
+    if not source_sequence_ids:
+        return
+
+    login, password = get_source_annotation_credentials()
+    token = annotation_api.get_auth_token(
+        source_annotation_url, username=login, password=password
+    )
+
+    updated = 0
+    missing = 0
+    errors = 0
+    for seq_id in source_sequence_ids:
+        resp = annotation_api.list_sequence_annotations(
+            source_annotation_url, token, sequence_id=seq_id, page=1, size=1
+        )
+        items = resp.get("items", []) if isinstance(resp, dict) else resp
+        if not items:
+            missing += 1
+            continue
+        ann_id = items[0]["id"]
+        try:
+            annotation_api.update_sequence_annotation(
+                source_annotation_url, token, ann_id, {"processing_stage": target_stage}
+            )
+            updated += 1
+        except Exception as exc:
+            errors += 1
+            console.print(
+                f"[yellow]⚠️ Failed to update annotation {ann_id} on source (sequence_id={seq_id}): {exc}[/]"
+            )
+
+    console.print(
+        f"[blue]ℹ️  Updated source annotations stage to {target_stage}: "
+        f"{updated} updated, {missing} missing, {errors} errors[/]"
+    )
+
+
 def fetch_records_from_annotation_api(
     source_annotation_url: str,
     selected_sequence_list: List[int],
@@ -395,7 +441,7 @@ def fetch_records_from_annotation_api(
     suppress_logs: bool,
     max_sequences: Optional[int] = None,
     clone_processing_stage: str = "no_annotation",
-) -> tuple[List[dict], str]:
+) -> tuple[List[dict], str, List[int]]:
     """
     Fetch sequences and detections directly from an annotation API instance.
 
@@ -422,6 +468,7 @@ def fetch_records_from_annotation_api(
     )
 
     records: List[dict] = []
+    source_sequence_ids: List[int] = []
     source_api = None
     size = 100
     page = 1
@@ -459,6 +506,7 @@ def fetch_records_from_annotation_api(
                 source_api = source_api or seq.get("source_api", "pyronear_french")
                 found_ids.add(alert_id)
                 cloned_sequences += 1
+                source_sequence_ids.append(seq["id"])
 
                 # Fetch detections for this sequence
                 det_page_num = 1
@@ -539,7 +587,7 @@ def fetch_records_from_annotation_api(
             f"[yellow]⚠️ Missing {len(missing)} requested sequence(s) in source annotation API: {sorted(missing)}[/]"
         )
 
-    return records, source_api or "pyronear_french"
+    return records, source_api or "pyronear_french", source_sequence_ids
 
 
 def main() -> None:
@@ -706,7 +754,7 @@ def main() -> None:
         if clone_from_annotation:
             # Fetch records directly from another annotation API instance
             try:
-                records, source_api = fetch_records_from_annotation_api(
+                records, source_api, source_sequence_ids = fetch_records_from_annotation_api(
                     source_annotation_url=args.source_annotation_url,
                     selected_sequence_list=selected_sequence_list,
                     console=console,
@@ -719,6 +767,13 @@ def main() -> None:
                 step_manager.complete_step(False, f"Annotation clone failed: {e}")
                 error_collector.print_summary(console, "Annotation Clone Errors")
                 sys.exit(1)
+            if not args.dry_run:
+                update_source_annotations_stage(
+                    args.source_annotation_url,
+                    source_sequence_ids,
+                    SequenceAnnotationProcessingStage.UNDER_ANNOTATION.value,
+                    console,
+                )
         else:
             # Get platform credentials
             platform_login = os.getenv("PLATFORM_LOGIN")
@@ -939,7 +994,7 @@ def main() -> None:
                         create_placeholder_sequence_annotation,
                         sequence_id=sequence_id,
                         annotation_api_url=args.url_api_annotation,
-                        processing_stage=SequenceAnnotationProcessingStage.UNDER_ANNOTATION,
+                        processing_stage=SequenceAnnotationProcessingStage.READY_TO_ANNOTATE,
                         dry_run=args.dry_run,
                     )
                 ): sequence_id

--- a/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
@@ -198,7 +198,7 @@ def main() -> None:
     parser.add_argument(
         "--remote-api",
         type=str,
-        default="https://annotationdev.pyronear.org",
+        default="https://annotationapi.pyronear.org",
         help="Remote (main) annotation API base URL",
     )
     parser.add_argument(

--- a/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
@@ -14,6 +14,7 @@ from typing import List, Optional, Dict, Any
 from dotenv import load_dotenv
 
 from app.clients import annotation_api
+from app.models import SequenceAnnotationProcessingStage
 from . import shared
 
 # Load environment variables from .env automatically
@@ -319,7 +320,7 @@ def main() -> None:
         payload = {
             "sequence_id": remote_seq_id,
             "annotation": remapped_annotation,
-            "processing_stage": local_ann.get("processing_stage", "annotated"),
+            "processing_stage": SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE.value,
             "has_missed_smoke": local_ann.get("has_missed_smoke", False),
         }
 

--- a/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
@@ -351,6 +351,21 @@ def main() -> None:
                     f"Created remote annotation for alert_api_id={alert_id} "
                     f"(remote_seq_id={remote_seq_id})"
                 )
+
+            # Update local annotation stage to seq_annotation_done for bookkeeping
+            try:
+                local_ann_id = local_ann.get("id")
+                if local_ann_id:
+                    annotation_api.update_sequence_annotation(
+                        args.local_api,
+                        local_token,
+                        local_ann_id,
+                        {"processing_stage": SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE.value},
+                    )
+            except Exception as exc:
+                logging.warning(
+                    f"Could not update local annotation stage for alert_api_id={alert_id}: {exc}"
+                )
         except Exception as exc:
             logging.error(
                 f"Failed to sync annotation for alert_api_id={alert_id}: {exc}"

--- a/annotation_api/src/app/models.py
+++ b/annotation_api/src/app/models.py
@@ -34,12 +34,25 @@ class SequenceAnnotationProcessingStage(str, Enum):
     Processing stages for sequence annotations in the wildfire monitoring workflow.
 
     These stages track the lifecycle of sequence annotations from initial data
-    import through preparation and final human annotation completion.
+    import through preparation and final human annotation completion, including
+    exclusive-annotation and review phases.
     """
 
     IMPORTED = "imported"  # Initial stage when sequence is imported from source API
     READY_TO_ANNOTATE = "ready_to_annotate"  # Sequence has been processed and is ready for human annotation
-    ANNOTATED = "annotated"  # Sequence has been fully annotated with smoke/false positive classifications
+    UNDER_ANNOTATION = (
+        "under_annotation"  # Someone is actively annotating this sequence locally to avoid contention
+    )
+    SEQ_ANNOTATION_DONE = (
+        "seq_annotation_done"  # Sequence annotation finished locally and ready to upload/share
+    )
+    IN_REVIEW = "in_review"  # Human is reviewing/QA the annotation
+    NEEDS_MANUAL = (
+        "needs_manual"  # Auto/triage flagged the sequence for manual intervention
+    )
+    ANNOTATED = (
+        "annotated"  # Sequence has been fully annotated and validated (final state)
+    )
 
 
 class SourceApi(str, Enum):

--- a/frontend/src/hooks/useAnnotationStats.ts
+++ b/frontend/src/hooks/useAnnotationStats.ts
@@ -5,6 +5,10 @@ import { QUERY_KEYS } from '@/utils/constants';
 export interface ProcessingStageStats {
   imported: number;
   ready_to_annotate: number;
+  under_annotation: number;
+  seq_annotation_done: number;
+  in_review: number;
+  needs_manual: number;
   annotated: number;
 }
 
@@ -84,6 +88,54 @@ export function useAnnotationStats(): AnnotationStats {
     gcTime: 10 * 60 * 1000,
   });
 
+  const { data: underAnnotationData, isLoading: underAnnotationLoading } = useQuery({
+    queryKey: [...QUERY_KEYS.ANNOTATION_STATS, 'under_annotation'],
+    queryFn: () =>
+      apiClient.getSequenceAnnotations({
+        processing_stage: 'under_annotation',
+        size: 1,
+        page: 1,
+      }),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+
+  const { data: seqAnnotationDoneData, isLoading: seqAnnotationDoneLoading } = useQuery({
+    queryKey: [...QUERY_KEYS.ANNOTATION_STATS, 'seq_annotation_done'],
+    queryFn: () =>
+      apiClient.getSequenceAnnotations({
+        processing_stage: 'seq_annotation_done',
+        size: 1,
+        page: 1,
+      }),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+
+  const { data: inReviewData, isLoading: inReviewLoading } = useQuery({
+    queryKey: [...QUERY_KEYS.ANNOTATION_STATS, 'in_review'],
+    queryFn: () =>
+      apiClient.getSequenceAnnotations({
+        processing_stage: 'in_review',
+        size: 1,
+        page: 1,
+      }),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+
+  const { data: needsManualData, isLoading: needsManualLoading } = useQuery({
+    queryKey: [...QUERY_KEYS.ANNOTATION_STATS, 'needs_manual'],
+    queryFn: () =>
+      apiClient.getSequenceAnnotations({
+        processing_stage: 'needs_manual',
+        size: 1,
+        page: 1,
+      }),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+
   // Fetch sequences with complete detection annotations
   const { data: completeDetectionsData, isLoading: completeDetectionsLoading } = useQuery({
     queryKey: [...QUERY_KEYS.ANNOTATION_STATS, 'complete_detections'],
@@ -131,6 +183,10 @@ export function useAnnotationStats(): AnnotationStats {
   const processingStages: ProcessingStageStats = {
     imported: importedData?.total ?? 0,
     ready_to_annotate: readyToAnnotateData?.total ?? 0,
+    under_annotation: underAnnotationData?.total ?? 0,
+    seq_annotation_done: seqAnnotationDoneData?.total ?? 0,
+    in_review: inReviewData?.total ?? 0,
+    needs_manual: needsManualData?.total ?? 0,
     annotated: annotatedData?.total ?? 0,
   };
 
@@ -140,6 +196,10 @@ export function useAnnotationStats(): AnnotationStats {
     importedLoading ||
     readyToAnnotateLoading ||
     annotatedLoading ||
+    underAnnotationLoading ||
+    seqAnnotationDoneLoading ||
+    inReviewLoading ||
+    needsManualLoading ||
     completeDetectionsLoading ||
     incompleteDetectionsLoading;
   const error = sequencesError || annotationsError;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -319,17 +319,17 @@ export default function DashboardPage() {
                   {
                     label: 'under annotation',
                     value: processingStages.under_annotation ?? 0,
-                    color: 'yellow',
+                    color: 'orange',
                   },
                   {
                     label: 'seq annotation done',
                     value: processingStages.seq_annotation_done ?? 0,
-                    color: 'blue',
+                    color: 'primary',
                   },
                   {
                     label: 'in review',
                     value: processingStages.in_review ?? 0,
-                    color: 'purple',
+                    color: 'gray',
                   },
                   {
                     label: 'needs manual',

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -308,24 +308,48 @@ export default function DashboardPage() {
                 stages={[
                   {
                     label: 'imported',
-                    value: processingStages.imported,
+                    value: processingStages.imported ?? 0,
                     color: 'gray',
                   },
                   {
                     label: 'ready to annotate',
-                    value: processingStages.ready_to_annotate,
+                    value: processingStages.ready_to_annotate ?? 0,
                     color: 'orange',
                   },
                   {
+                    label: 'under annotation',
+                    value: processingStages.under_annotation ?? 0,
+                    color: 'yellow',
+                  },
+                  {
+                    label: 'seq annotation done',
+                    value: processingStages.seq_annotation_done ?? 0,
+                    color: 'blue',
+                  },
+                  {
+                    label: 'in review',
+                    value: processingStages.in_review ?? 0,
+                    color: 'purple',
+                  },
+                  {
+                    label: 'needs manual',
+                    value: processingStages.needs_manual ?? 0,
+                    color: 'red',
+                  },
+                  {
                     label: 'annotated',
-                    value: processingStages.annotated,
+                    value: processingStages.annotated ?? 0,
                     color: 'green',
                   },
                 ]}
                 total={
-                  processingStages.imported +
-                  processingStages.ready_to_annotate +
-                  processingStages.annotated
+                  (processingStages.imported ?? 0) +
+                  (processingStages.ready_to_annotate ?? 0) +
+                  (processingStages.under_annotation ?? 0) +
+                  (processingStages.seq_annotation_done ?? 0) +
+                  (processingStages.in_review ?? 0) +
+                  (processingStages.needs_manual ?? 0) +
+                  (processingStages.annotated ?? 0)
                 }
                 height={32}
                 showLabels={true}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -123,7 +123,14 @@ export type FalsePositiveType =
   | 'water_body'
   | 'other';
 
-export type ProcessingStage = 'imported' | 'ready_to_annotate' | 'annotated';
+export type ProcessingStage =
+  | 'imported'
+  | 'ready_to_annotate'
+  | 'under_annotation'
+  | 'seq_annotation_done'
+  | 'in_review'
+  | 'needs_manual'
+  | 'annotated';
 
 // Detection-specific processing stages
 export type DetectionProcessingStage =

--- a/frontend/src/utils/processingStage.ts
+++ b/frontend/src/utils/processingStage.ts
@@ -168,6 +168,10 @@ export function getProcessingStageLabel(status: ProcessingStageStatus | Processi
     no_annotation: 'No annotation',
     imported: 'Imported',
     ready_to_annotate: 'Ready to annotate',
+    under_annotation: 'Under annotation',
+    seq_annotation_done: 'Seq annotation done',
+    in_review: 'In review',
+    needs_manual: 'Needs manual',
     annotated: 'Annotated',
   };
 
@@ -203,6 +207,10 @@ export function getProcessingStageColorClass(
     no_annotation: 'bg-gray-100 text-gray-800',
     imported: 'bg-blue-100 text-blue-800',
     ready_to_annotate: 'bg-yellow-100 text-yellow-800',
+    under_annotation: 'bg-yellow-200 text-yellow-900',
+    seq_annotation_done: 'bg-blue-100 text-blue-800',
+    in_review: 'bg-gray-100 text-gray-800',
+    needs_manual: 'bg-red-100 text-red-800',
     annotated: 'bg-green-100 text-green-800',
   };
 


### PR DESCRIPTION
This PR introduces full support for extended sequence annotation stages across the backend and the frontend, including under_annotation, seq_annotation_done, in_review, and needs_manual.

Key changes:

Clone and import workflows now set source annotations to under_annotation, create local placeholders, and remap detection IDs when pushing annotations.

Push workflow updates remote annotations to seq_annotation_done and synchronizes local status accordingly

Frontend dashboard and processing stage utilities now display and color code all new stages. Statistics queries include the new states.

Enum definitions were updated to prevent mismatch issues, and scripts now log and handle failures more gracefully