### PR TITLE
feat: bypass platform risk filter on import

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/platform/client.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/client.py
@@ -20,6 +20,7 @@ Functions:
 
 import logging
 from datetime import date
+from typing import Optional
 
 import requests
 
@@ -165,6 +166,7 @@ def list_sequences_for_date(
     limit: int,
     offset: int,
     access_token: str,
+    risk_score: Optional[str] = None,
 ) -> list[dict]:
     """
     List all sequences for a given date using the platform API.
@@ -175,11 +177,18 @@ def list_sequences_for_date(
         limit (int): The maximum number of sequences to return.
         offset (int): The number of sequences to skip before starting to collect the result set.
         access_token (str): The access token for API authentication.
+        risk_score (str | None): Optional FWI class override. When set (e.g. "extreme"),
+            the platform applies that single class to every camera and the FWI confidence
+            filter becomes a no-op for classes whose threshold is 0.0. Pass None to use
+            the platform's default per-camera risk-api lookup (which filters out low-FWI
+            sequences).
 
     Returns:
         list[dict]: A list of dictionaries containing sequence information.
     """
     url = f"{api_endpoint}/api/v1/sequences/all/fromdate?from_date={date:%Y-%m-%d}&limit={limit}&offset={offset}"
+    if risk_score:
+        url += f"&risk_score={risk_score}"
     return api_get(route=url, access_token=access_token)
 
 

--- a/annotation_api/scripts/data_transfer/ingestion/platform/client.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/client.py
@@ -21,6 +21,7 @@ Functions:
 import logging
 from datetime import date
 from typing import Optional
+from urllib.parse import urlencode
 
 import requests
 
@@ -186,9 +187,14 @@ def list_sequences_for_date(
     Returns:
         list[dict]: A list of dictionaries containing sequence information.
     """
-    url = f"{api_endpoint}/api/v1/sequences/all/fromdate?from_date={date:%Y-%m-%d}&limit={limit}&offset={offset}"
+    params: dict[str, object] = {
+        "from_date": f"{date:%Y-%m-%d}",
+        "limit": limit,
+        "offset": offset,
+    }
     if risk_score:
-        url += f"&risk_score={risk_score}"
+        params["risk_score"] = risk_score
+    url = f"{api_endpoint}/api/v1/sequences/all/fromdate?{urlencode(params)}"
     return api_get(route=url, access_token=access_token)
 
 

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import.py
@@ -192,6 +192,18 @@ def make_cli_parser() -> argparse.ArgumentParser:
         ),
         type=str,
     )
+    parser.add_argument(
+        "--risk-score",
+        help=(
+            "FWI class override sent to the platform's /sequences/all/fromdate. "
+            "Defaults to 'extreme' so the platform's per-camera risk filter is "
+            "bypassed and every sequence for the date is returned. Pass 'none' "
+            "to keep the platform default (filters low-FWI sequences)."
+        ),
+        type=str,
+        choices=["very_low", "low", "moderate", "high", "very_high", "extreme", "none"],
+        default="extreme",
+    )
 
     # Annotation analysis options
     parser.add_argument(
@@ -836,6 +848,9 @@ def main() -> None:
 
             # Fetch platform records
             try:
+                # "none" means: do not pass risk_score → platform applies its
+                # per-camera risk filter (default behaviour).
+                risk_score = args.risk_score if args.risk_score != "none" else None
                 records = fetch_all_sequences_within(
                     date_from=args.date_from,
                     date_end=args.date_end,
@@ -851,6 +866,7 @@ def main() -> None:
                     console=console,
                     error_collector=error_collector,
                     organization=organization,
+                    risk_score=risk_score,
                 )
             except Exception as e:
                 error_collector.add_error(f"Platform data fetching failed: {e}")

--- a/annotation_api/scripts/data_transfer/ingestion/platform/sequence_fetching.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/sequence_fetching.py
@@ -101,19 +101,27 @@ def fetch_sequences_for_date(
     Returns:
         List of sequence dictionaries for the specified date
     """
+    page_size = 1000
+    offset = 0
+    sequences: List[Dict[str, Any]] = []
     try:
-        sequences = platform_client.list_sequences_for_date(
-            api_endpoint=api_endpoint,
-            date=target_date,
-            limit=1000,  # Large limit to get all sequences for the date
-            offset=0,
-            access_token=access_token,
-            risk_score=risk_score,
-        )
+        while True:
+            page = platform_client.list_sequences_for_date(
+                api_endpoint=api_endpoint,
+                date=target_date,
+                limit=page_size,
+                offset=offset,
+                access_token=access_token,
+                risk_score=risk_score,
+            )
+            sequences.extend(page)
+            if len(page) < page_size:
+                break
+            offset += page_size
         return sequences
     except Exception as e:
         logging.error(f"Error fetching sequences for date {target_date}: {e}")
-        return []
+        return sequences
 
 
 def process_single_sequence_detections(

--- a/annotation_api/scripts/data_transfer/ingestion/platform/sequence_fetching.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/sequence_fetching.py
@@ -83,7 +83,10 @@ def get_dates_within(date_from: date, date_end: date) -> List[date]:
 
 
 def fetch_sequences_for_date(
-    api_endpoint: str, target_date: date, access_token: str
+    api_endpoint: str,
+    target_date: date,
+    access_token: str,
+    risk_score: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """
     Fetch sequences for a specific date from the platform API.
@@ -92,17 +95,11 @@ def fetch_sequences_for_date(
         api_endpoint: Platform API endpoint URL
         target_date: Date to fetch sequences for
         access_token: API access token for authentication
+        risk_score: Optional FWI class override forwarded to the platform.
+            None applies the default per-camera risk filter (drops low-FWI sequences).
 
     Returns:
         List of sequence dictionaries for the specified date
-
-    Example:
-        >>> sequences = fetch_sequences_for_date(
-        ...     "https://api.example.com",
-        ...     date(2024, 1, 1),
-        ...     "token123"
-        ... )
-        >>> print(f"Found {len(sequences)} sequences")
     """
     try:
         sequences = platform_client.list_sequences_for_date(
@@ -111,6 +108,7 @@ def fetch_sequences_for_date(
             limit=1000,  # Large limit to get all sequences for the date
             offset=0,
             access_token=access_token,
+            risk_score=risk_score,
         )
         return sequences
     except Exception as e:
@@ -225,6 +223,7 @@ def fetch_all_sequences_within(
     console: Optional[Console] = None,
     error_collector: Optional[ErrorCollector] = None,
     organization: Optional[str] = None,
+    risk_score: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """
     Fetch all sequences and detections between date_from and date_end.
@@ -334,7 +333,11 @@ def fetch_all_sequences_within(
     with concurrent.futures.ProcessPoolExecutor() as executor:
         future_to_date = {
             executor.submit(
-                fetch_sequences_for_date, api_endpoint, mdate, access_token
+                fetch_sequences_for_date,
+                api_endpoint,
+                mdate,
+                access_token,
+                risk_score,
             ): mdate
             for mdate in dates
         }
@@ -369,7 +372,11 @@ def fetch_all_sequences_within(
         )
 
     # Optionally cap total sequences
-    if max_sequences is not None and max_sequences > 0 and len(sequences) > max_sequences:
+    if (
+        max_sequences is not None
+        and max_sequences > 0
+        and len(sequences) > max_sequences
+    ):
         sequences = sequences[:max_sequences]
         console.print(
             f"[blue]🔍 Applying max_sequences cap[/] "


### PR DESCRIPTION
## Why
The platform's GET /sequences/all/fromdate applies a per-camera FWI risk filter by default, dropping low-FWI sequences. `make import-platform` inherited that filter and silently lost data depending on each camera's risk score.

## What
- New `--risk-score` CLI flag on the import script, threaded down to the platform call. Defaults to `extreme` (FWI threshold 0.0 → no filter) so imports return every sequence for the date by default.
- Pass `--risk-score none` to keep the platform's per-camera default.
- Build the platform query string with urllib.parse.urlencode to avoid any future query-param injection if the helper is called with an unsanitised value.
- Page through `/sequences/all/fromdate` until a partial page is seen. The previous single-shot `limit=1000, offset=0` silently dropped any results past 1000 — a latent bug the new default exposes.