### PR TITLE
feat(frontend): widen cropped sequence padding to 20%

### DIFF
--- a/frontend/src/components/annotation/CroppedImageSequence.tsx
+++ b/frontend/src/components/annotation/CroppedImageSequence.tsx
@@ -166,8 +166,8 @@ export default function CroppedImageSequence({
     const avgBbox = calculateAverageBbox(bboxes);
     const [avgX1, avgY1, avgX2, avgY2] = avgBbox;
 
-    // Add 10% padding to crop area (same as backend)
-    const padding = 0.1;
+    // 20% padding around the bbox to show surrounding context.
+    const padding = 0.2;
     const padX = (avgX2 - avgX1) * padding;
     const padY = (avgY2 - avgY1) * padding;
 


### PR DESCRIPTION
- Closes #108.
- Cropped sequence view was too tight on the bbox; widen padding from 10% to 20% so annotators can see surrounding context when judging the detection.
- Single-line constant change in `CroppedImageSequence.tsx`.