### PR TITLE
fix(push): park local at in_review instead of annotated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,15 @@ docker-build-local:
 docker-push-images:
 	@docker push pyronear/annotation-app:latest
 	@docker push pyronear/annotation-api:latest
+
+up:
+	@docker compose up -d --build
+
+logs:
+	@docker compose logs -f
+
+down:
+	@docker compose down
+
+clean:
+	@docker compose down -v

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ Start both the annotation API backend and frontend with a single command:
 
 ```bash
 # Start all services (database, backend API, frontend)
-docker compose up -d
+make up
 
 # View logs
-docker compose logs -f
+make logs
 
 # Stop all services
-docker compose down
+make down
 
 # Stop and remove all data (fresh start)
-docker compose down -v
+make clean
 ```
 
 ### Service Access
@@ -30,23 +30,9 @@ Once running, access the services at:
 - **PostgreSQL Database**: localhost:5432
 - **LocalStack S3**: http://localhost:4566
 
-### Build and Development
-
-The root docker-compose.yml orchestrates both services for production-like deployment. For active development on individual services, use their respective docker-compose files:
-
-```bash
-# Backend development (with live code reload)
-cd annotation_api
-make start  # Uses docker-compose-dev.yml with volume mounts
-
-# Frontend development (with hot reload)
-cd frontend
-npm run dev  # Vite dev server on port 5173
-```
-
 ## Main Workflow
 
-All workflows below assume the services are running locally (`docker compose up -d`) and that you have credentials to the remote annotation API. Run the `make` targets from the `annotation_api/` directory.
+All workflows below assume the services are running locally (`make up`) and that you have credentials to the remote annotation API. Run the `make` targets from the `annotation_api/` directory.
 
 Before anything that talks to the remote API, configure your credentials in `annotation_api/.env` (loaded by the data-transfer scripts at startup via python-dotenv):
 
@@ -84,6 +70,8 @@ Open the frontend at http://localhost:3000 and annotate. Sequences transition `R
 ```bash
 make push-annotations MAX_SEQUENCES=10
 ```
+
+After a successful push the local annotation is parked at `in_review` to mirror the remote progression and keep the row out of the next push selection. Re-runs are guarded: rows whose remote is already in `in_review`, `needs_manual`, or `annotated` are skipped instead of overwritten.
 
 #### B. Detection Annotation
 
@@ -210,7 +198,7 @@ make import-platform DATE_FROM=2025-03-04 DATE_END=2025-03-04 MAX_SEQUENCES=10
 **Services must be running first:**
 ```bash
 # Start all services
-docker compose up -d
+make up
 
 # Verify annotation API is accessible
 curl http://localhost:5050/docs
@@ -279,8 +267,8 @@ For detailed documentation, parameter reference, and troubleshooting, see [Data 
 
 **Fresh start (clear all data):**
 ```bash
-docker compose down -v  # Removes containers and volumes
-docker compose up -d    # Fresh start
+make clean  # Removes containers and volumes
+make up     # Fresh start
 ```
 
 ## Individual Modules

--- a/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
@@ -378,9 +378,9 @@ def main() -> None:
                     f"(remote_seq_id={remote_seq_id})"
                 )
 
-            # Park the local annotation in `annotated` so a rerun does not
-            # reselect this row and force-demote the remote back to
-            # seq_annotation_done.
+            # Park the local annotation in `in_review` to mirror the remote
+            # progression (the next op on the remote moves it to in_review)
+            # and to keep this row out of the next push selection.
             try:
                 local_ann_id = local_ann.get("id")
                 if local_ann_id:
@@ -389,7 +389,7 @@ def main() -> None:
                         local_token,
                         local_ann_id,
                         {
-                            "processing_stage": SequenceAnnotationProcessingStage.ANNOTATED.value
+                            "processing_stage": SequenceAnnotationProcessingStage.IN_REVIEW.value
                         },
                     )
             except Exception as exc:

--- a/frontend/src/utils/processingStage.ts
+++ b/frontend/src/utils/processingStage.ts
@@ -201,12 +201,14 @@ export function getProcessingStageLabel(status: ProcessingStageStatus | Processi
  * ```
  */
 /**
- * Returns true when the sequence annotation has been submitted by an annotator.
- * Covers both the freshly-submitted state (`seq_annotation_done`) and the
- * post-review final state (`annotated`).
+ * Returns true when the annotator has handed the sequence off — i.e. it has
+ * moved past `under_annotation`. Covers the freshly-submitted state
+ * (`seq_annotation_done`), the review handoff (`in_review`, set locally
+ * after `make push-annotations`), and the post-review final state
+ * (`annotated`).
  */
 export function isSequenceAnnotationSubmitted(status: string | undefined | null): boolean {
-  return status === 'seq_annotation_done' || status === 'annotated';
+  return status === 'seq_annotation_done' || status === 'in_review' || status === 'annotated';
 }
 
 export function getProcessingStageColorClass(


### PR DESCRIPTION
## Summary
Follow-up to #128. After a successful \`make push-annotations\`, the local annotation was parked in \`annotated\`, which conflated with the post-review final state and was confusing when running \`make pull-seq-annotations\` afterwards.

- \`push_sequence_annotations.py\`: park local rows in \`in_review\` after a successful push. Mirrors the remote progression — the next op on remote (pull-seq-annotations) sets remote to \`in_review\` — so local now tracks remote intent. The remote-downstream guard (skip if remote is already in_review/needs_manual/annotated) is unchanged.
- \`isSequenceAnnotationSubmitted\`: also recognize \`in_review\` so the post-push UI (Save Changes / Completed / green) keeps working when a user re-opens a row they've already pushed.
- README: document the post-push parking and the re-run guard. Adopt the new root-level \`make up/logs/down/clean\` targets.