### PR TITLE
 Speed up detection imports with server-side image fetch          

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
@@ -27,7 +27,7 @@ from rich.console import Console
 from app.clients.annotation_api import (
     get_auth_token,
     create_sequence,
-    create_detection,
+    create_detection_from_url,
     AnnotationAPIError,
     ValidationError,
 )
@@ -325,18 +325,15 @@ def _process_single_detection(
         "error": None,
     }
 
+    # Transform detection data
+    detection_data = transform_detection_data(record, annotation_sequence_id)
+    source_url = record["detection_url"]
+
     for attempt in range(max_retries + 1):
         try:
-            # Download image
-            image_data = download_image(record["detection_url"])
-
-            # Transform detection data
-            detection_data = transform_detection_data(record, annotation_sequence_id)
-
-            # Create detection in annotation API
-            filename = f"detection_{record['detection_id']}.jpg"
-            annotation_detection = create_detection(
-                annotation_api_url, auth_token, detection_data, image_data, filename
+            # Let the server fetch the image directly from source URL
+            annotation_detection = create_detection_from_url(
+                annotation_api_url, auth_token, detection_data, source_url
             )
 
             logging.debug(f"Created detection with ID: {annotation_detection['id']}")
@@ -349,17 +346,6 @@ def _process_single_detection(
             if e.field_errors:
                 for field_error in e.field_errors:
                     logging.error(f"  - {field_error['field']}: {field_error['message']}")
-            result["error"] = error_msg
-            return result
-
-        except requests.RequestException as e:
-            error_msg = f"Network error downloading image for detection {record['detection_id']}: {e}"
-            if attempt < max_retries:
-                delay = base_delay * (2 ** attempt)
-                logging.warning(f"⚠️ {error_msg} — retrying in {delay:.0f}s (attempt {attempt + 1}/{max_retries})")
-                time.sleep(delay)
-                continue
-            logging.error(error_msg)
             result["error"] = error_msg
             return result
 

--- a/annotation_api/src/app/api/api_v1/endpoints/detections.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/detections.py
@@ -30,10 +30,11 @@ from app.db import get_session
 from app.models import Detection
 from app.schemas.annotation_validation import AlgoPredictions
 from app.schemas.detection import (
+    DetectionCreateFromUrl,
     DetectionRead,
     DetectionUrl,
 )
-from app.services.storage import s3_service, upload_file
+from app.services.storage import s3_service, upload_file, upload_file_from_url
 
 router = APIRouter()
 logger = logging.getLogger("uvicorn.error")
@@ -110,6 +111,49 @@ async def create_detection(
     )
 
     # Update detection with the actual bucket key
+    detection.bucket_key = bucket_key
+    detections.session.add(detection)
+    await detections.session.commit()
+    await detections.session.refresh(detection)
+
+    return detection
+
+
+@router.post(
+    "/from-url",
+    status_code=status.HTTP_201_CREATED,
+    summary="Create detection from a source image URL (server-side fetch)",
+)
+async def create_detection_from_url(
+    payload: DetectionCreateFromUrl,
+    detections: DetectionCRUD = Depends(get_detection_crud),
+    current_user: User = Depends(get_current_user),
+) -> DetectionRead:
+    """Create a detection by having the server download the image from a URL.
+
+    This is faster than the multipart upload endpoint for bulk imports
+    because the client does not need to download and re-upload the image.
+    """
+    detection = Detection(
+        sequence_id=payload.sequence_id,
+        alert_api_id=payload.alert_api_id,
+        recorded_at=payload.recorded_at,
+        bucket_key="",
+        algo_predictions=payload.algo_predictions.model_dump(),
+        created_at=datetime.now(UTC),
+    )
+
+    detections.session.add(detection)
+    await detections.session.commit()
+    await detections.session.refresh(detection)
+
+    bucket_key = await upload_file_from_url(
+        source_url=payload.source_url,
+        sequence_id=payload.sequence_id,
+        detection_id=detection.id,
+        recorded_at=payload.recorded_at,
+    )
+
     detection.bucket_key = bucket_key
     detections.session.add(detection)
     await detections.session.commit()

--- a/annotation_api/src/app/clients/annotation_api.py
+++ b/annotation_api/src/app/clients/annotation_api.py
@@ -411,6 +411,49 @@ def create_detection(
     return _handle_response(response, operation=operation)
 
 
+def create_detection_from_url(
+    base_url: str,
+    auth_token: str,
+    detection_data: Dict,
+    source_url: str,
+) -> Dict:
+    """
+    Create a detection by having the server fetch the image from a URL.
+
+    This is faster for bulk imports because the client does not need to
+    download and re-upload the image bytes.
+
+    Args:
+        base_url: Base URL of the annotation API
+        auth_token: JWT authentication token
+        detection_data: Dictionary with algo_predictions, alert_api_id,
+                        sequence_id, recorded_at
+        source_url: HTTP(S) URL the server will download the image from
+
+    Returns:
+        Dictionary containing the created detection data
+
+    Raises:
+        ValidationError: If detection data is invalid
+        AnnotationAPIError: For other API errors
+    """
+    url = f"{base_url.rstrip('/')}/api/v1/detections/from-url"
+
+    json_payload = {
+        "source_url": source_url,
+        "algo_predictions": detection_data["algo_predictions"],
+        "alert_api_id": detection_data["alert_api_id"],
+        "sequence_id": detection_data["sequence_id"],
+        "recorded_at": detection_data["recorded_at"],
+    }
+
+    operation = f"create detection from URL with alert_api_id={detection_data.get('alert_api_id', 'unknown')}"
+    response = _make_request(
+        "POST", url, auth_token, operation=operation, json=json_payload
+    )
+    return _handle_response(response, operation=operation)
+
+
 def get_detection(base_url: str, auth_token: str, detection_id: int) -> Dict:
     """
     Get a specific detection by ID.

--- a/annotation_api/src/app/schemas/detection.py
+++ b/annotation_api/src/app/schemas/detection.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 
 from app.schemas.annotation_validation import AlgoPredictions
 
-__all__ = ["DetectionCreate", "DetectionRead", "DetectionUrl", "DetectionWithUrl"]
+__all__ = ["DetectionCreate", "DetectionCreateFromUrl", "DetectionRead", "DetectionUrl", "DetectionWithUrl"]
 
 
 class DetectionCreate(BaseModel):
@@ -19,6 +19,14 @@ class DetectionCreate(BaseModel):
     recorded_at: datetime
     alert_api_id: int
     bucket_key: str
+    algo_predictions: AlgoPredictions
+
+
+class DetectionCreateFromUrl(BaseModel):
+    source_url: str
+    sequence_id: Optional[int]
+    recorded_at: datetime
+    alert_api_id: int
     algo_predictions: AlgoPredictions
 
 

--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -305,6 +305,96 @@ def _generate_detection_bucket_key(
     return f"detections/legacy/{timestamp_str}_{sha_hash}{extension}"
 
 
+async def upload_file_from_url(
+    source_url: str,
+    sequence_id: Optional[int] = None,
+    detection_id: Optional[int] = None,
+    recorded_at: Optional[datetime] = None,
+    download_timeout: int = 30,
+) -> str:
+    """Download image from a URL and upload to S3. Returns the bucket key.
+
+    This avoids the client downloading the image and re-uploading it via
+    multipart form, cutting out one full network round-trip per detection.
+    """
+    import httpx
+
+    try:
+        async with httpx.AsyncClient(timeout=download_timeout) as client:
+            resp = await client.get(source_url)
+            resp.raise_for_status()
+            image_bytes = resp.content
+    except httpx.TimeoutException:
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail=f"Timeout downloading image from source URL: {source_url}",
+        )
+    except httpx.ConnectError:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Could not connect to source URL: {source_url}",
+        )
+    except httpx.HTTPStatusError as exc:
+        code = exc.response.status_code
+        if 400 <= code < 500:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Source URL returned HTTP {code}",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Source URL server error: HTTP {code}",
+        )
+
+    if not image_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Source URL returned empty response",
+        )
+
+    sha_hash = hashlib.sha256(image_bytes).hexdigest()
+    md5_hash = hashlib.md5(image_bytes).hexdigest()  # noqa: S324
+    extension = guess_extension(magic.from_buffer(image_bytes, mime=True)) or ""
+
+    bucket_key = _generate_detection_bucket_key(
+        sequence_id=sequence_id,
+        detection_id=detection_id,
+        recorded_at=recorded_at,
+        sha_hash=sha_hash[:8],
+        extension=extension,
+    )
+
+    bucket_name = s3_service.resolve_bucket_name()
+    bucket = s3_service.get_bucket(bucket_name)
+
+    content_type = magic.from_buffer(image_bytes, mime=True) or "application/octet-stream"
+    if not bucket.upload_file_bytes(image_bytes, bucket_key, content_type):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed upload",
+        )
+    logging.info("File uploaded to bucket %s with key %s.", bucket_name, bucket_key)
+
+    # Data integrity check
+    try:
+        file_meta = bucket.get_file_metadata(bucket_key)
+    except Exception as exc:
+        logging.warning("Could not retrieve file metadata for %s: %s", bucket_key, exc)
+    else:
+        etag = file_meta.get("ETag") or file_meta.get("etag")
+        if etag is not None and md5_hash != etag.replace('"', ""):
+            try:
+                bucket.delete_file(bucket_key)
+            except Exception as exc:
+                logging.warning("Failed to delete corrupted file %s: %s", bucket_key, exc)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Data was corrupted during upload",
+            )
+
+    return bucket_key
+
+
 s3_service = S3Service(
     settings.S3_REGION,
     settings.S3_ENDPOINT_URL,


### PR DESCRIPTION
  - Add POST /api/v1/detections/from-url endpoint that accepts a source_url instead of a file upload — the server downloads the image directly and uploads to S3, eliminating 
  the client download+reupload round-trip                                                                                                                                     
  - Add upload_file_from_url() in storage service with proper error handling (timeout → 504, connection error → 502, source 4xx → 422, source 5xx → 502)                      
  - Add create_detection_from_url() client function (sends JSON instead of multipart form)                                                                                    
  - Update import script to use the new endpoint — _process_single_detection no longer downloads images client-side                                                           
                                                                                                                                                                              
  Why                                                                                                                                                                         
                                                                                                                                                                              
  The import pipeline (make import-platform) was very slow because each detection required 3 network hops: client downloads image from platform → client uploads to annotation
   API → API uploads to S3. With ~30 detections per sequence, this adds up fast. Now it's 1 hop: API server fetches from platform → uploads to S3 (co-located).