### PR TITLE
fix(annotation): submit sequences as seq_annotation_done

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
@@ -164,7 +164,9 @@ def build_detection_id_map(
     return local_map
 
 
-def remap_annotation_bboxes(annotation: Dict[str, Any], id_map: Dict[int, int]) -> Dict[str, Any]:
+def remap_annotation_bboxes(
+    annotation: Dict[str, Any], id_map: Dict[int, int]
+) -> Dict[str, Any]:
     """
     Replace detection_id in annotation bboxes using the provided mapping.
     Bboxes without a mapping are dropped.
@@ -253,7 +255,17 @@ def main() -> None:
     local_sequences = fetch_local_sequences_to_push(
         args.local_api, local_token, sequence_filter, args.max_sequences
     )
-    logging.info(f"Found {len(local_sequences)} seq_annotation_done sequence(s) locally")
+    logging.info(
+        f"Found {len(local_sequences)} seq_annotation_done sequence(s) locally"
+    )
+
+    # Stages that mean the remote has already moved past the seq_annotation_done
+    # handoff. Re-pushing into these would clobber review progress, so we skip.
+    remote_downstream_stages = {
+        SequenceAnnotationProcessingStage.IN_REVIEW.value,
+        SequenceAnnotationProcessingStage.NEEDS_MANUAL.value,
+        SequenceAnnotationProcessingStage.ANNOTATED.value,
+    }
 
     stats = {
         "attempted": 0,
@@ -261,6 +273,7 @@ def main() -> None:
         "synced_updated": 0,
         "skipped_no_annotation": 0,
         "skipped_no_detections_mapped": 0,
+        "skipped_remote_downstream": 0,
         "missing_remote": 0,
         "errors": 0,
     }
@@ -271,7 +284,9 @@ def main() -> None:
         source_api = seq.get("source_api")
 
         # Fetch local annotation
-        local_ann = get_sequence_annotation_single(args.local_api, local_token, seq["id"])
+        local_ann = get_sequence_annotation_single(
+            args.local_api, local_token, seq["id"]
+        )
         if not local_ann:
             logging.warning(f"Skipping alert_api_id={alert_id}: no local annotation")
             stats["skipped_no_annotation"] += 1
@@ -316,6 +331,16 @@ def main() -> None:
         remote_ann = get_sequence_annotation_single(
             args.remote_api, remote_token, remote_seq_id
         )
+        if (
+            remote_ann
+            and remote_ann.get("processing_stage") in remote_downstream_stages
+        ):
+            logging.warning(
+                f"Skipping alert_api_id={alert_id}: remote already in "
+                f"'{remote_ann['processing_stage']}', refusing to overwrite"
+            )
+            stats["skipped_remote_downstream"] += 1
+            continue
 
         # Build payload from local annotation
         payload = {
@@ -353,7 +378,9 @@ def main() -> None:
                     f"(remote_seq_id={remote_seq_id})"
                 )
 
-            # Update local annotation stage to seq_annotation_done for bookkeeping
+            # Park the local annotation in `annotated` so a rerun does not
+            # reselect this row and force-demote the remote back to
+            # seq_annotation_done.
             try:
                 local_ann_id = local_ann.get("id")
                 if local_ann_id:
@@ -361,7 +388,9 @@ def main() -> None:
                         args.local_api,
                         local_token,
                         local_ann_id,
-                        {"processing_stage": SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE.value},
+                        {
+                            "processing_stage": SequenceAnnotationProcessingStage.ANNOTATED.value
+                        },
                     )
             except Exception as exc:
                 logging.warning(
@@ -379,6 +408,7 @@ def main() -> None:
         f"missing_remote={stats['missing_remote']}, "
         f"no_local_annotation={stats['skipped_no_annotation']}, "
         f"no_detections_mapped={stats['skipped_no_detections_mapped']}, "
+        f"remote_downstream={stats['skipped_remote_downstream']}, "
         f"errors={stats['errors']}"
     )
 

--- a/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
@@ -2,7 +2,8 @@
 Sync local sequence annotations to a remote annotation API.
 
 Workflow:
-1. List annotated sequences on the local API (optionally filter by alert_api_id and limit).
+1. List sequences in `seq_annotation_done` on the local API (optionally filter by
+   alert_api_id and limit).
 2. For each, find the corresponding sequence on the remote API by alert_api_id.
 3. Create or update the sequence annotation on the remote API.
 """
@@ -33,13 +34,13 @@ def parse_sequence_selection(sequence_arg: str) -> List[int]:
     return ids
 
 
-def fetch_local_annotated_sequences(
+def fetch_local_sequences_to_push(
     base_url: str,
     token: str,
     sequence_filter: Optional[List[int]],
     max_sequences: Optional[int],
 ) -> List[Dict[str, Any]]:
-    """Fetch annotated sequences from local API with optional filtering/limit."""
+    """Fetch sequences in seq_annotation_done from local API with optional filtering/limit."""
     page = 1
     size = 100
     results: List[Dict[str, Any]] = []
@@ -49,7 +50,7 @@ def fetch_local_annotated_sequences(
         params = {
             "page": page,
             "size": size,
-            "processing_stage": "annotated",
+            "processing_stage": SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE.value,
         }
         resp = annotation_api.list_sequences(base_url, token, **params)
         items = resp.get("items", [])
@@ -246,13 +247,13 @@ def main() -> None:
     )
 
     logging.info(
-        f"Fetching annotated sequences from local API {args.local_api} "
+        f"Fetching seq_annotation_done sequences from local API {args.local_api} "
         f"(filter={sequence_filter or 'none'}, max={args.max_sequences or 'all'})"
     )
-    local_sequences = fetch_local_annotated_sequences(
+    local_sequences = fetch_local_sequences_to_push(
         args.local_api, local_token, sequence_filter, args.max_sequences
     )
-    logging.info(f"Found {len(local_sequences)} annotated sequence(s) locally")
+    logging.info(f"Found {len(local_sequences)} seq_annotation_done sequence(s) locally")
 
     stats = {
         "attempted": 0,

--- a/frontend/src/components/sequence-annotation/AnnotationHeader.tsx
+++ b/frontend/src/components/sequence-annotation/AnnotationHeader.tsx
@@ -21,6 +21,7 @@ import {
   formatProgressDisplay,
   getProgressColor,
 } from '@/utils/annotation/progressUtils';
+import { isSequenceAnnotationSubmitted } from '@/utils/processingStage';
 
 interface AnnotationHeaderProps {
   // Navigation
@@ -74,9 +75,10 @@ export const AnnotationHeader: React.FC<AnnotationHeaderProps> = ({
   onUnsureChange,
   fromParam,
 }) => {
+  const isSubmitted = isSequenceAnnotationSubmitted(annotation?.processing_stage);
   const headerBgClass = isUnsure
     ? 'bg-amber-50/90 border-b border-amber-200 border-l-4 border-l-amber-500'
-    : annotation?.processing_stage === 'annotated'
+    : isSubmitted
       ? 'bg-green-50/90 border-b border-green-200 border-l-4 border-l-green-500'
       : 'bg-white/85 border-b border-gray-200';
 
@@ -142,7 +144,7 @@ export const AnnotationHeader: React.FC<AnnotationHeaderProps> = ({
               )}
 
               {/* Completion Badge for Annotated Sequences */}
-              {annotation?.processing_stage === 'annotated' && fromParam !== 'review' && (
+              {isSubmitted && fromParam !== 'review' && (
                 <>
                   <span className="text-gray-400">•</span>
                   <span className="inline-flex items-center text-xs text-green-600 font-medium">
@@ -203,7 +205,7 @@ export const AnnotationHeader: React.FC<AnnotationHeaderProps> = ({
               title={
                 isUnsure
                   ? 'Submit as unsure (Enter)'
-                  : annotation?.processing_stage === 'annotated'
+                  : isSubmitted
                     ? 'Save changes (Enter)'
                     : 'Submit annotation (Enter)'
               }
@@ -213,11 +215,7 @@ export const AnnotationHeader: React.FC<AnnotationHeaderProps> = ({
               ) : (
                 <Upload className="w-3 h-3 mr-1" />
               )}
-              {isUnsure
-                ? 'Submit Unsure'
-                : annotation?.processing_stage === 'annotated'
-                  ? 'Save Changes'
-                  : 'Submit'}
+              {isUnsure ? 'Submit Unsure' : isSubmitted ? 'Save Changes' : 'Submit'}
             </button>
 
             <button

--- a/frontend/src/components/sequence-annotation/ProcessingStageMessages.tsx
+++ b/frontend/src/components/sequence-annotation/ProcessingStageMessages.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { AlertCircle } from 'lucide-react';
 import { SequenceAnnotation } from '@/types/api';
+import { isSequenceAnnotationSubmitted } from '@/utils/processingStage';
 
 interface ProcessingStageMessagesProps {
   annotation: SequenceAnnotation;
@@ -14,7 +15,7 @@ interface ProcessingStageMessagesProps {
 export const ProcessingStageMessages: React.FC<ProcessingStageMessagesProps> = ({ annotation }) => {
   if (
     annotation.processing_stage === 'ready_to_annotate' ||
-    annotation.processing_stage === 'annotated'
+    isSequenceAnnotationSubmitted(annotation.processing_stage)
   ) {
     return null;
   }

--- a/frontend/src/pages/AnnotationInterface.tsx
+++ b/frontend/src/pages/AnnotationInterface.tsx
@@ -189,11 +189,14 @@ export default function AnnotationInterface() {
   // Save annotation mutation
   const saveAnnotation = useMutation({
     mutationFn: async (updatedBboxes: SequenceBbox[]) => {
+      // Don't demote a post-review 'annotated' sequence back into the review pipeline
+      // when a reviewer edits it from the review page.
+      const isAlreadyFinalised = annotation?.processing_stage === 'annotated';
       const updatedAnnotation: Partial<SequenceAnnotation> = {
         annotation: {
           sequences_bbox: updatedBboxes, // Always preserve the actual bbox data
         },
-        processing_stage: 'seq_annotation_done', // Hand off to the review pipeline
+        processing_stage: isAlreadyFinalised ? 'annotated' : 'seq_annotation_done',
         // Update derived fields - all false for unsure sequences
         has_smoke: isUnsure ? false : updatedBboxes.some(bbox => bbox.is_smoke),
         has_false_positives: isUnsure

--- a/frontend/src/pages/AnnotationInterface.tsx
+++ b/frontend/src/pages/AnnotationInterface.tsx
@@ -193,7 +193,7 @@ export default function AnnotationInterface() {
         annotation: {
           sequences_bbox: updatedBboxes, // Always preserve the actual bbox data
         },
-        processing_stage: 'annotated', // Move to annotated stage
+        processing_stage: 'seq_annotation_done', // Hand off to the review pipeline
         // Update derived fields - all false for unsure sequences
         has_smoke: isUnsure ? false : updatedBboxes.some(bbox => bbox.is_smoke),
         has_false_positives: isUnsure

--- a/frontend/src/pages/DetectionAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionAnnotatePage.tsx
@@ -27,11 +27,11 @@ export default function DetectionAnnotatePage() {
 
   // Create default state specific to detection annotation page
   const defaultState = {
-    ...createDefaultFilterState(),
+    ...createDefaultFilterState('needs_manual'),
     filters: {
-      ...createDefaultFilterState().filters,
-      // Keep server filters minimal; we'll filter by annotation stage client-side
-      processing_stage: undefined,
+      ...createDefaultFilterState('needs_manual').filters,
+      // Server-side filter: only sequences flagged for manual detection-level rework.
+      processing_stage: 'needs_manual' as const,
       include_annotation: true,
       size: 100,
     },
@@ -128,35 +128,8 @@ export default function DetectionAnnotatePage() {
     [sequenceAnnotations]
   );
 
-  const filteredSequences = useMemo(() => {
-    if (!sequences) return sequences;
-
-    const needsManual = sequences.items.filter(sequence => {
-      const annotation = annotationMap[sequence.id];
-      return annotation?.processing_stage === 'needs_manual';
-    });
-
-    const accuracyFiltered =
-      selectedModelAccuracy === 'all'
-        ? needsManual
-        : needsManual.filter(sequence => {
-            const annotation = annotationMap[sequence.id];
-            if (!annotation) {
-              return selectedModelAccuracy === 'unknown';
-            }
-            // Model accuracy filtering is optional; keep only if desired
-            // Here we treat missing annotation as unknown
-            // If you don’t need accuracy filters, drop this block entirely
-            return true;
-          });
-
-    return {
-      ...sequences,
-      items: accuracyFiltered,
-      total: accuracyFiltered.length,
-      pages: Math.ceil(accuracyFiltered.length / sequences.size),
-    };
-  }, [sequences, annotationMap, selectedModelAccuracy]);
+  // Server already filters on processing_stage=needs_manual; no client-side narrow.
+  const filteredSequences = sequences;
 
   // Navigation handlers
   const handleSequenceClick = (sequence: SequenceWithDetectionProgress) => {

--- a/frontend/src/utils/annotation/progressUtils.ts
+++ b/frontend/src/utils/annotation/progressUtils.ts
@@ -5,6 +5,7 @@
 
 import { SequenceBbox } from '@/types/api';
 import { hasUserAnnotations } from './sequenceUtils';
+import { isSequenceAnnotationSubmitted } from '@/utils/processingStage';
 
 /**
  * Progress information for annotation workflow.
@@ -203,7 +204,7 @@ export const getProgressColor = (
   processingStage?: string
 ): string => {
   if (progress.isComplete) {
-    return processingStage === 'annotated' ? 'bg-green-600' : 'bg-amber-600';
+    return isSequenceAnnotationSubmitted(processingStage) ? 'bg-green-600' : 'bg-amber-600';
   }
 
   return 'bg-primary-600';

--- a/frontend/src/utils/annotation/sequenceUtils.ts
+++ b/frontend/src/utils/annotation/sequenceUtils.ts
@@ -4,6 +4,7 @@
  */
 
 import { SequenceAnnotation, SequenceBbox, FalsePositiveType, SmokeType } from '@/types/api';
+import { isSequenceAnnotationSubmitted } from '@/utils/processingStage';
 
 /**
  * Determines the classification type for a bbox based on user choice and existing data.
@@ -70,8 +71,8 @@ export const initializeCleanBbox = (originalBbox: SequenceBbox): SequenceBbox =>
  * Determines if a bbox should show as annotated based on processing stage.
  */
 export const shouldShowAsAnnotated = (bbox: SequenceBbox, processingStage: string): boolean => {
-  // If already marked as annotated in processing stage, show as annotated
-  if (processingStage === 'annotated') {
+  // If the user has already submitted, treat the bbox as annotated
+  if (isSequenceAnnotationSubmitted(processingStage)) {
     return true;
   }
   // If ready to annotate, only show as annotated if user has made selections
@@ -99,8 +100,8 @@ export const isAnnotationDataValid = (
 export const getInitialMissedSmokeReview = (
   annotation: SequenceAnnotation
 ): 'yes' | 'no' | null => {
-  if (annotation.processing_stage === 'annotated') {
-    // For annotated sequences, the has_missed_smoke boolean reflects the actual review result
+  if (isSequenceAnnotationSubmitted(annotation.processing_stage)) {
+    // Once submitted, the has_missed_smoke boolean reflects the annotator's actual answer
     return annotation.has_missed_smoke ? 'yes' : 'no';
   } else {
     // For other stages (like ready_to_annotate), null means not reviewed yet
@@ -120,7 +121,7 @@ export const createAnnotationPayload = (
     annotation: {
       sequences_bbox: updatedBboxes, // Always preserve the actual bbox data
     },
-    processing_stage: 'annotated', // Move to annotated stage
+    processing_stage: 'seq_annotation_done', // Hand off to the review pipeline
     // Update derived fields - all false for unsure sequences
     has_smoke: isUnsure ? false : updatedBboxes.some(bbox => bbox.is_smoke),
     has_false_positives: isUnsure

--- a/frontend/src/utils/annotation/sequenceUtils.ts
+++ b/frontend/src/utils/annotation/sequenceUtils.ts
@@ -111,17 +111,21 @@ export const getInitialMissedSmokeReview = (
 
 /**
  * Creates updated annotation payload for API submission.
+ *
+ * If the annotation is already in the post-review `annotated` stage, the stage
+ * is preserved so reviewer edits don't demote it back into the review pipeline.
  */
 export const createAnnotationPayload = (
   updatedBboxes: SequenceBbox[],
   isUnsure: boolean,
-  hasMissedSmoke: boolean
+  hasMissedSmoke: boolean,
+  currentStage?: SequenceAnnotation['processing_stage']
 ): Partial<SequenceAnnotation> => {
   return {
     annotation: {
       sequences_bbox: updatedBboxes, // Always preserve the actual bbox data
     },
-    processing_stage: 'seq_annotation_done', // Hand off to the review pipeline
+    processing_stage: currentStage === 'annotated' ? 'annotated' : 'seq_annotation_done',
     // Update derived fields - all false for unsure sequences
     has_smoke: isUnsure ? false : updatedBboxes.some(bbox => bbox.is_smoke),
     has_false_positives: isUnsure

--- a/frontend/src/utils/processingStage.ts
+++ b/frontend/src/utils/processingStage.ts
@@ -200,6 +200,15 @@ export function getProcessingStageLabel(status: ProcessingStageStatus | Processi
  * // Returns: 'bg-gray-100 text-gray-800'
  * ```
  */
+/**
+ * Returns true when the sequence annotation has been submitted by an annotator.
+ * Covers both the freshly-submitted state (`seq_annotation_done`) and the
+ * post-review final state (`annotated`).
+ */
+export function isSequenceAnnotationSubmitted(status: string | undefined | null): boolean {
+  return status === 'seq_annotation_done' || status === 'annotated';
+}
+
 export function getProcessingStageColorClass(
   status: ProcessingStageStatus | ProcessingStage
 ): string {

--- a/frontend/tests/utils/annotation/sequenceUtils.test.ts
+++ b/frontend/tests/utils/annotation/sequenceUtils.test.ts
@@ -208,14 +208,20 @@ describe('sequenceUtils', () => {
         createMockBbox({ is_smoke: true, smoke_type: 'wildfire' }),
         createMockBbox({ false_positive_types: ['antenna'] })
       ];
-      
+
       const payload = createAnnotationPayload(bboxes, true, true);
-      
+
       expect(payload.has_smoke).toBe(false);
       expect(payload.has_false_positives).toBe(false);
       expect(payload.has_missed_smoke).toBe(false);
       expect(payload.is_unsure).toBe(true);
       expect(payload.false_positive_types).toBe("[]");
+    });
+
+    it('should preserve annotated stage when reviewer re-saves', () => {
+      const bboxes = [createMockBbox({ is_smoke: true, smoke_type: 'wildfire' })];
+      const payload = createAnnotationPayload(bboxes, false, false, 'annotated');
+      expect(payload.processing_stage).toBe('annotated');
     });
   });
 

--- a/frontend/tests/utils/annotation/sequenceUtils.test.ts
+++ b/frontend/tests/utils/annotation/sequenceUtils.test.ts
@@ -195,7 +195,7 @@ describe('sequenceUtils', () => {
       
       const payload = createAnnotationPayload(bboxes, false, true);
       
-      expect(payload.processing_stage).toBe('annotated');
+      expect(payload.processing_stage).toBe('seq_annotation_done');
       expect(payload.has_smoke).toBe(true);
       expect(payload.has_false_positives).toBe(true);
       expect(payload.has_missed_smoke).toBe(true);


### PR DESCRIPTION
## Summary
- Frontend submit was setting `processing_stage: 'annotated'`, skipping `seq_annotation_done`. `make push-annotations` looks for `seq_annotation_done`, so submitted sequences never made it into the review pipeline.
- Switch the two write sites (`createAnnotationPayload`, `saveAnnotation` mutation) to `seq_annotation_done`.
- Add `isSequenceAnnotationSubmitted(stage)` and use it in places that previously hinged on `=== 'annotated'` to mean "user has submitted" — header bg/badge/button label, `ProcessingStageMessages`, `shouldShowAsAnnotated`, `getInitialMissedSmokeReview`, `getProgressColor` — so the post-submit UI behaves the same for both stages.
- Detection-level files and the post-review queue listings are untouched on purpose.