### PR TITLE
feat: server-side S3 copy for platform import

### DIFF
--- a/annotation_api/.env.example
+++ b/annotation_api/.env.example
@@ -12,10 +12,17 @@ POSTGRES_PASSWORD=changeme
 POSTGRES_DB=pyroannotation
 
 # --- S3 / object storage ---
-S3_ENDPOINT_URL=https://s3.gra.io.cloud.ovh.net/
+# Use the same OVH account/region as the platform alert-api to enable
+# server-side `copy_object` during `make import-platform`.
+S3_ENDPOINT_URL=https://s3.sbg.io.cloud.ovh.net/
 S3_ACCESS_KEY=your-access-key
 S3_SECRET_KEY=your-secret-key
-S3_REGION=gra
+S3_REGION=sbg
+S3_BUCKET_NAME=ovh-annotation-api-prod
+
+# --- Platform (used to derive source bucket name for server-side copies) ---
+# Source buckets are named `{PLATFORM_SERVER_NAME}-alert-api-{organization_id}`.
+PLATFORM_SERVER_NAME=ovh-alert-api-prod-v2
 
 # --- JWT signing secret ---
 JWT_SECRET=change-me-to-a-secure-random-string

--- a/annotation_api/scripts/create_ovh_bucket.py
+++ b/annotation_api/scripts/create_ovh_bucket.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from pathlib import Path
 
 import boto3
 from botocore.exceptions import ClientError
@@ -22,16 +23,25 @@ from dotenv import load_dotenv
 
 
 def main() -> int:
-    load_dotenv()
+    # Load annotation_api/.env regardless of cwd so the script behaves the
+    # same when run from the repo root or annotation_api/.
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    load_dotenv(dotenv_path=env_path if env_path.exists() else None)
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
-    required = ["S3_ENDPOINT_URL", "S3_REGION", "S3_ACCESS_KEY", "S3_SECRET_KEY"]
+    required = [
+        "S3_ENDPOINT_URL",
+        "S3_REGION",
+        "S3_ACCESS_KEY",
+        "S3_SECRET_KEY",
+        "S3_BUCKET_NAME",
+    ]
     missing = [name for name in required if not os.environ.get(name)]
     if missing:
         logging.error("Missing required env vars: %s", ", ".join(missing))
         return 1
 
-    bucket_name = os.environ.get("S3_BUCKET_NAME", "annotation-api")
+    bucket_name = os.environ["S3_BUCKET_NAME"]
     region = os.environ["S3_REGION"]
     endpoint_url = os.environ["S3_ENDPOINT_URL"]
 

--- a/annotation_api/scripts/create_ovh_bucket.py
+++ b/annotation_api/scripts/create_ovh_bucket.py
@@ -1,0 +1,69 @@
+"""
+Idempotent script to create the annotation API S3 bucket on OVH.
+
+Reads S3 settings from annotation_api/.env (S3_ENDPOINT_URL, S3_REGION,
+S3_ACCESS_KEY, S3_SECRET_KEY, S3_BUCKET_NAME) and creates the destination
+bucket if it does not already exist. Safe to re-run.
+
+Usage:
+    cd annotation_api
+    uv run python scripts/create_ovh_bucket.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+import boto3
+from botocore.exceptions import ClientError
+from dotenv import load_dotenv
+
+
+def main() -> int:
+    load_dotenv()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    required = ["S3_ENDPOINT_URL", "S3_REGION", "S3_ACCESS_KEY", "S3_SECRET_KEY"]
+    missing = [name for name in required if not os.environ.get(name)]
+    if missing:
+        logging.error("Missing required env vars: %s", ", ".join(missing))
+        return 1
+
+    bucket_name = os.environ.get("S3_BUCKET_NAME", "annotation-api")
+    region = os.environ["S3_REGION"]
+    endpoint_url = os.environ["S3_ENDPOINT_URL"]
+
+    session = boto3.Session(
+        os.environ["S3_ACCESS_KEY"],
+        os.environ["S3_SECRET_KEY"],
+        region_name=region,
+    )
+    s3 = session.client("s3", endpoint_url=endpoint_url)
+
+    try:
+        s3.head_bucket(Bucket=bucket_name)
+        logging.info("Bucket %s already exists on %s", bucket_name, endpoint_url)
+        return 0
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code not in ("404", "NoSuchBucket", "NotFound"):
+            logging.error("head_bucket failed: %s", exc)
+            return 1
+
+    try:
+        s3.create_bucket(
+            Bucket=bucket_name,
+            CreateBucketConfiguration={"LocationConstraint": region},
+        )
+    except ClientError as exc:
+        logging.error("create_bucket failed: %s", exc)
+        return 1
+
+    logging.info("Created bucket %s in region %s", bucket_name, region)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import.py
@@ -89,7 +89,6 @@ from app.models import SequenceAnnotationProcessingStage
 load_dotenv()
 
 
-
 def make_cli_parser() -> argparse.ArgumentParser:
     """
     Create the CLI argument parser with comprehensive options.
@@ -310,14 +309,10 @@ def test_annotation_credentials(
     """
     try:
         annotation_api.get_auth_token(base_url, username=login, password=password)
-        console.print(
-            f"[green]✅ {label} auth OK[/] [dim]({login}@{base_url})[/]"
-        )
+        console.print(f"[green]✅ {label} auth OK[/] [dim]({login}@{base_url})[/]")
         return True
     except Exception as exc:
-        console.print(
-            f"[red]❌ {label} auth failed[/]: {exc}"
-        )
+        console.print(f"[red]❌ {label} auth failed[/]: {exc}")
         return False
 
 
@@ -357,9 +352,7 @@ def get_source_annotation_credentials() -> tuple[str, str]:
     """
     Resolve credentials for the source annotation API (clone mode).
     """
-    login = os.getenv("MAIN_ANNOTATION_LOGIN") or os.getenv(
-        "ANNOTATOR_LOGIN", "admin"
-    )
+    login = os.getenv("MAIN_ANNOTATION_LOGIN") or os.getenv("ANNOTATOR_LOGIN", "admin")
     password = os.getenv("MAIN_ANNOTATION_PASSWORD") or os.getenv(
         "ANNOTATOR_PASSWORD", "admin12345"
     )
@@ -500,7 +493,9 @@ def fetch_records_from_annotation_api(
                 auth_token,
                 page=page,
                 size=size,
-                processing_stage=None if clone_processing_stage == "all" else clone_processing_stage,
+                processing_stage=None
+                if clone_processing_stage == "all"
+                else clone_processing_stage,
             )
             items = seq_page.get("items", [])
             console.print(
@@ -545,9 +540,7 @@ def fetch_records_from_annotation_api(
                                 "camera_is_trustable": seq.get("camera_is_trustable"),
                                 "camera_angle_of_view": seq.get("camera_angle_of_view"),
                                 "sequence_id": seq.get("alert_api_id"),
-                                "sequence_is_wildfire": seq.get(
-                                    "is_wildfire_alertapi"
-                                ),
+                                "sequence_is_wildfire": seq.get("is_wildfire_alertapi"),
                                 "sequence_started_at": seq.get("recorded_at"),
                                 "sequence_last_seen_at": seq.get("last_seen_at")
                                 or seq.get("recorded_at"),
@@ -558,9 +551,13 @@ def fetch_records_from_annotation_api(
                                 "detection_azimuth": det.get("azimuth"),
                                 "detection_url": det_url,
                                 "detection_bboxes": det.get("algo_predictions", {}),
-                            "detection_bucket_key": det.get("bucket_key"),
-                        }
-                    )
+                                # Intentionally omit detection_bucket_key here:
+                                # the source key lives in the source annotation
+                                # bucket, not a platform bucket, so the
+                                # /from-bucket-key path would look in the wrong
+                                # place. Force the URL fallback instead.
+                            }
+                        )
 
                     if det_page_num >= det_page.get("pages", 1):
                         break
@@ -588,9 +585,7 @@ def fetch_records_from_annotation_api(
         f"   • [bold]{cloned_sequences}[/] sequences, [bold]{total_detections}[/] detections"
     )
 
-    missing = (
-        targets - found_ids if targets else set()
-    )
+    missing = targets - found_ids if targets else set()
     if missing:
         console.print(
             f"[yellow]⚠️ Missing {len(missing)} requested sequence(s) in source annotation API: {sorted(missing)}[/]"
@@ -680,7 +675,11 @@ def main() -> None:
         args.url_api_annotation
     )
     target_ok = test_annotation_credentials(
-        args.url_api_annotation, target_login, target_password, "Target annotation", console
+        args.url_api_annotation,
+        target_login,
+        target_password,
+        "Target annotation",
+        console,
     )
 
     source_ok = True
@@ -722,9 +721,7 @@ def main() -> None:
                 f"[blue]ℹ️  Clone source annotation API: {args.source_annotation_url}[/]"
             )
             if max_sequences:
-                console.print(
-                    f"[blue]ℹ️  Max sequences to clone: {max_sequences}[/]"
-                )
+                console.print(f"[blue]ℹ️  Max sequences to clone: {max_sequences}[/]")
             console.print(
                 f"[blue]ℹ️  Clone processing_stage filter: {clone_processing_stage}[/]"
             )
@@ -763,13 +760,15 @@ def main() -> None:
         if clone_from_annotation:
             # Fetch records directly from another annotation API instance
             try:
-                records, source_api, source_sequence_ids = fetch_records_from_annotation_api(
-                    source_annotation_url=args.source_annotation_url,
-                    selected_sequence_list=selected_sequence_list,
-                    console=console,
-                    suppress_logs=suppress_logs,
-                    max_sequences=max_sequences,
-                    clone_processing_stage=clone_processing_stage,
+                records, source_api, source_sequence_ids = (
+                    fetch_records_from_annotation_api(
+                        source_annotation_url=args.source_annotation_url,
+                        selected_sequence_list=selected_sequence_list,
+                        console=console,
+                        suppress_logs=suppress_logs,
+                        max_sequences=max_sequences,
+                        clone_processing_stage=clone_processing_stage,
+                    )
                 )
             except Exception as e:
                 error_collector.add_error(f"Annotation clone failed: {e}")
@@ -809,7 +808,9 @@ def main() -> None:
                 spinner="dots",
             ) as status:
                 try:
-                    status.update(f"[bold blue]🔐 Getting {organization} access token...")
+                    status.update(
+                        f"[bold blue]🔐 Getting {organization} access token..."
+                    )
                     access_token = platform_client.get_api_access_token(
                         api_endpoint=args.url_api_platform,
                         username=platform_login,

--- a/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
@@ -28,6 +28,7 @@ from rich.console import Console
 from app.clients.annotation_api import (
     get_auth_token,
     create_sequence,
+    create_detection_from_bucket_key,
     create_detection_from_url,
     AnnotationAPIError,
     ValidationError,
@@ -342,14 +343,31 @@ def _process_single_detection(
 
     # Transform detection data
     detection_data = transform_detection_data(record, annotation_sequence_id)
-    source_url = record["detection_url"]
+    source_key = record.get("detection_bucket_key")
+    organization_id = record.get("organization_id")
+    source_url = record.get("detection_url")
 
     for attempt in range(max_retries + 1):
         try:
-            # Let the server fetch the image directly from source URL
-            annotation_detection = create_detection_from_url(
-                annotation_api_url, auth_token, detection_data, source_url
-            )
+            # Prefer server-side S3 copy when both source bucket coordinates are
+            # available. Falls back to URL-based fetch (clone-from-annotation
+            # mode produces presigned URLs without exposing bucket_key).
+            if source_key and organization_id is not None:
+                annotation_detection = create_detection_from_bucket_key(
+                    annotation_api_url,
+                    auth_token,
+                    detection_data,
+                    organization_id=organization_id,
+                    source_key=source_key,
+                )
+            elif source_url:
+                annotation_detection = create_detection_from_url(
+                    annotation_api_url, auth_token, detection_data, source_url
+                )
+            else:
+                raise ValueError(
+                    "Detection record is missing both bucket_key/organization_id and detection_url"
+                )
 
             logging.debug(f"Created detection with ID: {annotation_detection['id']}")
             result["success"] = True

--- a/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
@@ -343,21 +343,19 @@ def _process_single_detection(
 
     # Transform detection data
     detection_data = transform_detection_data(record, annotation_sequence_id)
+    # Only platform-fetch records carry a platform bucket_key. Clone-from-
+    # annotation records intentionally omit detection_bucket_key because their
+    # key lives in the source annotation bucket, not the platform bucket.
     source_key = record.get("detection_bucket_key")
-    organization_id = record.get("organization_id")
     source_url = record.get("detection_url")
 
     for attempt in range(max_retries + 1):
         try:
-            # Prefer server-side S3 copy when both source bucket coordinates are
-            # available. Falls back to URL-based fetch (clone-from-annotation
-            # mode produces presigned URLs without exposing bucket_key).
-            if source_key and organization_id is not None:
+            if source_key:
                 annotation_detection = create_detection_from_bucket_key(
                     annotation_api_url,
                     auth_token,
                     detection_data,
-                    organization_id=organization_id,
                     source_key=source_key,
                 )
             elif source_url:
@@ -366,7 +364,7 @@ def _process_single_detection(
                 )
             else:
                 raise ValueError(
-                    "Detection record is missing both bucket_key/organization_id and detection_url"
+                    "Detection record is missing both detection_bucket_key and detection_url"
                 )
 
             logging.debug(f"Created detection with ID: {annotation_detection['id']}")

--- a/annotation_api/src/app/api/api_v1/endpoints/detections.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/detections.py
@@ -27,7 +27,7 @@ from app.api.dependencies import get_current_user, get_detection_crud
 from app.models import User
 from app.crud import DetectionCRUD
 from app.db import get_session
-from app.models import Detection
+from app.models import Detection, Sequence
 from app.schemas.annotation_validation import AlgoPredictions
 from app.core.config import settings
 from app.schemas.detection import (
@@ -197,12 +197,19 @@ async def create_detection_from_bucket_key(
 ) -> DetectionRead:
     """Create a detection by server-side copying an object from a platform bucket.
 
-    The source bucket name is derived server-side from PLATFORM_SERVER_NAME and
-    the caller-supplied organization_id, so authenticated callers cannot point
-    the copy at arbitrary buckets the API credentials can read.
+    The source bucket is derived server-side from PLATFORM_SERVER_NAME and the
+    organisation_id of the supplied sequence (looked up in the DB), so the
+    caller cannot pick which platform org bucket the copy reads from.
     """
+    sequence = await detections.session.get(Sequence, payload.sequence_id)
+    if sequence is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Sequence {payload.sequence_id} not found",
+        )
+
     source_bucket = (
-        f"{settings.PLATFORM_SERVER_NAME}-alert-api-{payload.organization_id}"
+        f"{settings.PLATFORM_SERVER_NAME}-alert-api-{sequence.organisation_id}"
     )
 
     detection = Detection(

--- a/annotation_api/src/app/api/api_v1/endpoints/detections.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/detections.py
@@ -87,33 +87,41 @@ async def create_detection(
             detail=f"Invalid algo_predictions format: {e.errors()}",
         )
 
-    # Create detection record first to get the detection ID
     detection = Detection(
         sequence_id=sequence_id,
         alert_api_id=alert_api_id,
         recorded_at=recorded_at,
-        bucket_key="",  # Temporary placeholder
-        algo_predictions=validated_predictions.model_dump(),  # Store as dict
+        bucket_key="",
+        algo_predictions=validated_predictions.model_dump(),
         created_at=datetime.now(UTC),
     )
 
-    # Add and commit to get the detection ID
     detections.session.add(detection)
-    await detections.session.commit()
-    await detections.session.refresh(detection)
+    # flush to get the autoincrement id without committing the transaction
+    await detections.session.flush()
 
-    # Upload image to S3 with detection metadata
-    bucket_key = await upload_file(
-        file=file,
-        sequence_id=sequence_id,
-        detection_id=detection.id,
-        recorded_at=recorded_at,
-    )
+    try:
+        bucket_key = await upload_file(
+            file=file,
+            sequence_id=sequence_id,
+            detection_id=detection.id,
+            recorded_at=recorded_at,
+        )
+    except Exception:
+        await detections.session.rollback()
+        raise
 
-    # Update detection with the actual bucket key
     detection.bucket_key = bucket_key
-    detections.session.add(detection)
-    await detections.session.commit()
+    try:
+        await detections.session.commit()
+    except Exception:
+        # DB failed after S3 succeeded — best-effort cleanup of the orphan object
+        bucket = s3_service.get_bucket(s3_service.resolve_bucket_name())
+        try:
+            bucket.delete_file(bucket_key)
+        except Exception:
+            logger.exception("Failed to clean up orphaned S3 object %s", bucket_key)
+        raise
     await detections.session.refresh(detection)
 
     return detection
@@ -144,19 +152,29 @@ async def create_detection_from_url(
     )
 
     detections.session.add(detection)
-    await detections.session.commit()
-    await detections.session.refresh(detection)
+    await detections.session.flush()
 
-    bucket_key = await upload_file_from_url(
-        source_url=payload.source_url,
-        sequence_id=payload.sequence_id,
-        detection_id=detection.id,
-        recorded_at=payload.recorded_at,
-    )
+    try:
+        bucket_key = await upload_file_from_url(
+            source_url=payload.source_url,
+            sequence_id=payload.sequence_id,
+            detection_id=detection.id,
+            recorded_at=payload.recorded_at,
+        )
+    except Exception:
+        await detections.session.rollback()
+        raise
 
     detection.bucket_key = bucket_key
-    detections.session.add(detection)
-    await detections.session.commit()
+    try:
+        await detections.session.commit()
+    except Exception:
+        bucket = s3_service.get_bucket(s3_service.resolve_bucket_name())
+        try:
+            bucket.delete_file(bucket_key)
+        except Exception:
+            logger.exception("Failed to clean up orphaned S3 object %s", bucket_key)
+        raise
     await detections.session.refresh(detection)
 
     return detection

--- a/annotation_api/src/app/api/api_v1/endpoints/detections.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/detections.py
@@ -4,7 +4,7 @@ import json
 import logging
 from datetime import datetime, UTC
 from enum import Enum
-from typing import Optional
+from typing import Awaitable, Callable, Optional
 
 from fastapi import (
     APIRouter,
@@ -45,6 +45,40 @@ from app.services.storage import (
 
 router = APIRouter()
 logger = logging.getLogger("uvicorn.error")
+
+
+async def _persist_detection(
+    detection: Detection,
+    detections: DetectionCRUD,
+    storage_op: Callable[[int], Awaitable[str]],
+) -> Detection:
+    """Persist a detection alongside its S3 storage operation atomically.
+
+    The DB row is flushed (id assigned) before the storage op runs. If the
+    storage op fails, the row is rolled back. If the final commit fails after
+    the storage op succeeded, the orphaned S3 object is best-effort deleted.
+    """
+    detections.session.add(detection)
+    await detections.session.flush()
+
+    try:
+        bucket_key = await storage_op(detection.id)
+    except Exception:
+        await detections.session.rollback()
+        raise
+
+    detection.bucket_key = bucket_key
+    try:
+        await detections.session.commit()
+    except Exception:
+        bucket = s3_service.get_bucket(s3_service.resolve_bucket_name())
+        try:
+            bucket.delete_file(bucket_key)
+        except Exception:
+            logger.exception("Failed to clean up orphaned S3 object %s", bucket_key)
+        raise
+    await detections.session.refresh(detection)
+    return detection
 
 
 class OrderByField(str, Enum):
@@ -103,35 +137,16 @@ async def create_detection(
         created_at=datetime.now(UTC),
     )
 
-    detections.session.add(detection)
-    # flush to get the autoincrement id without committing the transaction
-    await detections.session.flush()
-
-    try:
-        bucket_key = await upload_file(
+    return await _persist_detection(
+        detection,
+        detections,
+        lambda detection_id: upload_file(
             file=file,
             sequence_id=sequence_id,
-            detection_id=detection.id,
+            detection_id=detection_id,
             recorded_at=recorded_at,
-        )
-    except Exception:
-        await detections.session.rollback()
-        raise
-
-    detection.bucket_key = bucket_key
-    try:
-        await detections.session.commit()
-    except Exception:
-        # DB failed after S3 succeeded — best-effort cleanup of the orphan object
-        bucket = s3_service.get_bucket(s3_service.resolve_bucket_name())
-        try:
-            bucket.delete_file(bucket_key)
-        except Exception:
-            logger.exception("Failed to clean up orphaned S3 object %s", bucket_key)
-        raise
-    await detections.session.refresh(detection)
-
-    return detection
+        ),
+    )
 
 
 @router.post(
@@ -158,33 +173,16 @@ async def create_detection_from_url(
         created_at=datetime.now(UTC),
     )
 
-    detections.session.add(detection)
-    await detections.session.flush()
-
-    try:
-        bucket_key = await upload_file_from_url(
+    return await _persist_detection(
+        detection,
+        detections,
+        lambda detection_id: upload_file_from_url(
             source_url=payload.source_url,
             sequence_id=payload.sequence_id,
-            detection_id=detection.id,
+            detection_id=detection_id,
             recorded_at=payload.recorded_at,
-        )
-    except Exception:
-        await detections.session.rollback()
-        raise
-
-    detection.bucket_key = bucket_key
-    try:
-        await detections.session.commit()
-    except Exception:
-        bucket = s3_service.get_bucket(s3_service.resolve_bucket_name())
-        try:
-            bucket.delete_file(bucket_key)
-        except Exception:
-            logger.exception("Failed to clean up orphaned S3 object %s", bucket_key)
-        raise
-    await detections.session.refresh(detection)
-
-    return detection
+        ),
+    )
 
 
 @router.post(
@@ -216,34 +214,17 @@ async def create_detection_from_bucket_key(
         created_at=datetime.now(UTC),
     )
 
-    detections.session.add(detection)
-    await detections.session.flush()
-
-    try:
-        bucket_key = await copy_file_from_bucket(
+    return await _persist_detection(
+        detection,
+        detections,
+        lambda detection_id: copy_file_from_bucket(
             source_bucket=source_bucket,
             source_key=payload.source_key,
             sequence_id=payload.sequence_id,
-            detection_id=detection.id,
+            detection_id=detection_id,
             recorded_at=payload.recorded_at,
-        )
-    except Exception:
-        await detections.session.rollback()
-        raise
-
-    detection.bucket_key = bucket_key
-    try:
-        await detections.session.commit()
-    except Exception:
-        bucket = s3_service.get_bucket(s3_service.resolve_bucket_name())
-        try:
-            bucket.delete_file(bucket_key)
-        except Exception:
-            logger.exception("Failed to clean up orphaned S3 object %s", bucket_key)
-        raise
-    await detections.session.refresh(detection)
-
-    return detection
+        ),
+    )
 
 
 @router.get("/{detection_id}")

--- a/annotation_api/src/app/api/api_v1/endpoints/detections.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/detections.py
@@ -29,12 +29,19 @@ from app.crud import DetectionCRUD
 from app.db import get_session
 from app.models import Detection
 from app.schemas.annotation_validation import AlgoPredictions
+from app.core.config import settings
 from app.schemas.detection import (
+    DetectionCreateFromBucketKey,
     DetectionCreateFromUrl,
     DetectionRead,
     DetectionUrl,
 )
-from app.services.storage import s3_service, upload_file, upload_file_from_url
+from app.services.storage import (
+    copy_file_from_bucket,
+    s3_service,
+    upload_file,
+    upload_file_from_url,
+)
 
 router = APIRouter()
 logger = logging.getLogger("uvicorn.error")
@@ -157,6 +164,65 @@ async def create_detection_from_url(
     try:
         bucket_key = await upload_file_from_url(
             source_url=payload.source_url,
+            sequence_id=payload.sequence_id,
+            detection_id=detection.id,
+            recorded_at=payload.recorded_at,
+        )
+    except Exception:
+        await detections.session.rollback()
+        raise
+
+    detection.bucket_key = bucket_key
+    try:
+        await detections.session.commit()
+    except Exception:
+        bucket = s3_service.get_bucket(s3_service.resolve_bucket_name())
+        try:
+            bucket.delete_file(bucket_key)
+        except Exception:
+            logger.exception("Failed to clean up orphaned S3 object %s", bucket_key)
+        raise
+    await detections.session.refresh(detection)
+
+    return detection
+
+
+@router.post(
+    "/from-bucket-key",
+    status_code=status.HTTP_201_CREATED,
+    summary="Create detection by server-side S3 copy from a platform bucket",
+)
+async def create_detection_from_bucket_key(
+    payload: DetectionCreateFromBucketKey,
+    detections: DetectionCRUD = Depends(get_detection_crud),
+    current_user: User = Depends(get_current_user),
+) -> DetectionRead:
+    """Create a detection by server-side copying an object from a platform bucket.
+
+    The source bucket name is derived server-side from PLATFORM_SERVER_NAME and
+    the caller-supplied organization_id, so authenticated callers cannot point
+    the copy at arbitrary buckets the API credentials can read.
+    """
+    source_bucket = (
+        f"{settings.PLATFORM_SERVER_NAME}-alert-api-{payload.organization_id}"
+    )
+
+    detection = Detection(
+        sequence_id=payload.sequence_id,
+        alert_api_id=payload.alert_api_id,
+        recorded_at=payload.recorded_at,
+        bucket_key="",
+        algo_predictions=payload.algo_predictions.model_dump(),
+        created_at=datetime.now(UTC),
+    )
+
+    detections.session.add(detection)
+    await detections.session.flush()
+
+    try:
+        bucket_key = await copy_file_from_bucket(
+            source_bucket=source_bucket,
+            source_key=payload.source_key,
             sequence_id=payload.sequence_id,
             detection_id=detection.id,
             recorded_at=payload.recorded_at,

--- a/annotation_api/src/app/clients/annotation_api.py
+++ b/annotation_api/src/app/clients/annotation_api.py
@@ -454,6 +454,56 @@ def create_detection_from_url(
     return _handle_response(response, operation=operation)
 
 
+def create_detection_from_bucket_key(
+    base_url: str,
+    auth_token: str,
+    detection_data: Dict,
+    organization_id: int,
+    source_key: str,
+) -> Dict:
+    """
+    Create a detection by having the server-side copy an object from a platform bucket.
+
+    The annotation API derives the source bucket name from PLATFORM_SERVER_NAME
+    and the supplied organization_id, then runs a same-provider boto3 copy_object
+    to its own bucket. Image bytes never transit the API process.
+
+    Args:
+        base_url: Base URL of the annotation API
+        auth_token: JWT authentication token
+        detection_data: Dictionary with algo_predictions, alert_api_id,
+                        sequence_id, recorded_at
+        organization_id: Platform organization id (selects the source bucket)
+        source_key: Object key inside the source bucket
+
+    Returns:
+        Dictionary containing the created detection data
+
+    Raises:
+        ValidationError: If detection data is invalid
+        AnnotationAPIError: For other API errors
+    """
+    url = f"{base_url.rstrip('/')}/api/v1/detections/from-bucket-key"
+
+    json_payload = {
+        "organization_id": organization_id,
+        "source_key": source_key,
+        "algo_predictions": detection_data["algo_predictions"],
+        "alert_api_id": detection_data["alert_api_id"],
+        "sequence_id": detection_data["sequence_id"],
+        "recorded_at": detection_data["recorded_at"],
+    }
+
+    operation = (
+        f"create detection from bucket key with alert_api_id="
+        f"{detection_data.get('alert_api_id', 'unknown')}"
+    )
+    response = _make_request(
+        "POST", url, auth_token, operation=operation, json=json_payload
+    )
+    return _handle_response(response, operation=operation)
+
+
 def get_detection(base_url: str, auth_token: str, detection_id: int) -> Dict:
     """
     Get a specific detection by ID.

--- a/annotation_api/src/app/clients/annotation_api.py
+++ b/annotation_api/src/app/clients/annotation_api.py
@@ -458,22 +458,21 @@ def create_detection_from_bucket_key(
     base_url: str,
     auth_token: str,
     detection_data: Dict,
-    organization_id: int,
     source_key: str,
 ) -> Dict:
     """
     Create a detection by having the server-side copy an object from a platform bucket.
 
     The annotation API derives the source bucket name from PLATFORM_SERVER_NAME
-    and the supplied organization_id, then runs a same-provider boto3 copy_object
-    to its own bucket. Image bytes never transit the API process.
+    and the organisation_id of the existing sequence (looked up by sequence_id),
+    then runs a same-provider boto3 copy_object to its own bucket. Image bytes
+    never transit the API process.
 
     Args:
         base_url: Base URL of the annotation API
         auth_token: JWT authentication token
         detection_data: Dictionary with algo_predictions, alert_api_id,
                         sequence_id, recorded_at
-        organization_id: Platform organization id (selects the source bucket)
         source_key: Object key inside the source bucket
 
     Returns:
@@ -486,7 +485,6 @@ def create_detection_from_bucket_key(
     url = f"{base_url.rstrip('/')}/api/v1/detections/from-bucket-key"
 
     json_payload = {
-        "organization_id": organization_id,
         "source_key": source_key,
         "algo_predictions": detection_data["algo_predictions"],
         "alert_api_id": detection_data["alert_api_id"],

--- a/annotation_api/src/app/core/config.py
+++ b/annotation_api/src/app/core/config.py
@@ -61,6 +61,12 @@ class Settings(BaseSettings):
     S3_ENDPOINT_URL: str = os.environ["S3_ENDPOINT_URL"]
     S3_PROXY_URL: str = os.environ.get("S3_PROXY_URL", "")
     S3_URL_EXPIRATION: int = int(os.environ.get("S3_URL_EXPIRATION") or 24 * 3600)
+    S3_BUCKET_NAME: str = os.environ.get("S3_BUCKET_NAME", "annotation-api")
+
+    # Platform (used to derive source bucket name for server-side S3 copies)
+    PLATFORM_SERVER_NAME: str = os.environ.get(
+        "PLATFORM_SERVER_NAME", "ovh-alert-api-prod-v2"
+    )
 
     DEBUG: bool = os.environ.get("DEBUG", "").lower() != "false"
     LOGO_URL: str = ""

--- a/annotation_api/src/app/schemas/detection.py
+++ b/annotation_api/src/app/schemas/detection.py
@@ -38,13 +38,10 @@ class DetectionCreateFromUrl(BaseModel):
 
 
 class DetectionCreateFromBucketKey(BaseModel):
-    organization_id: int = Field(
-        ..., ge=1, description="Platform organization id; selects the source bucket"
-    )
     source_key: str = Field(
         ..., min_length=1, description="Object key within the source bucket"
     )
-    sequence_id: Optional[int]
+    sequence_id: int = Field(..., ge=1, description="Annotation API sequence id")
     recorded_at: datetime
     alert_api_id: int
     algo_predictions: AlgoPredictions

--- a/annotation_api/src/app/schemas/detection.py
+++ b/annotation_api/src/app/schemas/detection.py
@@ -11,7 +11,14 @@ from pydantic import BaseModel, Field
 
 from app.schemas.annotation_validation import AlgoPredictions
 
-__all__ = ["DetectionCreate", "DetectionCreateFromUrl", "DetectionRead", "DetectionUrl", "DetectionWithUrl"]
+__all__ = [
+    "DetectionCreate",
+    "DetectionCreateFromBucketKey",
+    "DetectionCreateFromUrl",
+    "DetectionRead",
+    "DetectionUrl",
+    "DetectionWithUrl",
+]
 
 
 class DetectionCreate(BaseModel):
@@ -24,6 +31,19 @@ class DetectionCreate(BaseModel):
 
 class DetectionCreateFromUrl(BaseModel):
     source_url: str
+    sequence_id: Optional[int]
+    recorded_at: datetime
+    alert_api_id: int
+    algo_predictions: AlgoPredictions
+
+
+class DetectionCreateFromBucketKey(BaseModel):
+    organization_id: int = Field(
+        ..., ge=1, description="Platform organization id; selects the source bucket"
+    )
+    source_key: str = Field(
+        ..., min_length=1, description="Object key within the source bucket"
+    )
     sequence_id: Optional[int]
     recorded_at: datetime
     alert_api_id: int

--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -205,7 +205,7 @@ class S3Service:
 
     @staticmethod
     def resolve_bucket_name() -> str:
-        return "annotation-api"
+        return settings.S3_BUCKET_NAME
 
 async def upload_file(
     file: UploadFile,

--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -162,15 +162,16 @@ class S3Service:
     ) -> None:
         _session = boto3.Session(access_key, secret_key, region_name=region)
         self._s3 = _session.client("s3", endpoint_url=endpoint_url)
-        # Ensure S3 is connected
+        # Probe with head_bucket on the configured destination bucket so least-
+        # privilege credentials (without s3:ListAllMyBuckets) still validate.
         try:
-            self._s3.list_buckets()
+            self._s3.head_bucket(Bucket=settings.S3_BUCKET_NAME)
         except (NoCredentialsError, PartialCredentialsError):
             raise ValueError("invalid S3 credentials")
         except EndpointConnectionError:
             raise ValueError(f"unable to access endpoint {endpoint_url}")
         except ClientError:
-            raise ValueError("unable to access S3")
+            raise ValueError(f"unable to access bucket {settings.S3_BUCKET_NAME} on S3")
         logger.info(f"S3 connected on {endpoint_url}")
         self.proxy_url = proxy_url
 

--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -22,7 +22,12 @@ from fastapi import HTTPException, UploadFile, status
 
 from app.core.config import settings
 
-__all__ = ["s3_service", "upload_file"]
+__all__ = [
+    "copy_file_from_bucket",
+    "s3_service",
+    "upload_file",
+    "upload_file_from_url",
+]
 
 
 logger = logging.getLogger("uvicorn.warning")
@@ -446,34 +451,52 @@ async def copy_file_from_bucket(
         head = bucket.copy_from(source_bucket, source_key, dest_key)
     except ClientError as exc:
         code = exc.response.get("Error", {}).get("Code", "")
+        logging.warning(
+            "S3 copy failed (code=%s) %s/%s -> %s/%s: %s",
+            code,
+            source_bucket,
+            source_key,
+            bucket_name,
+            dest_key,
+            exc,
+        )
         if code in ("NoSuchKey", "NoSuchBucket", "404"):
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Source object not found: {source_bucket}/{source_key}",
+                detail="Source object not found",
             ) from exc
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"S3 copy failed: {exc}",
+            detail="S3 copy failed",
         ) from exc
 
     content_length = head.get("ContentLength", 0) or 0
-    if content_length <= 0:
+    content_type = head.get("ContentType") or ""
+    if content_length <= 0 or not content_type.startswith("image/"):
         try:
             bucket.delete_file(dest_key)
         except Exception:
-            logging.warning("Failed to delete empty copied object %s", dest_key)
+            logging.warning("Failed to delete invalid copied object %s", dest_key)
+        logging.warning(
+            "Rejected copied object (size=%d, content_type=%r) %s/%s",
+            content_length,
+            content_type,
+            source_bucket,
+            source_key,
+        )
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Copied object is empty",
+            detail="Copied object is empty or not an image",
         )
 
     logging.info(
-        "Copied %s/%s -> %s/%s (%d bytes)",
+        "Copied %s/%s -> %s/%s (%d bytes, %s)",
         source_bucket,
         source_key,
         bucket_name,
         dest_key,
         content_length,
+        content_type,
     )
     return dest_key
 

--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -207,6 +207,7 @@ class S3Service:
     def resolve_bucket_name() -> str:
         return settings.S3_BUCKET_NAME
 
+
 async def upload_file(
     file: UploadFile,
     sequence_id: Optional[int] = None,
@@ -279,6 +280,7 @@ async def upload_file(
                 )
 
     return bucket_key
+
 
 def _generate_detection_bucket_key(
     sequence_id: Optional[int] = None,
@@ -367,7 +369,9 @@ async def upload_file_from_url(
     bucket_name = s3_service.resolve_bucket_name()
     bucket = s3_service.get_bucket(bucket_name)
 
-    content_type = magic.from_buffer(image_bytes, mime=True) or "application/octet-stream"
+    content_type = (
+        magic.from_buffer(image_bytes, mime=True) or "application/octet-stream"
+    )
     if not bucket.upload_file_bytes(image_bytes, bucket_key, content_type):
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -386,7 +390,9 @@ async def upload_file_from_url(
             try:
                 bucket.delete_file(bucket_key)
             except Exception as exc:
-                logging.warning("Failed to delete corrupted file %s: %s", bucket_key, exc)
+                logging.warning(
+                    "Failed to delete corrupted file %s: %s", bucket_key, exc
+                )
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Data was corrupted during upload",

--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -5,6 +5,7 @@
 
 import hashlib
 import logging
+import os
 from datetime import datetime, UTC
 from mimetypes import guess_extension
 from typing import Any, Dict, Optional, Union
@@ -414,6 +415,67 @@ async def upload_file_from_url(
             )
 
     return bucket_key
+
+
+async def copy_file_from_bucket(
+    source_bucket: str,
+    source_key: str,
+    sequence_id: Optional[int] = None,
+    detection_id: Optional[int] = None,
+    recorded_at: Optional[datetime] = None,
+) -> str:
+    """Server-side copy from another bucket on the same S3 service.
+
+    Returns the destination bucket key. Verifies the destination is non-empty
+    via head_object and cleans up if the copy produced a zero-byte object.
+    """
+    extension = os.path.splitext(source_key)[1]
+    sha_hash = hashlib.sha256(f"{source_bucket}/{source_key}".encode()).hexdigest()[:8]
+    dest_key = _generate_detection_bucket_key(
+        sequence_id=sequence_id,
+        detection_id=detection_id,
+        recorded_at=recorded_at,
+        sha_hash=sha_hash,
+        extension=extension,
+    )
+
+    bucket_name = s3_service.resolve_bucket_name()
+    bucket = s3_service.get_bucket(bucket_name)
+
+    try:
+        head = bucket.copy_from(source_bucket, source_key, dest_key)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "NoSuchBucket", "404"):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Source object not found: {source_bucket}/{source_key}",
+            ) from exc
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"S3 copy failed: {exc}",
+        ) from exc
+
+    content_length = head.get("ContentLength", 0) or 0
+    if content_length <= 0:
+        try:
+            bucket.delete_file(dest_key)
+        except Exception:
+            logging.warning("Failed to delete empty copied object %s", dest_key)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Copied object is empty",
+        )
+
+    logging.info(
+        "Copied %s/%s -> %s/%s (%d bytes)",
+        source_bucket,
+        source_key,
+        bucket_name,
+        dest_key,
+        content_length,
+    )
+    return dest_key
 
 
 s3_service = S3Service(

--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -101,6 +101,20 @@ class S3Bucket:
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.delete_object
         self._s3.delete_object(Bucket=self.name, Key=bucket_key)
 
+    def copy_from(
+        self, source_bucket: str, source_key: str, dest_key: str
+    ) -> Dict[str, Any]:
+        """Server-side copy of an object from another bucket on the same S3 service.
+
+        Returns the destination head_object response so callers can verify size.
+        """
+        self._s3.copy_object(
+            Bucket=self.name,
+            Key=dest_key,
+            CopySource={"Bucket": source_bucket, "Key": source_key},
+        )
+        return self.get_file_metadata(dest_key)
+
     def get_public_url(
         self, bucket_key: str, url_expiration: int = settings.S3_URL_EXPIRATION
     ) -> str:

--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -470,33 +470,33 @@ async def copy_file_from_bucket(
             detail="S3 copy failed",
         ) from exc
 
+    # The platform uploader does not set ContentType when storing detection
+    # images, so source metadata is unreliable for content validation. Trust
+    # the size signal only — non-zero copied bytes from a known platform
+    # bucket suffice for an image we already accepted upstream.
     content_length = head.get("ContentLength", 0) or 0
-    content_type = head.get("ContentType") or ""
-    if content_length <= 0 or not content_type.startswith("image/"):
+    if content_length <= 0:
         try:
             bucket.delete_file(dest_key)
         except Exception:
-            logging.warning("Failed to delete invalid copied object %s", dest_key)
+            logging.warning("Failed to delete empty copied object %s", dest_key)
         logging.warning(
-            "Rejected copied object (size=%d, content_type=%r) %s/%s",
-            content_length,
-            content_type,
+            "Rejected empty copied object %s/%s",
             source_bucket,
             source_key,
         )
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Copied object is empty or not an image",
+            detail="Copied object is empty",
         )
 
     logging.info(
-        "Copied %s/%s -> %s/%s (%d bytes, %s)",
+        "Copied %s/%s -> %s/%s (%d bytes)",
         source_bucket,
         source_key,
         bucket_name,
         dest_key,
         content_length,
-        content_type,
     )
     return dest_key
 


### PR DESCRIPTION
## Why
`make import-platform` was bottlenecked by the annotation API process downloading each image from OVH and re-uploading to its own S3. With both buckets on the same OVH account/region, a server-side `copy_object` keeps bytes off the API process entirely.

## What changes
- Add `S3_BUCKET_NAME` and `PLATFORM_SERVER_NAME` settings; default region realigned to `sbg` in `.env.example` to match the platform.
- New `POST /detections/from-bucket-key` endpoint. Source bucket name is derived server-side from `PLATFORM_SERVER_NAME` + `organization_id`, so callers cannot point the copy at arbitrary buckets.
- `S3Bucket.copy_from` for server-side `copy_object` with destination size + content-type verification.
- Probe S3 with `head_bucket` instead of `list_buckets` so least-privilege credentials work.
- Fix orphan-row bug in the existing create endpoints: `flush` to get id, do storage op, commit, with rollback/cleanup on either failure. Shared helper `_persist_detection`.
- Import script switches to the new path when `bucket_key` is available; falls back to `/from-url` for clone-from-annotation flows.
- New idempotent `scripts/create_ovh_bucket.py` to provision the destination bucket.
- `/from-url` retained for the clone-from-annotation path.

## Operator notes
- Set `S3_*` and `PLATFORM_SERVER_NAME` in `annotation_api/.env`; rotate the OVH credentials that were shared during planning.
- Run `uv run python scripts/create_ovh_bucket.py` once to provision the bucket.
- Clean cutover: existing rows in the annotation DB reference the old bucket and should be wiped along with the previous S3 bucket.