### PR TITLE
feat(sequences-review): add stage selector with seq_annotation_done default

### DIFF
--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo } from 'react';
+import { ReactNode, useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { apiClient } from '@/services/api';
@@ -27,17 +27,17 @@ import { hasActiveUserFilters } from '@/utils/filterHelpers';
 
 interface SequencesPageProps {
   defaultProcessingStage?: ProcessingStageStatus;
+  isReviewPage?: boolean;
   stageSelector?: ReactNode;
 }
 
 export default function SequencesPage({
   defaultProcessingStage = 'ready_to_annotate',
+  isReviewPage = false,
   stageSelector,
 }: SequencesPageProps = {}) {
   const navigate = useNavigate();
   const { startAnnotationWorkflow } = useSequenceStore();
-
-  const isReviewPage = stageSelector !== undefined;
 
   // Storage key separates review vs annotate filters; review filters are shared across stages.
   const storageKey = isReviewPage ? 'filters-sequences-review' : 'filters-sequences-annotate';
@@ -60,6 +60,15 @@ export default function SequencesPage({
     setSelectedUnsure,
     resetFilters,
   } = usePersistedFilters(storageKey, createDefaultFilterState(defaultProcessingStage));
+
+  // Keep filters.processing_stage in sync with the parent-controlled stage prop
+  // (used by the review page stage selector). Reset to page 1 on stage change.
+  useEffect(() => {
+    if (filters.processing_stage !== defaultProcessingStage) {
+      setFilters({ ...filters, processing_stage: defaultProcessingStage, page: 1 });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultProcessingStage]);
 
   // Fetch cameras, organizations, and source APIs for dropdown options
   const { data: cameras = [], isLoading: camerasLoading } = useCameras();

--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -111,14 +111,26 @@ export default function SequencesPage({
     handleFilterChange({ recorded_at_lte: dateTimeValue });
   };
 
+  // Annotated-only filters are hidden on other review stages, but their values
+  // persist in shared state. Strip them from API calls so they don't silently
+  // narrow results on stages where the controls aren't visible.
+  const apiFilters = useMemo<ExtendedSequenceFilters>(() => {
+    if (defaultProcessingStage === 'annotated') return filters;
+    const stripped: ExtendedSequenceFilters = { ...filters };
+    delete stripped.false_positive_types;
+    delete stripped.smoke_types;
+    delete stripped.is_unsure;
+    return stripped;
+  }, [filters, defaultProcessingStage]);
+
   // Fetch sequences with annotations in a single efficient call
   const {
     data: sequences,
     isLoading,
     error,
   } = useQuery({
-    queryKey: [...QUERY_KEYS.SEQUENCES, 'with-annotations', filters],
-    queryFn: () => apiClient.getSequencesWithAnnotations(filters),
+    queryKey: [...QUERY_KEYS.SEQUENCES, 'with-annotations', apiFilters],
+    queryFn: () => apiClient.getSequencesWithAnnotations(apiFilters),
   });
 
   // Filter sequences by model accuracy (only for review page)
@@ -159,7 +171,7 @@ export default function SequencesPage({
   const handleSequenceClick = (clickedSequence: SequenceWithAnnotation) => {
     // Initialize annotation workflow if we have sequences data
     if (sequences?.items) {
-      startAnnotationWorkflow(sequences.items, clickedSequence.id, filters);
+      startAnnotationWorkflow(sequences.items, clickedSequence.id, apiFilters);
     }
 
     // Navigate to annotation interface with context about source page

--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { ReactNode, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { apiClient } from '@/services/api';
@@ -9,6 +9,7 @@ import {
 } from '@/types/api';
 import { QUERY_KEYS } from '@/utils/constants';
 import { analyzeSequenceAccuracy } from '@/utils/modelAccuracy';
+import { getProcessingStageLabel } from '@/utils/processingStage';
 import TabbedFilters from '@/components/filters/TabbedFilters';
 import {
   SequencesTableHeader,
@@ -26,19 +27,20 @@ import { hasActiveUserFilters } from '@/utils/filterHelpers';
 
 interface SequencesPageProps {
   defaultProcessingStage?: ProcessingStageStatus;
+  stageSelector?: ReactNode;
 }
 
 export default function SequencesPage({
   defaultProcessingStage = 'ready_to_annotate',
+  stageSelector,
 }: SequencesPageProps = {}) {
   const navigate = useNavigate();
   const { startAnnotationWorkflow } = useSequenceStore();
 
-  // Determine storage key based on processing stage to separate annotate vs review filters
-  const storageKey =
-    defaultProcessingStage === 'annotated'
-      ? 'filters-sequences-review'
-      : 'filters-sequences-annotate';
+  const isReviewPage = stageSelector !== undefined;
+
+  // Storage key separates review vs annotate filters; review filters are shared across stages.
+  const storageKey = isReviewPage ? 'filters-sequences-review' : 'filters-sequences-annotate';
 
   // Use persisted filters hook
   const {
@@ -152,7 +154,7 @@ export default function SequencesPage({
     }
 
     // Navigate to annotation interface with context about source page
-    const queryParam = defaultProcessingStage === 'annotated' ? '?from=review' : '';
+    const queryParam = isReviewPage ? '?from=review' : '';
     navigate(`/sequences/${clickedSequence.id}/annotate${queryParam}`);
   };
 
@@ -200,6 +202,7 @@ export default function SequencesPage({
             <h1 className="text-2xl font-bold text-gray-900">Sequences</h1>
             <p className="text-gray-600">Manage and annotate wildfire detection sequences</p>
           </div>
+          {stageSelector}
         </div>
 
         {/* Filters */}
@@ -243,16 +246,15 @@ export default function SequencesPage({
                 <h3 className="text-lg font-semibold text-gray-900 mb-2">
                   No matching sequences found
                 </h3>
-                <p className="text-gray-500 mb-4">
-                  {defaultProcessingStage === 'annotated'
-                    ? 'No completed sequences match your current filters.'
-                    : 'No sequences match your current filters.'}
-                </p>
+                <p className="text-gray-500 mb-4">No sequences match your current filters.</p>
                 <p className="text-gray-400 text-sm">Try adjusting your search criteria above.</p>
               </>
-            ) : defaultProcessingStage === 'annotated' ? (
-              // Review page - simple message without celebration
-              <p className="text-gray-500">No completed sequences to review at the moment.</p>
+            ) : isReviewPage ? (
+              // Review page - simple message scoped to the selected stage
+              <p className="text-gray-500">
+                No sequences in &quot;{getProcessingStageLabel(defaultProcessingStage)}&quot; at the
+                moment.
+              </p>
             ) : (
               // Annotation page - celebratory message
               <>
@@ -277,6 +279,7 @@ export default function SequencesPage({
           <h1 className="text-2xl font-bold text-gray-900">Sequences</h1>
           <p className="text-gray-600">Manage and annotate wildfire detection sequences</p>
         </div>
+        {stageSelector}
       </div>
 
       {/* Filters */}

--- a/frontend/src/pages/SequencesPageWrapper.tsx
+++ b/frontend/src/pages/SequencesPageWrapper.tsx
@@ -30,8 +30,8 @@ export default function SequencesPageWrapper({
 
   return (
     <SequencesPage
-      key={stage}
       defaultProcessingStage={stage}
+      isReviewPage
       stageSelector={
         <div className="flex items-center space-x-2">
           <label htmlFor="review-stage" className="text-sm text-gray-700">

--- a/frontend/src/pages/SequencesPageWrapper.tsx
+++ b/frontend/src/pages/SequencesPageWrapper.tsx
@@ -1,12 +1,56 @@
 import SequencesPage from './SequencesPage';
-import { ProcessingStageStatus } from '@/types/api';
+import { ProcessingStage, ProcessingStageStatus } from '@/types/api';
+import { usePersistedTabState } from '@/hooks/usePersistedTabState';
+import { getProcessingStageLabel } from '@/utils/processingStage';
 
 interface SequencesPageWrapperProps {
   defaultProcessingStage?: ProcessingStageStatus;
 }
 
+const REVIEW_STAGES: ProcessingStage[] = [
+  'seq_annotation_done',
+  'in_review',
+  'annotated',
+  'needs_manual',
+];
+
 export default function SequencesPageWrapper({
   defaultProcessingStage,
 }: SequencesPageWrapperProps) {
-  return <SequencesPage defaultProcessingStage={defaultProcessingStage} />;
+  const isReview = defaultProcessingStage === 'annotated';
+
+  const [stage, setStage] = usePersistedTabState<ProcessingStage>(
+    'sequences-review-stage',
+    'seq_annotation_done'
+  );
+
+  if (!isReview) {
+    return <SequencesPage defaultProcessingStage={defaultProcessingStage} />;
+  }
+
+  return (
+    <SequencesPage
+      key={stage}
+      defaultProcessingStage={stage}
+      stageSelector={
+        <div className="flex items-center space-x-2">
+          <label htmlFor="review-stage" className="text-sm text-gray-700">
+            Stage:
+          </label>
+          <select
+            id="review-stage"
+            value={stage}
+            onChange={e => setStage(e.target.value as ProcessingStage)}
+            className="border border-gray-300 rounded px-2 py-1 text-sm"
+          >
+            {REVIEW_STAGES.map(s => (
+              <option key={s} value={s}>
+                {getProcessingStageLabel(s)}
+              </option>
+            ))}
+          </select>
+        </div>
+      }
+    />
+  );
 }


### PR DESCRIPTION
- `/sequences/review` previously listed only `annotated` sequences. It now exposes a stage dropdown covering `Seq annotation done` (default), `In review`, `Annotated`, and `Needs manual`, with the choice persisted in localStorage.
- For `annotated`, behavior is unchanged (model accuracy, smoke/FP type filters, unsure filter, legend, row coloring). For the other three stages, the page mirrors `/sequences/annotate` (plain list).
- Stage syncs into `filters.processing_stage` via a `useEffect`, resetting pagination on switch; user filters (date range, camera, etc.) persist across stage changes.
- Codex review applied: explicit `isReviewPage` prop replaces the implicit "stageSelector defined" flag; `key={stage}` remount removed in favor of the effect.

Verified via `tsc --noEmit`, `eslint` (no new warnings), and `vitest` (615/615). Full UI walkthrough was not run since the Docker stack was not started locally.