### PR TITLE
  Refine label pipeline: FP workflow, retry, presigned URLs, export naming   

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ make pull-seq-annotations MAX_SEQUENCES=20 SMOKE_TYPE=wildfire
 - Set `MAX_SEQUENCES=0` to pull all; override `SMOKE_TYPE` (or call the script directly without `--smoke-type`) to pull every smoke type.
 - TLS is verified by default; pass `--skip-ssl-verify` to the underlying script if you trust the host and need to silence self-signed cert issues.
 
-**Step 2 — `auto-annotate`**: auto-fill missing boxes with the pyronear YOLO11s model (downloads on first run):
+**Step 2 — `auto-annotate`**: auto-fill missing boxes with the pyronear YOLO11s sensitive-detector model (downloads on first run):
 
 ```bash
-make auto-annotate CONF_TH=0.05
+make auto-annotate CONF_TH=0.01
 ```
 
 **Step 3 — `visual-check`**: review the exported sequences (images + YOLO labels) in FiftyOne:

--- a/annotation_api/Makefile
+++ b/annotation_api/Makefile
@@ -40,7 +40,7 @@ DATA_ROOT        ?= outputs/seq_annotation_done
 SMOKE_TYPE       ?= wildfire
 DATASET_NAME     ?= visual_check
 LOGLEVEL         ?= info
-CONF_TH          ?= 0.05
+CONF_TH          ?= 0.01
 FROM_STAGE       ?= in_review
 TO_STAGE         ?= seq_annotation_done
 OUTPUT_DIR       ?= outputs/datasets
@@ -136,7 +136,7 @@ pull-seq-annotations:
 		--loglevel $(LOGLEVEL)
 
 # Auto-fill missing boxes using the pyronear YOLO11s model.
-# Usage: make auto-annotate [DATA_ROOT=...] [CONF_TH=0.05]
+# Usage: make auto-annotate [DATA_ROOT=...] [CONF_TH=0.01]
 auto-annotate:
 	uv run --active python -m scripts.data_transfer.ingestion.platform.auto_annotate \
 		--data-root $(DATA_ROOT) \

--- a/annotation_api/Makefile
+++ b/annotation_api/Makefile
@@ -21,6 +21,11 @@ help:
 	@echo "  visual-check         - Review exported sequences in FiftyOne"
 	@echo "  apply-review         - Apply FiftyOne review tags back to remote API"
 	@echo ""
+	@echo "False-positive workflow:"
+	@echo "  pull-fp              - Pull seq_annotation_done sequences for FP review"
+	@echo "  visual-check-fp      - Review FP sequences in FiftyOne (check no fire missed)"
+	@echo "  apply-review-fp      - Push clean FP sequences as 'managed' (no labels)"
+	@echo ""
 	@echo "Other data commands:"
 	@echo "  export-dataset       - Export images + YOLO labels from remote API"
 	@echo "  import-yolo-sequence - Import one YOLO folder into an API (needs SEQUENCE_DIR=...)"
@@ -40,6 +45,7 @@ DATA_ROOT        ?= outputs/seq_annotation_done
 SMOKE_TYPE       ?= wildfire
 DATASET_NAME     ?= visual_check
 LOGLEVEL         ?= info
+MAX_WORKERS      ?= 4
 CONF_TH          ?= 0.01
 FROM_STAGE       ?= in_review
 TO_STAGE         ?= seq_annotation_done
@@ -163,6 +169,41 @@ apply-review:
 		--remote-api $(REMOTE_API) \
 		--loglevel $(LOGLEVEL)
 
+# --- 1C. False-positive workflow ---
+# Same pull as detection workflow but uses a separate output dir and FiftyOne dataset
+# to avoid collisions with the TP pipeline.
+
+FP_DATA_ROOT   ?= outputs/fp_review
+FP_DATASET     ?= fp_check
+
+# Pull seq_annotation_done sequences for FP review.
+# Usage: make pull-fp [MAX_SEQUENCES=20] [SMOKE_TYPE=wildfire]
+pull-fp:
+	uv run python -m scripts.data_transfer.ingestion.platform.pull_sequence_annotations \
+		--remote-api $(REMOTE_API) \
+		--max-sequences $(MAX_SEQUENCES) \
+		--output-dir $(FP_DATA_ROOT) \
+		--smoke-type $(SMOKE_TYPE) \
+		--loglevel $(LOGLEVEL)
+
+# Visual check FP sequences in FiftyOne (confirm no fire was missed).
+# Usage: make visual-check-fp [FP_DATA_ROOT=outputs/fp_review]
+visual-check-fp:
+	uv run --active python -m scripts.data_transfer.ingestion.platform.visual_check_fiftyone \
+		--data-root $(FP_DATA_ROOT) \
+		--dataset-name $(FP_DATASET) \
+		--conf-th 0.0
+
+# Apply FP review: clean sequences → managed (no labels), issue sequences → needs_manual.
+# Usage: make apply-review-fp [FP_DATASET=fp_check] [FP_DATA_ROOT=outputs/fp_review]
+apply-review-fp:
+	uv run --active python -m scripts.data_transfer.ingestion.platform.apply_fiftyone_review \
+		--dataset-name $(FP_DATASET) \
+		--labels-root $(FP_DATA_ROOT) \
+		--remote-api $(REMOTE_API) \
+		--fp-mode \
+		--loglevel $(LOGLEVEL)
+
 # --- Other data commands ---
 
 # Export images + YOLO labels from a remote API.
@@ -237,10 +278,12 @@ import-platform:
 		--date-from $(DATE_FROM) --date-end $(DATE_END) \
 		--url-api-annotation $(REMOTE_API) \
 		--max-sequences $(MAX_SEQUENCES) \
+		--max-workers $(MAX_WORKERS) \
 		--loglevel $(LOGLEVEL)
 
 .PHONY: help lint fix setup docker-build start stop clean test test-specific \
 	pull-sequences push-annotations \
 	pull-seq-annotations auto-annotate visual-check apply-review \
+	pull-fp visual-check-fp apply-review-fp \
 	export-dataset import-yolo-sequence update-stage-remote update-stage-local \
 	import-platform

--- a/annotation_api/pyproject.toml
+++ b/annotation_api/pyproject.toml
@@ -58,7 +58,7 @@ dev = [
     "aiosqlite>=0.16.0,<1.0.0",
     "pyyaml>=6.0",
     "pillow>=10.0.0",
-    "fiftyone>=0.25.0",
+    "fiftyone>=1.13.4",
 ]
 
 [tool.coverage.run]

--- a/annotation_api/scripts/data_transfer/ingestion/platform/apply_fiftyone_review.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/apply_fiftyone_review.py
@@ -17,6 +17,7 @@ import logging
 import os
 import re
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
@@ -66,6 +67,17 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=Path("outputs/seq_annotation_done"),
         help="Root folder containing seq_<alert_api_id>/labels/detection_<id>.txt files",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=4,
+        help="Number of worker threads for parallel processing",
+    )
+    parser.add_argument(
+        "--fp-mode",
+        action="store_true",
+        help="False-positive mode: clean sequences get 'managed' stage with empty annotations instead of 'annotated'",
     )
     parser.add_argument(
         "--dry-run",
@@ -126,28 +138,31 @@ def group_reviews(dataset: fo.Dataset) -> Dict[int, Dict[str, Set[int]]]:
     return per_seq
 
 
-def find_remote_sequence(remote_api: str, token: str, alert_id: int) -> Dict | None:
+def fetch_all_sequences(remote_api: str, token: str) -> Dict[int, Dict]:
     """
-    Find a remote sequence by alert_api_id by scanning pages to avoid relying on backend filters.
+    Fetch in_review sequences and return a lookup dict keyed by alert_api_id.
     """
     page = 1
     size = 100
+    lookup: Dict[int, Dict] = {}
     while True:
         resp = annotation_api.list_sequences(
             remote_api,
             token,
+            processing_stage="in_review",
             page=page,
             size=size,
             include_annotation=True,
         )
         items = resp.get("items", [])
         for item in items:
-            if item.get("alert_api_id") == alert_id:
-                return item
+            aid = item.get("alert_api_id")
+            if aid is not None:
+                lookup[aid] = item
         if page >= resp.get("pages", 1):
             break
         page += 1
-    return None
+    return lookup
 
 
 def update_sequence_stage(remote_api: str, token: str, seq_id: int, stage: str, dry_run: bool) -> bool:
@@ -225,26 +240,22 @@ def ensure_detection_annotations(
             break
         page += 1
 
-    missing: List[int] = []
-    for det_id in detection_ids:
-        if det_id in annotated_dets:
-            continue
-        missing.append(det_id)
-        if dry_run:
-            logging.info("[DRY-RUN] Would create detection annotation for detection_id=%s", det_id)
-            continue
+    missing = [det_id for det_id in detection_ids if det_id not in annotated_dets]
+    if not missing or dry_run:
+        if dry_run and missing:
+            logging.info("[DRY-RUN] Would create %d detection annotations", len(missing))
+        return missing
+
+    def _create_one(det_id: int) -> None:
         try:
             ann_payload = {"annotation": annotation_map[det_id]} if annotation_map and det_id in annotation_map else {"annotation": []}
-            annotation_api.create_detection_annotation(
-                remote_api,
-                token,
-                det_id,
-                ann_payload,
-                default_stage,
-            )
-            logging.info("Created detection annotation placeholder for detection_id=%s", det_id)
+            annotation_api.create_detection_annotation(remote_api, token, det_id, ann_payload, default_stage)
         except Exception as exc:  # noqa: BLE001
             logging.error("Failed to create detection annotation for detection_id=%s: %s", det_id, exc)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        pool.map(_create_one, missing)
+    logging.info("Created %d detection annotation placeholders", len(missing))
     return missing
 
 
@@ -288,14 +299,19 @@ def delete_detection_annotations_for_sequence(
     if not ann_ids:
         return 0
 
-    for ann_id in ann_ids:
-        if dry_run:
-            logging.info("[DRY-RUN] Would delete detection annotation %s", ann_id)
-        else:
-            try:
-                annotation_api.delete_detection_annotation(remote_api, token, ann_id)
-            except Exception as exc:  # noqa: BLE001
-                logging.error("Failed to delete detection annotation %s: %s", ann_id, exc)
+    if dry_run:
+        logging.info("[DRY-RUN] Would delete %d detection annotations", len(ann_ids))
+        return len(ann_ids)
+
+    def _delete_one(ann_id: int) -> None:
+        try:
+            annotation_api.delete_detection_annotation(remote_api, token, ann_id)
+        except Exception as exc:  # noqa: BLE001
+            logging.error("Failed to delete detection annotation %s: %s", ann_id, exc)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        pool.map(_delete_one, ann_ids)
+    logging.info("Deleted %d detection annotations", len(ann_ids))
     return len(ann_ids)
 
 
@@ -343,6 +359,78 @@ def load_yolo_annotation(labels_root: Path, alert_id: int, det_id: int) -> Optio
     return items if items else None
 
 
+def process_one_sequence(
+    alert_id: int,
+    info: Dict,
+    seq_lookup: Dict[int, Dict],
+    remote_api: str,
+    token: str,
+    labels_root: Path,
+    dry_run: bool,
+    fp_mode: bool = False,
+) -> str:
+    """Process a single sequence. Returns status string."""
+    seq = seq_lookup.get(alert_id)
+    if not seq:
+        logging.warning("No remote sequence found for alert_api_id=%s", alert_id)
+        return "not_found"
+    seq_id = seq["id"]
+
+    # Remove any existing detection annotations so we can recreate from labels cleanly
+    deleted_count = delete_detection_annotations_for_sequence(remote_api, token, seq_id, dry_run)
+    if dry_run and deleted_count:
+        logging.info("[DRY-RUN] Would delete %s detection annotations for sequence_id=%s", deleted_count, seq_id)
+
+    # Load detections and ensure annotations exist for them
+    detections = list_all_detections(remote_api, token, seq_id)
+    detection_ids = [d["id"] for d in detections]
+    annotation_map: Dict[int, List[Dict]] = {}
+    for det in detections:
+        data = load_yolo_annotation(labels_root, alert_id, det["id"])
+        if data is not None:
+            annotation_map[det["id"]] = data
+    ensure_detection_annotations(
+        remote_api, token, seq_id, detection_ids,
+        default_stage="bbox_annotation", dry_run=dry_run, annotation_map=annotation_map,
+    )
+
+    issue_frames = info["issue_frames"]
+    whole_issue = info["whole_issue"]
+    all_frames = info["all_frames"]
+
+    if not issue_frames and not whole_issue:
+        update_sequence_stage(remote_api, token, seq_id, "annotated", dry_run)
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            # In FP mode, push empty annotations (no bboxes); otherwise push the YOLO labels
+            pool.map(
+                lambda det_id: update_detection_stage(
+                    remote_api, token, det_id, "annotated", dry_run,
+                    [] if fp_mode else annotation_map.get(det_id),
+                ),
+                all_frames,
+            )
+        return "ok"
+
+    update_sequence_stage(remote_api, token, seq_id, "needs_manual", dry_run)
+    status = "whole_issue" if whole_issue else "partial_issue"
+    target_dets: List[int] = list(all_frames) if whole_issue else list(issue_frames)
+
+    # Build list of (det_id, stage, annotation_data) for all detections
+    updates: List[tuple] = [(det_id, "bbox_annotation", annotation_map.get(det_id)) for det_id in target_dets]
+    updated_set = set(target_dets)
+    for det_id, ann_payload in annotation_map.items():
+        if det_id not in updated_set:
+            updates.append((det_id, "annotated", ann_payload))
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        pool.map(
+            lambda args: update_detection_stage(remote_api, token, args[0], args[1], dry_run, args[2]),
+            updates,
+        )
+
+    return status
+
+
 def main() -> None:
     args = parse_args()
     logging.basicConfig(level=args.loglevel.upper(), format="%(levelname)s - %(message)s")
@@ -352,112 +440,43 @@ def main() -> None:
 
     token = annotation_api.get_auth_token(args.remote_api, args.username, args.password)
 
-    processed = 0
-    seq_ok = 0
-    seq_whole_issue = 0
-    seq_partial_issue = 0
-    seq_not_found = 0
+    # Fetch in_review sequences once upfront instead of per-alert_id
+    logging.info("Fetching in_review sequences...")
+    seq_lookup = fetch_all_sequences(args.remote_api, token)
+    logging.info("Loaded %d remote sequences", len(seq_lookup))
 
-    for alert_id, info in reviews.items():
-        if args.max_sequences and processed >= args.max_sequences:
-            break
-        processed += 1
+    items = list(reviews.items())
+    if args.max_sequences:
+        items = items[: args.max_sequences]
 
-        seq = find_remote_sequence(args.remote_api, token, alert_id)
-        if not seq:
-            logging.warning("No remote sequence found for alert_api_id=%s", alert_id)
-            seq_not_found += 1
-            continue
-        seq_id = seq["id"]
+    results: Dict[str, int] = {"ok": 0, "whole_issue": 0, "partial_issue": 0, "not_found": 0, "errors": 0}
 
-        # Remove any existing detection annotations so we can recreate from labels cleanly
-        deleted_count = delete_detection_annotations_for_sequence(
-            args.remote_api, token, seq_id, args.dry_run
-        )
-        if args.dry_run and deleted_count:
-            logging.info("[DRY-RUN] Would delete %s detection annotations for sequence_id=%s", deleted_count, seq_id)
-
-        # Load detections and ensure annotations exist for them
-        detections = list_all_detections(args.remote_api, token, seq_id)
-        detection_ids = [d["id"] for d in detections]
-        annotation_map: Dict[int, List[Dict]] = {}
-        for det in detections:
-            data = load_yolo_annotation(args.labels_root, alert_id, det["id"])
-            if data is not None:
-                annotation_map[det["id"]] = data
-        missing_dets = ensure_detection_annotations(
-            args.remote_api,
-            token,
-            seq_id,
-            detection_ids,
-            default_stage="bbox_annotation",
-            dry_run=args.dry_run,
-            annotation_map=annotation_map,
-        )
-        if args.dry_run and missing_dets:
-            logging.info(
-                "[DRY-RUN] Sequence %s would need %d detection annotations created (ids: %s)",
-                seq_id,
-                len(missing_dets),
-                missing_dets,
-            )
-
-        issue_frames = info["issue_frames"]
-        whole_issue = info["whole_issue"]
-        all_frames = info["all_frames"]
-
-        if not issue_frames and not whole_issue:
-            if update_sequence_stage(args.remote_api, token, seq_id, "annotated", args.dry_run):
-                seq_ok += 1
-            for det_id in all_frames:
-                update_detection_stage(
-                    args.remote_api,
-                    token,
-                    det_id,
-                    "annotated",
-                    args.dry_run,
-                    annotation_map.get(det_id),
-                )
-            continue
-
-        if update_sequence_stage(args.remote_api, token, seq_id, "needs_manual", args.dry_run):
-            if whole_issue:
-                seq_whole_issue += 1
-            else:
-                seq_partial_issue += 1
-        target_dets: List[int] = list(all_frames) if whole_issue else list(issue_frames)
-        for det_id in target_dets:
-            update_detection_stage(
-                args.remote_api,
-                token,
-                det_id,
-                "bbox_annotation",
-                args.dry_run,
-                annotation_map.get(det_id),
-            )
-
-        # For any remaining detections that have label data but were not staged above,
-        # push the annotation payload while keeping them annotated.
-        updated = set(target_dets) if target_dets else set()
-        for det_id, ann_payload in annotation_map.items():
-            if det_id in updated:
-                continue
-            update_detection_stage(
-                args.remote_api,
-                token,
-                det_id,
-                "annotated",
-                args.dry_run,
-                ann_payload,
-            )
+    with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+        future_map = {
+            executor.submit(
+                process_one_sequence,
+                alert_id, info, seq_lookup,
+                args.remote_api, token, args.labels_root, args.dry_run, args.fp_mode,
+            ): alert_id
+            for alert_id, info in items
+        }
+        for future in as_completed(future_map):
+            alert_id = future_map[future]
+            try:
+                status = future.result()
+                results[status] = results.get(status, 0) + 1
+            except Exception as exc:  # noqa: BLE001
+                results["errors"] += 1
+                logging.error("Unhandled error on alert_api_id=%s: %s", alert_id, exc)
 
     logging.info(
-        "Done. Processed=%s, ok=%s, whole_issue=%s, partial_issue=%s, not_found=%s",
-        processed,
-        seq_ok,
-        seq_whole_issue,
-        seq_partial_issue,
-        seq_not_found,
+        "Done. Processed=%s, ok=%s, whole_issue=%s, partial_issue=%s, not_found=%s, errors=%s",
+        len(items),
+        results["ok"],
+        results["whole_issue"],
+        results["partial_issue"],
+        results["not_found"],
+        results["errors"],
     )
 
 

--- a/annotation_api/scripts/data_transfer/ingestion/platform/auto_annotate.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/auto_annotate.py
@@ -21,8 +21,8 @@ from PIL import Image
 from tqdm import tqdm
 
 
-MODEL_URL_FOLDER = "https://huggingface.co/pyronear/yolo11s_mighty-mongoose_v5.1.0/resolve/main/"
-MODEL_NAME = "ncnn_cpu_yolo11s_mighty-mongoose_v5.1.0.tar.gz"
+MODEL_URL_FOLDER = "https://huggingface.co/pyronear/yolo11s_sensitive-detector_v1.0.0/resolve/main/"
+MODEL_NAME = "ncnn_cpu.tar.gz"
 
 
 def parse_args() -> argparse.Namespace:
@@ -36,7 +36,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--conf-th",
         type=float,
-        default=0.05,
+        default=0.01,
         help="Confidence threshold for model predictions",
     )
     parser.add_argument(
@@ -261,21 +261,32 @@ class Classifier:
                 base_name = os.path.basename(model_path).replace(".tar.gz", "")
                 extract_path = os.path.join(model_folder, base_name)
                 if not os.path.isdir(extract_path):
+                    os.makedirs(extract_path, exist_ok=True)
                     with tarfile.open(model_path, "r:gz") as tar:
-                        tar.extractall(model_folder)
+                        tar.extractall(extract_path)
                     logging.info("Extracted model to: %s", extract_path)
                 model_path = extract_path
             if format == "onnx":
-                onnx_file = model_path if model_path.endswith(".onnx") else os.path.join(model_path, "best.onnx")
+                if model_path.endswith(".onnx"):
+                    onnx_file = model_path
+                else:
+                    candidates = sorted(Path(model_path).rglob("*.onnx"))
+                    if not candidates:
+                        raise RuntimeError(f"No .onnx file found under {model_path}")
+                    onnx_file = str(candidates[0])
 
         if self.format == "ncnn":
             try:
                 import ncnn  # type: ignore
             except ImportError as exc:  # noqa: BLE001
                 raise RuntimeError("ncnn package is required for format='ncnn'") from exc
+            param_candidates = sorted(Path(model_path).rglob("*.ncnn.param"))
+            bin_candidates = sorted(Path(model_path).rglob("*.ncnn.bin"))
+            if not param_candidates or not bin_candidates:
+                raise RuntimeError(f"No ncnn .param/.bin files found under {model_path}")
             self.model = ncnn.Net()
-            self.model.load_param(os.path.join(model_path, "best_ncnn_model", "model.ncnn.param"))
-            self.model.load_model(os.path.join(model_path, "best_ncnn_model", "model.ncnn.bin"))
+            self.model.load_param(str(param_candidates[0]))
+            self.model.load_model(str(bin_candidates[0]))
         else:
             try:
                 import onnxruntime  # type: ignore
@@ -410,7 +421,10 @@ def process_sequence(seq_dir: Path, model: Classifier, conf_th: float, iou_nms: 
             logging.debug("[%s] step 3: group %d (%d boxes):\n%s",
                           seq_dir.name, gid, gboxes.shape[0], _format_boxes(gboxes))
 
-    # ----- Steps 4-6: per-frame inference, filter, write -----
+    # ----- Steps 4-6: per-frame inference, filter by group overlap, write -----
+    # Strategy: drop the seed labels and write only the model's predictions that
+    # overlap at least one persistent group. The seed labels are used solely to
+    # localize the smoke region (via the clusters built in step 3).
     changed = 0
     total_raw = 0
     total_after_conf = 0
@@ -420,15 +434,13 @@ def process_sequence(seq_dir: Path, model: Classifier, conf_th: float, iou_nms: 
         label_path = lbl_dir / (img_path.stem + ".txt")
         im = Image.open(img_path)
 
-        # Step 4: model inference (post-processing already applied inside Classifier.__call__)
+        # Step 4: model inference
         preds_raw = model(im)
         total_raw += preds_raw.shape[0]
         logging.debug(
             "[%s] frame %s step 4: model returned %d prediction(s) (after internal NMS / max-size filter):\n%s",
             seq_dir.name, img_path.stem, preds_raw.shape[0], _format_boxes(preds_raw),
         )
-
-        # Confidence gate (--conf-th)
         preds = preds_raw[preds_raw[:, 4] >= conf_th] if preds_raw.shape[0] else preds_raw
         total_after_conf += preds.shape[0]
         logging.debug(
@@ -436,7 +448,7 @@ def process_sequence(seq_dir: Path, model: Classifier, conf_th: float, iou_nms: 
             seq_dir.name, img_path.stem, preds.shape[0], conf_th, _format_boxes(preds),
         )
 
-        # Step 5: keep only predictions overlapping any existing group.
+        # Step 5: keep only predictions overlapping any persistent group.
         # box_iou(preds, group_boxes) returns shape (M_group, N_preds);
         # max over axis 0 gives the best-IoU per prediction against this group.
         keep_any = np.zeros(preds.shape[0], dtype=bool)
@@ -450,7 +462,6 @@ def process_sequence(seq_dir: Path, model: Classifier, conf_th: float, iou_nms: 
                         seq_dir.name, img_path.stem, gid, int(hits.sum()), preds.shape[0],
                     )
                 keep_any |= hits
-
         new_bbox = preds[keep_any, :] if preds.shape[0] else np.zeros((0, 5))
         total_kept += new_bbox.shape[0]
         logging.debug(
@@ -458,7 +469,7 @@ def process_sequence(seq_dir: Path, model: Classifier, conf_th: float, iou_nms: 
             seq_dir.name, img_path.stem, new_bbox.shape[0], _format_boxes(new_bbox),
         )
 
-        # Step 6: overwrite label file
+        # Step 6: overwrite label file with model preds only
         write_bboxes_to_label_file(label_path, [new_bbox], class_id=1)
         if new_bbox.shape[0]:
             changed += 1

--- a/annotation_api/scripts/data_transfer/ingestion/platform/export_dataset.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/export_dataset.py
@@ -7,12 +7,17 @@ For each detection, this script:
 - Uses sequence level annotations (sequences_bbox) to create YOLO labels
 - Organizes data as:
     dataset_exported_{timestamp}/
-        <seq_type>/                # smoke type, false positive type or "no_label"
-            <sequence_folder>/     # named after first image basename for this sequence and type
+        <category>/                # wildfire, other_smoke, fp, or no_label
+            <sequence_folder>/     # named {prefix}-{org}_{camera}_{azimuth}_{datetime}
                 images/
-                    pyronear-{organisation_name}-{camera_name}-{azimuth}-{recorded_at}.jpg
+                    {prefix}-{org}_{camera}_{azimuth}_{recorded_at}.jpg
                 labels/
-                    pyronear-{organisation_name}-{camera_name}-{azimuth}-{recorded_at}.txt  # empty if no bbox
+                    {prefix}-{org}_{camera}_{azimuth}_{recorded_at}.txt  # empty if no bbox
+
+Categories:
+    wildfire     - smoke_type == wildfire
+    other_smoke  - smoke_type == industrial or other
+    fp           - all false positive types
 
 YOLO format per line:
     class_id x_center y_center width height
@@ -210,6 +215,22 @@ FALSE_POSITIVE_TYPES: List[str] = [
 ALL_CLASSES: List[str] = SMOKE_TYPES + FALSE_POSITIVE_TYPES
 CLASS_ID: Dict[str, int] = {name: idx for idx, name in enumerate(ALL_CLASSES)}
 
+# Top-level folder categories
+CATEGORY_WILDFIRE = "wildfire"
+CATEGORY_OTHER_SMOKE = "other_smoke"
+CATEGORY_FP = "fp"
+
+
+def seq_type_to_category(seq_type: str) -> str:
+    """Map a detailed seq_type to one of the three top-level categories."""
+    if seq_type == "wildfire":
+        return CATEGORY_WILDFIRE
+    if seq_type in ("industrial", "other"):
+        return CATEGORY_OTHER_SMOKE
+    if seq_type in FALSE_POSITIVE_TYPES:
+        return CATEGORY_FP
+    return CATEGORY_FP
+
 
 def format_recorded_at(raw: Any) -> str:
     """
@@ -247,28 +268,39 @@ def normalize_slug(s: str) -> str:
     return s.strip("-")
 
 
+SOURCE_API_PREFIX: Dict[str, str] = {
+    "pyronear_french": "pyronear",
+    "alert_wildfire": "awf",
+    "api_cenia": "cenia",
+}
+
+
 def build_file_basename(row: Dict[str, Any]) -> str:
     """
     Build base filename:
-        pyronear-{organisation_name}-{camera_name}-{azimuth}-{recorded_at}
-    where recorded_at is formatted as YYYY-MM-DDTHH-MM-SS.
-    If azimuth is missing use 000.
+        {prefix}-{org}_{camera}_{azimuth}_{recorded_at}
+    where prefix is derived from source_api (pyronear, awf, cenia),
+    recorded_at is formatted as YYYY-MM-DDTHH-MM-SS,
+    and azimuth defaults to 0.
     """
-    org_raw = row.get("organisation_name", "unknown_org")
-    cam_raw = row.get("camera_name", "unknown_camera")
+    source_raw = str(row.get("source_api", "unknown"))
+    prefix = SOURCE_API_PREFIX.get(source_raw, normalize_slug(source_raw))
 
+    org_raw = row.get("organisation_name", "unknown")
     org = normalize_slug(str(org_raw))
+
+    cam_raw = row.get("camera_name", "unknown_camera")
     cam = normalize_slug(str(cam_raw))
 
     az = row.get("azimuth", None)
-    az_str = f"{az:03d}" if isinstance(az, int) else "000"
+    az_str = str(az) if isinstance(az, int) else "0"
 
     recorded_at_raw = row.get("recorded_at")
     if recorded_at_raw is None:
         raise ValueError("Missing recorded_at in export row")
     recorded_at_str = format_recorded_at(recorded_at_raw)
 
-    return f"pyronear-{org}-{cam}-{az_str}-{recorded_at_str}"
+    return f"{prefix}-{org}_{cam}_{az_str}_{recorded_at_str}"
 
 
 def recorded_at_sort_key(row: Dict[str, Any]) -> Tuple[int, str]:
@@ -285,13 +317,12 @@ def recorded_at_sort_key(row: Dict[str, Any]) -> Tuple[int, str]:
     return int(seq_id), rec_str
 
 
-def compute_sequence_types(rows: List[Dict[str, Any]]) -> Dict[int, List[str]]:
+def compute_sequence_categories(rows: List[Dict[str, Any]]) -> Dict[int, List[str]]:
     """
-    For each sequence, compute the set of seq_types present in sequences_bbox.
-    seq_type is smoke_type if is_smoke is true,
-    otherwise the first false_positive_type if present.
+    For each sequence, compute the set of top-level categories
+    (wildfire, other_smoke, fp) present in sequences_bbox.
     """
-    seq_types: Dict[int, set] = defaultdict(set)
+    seq_cats: Dict[int, set] = defaultdict(set)
     for row in rows:
         seq_id = row.get("sequence_id")
         if seq_id is None:
@@ -312,19 +343,18 @@ def compute_sequence_types(rows: List[Dict[str, Any]]) -> Dict[int, List[str]]:
 
             if seq_type not in CLASS_ID:
                 seq_type = "other"
-            seq_types[int(seq_id)].add(seq_type)
+            seq_cats[int(seq_id)].add(seq_type_to_category(seq_type))
 
-    return {seq_id: sorted(types) for seq_id, types in seq_types.items()}
+    return {seq_id: sorted(cats) for seq_id, cats in seq_cats.items()}
 
 
 def extract_labels_for_detection(row: Dict[str, Any]) -> Dict[str, List[str]]:
     """
     From one export row, build:
-      { seq_type: [ 'class_id x_center y_center width height', ... ] }
+      { category: [ 'class_id x_center y_center width height', ... ] }
 
-    seq_type is smoke_type if is_smoke is true,
-    otherwise the first false_positive_type if present,
-    otherwise "other".
+    category is one of wildfire, other_smoke, fp.
+    class_id uses the detailed type index from ALL_CLASSES.
 
     Only boxes whose detection_id matches row["detection_id"] are used.
 
@@ -334,7 +364,7 @@ def extract_labels_for_detection(row: Dict[str, Any]) -> Dict[str, List[str]]:
     seq_ann = row.get("sequence_annotation") or {}
     sequences_bbox = seq_ann.get("sequences_bbox") or []
 
-    labels_by_type: Dict[str, List[str]] = {}
+    labels_by_category: Dict[str, List[str]] = {}
 
     for group in sequences_bbox:
         is_smoke = group.get("is_smoke", False)
@@ -352,6 +382,7 @@ def extract_labels_for_detection(row: Dict[str, Any]) -> Dict[str, List[str]]:
             seq_type = "other"
 
         class_id = CLASS_ID[seq_type]
+        category = seq_type_to_category(seq_type)
 
         for bbox in group.get("bboxes", []):
             if bbox.get("detection_id") != detection_id:
@@ -371,9 +402,9 @@ def extract_labels_for_detection(row: Dict[str, Any]) -> Dict[str, List[str]]:
                 f"{class_id} "
                 f"{x_center:.6f} {y_center:.6f} {width:.6f} {height:.6f}"
             )
-            labels_by_type.setdefault(seq_type, []).append(line)
+            labels_by_category.setdefault(category, []).append(line)
 
-    return labels_by_type
+    return labels_by_category
 
 
 def fetch_detections(
@@ -580,8 +611,8 @@ def build_dataset(
     # sort rows by (sequence_id, recorded_at)
     rows_sorted = sorted(rows, key=recorded_at_sort_key)
 
-    # compute sequence -> list of seq_types present in annotation
-    seq_types_map = compute_sequence_types(rows_sorted)
+    # compute sequence -> list of categories present in annotation
+    seq_types_map = compute_sequence_categories(rows_sorted)
 
     # Prepare folder name map and tasks
     folder_name_map: Dict[Tuple[str, int], str] = {}

--- a/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
@@ -69,9 +69,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--smoke-type",
         type=str,
-        choices=["wildfire", "industrial", "other"],
+        choices=["wildfire", "industrial", "other", "any"],
         default=None,
-        help="Only pull sequences whose annotation smoke_types includes this value",
+        help="Only pull sequences whose annotation smoke_types includes this value (use 'any' to include all smoke types)",
     )
     parser.add_argument(
         "--loglevel",
@@ -151,9 +151,15 @@ def main() -> None:
             logging.warning("No annotation for sequence %s, skipping", seq_id)
             return ("no_annotation", seq_id)
 
-        if args.smoke_type and args.smoke_type not in ann.get("smoke_types", []):
-            logging.info("Skipping sequence %s (smoke_types=%s not matching %s)", seq_id, ann.get("smoke_types"), args.smoke_type)
-            return ("filter_skip", seq_id)
+        smoke_types = ann.get("smoke_types", [])
+        if args.smoke_type and args.smoke_type != "any":
+            if args.smoke_type not in smoke_types:
+                logging.info("Skipping sequence %s (smoke_types=%s not matching %s)", seq_id, smoke_types, args.smoke_type)
+                return ("filter_skip", seq_id)
+        elif args.smoke_type == "any":
+            if not smoke_types:
+                logging.info("Skipping sequence %s (no smoke_types)", seq_id)
+                return ("filter_skip", seq_id)
 
         det_resp = annotation_api.list_detections(
             args.remote_api, token, sequence_id=seq_id, page=1, size=100

--- a/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
@@ -8,6 +8,7 @@ and fetch_platform_sequences.py to avoid code duplication.
 import concurrent.futures
 import logging
 import os
+import time
 from collections import defaultdict
 from typing import Dict, List, Any
 from urllib.parse import urlparse
@@ -298,15 +299,22 @@ def _process_single_detection(
     annotation_api_url: str,
     auth_token: str,
     annotation_sequence_id: int,
+    max_retries: int = 3,
+    base_delay: float = 5.0,
 ) -> Dict[str, Any]:
     """
     Process a single detection: download image and create detection in API.
+
+    Retries on transient server errors (502, 503, 504) and network errors
+    with exponential backoff.
 
     Args:
         record: Detection record from platform
         annotation_api_url: Annotation API base URL
         auth_token: JWT authentication token
         annotation_sequence_id: Sequence ID in annotation API
+        max_retries: Maximum number of retry attempts for transient errors
+        base_delay: Base delay in seconds between retries (doubles each attempt)
 
     Returns:
         Dictionary with processing results
@@ -317,55 +325,71 @@ def _process_single_detection(
         "error": None,
     }
 
-    try:
-        # Download image
-        image_data = download_image(record["detection_url"])
+    for attempt in range(max_retries + 1):
+        try:
+            # Download image
+            image_data = download_image(record["detection_url"])
 
-        # Transform detection data
-        detection_data = transform_detection_data(record, annotation_sequence_id)
+            # Transform detection data
+            detection_data = transform_detection_data(record, annotation_sequence_id)
 
-        # Create detection in annotation API
-        filename = f"detection_{record['detection_id']}.jpg"
-        annotation_detection = create_detection(
-            annotation_api_url, auth_token, detection_data, image_data, filename
-        )
+            # Create detection in annotation API
+            filename = f"detection_{record['detection_id']}.jpg"
+            annotation_detection = create_detection(
+                annotation_api_url, auth_token, detection_data, image_data, filename
+            )
 
-        logging.debug(f"Created detection with ID: {annotation_detection['id']}")
-        result["success"] = True
-        return result
+            logging.debug(f"Created detection with ID: {annotation_detection['id']}")
+            result["success"] = True
+            return result
 
-    except ValidationError as e:
-        error_msg = f"Detection {record['detection_id']} validation failed: {e.message}"
-        logging.error(error_msg)
-        if e.field_errors:
-            for field_error in e.field_errors:
-                logging.error(f"  - {field_error['field']}: {field_error['message']}")
-        result["error"] = error_msg
-        return result
+        except ValidationError as e:
+            error_msg = f"Detection {record['detection_id']} validation failed: {e.message}"
+            logging.error(error_msg)
+            if e.field_errors:
+                for field_error in e.field_errors:
+                    logging.error(f"  - {field_error['field']}: {field_error['message']}")
+            result["error"] = error_msg
+            return result
 
-    except requests.RequestException as e:
-        error_msg = f"Network error downloading image for detection {record['detection_id']}: {e}"
-        logging.error(error_msg)
-        result["error"] = error_msg
-        return result
+        except requests.RequestException as e:
+            error_msg = f"Network error downloading image for detection {record['detection_id']}: {e}"
+            if attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                logging.warning(f"⚠️ {error_msg} — retrying in {delay:.0f}s (attempt {attempt + 1}/{max_retries})")
+                time.sleep(delay)
+                continue
+            logging.error(error_msg)
+            result["error"] = error_msg
+            return result
 
-    except AnnotationAPIError as e:
-        error_msg = (
-            f"API error processing detection {record['detection_id']}: {e.message}"
-        )
-        logging.error(error_msg)
-        if e.status_code:
-            logging.error(f"HTTP Status: {e.status_code}")
-        result["error"] = error_msg
-        return result
+        except AnnotationAPIError as e:
+            if e.status_code in (502, 503, 504) and attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                logging.warning(
+                    f"⚠️ Detection {record['detection_id']} got HTTP {e.status_code} "
+                    f"— retrying in {delay:.0f}s (attempt {attempt + 1}/{max_retries})"
+                )
+                time.sleep(delay)
+                continue
+            error_msg = (
+                f"API error processing detection {record['detection_id']}: {e.message}"
+            )
+            logging.error(error_msg)
+            if e.status_code:
+                logging.error(f"HTTP Status: {e.status_code}")
+            result["error"] = error_msg
+            return result
 
-    except Exception as e:
-        error_msg = (
-            f"Unexpected error processing detection {record['detection_id']}: {e}"
-        )
-        logging.error(error_msg)
-        result["error"] = error_msg
-        return result
+        except Exception as e:
+            error_msg = (
+                f"Unexpected error processing detection {record['detection_id']}: {e}"
+            )
+            logging.error(error_msg)
+            result["error"] = error_msg
+            return result
+
+    return result
 
 
 def post_sequence_to_annotation_api(

--- a/annotation_api/src/app/api/api_v1/endpoints/export.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/export.py
@@ -371,7 +371,7 @@ async def export_detections(
         bucket_key = data.get("bucket_key")
         image_url: Optional[str] = None
         if bucket_key:
-            image_url = bucket.get_public_url(bucket_key)
+            image_url = bucket.generate_presigned_url(bucket_key)
 
         data["image_url"] = image_url
 

--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -111,7 +111,16 @@ class S3Bucket:
                 detail="File cannot be found on the bucket storage",
             )
 
-        # Generate a public URL for it using boto3 presign URL generation\
+        return self.generate_presigned_url(bucket_key, url_expiration)
+
+    def generate_presigned_url(
+        self, bucket_key: str, url_expiration: int = settings.S3_URL_EXPIRATION
+    ) -> str:
+        """Generate a presigned URL without checking file existence.
+
+        Use this for bulk operations where the file is known to exist
+        (e.g. exporting rows from the database).
+        """
         presigned_url = self._s3.generate_presigned_url(
             "get_object",
             Params={"Bucket": self.name, "Key": bucket_key},

--- a/annotation_api/src/tests/endpoints/test_export.py
+++ b/annotation_api/src/tests/endpoints/test_export.py
@@ -62,6 +62,12 @@ class DummyBucket:
             self.public_urls[key] = f"https://dummy-bucket.local/{key}"
         return self.public_urls[key]
 
+    def generate_presigned_url(self, key: str, url_expiration: int = 3600) -> str:
+        """
+        Fast presigned URL generation without existence check (used by export).
+        """
+        return self.get_public_url(key)
+
     def get_file(self, key: str) -> BytesIO:
         """
         Optional helper if export code ever wants to read back the file.

--- a/annotation_api/uv.lock
+++ b/annotation_api/uv.lock
@@ -147,7 +147,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "aiosqlite", specifier = ">=0.16.0,<1.0.0" },
-    { name = "fiftyone", specifier = ">=0.25.0" },
+    { name = "fiftyone", specifier = ">=1.13.4" },
     { name = "httpx", specifier = ">=0.23.0" },
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "pillow", specifier = ">=10.0.0" },
@@ -444,7 +444,7 @@ name = "brotlicffi"
 version = "1.2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "python_full_version < '3.12' or platform_python_implementation == 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/85/57c314a6b35336efbbdc13e5fc9ae13f6b60a0647cfa7c1221178ac6d8ae/brotlicffi-1.2.0.0.tar.gz", hash = "sha256:34345d8d1f9d534fcac2249e57a4c3c8801a33c9942ff9f8574f67a175e17adb", size = 476682, upload_time = "2025-11-21T18:17:57.334Z" }
 wheels = [
@@ -971,6 +971,18 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload_time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload_time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.116.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1000,7 +1012,7 @@ wheels = [
 
 [[package]]
 name = "fiftyone"
-version = "1.11.0"
+version = "1.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1012,6 +1024,7 @@ dependencies = [
     { name = "dacite" },
     { name = "deprecated" },
     { name = "dill" },
+    { name = "exceptiongroup" },
     { name = "fiftyone-brain" },
     { name = "fiftyone-db" },
     { name = "ftfy" },
@@ -1051,23 +1064,23 @@ dependencies = [
     { name = "voxel51-eta" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/65/fe4cbea11e82404dc2426ba4a87da62171752fee2a58fcb0f2c305f23117/fiftyone-1.11.0.tar.gz", hash = "sha256:13bc586c1ebd14cb5d9f70e15f7625f4ef158efd5772d82339326539ab49198c", size = 11162194, upload_time = "2025-12-05T19:28:17.191Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/11/a11e9e0d9ba9a35d7233b435738528a8f1bfa56a82311442e58681b6c0a6/fiftyone-1.14.1.tar.gz", hash = "sha256:6de394efb073ffce091c1a40705d9aa486e0462412a2dbb863c65102428e6509", size = 17505903, upload_time = "2026-04-07T01:14:02.111Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/2c/145fa10dffed9ee2ee652c69029d906e75523aef3d122c72b9520e022979/fiftyone-1.11.0-py3-none-any.whl", hash = "sha256:e950e32ee529d520e2ea433cc0e7a61bcb092e797f2b0235abf1bd4868aeec56", size = 11294798, upload_time = "2025-12-05T19:28:14.277Z" },
+    { url = "https://files.pythonhosted.org/packages/26/5b/42eff1f8c935b77f99d76091cac8e87ba5aeab6e6fab82f29aaaa96ff316/fiftyone-1.14.1-py3-none-any.whl", hash = "sha256:953b330dd59051de139af5ef022872be89a58eb63058a70566bea706184a9d22", size = 17721989, upload_time = "2026-04-07T01:13:59.175Z" },
 ]
 
 [[package]]
 name = "fiftyone-brain"
-version = "0.21.4"
+version = "0.21.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "scikit-learn" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/68/4346106657480692a8d45202950ae3b25e0121ff624ee4b94c4b48338c95/fiftyone_brain-0.21.4.tar.gz", hash = "sha256:00eeca6dd3bf32c29c95c9a38feadc39bd58f9c0aa9fc84ecce843b1127bc699", size = 107095, upload_time = "2025-11-03T14:29:10.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/98/566fcf61a2051ad88667c2a89b3d7267a312de14a49bbe8243511f8f2e9b/fiftyone_brain-0.21.5.tar.gz", hash = "sha256:1f5777e97266ca304c5e63563c19e4bad8108870d1f537b86cec07a3081efead", size = 108551, upload_time = "2026-01-26T13:57:14.134Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/ba/e5c7c5a1eba0edefb5b3339d7c650bd76c0a448ee3fbbbc38dcbf2f6fb18/fiftyone_brain-0.21.4-py3-none-any.whl", hash = "sha256:f606749aa9f21a96051471aaef80c14db88c988ea48f321a3bb0fefdd13f5f10", size = 112648, upload_time = "2025-11-03T14:29:08.403Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/48/676794632b26c8a0379deed8c7be30f9b1e9b98887de236e5189a3f92912/fiftyone_brain-0.21.5-py3-none-any.whl", hash = "sha256:5b71178e4994a1449183eb0d1211cce141ef11c74af7b413df89697236f322a3", size = 112827, upload_time = "2026-01-26T13:57:12.555Z" },
 ]
 
 [[package]]
@@ -3544,7 +3557,7 @@ wheels = [
 
 [[package]]
 name = "voxel51-eta"
-version = "0.15.1"
+version = "0.15.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
@@ -3568,9 +3581,9 @@ dependencies = [
     { name = "tzlocal" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/26/b27fff15c5ec51787b6849a6261604261ba78d104117e5b846aafaca0637/voxel51_eta-0.15.1.tar.gz", hash = "sha256:df70eff91efac49fa40d7bf877a4d7ea0af26e7a614e0bb899fa98107659cb97", size = 904793, upload_time = "2025-09-04T15:49:25.772Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/92/cfef6b9de0f922fe77e93fb893ac4976df52465a136bdbeb5946bd1069ce/voxel51_eta-0.15.4.tar.gz", hash = "sha256:eff65f7f6442fac86a196f145e40c2fe51a17143b36a527996ee8e11e6a37fa3", size = 905854, upload_time = "2026-03-19T15:11:47.71Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/b1/858b9f6b7505527321be1a4350f737801c81ebdf935b68642767af938f0d/voxel51_eta-0.15.1-py2.py3-none-any.whl", hash = "sha256:2357063b9df41e703652c640ac97d78956b6b12cf5baeca06d45176ca5012c87", size = 934264, upload_time = "2025-09-04T15:49:23.925Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f8/ab2b00b0c830bdcaccd0a7640606edccd0c88187cfc3f118195b45efe9a4/voxel51_eta-0.15.4-py2.py3-none-any.whl", hash = "sha256:85986f1a3c1638ebeaffec1434a303c588a2f587290a7ada34005cad89c41c1b", size = 934583, upload_time = "2026-03-19T15:11:45.719Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
  - **FP review workflow**: Add `pull-fp`, `visual-check-fp`, `apply-review-fp` make targets for false-positive sequences — separate output dirs/datasets to avoid collisions 
  with the TP pipeline, `--fp-mode` flag pushes clean FP sequences as managed with no labels                                                                                  
  - **Parallelize apply_fiftyone_review**: Batch-fetch `in_review` sequences upfront instead of per-alert lookup; parallelize detection annotation create/delete and sequence 
  processing                                                                                                                                                                  
  - **Retry with exponential backoff**: Retries on network errors and 502/503/504 responses in detection processing (configurable `max_retries`/`base_delay`)                 
  - **Presigned URLs for export**: Add `generate_presigned_url` to skip per-row S3 HEAD checks when exporting detections in bulk                                              
  - **Export naming & category rework**: File/folder naming changed to `{prefix}-{org}_{camera}_{azimuth}_{datetime}` with source API prefix mapping; output split into       
  `wildfire/`, `other_smoke/`, `fp/` top-level folders                                                                                                                        
  - **Lower default confidence threshold** from 0.05 → 0.01 (super sensitive model)                                                                                           
  - **`any` smoke type filter** in `pull_sequence_annotations`      