### PR TITLE
feat: split sibling bboxes from auto-annotation, default IoU=0

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/platform/annotation_management.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/annotation_management.py
@@ -181,7 +181,7 @@ def create_annotation_from_data(
                 update_dict.update(
                     {
                         "confidence_threshold": config.get("confidence_threshold", 0.0),
-                        "iou_threshold": config.get("iou_threshold", 0.3),
+                        "iou_threshold": config.get("iou_threshold", 0.0),
                         "min_cluster_size": config.get("min_cluster_size", 1),
                     }
                 )
@@ -226,7 +226,7 @@ def create_annotation_from_data(
                 create_dict.update(
                     {
                         "confidence_threshold": config.get("confidence_threshold", 0.0),
-                        "iou_threshold": config.get("iou_threshold", 0.3),
+                        "iou_threshold": config.get("iou_threshold", 0.0),
                         "min_cluster_size": config.get("min_cluster_size", 1),
                     }
                 )

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import.py
@@ -214,9 +214,12 @@ def make_cli_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--iou-threshold",
-        help="Minimum IoU for clustering overlapping boxes (0.0-1.0)",
+        help=(
+            "IoU threshold for clustering overlapping boxes (0.0-1.0). "
+            "0.0 = any positive overlap merges (default)."
+        ),
         type=float,
-        default=0.3,
+        default=0.0,
     )
     parser.add_argument(
         "--min-cluster-size",

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import.py
@@ -563,6 +563,7 @@ def fetch_records_from_annotation_api(
                                 "detection_azimuth": det.get("azimuth"),
                                 "detection_url": det_url,
                                 "detection_bboxes": det.get("algo_predictions", {}),
+                                "detection_others_bboxes": det.get("others_bboxes"),
                                 # Intentionally omit detection_bucket_key here:
                                 # the source key lives in the source annotation
                                 # bucket, not a platform bucket, so the

--- a/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
@@ -252,6 +252,11 @@ def transform_detection_data(record: dict, annotation_sequence_id: int) -> dict:
     """
     Transform platform detection data to annotation API format.
 
+    `detection_bboxes` (the tracked `bbox`) becomes `algo_predictions` and
+    drives auto-annotation. `detection_others_bboxes` (sibling boxes on the
+    same image) is forwarded separately so the UI can show them read-only
+    without injecting them into the auto-generated annotation.
+
     Args:
         record: Platform record containing detection metadata
         annotation_sequence_id: The sequence ID from annotation API (not platform ID)
@@ -259,18 +264,27 @@ def transform_detection_data(record: dict, annotation_sequence_id: int) -> dict:
     Returns:
         Dictionary formatted for annotation API detection creation
     """
-    # Transform detection_bboxes to algo_predictions format
     parsed = parse_platform_bboxes(record["detection_bboxes"])
-    predictions = parsed.get("predictions", [])
-    predictions = _sanitize_predictions(predictions)
+    predictions = _sanitize_predictions(parsed.get("predictions", []))
     algo_predictions = {"predictions": predictions}
 
-    return {
+    others_payload: dict | None = None
+    raw_others = record.get("detection_others_bboxes")
+    if raw_others:
+        others_parsed = parse_platform_bboxes(raw_others)
+        others_clean = _sanitize_predictions(others_parsed.get("predictions", []))
+        if others_clean:
+            others_payload = {"predictions": others_clean}
+
+    payload = {
         "sequence_id": annotation_sequence_id,  # NEW sequence ID from annotation API
         "alert_api_id": record["detection_id"],  # Platform detection ID
         "recorded_at": record["detection_created_at"],
         "algo_predictions": algo_predictions,
     }
+    if others_payload is not None:
+        payload["others_bboxes"] = others_payload
+    return payload
 
 
 def download_image(url: str, timeout: int = 30) -> bytes:

--- a/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
@@ -5,6 +5,7 @@ This module contains common functions used by both fetch_platform_sequence_id.py
 and fetch_platform_sequences.py to avoid code duplication.
 """
 
+import ast
 import concurrent.futures
 import logging
 import os
@@ -192,15 +193,11 @@ def parse_platform_bboxes(bboxes_str: str) -> dict:
     """
     Parse platform bboxes string into AlgoPredictions format.
 
-    Args:
-        bboxes_str: String representation or object of bounding boxes
-
-    Returns:
-        Dictionary in AlgoPredictions format with predictions list
-
-    Note:
-        This function needs to be refined based on actual platform bbox format.
-        Currently assumes a simple format that can be eval'd.
+    Accepts:
+        - dict already in AlgoPredictions shape
+        - list of `[x1, y1, x2, y2, conf, ...]` boxes
+        - string representation of such a list (parsed safely with
+          `ast.literal_eval`, never `eval`)
     """
     try:
         if isinstance(bboxes_str, dict) and "predictions" in bboxes_str:
@@ -210,8 +207,7 @@ def parse_platform_bboxes(bboxes_str: str) -> dict:
         if isinstance(bboxes_str, list):
             bboxes_data = bboxes_str
         else:
-            # Parse the bboxes string - format needs to be determined from actual data
-            bboxes_data = eval(bboxes_str) if bboxes_str else []
+            bboxes_data = ast.literal_eval(bboxes_str) if bboxes_str else []
 
         predictions = []
         for bbox in bboxes_data:

--- a/annotation_api/scripts/data_transfer/ingestion/platform/utils.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/utils.py
@@ -83,9 +83,12 @@ def to_record(
         dict: A structured record containing relevant metadata for the detection.
     """
 
-    bboxes = _parse_bbox_string(detection.get("bbox")) + _parse_bbox_string(
-        detection.get("others_bboxes")
-    )
+    # `bbox` = the tracked detection that drives auto-annotation.
+    # `others_bboxes` = sibling boxes seen on the same image, kept separate so
+    # they can be displayed read-only in the UI without leaking into the
+    # auto-generated annotation.
+    primary_bboxes = _parse_bbox_string(detection.get("bbox"))
+    others_bboxes = _parse_bbox_string(detection.get("others_bboxes"))
 
     return {
         # Organization metadata
@@ -113,6 +116,7 @@ def to_record(
         "detection_created_at": detection["created_at"],
         "detection_azimuth": None,
         "detection_url": detection.get("url"),
-        "detection_bboxes": bboxes,
+        "detection_bboxes": primary_bboxes,
+        "detection_others_bboxes": others_bboxes,
         "detection_bucket_key": detection["bucket_key"],
     }

--- a/annotation_api/src/app/api/api_v1/endpoints/detections.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/detections.py
@@ -106,6 +106,7 @@ async def create_detection(
     sequence_id: int = Form(...),
     recorded_at: datetime = Form(),
     file: UploadFile = File(..., alias="file"),
+    others_bboxes: Optional[str] = Form(default=None),
     detections: DetectionCRUD = Depends(get_detection_crud),
     current_user: User = Depends(get_current_user),
 ) -> DetectionRead:
@@ -128,12 +129,23 @@ async def create_detection(
             detail=f"Invalid algo_predictions format: {e.errors()}",
         )
 
+    validated_others = None
+    if others_bboxes:
+        try:
+            validated_others = AlgoPredictions(**json.loads(others_bboxes))
+        except (ValidationError, json.JSONDecodeError) as e:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Invalid others_bboxes format: {e}",
+            )
+
     detection = Detection(
         sequence_id=sequence_id,
         alert_api_id=alert_api_id,
         recorded_at=recorded_at,
         bucket_key="",
         algo_predictions=validated_predictions.model_dump(),
+        others_bboxes=validated_others.model_dump() if validated_others else None,
         created_at=datetime.now(UTC),
     )
 
@@ -170,6 +182,9 @@ async def create_detection_from_url(
         recorded_at=payload.recorded_at,
         bucket_key="",
         algo_predictions=payload.algo_predictions.model_dump(),
+        others_bboxes=payload.others_bboxes.model_dump()
+        if payload.others_bboxes
+        else None,
         created_at=datetime.now(UTC),
     )
 
@@ -218,6 +233,9 @@ async def create_detection_from_bucket_key(
         recorded_at=payload.recorded_at,
         bucket_key="",
         algo_predictions=payload.algo_predictions.model_dump(),
+        others_bboxes=payload.others_bboxes.model_dump()
+        if payload.others_bboxes
+        else None,
         created_at=datetime.now(UTC),
     )
 

--- a/annotation_api/src/app/api/api_v1/endpoints/detections.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/detections.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2024, Pyronear.
 
-import json
 import logging
 from datetime import datetime, UTC
 from enum import Enum
@@ -110,30 +109,29 @@ async def create_detection(
     detections: DetectionCRUD = Depends(get_detection_crud),
     current_user: User = Depends(get_current_user),
 ) -> DetectionRead:
-    # Parse string JSON -> dict
-    parsed_predictions = json.loads(algo_predictions)
-
-    # Validate the parsed predictions using Pydantic model
+    # Validate the algo_predictions JSON. Catch JSON decode errors and
+    # non-object payloads (`null`, lists, etc.) the same way as schema
+    # violations so callers get a clean 422 instead of a 500.
     try:
-        validated_predictions = AlgoPredictions(**parsed_predictions)
-    except ValidationError as e:
+        validated_predictions = AlgoPredictions.model_validate_json(algo_predictions)
+    except (ValidationError, ValueError) as e:
         logger.error(
             f"Detection algo_predictions validation failed for sequence_id={sequence_id}\n"
             f"Alert API ID: {alert_api_id}\n"
             f"Recorded at: {recorded_at}\n"
-            f"Algo predictions data: {parsed_predictions}\n"
-            f"Validation errors: {e.errors()}"
+            f"Algo predictions data: {algo_predictions}\n"
+            f"Error: {e}"
         )
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Invalid algo_predictions format: {e.errors()}",
+            detail=f"Invalid algo_predictions format: {e}",
         )
 
     validated_others = None
     if others_bboxes:
         try:
-            validated_others = AlgoPredictions(**json.loads(others_bboxes))
-        except (ValidationError, json.JSONDecodeError) as e:
+            validated_others = AlgoPredictions.model_validate_json(others_bboxes)
+        except (ValidationError, ValueError) as e:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail=f"Invalid others_bboxes format: {e}",

--- a/annotation_api/src/app/api/api_v1/endpoints/detections.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/detections.py
@@ -116,11 +116,14 @@ async def create_detection(
         validated_predictions = AlgoPredictions.model_validate_json(algo_predictions)
     except (ValidationError, ValueError) as e:
         logger.error(
-            f"Detection algo_predictions validation failed for sequence_id={sequence_id}\n"
-            f"Alert API ID: {alert_api_id}\n"
-            f"Recorded at: {recorded_at}\n"
-            f"Algo predictions data: {algo_predictions}\n"
-            f"Error: {e}"
+            "Detection algo_predictions validation failed "
+            "for sequence_id=%s alert_api_id=%s recorded_at=%s "
+            "(payload bytes=%d): %s",
+            sequence_id,
+            alert_api_id,
+            recorded_at,
+            len(algo_predictions or ""),
+            e,
         )
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -175,7 +175,7 @@ async def auto_generate_annotation(
     sequence_id: int,
     session: AsyncSession,
     confidence_threshold: float = 0.0,
-    iou_threshold: float = 0.3,
+    iou_threshold: float = 0.0,
     min_cluster_size: int = 1,
 ) -> Optional[SequenceAnnotationData]:
     """
@@ -373,7 +373,7 @@ async def create_sequence_annotation(
             sequence_id=create_data.sequence_id,
             session=annotations.session,
             confidence_threshold=create_data.confidence_threshold or 0.0,
-            iou_threshold=create_data.iou_threshold or 0.3,
+            iou_threshold=create_data.iou_threshold or 0.0,
             min_cluster_size=create_data.min_cluster_size or 1,
         )
 
@@ -643,7 +643,7 @@ async def update_sequence_annotation(
             sequence_id=existing.sequence_id,
             session=annotations.session,
             confidence_threshold=payload.confidence_threshold or 0.0,
-            iou_threshold=payload.iou_threshold or 0.3,
+            iou_threshold=payload.iou_threshold or 0.0,
             min_cluster_size=payload.min_cluster_size or 1,
         )
 

--- a/annotation_api/src/app/clients/annotation_api.py
+++ b/annotation_api/src/app/clients/annotation_api.py
@@ -400,6 +400,8 @@ def create_detection(
         "sequence_id": detection_data["sequence_id"],
         "recorded_at": detection_data["recorded_at"],
     }
+    if detection_data.get("others_bboxes") is not None:
+        data["others_bboxes"] = json.dumps(detection_data["others_bboxes"])
 
     # Prepare file upload
     files = {"file": (filename, image_file, "image/jpeg")}

--- a/annotation_api/src/app/clients/annotation_api.py
+++ b/annotation_api/src/app/clients/annotation_api.py
@@ -446,6 +446,8 @@ def create_detection_from_url(
         "sequence_id": detection_data["sequence_id"],
         "recorded_at": detection_data["recorded_at"],
     }
+    if detection_data.get("others_bboxes") is not None:
+        json_payload["others_bboxes"] = detection_data["others_bboxes"]
 
     operation = f"create detection from URL with alert_api_id={detection_data.get('alert_api_id', 'unknown')}"
     response = _make_request(
@@ -491,6 +493,8 @@ def create_detection_from_bucket_key(
         "sequence_id": detection_data["sequence_id"],
         "recorded_at": detection_data["recorded_at"],
     }
+    if detection_data.get("others_bboxes") is not None:
+        json_payload["others_bboxes"] = detection_data["others_bboxes"]
 
     operation = (
         f"create detection from bucket key with alert_api_id="

--- a/annotation_api/src/app/models.py
+++ b/annotation_api/src/app/models.py
@@ -2,11 +2,25 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import List, Optional
 
-from sqlalchemy import Column, DateTime, ForeignKey, Index, UniqueConstraint, Enum as SQLEnum
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    UniqueConstraint,
+    Enum as SQLEnum,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
 
-__all__ = ["Detection", "DetectionAnnotation", "Sequence", "SequenceAnnotation", "User", "AnnotationType"]
+__all__ = [
+    "Detection",
+    "DetectionAnnotation",
+    "Sequence",
+    "SequenceAnnotation",
+    "User",
+    "AnnotationType",
+]
 
 # -------------------- ENUMS --------------------
 
@@ -40,12 +54,8 @@ class SequenceAnnotationProcessingStage(str, Enum):
 
     IMPORTED = "imported"  # Initial stage when sequence is imported from source API
     READY_TO_ANNOTATE = "ready_to_annotate"  # Sequence has been processed and is ready for human annotation
-    UNDER_ANNOTATION = (
-        "under_annotation"  # Someone is actively annotating this sequence locally to avoid contention
-    )
-    SEQ_ANNOTATION_DONE = (
-        "seq_annotation_done"  # Sequence annotation finished locally and ready to upload/share
-    )
+    UNDER_ANNOTATION = "under_annotation"  # Someone is actively annotating this sequence locally to avoid contention
+    SEQ_ANNOTATION_DONE = "seq_annotation_done"  # Sequence annotation finished locally and ready to upload/share
     IN_REVIEW = "in_review"  # Human is reviewing/QA the annotation
     NEEDS_MANUAL = (
         "needs_manual"  # Auto/triage flagged the sequence for manual intervention
@@ -125,7 +135,7 @@ class FalsePositiveType(str, Enum):
 class AnnotationType(str, Enum):
     """
     Classification of annotation types from external wildfire detection APIs.
-    
+
     These values correspond to the classification provided by platform APIs
     to indicate the type of detection (wildfire smoke vs other sources).
     Used to maintain the original classification from external systems.
@@ -279,6 +289,10 @@ class Detection(SQLModel, table=True):
     )
     bucket_key: str
     algo_predictions: Optional[dict] = Field(default=None, sa_column=Column(JSONB))
+    # Sibling boxes seen on the same image but not part of the tracked sequence.
+    # Stored read-only for the UI so annotators can spot missed smoke; never fed
+    # into auto-annotation.
+    others_bboxes: Optional[dict] = Field(default=None, sa_column=Column(JSONB))
 
 
 class DetectionAnnotation(SQLModel, table=True):

--- a/annotation_api/src/app/schemas/detection.py
+++ b/annotation_api/src/app/schemas/detection.py
@@ -27,6 +27,7 @@ class DetectionCreate(BaseModel):
     alert_api_id: int
     bucket_key: str
     algo_predictions: AlgoPredictions
+    others_bboxes: Optional[AlgoPredictions] = None
 
 
 class DetectionCreateFromUrl(BaseModel):
@@ -35,6 +36,7 @@ class DetectionCreateFromUrl(BaseModel):
     recorded_at: datetime
     alert_api_id: int
     algo_predictions: AlgoPredictions
+    others_bboxes: Optional[AlgoPredictions] = None
 
 
 class DetectionCreateFromBucketKey(BaseModel):
@@ -45,6 +47,7 @@ class DetectionCreateFromBucketKey(BaseModel):
     recorded_at: datetime
     alert_api_id: int
     algo_predictions: AlgoPredictions
+    others_bboxes: Optional[AlgoPredictions] = None
 
 
 class DetectionRead(BaseModel):
@@ -54,6 +57,7 @@ class DetectionRead(BaseModel):
     alert_api_id: int
     bucket_key: str
     algo_predictions: AlgoPredictions
+    others_bboxes: Optional[AlgoPredictions] = None
     created_at: datetime
 
 

--- a/annotation_api/src/app/schemas/sequence_annotations.py
+++ b/annotation_api/src/app/schemas/sequence_annotations.py
@@ -133,7 +133,7 @@ class SequenceAnnotationUpdate(BaseModel):
     )
     iou_threshold: Optional[float] = Field(
         default=None,
-        description="Minimum IoU for clustering overlapping boxes (0.0-1.0). Used when auto-generating annotations.",
+        description="IoU threshold for clustering overlapping boxes (0.0-1.0). 0.0 means any positive overlap merges. Used when auto-generating annotations.",
         ge=0.0,
         le=1.0,
     )

--- a/annotation_api/src/app/schemas/sequence_annotations.py
+++ b/annotation_api/src/app/schemas/sequence_annotations.py
@@ -78,8 +78,8 @@ class SequenceAnnotationCreate(BaseModel):
         le=1.0,
     )
     iou_threshold: Optional[float] = Field(
-        default=0.3,
-        description="Minimum IoU for clustering overlapping boxes (0.0-1.0). Used when auto-generating annotations.",
+        default=0.0,
+        description="IoU threshold for clustering overlapping boxes (0.0-1.0). 0.0 means any positive overlap merges.",
         ge=0.0,
         le=1.0,
     )

--- a/annotation_api/src/app/services/annotation_generation.py
+++ b/annotation_api/src/app/services/annotation_generation.py
@@ -123,14 +123,15 @@ def cluster_boxes_by_iou(
     """
     Cluster bounding boxes by IoU similarity using greedy clustering.
 
-    This function groups bounding boxes that overlap significantly (IoU >= threshold)
-    into clusters. This is useful for temporal clustering of detections across frames
-    or for grouping multiple detections of the same object.
+    Boxes are grouped together when their IoU is *strictly greater* than
+    `iou_threshold`. Using `>` (rather than `>=`) lets `iou_threshold=0.0`
+    mean "any positive overlap merges" — at `>=` it would collapse every
+    box into one cluster regardless of overlap.
 
     Args:
         boxes_with_ids: List of tuples (bbox_coords, identifier) where bbox_coords
                        is [x1, y1, x2, y2] and identifier can be any type
-        iou_threshold: Minimum IoU for boxes to be considered part of the same cluster
+        iou_threshold: Boxes are clustered together iff their IoU is > this value
 
     Returns:
         List of clusters, where each cluster is a list of (bbox, id) tuples
@@ -141,7 +142,7 @@ def cluster_boxes_by_iou(
         ...     ([0.15, 0.15, 0.35, 0.35], "detection_2"),  # Overlaps with first
         ...     ([0.7, 0.7, 0.9, 0.9], "detection_3")       # Separate
         ... ]
-        >>> clusters = cluster_boxes_by_iou(boxes, iou_threshold=0.3)
+        >>> clusters = cluster_boxes_by_iou(boxes, iou_threshold=0.0)
         >>> len(clusters)  # Returns 2 clusters
         2
     """
@@ -160,7 +161,7 @@ def cluster_boxes_by_iou(
 
             overlaps = False
             for cluster_box, _ in current_cluster:
-                if box_iou(box_to_test, cluster_box) >= iou_threshold:
+                if box_iou(box_to_test, cluster_box) > iou_threshold:
                     overlaps = True
                     break
 
@@ -205,7 +206,7 @@ class AnnotationGenerationService:
         self,
         session: AsyncSession,
         confidence_threshold: float = 0.0,
-        iou_threshold: float = 0.3,
+        iou_threshold: float = 0.0,
         min_cluster_size: int = 1,
     ) -> None:
         """

--- a/annotation_api/src/migrations/versions/2026_05_10_0430-a1b2c3d4e5f6_add_detection_others_bboxes.py
+++ b/annotation_api/src/migrations/versions/2026_05_10_0430-a1b2c3d4e5f6_add_detection_others_bboxes.py
@@ -1,0 +1,34 @@
+"""add detection.others_bboxes
+
+Revision ID: a1b2c3d4e5f6
+Revises: 063dc76c9846
+Create Date: 2026-05-10 04:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "063dc76c9846"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "detections",
+        sa.Column(
+            "others_bboxes",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("detections", "others_bboxes")

--- a/annotation_api/src/tests/endpoints/test_detections.py
+++ b/annotation_api/src/tests/endpoints/test_detections.py
@@ -42,6 +42,55 @@ async def test_create_detection(
 
 
 @pytest.mark.asyncio
+async def test_create_detection_with_others_bboxes(
+    authenticated_client: AsyncClient, sequence_session: AsyncSession, mock_img: bytes
+):
+    """`others_bboxes` is optional sibling-box context for the UI: it must
+    persist alongside `algo_predictions` and round-trip on GET, but it never
+    flows into auto-annotation."""
+    others = {
+        "predictions": [
+            {
+                "xyxyn": [0.5, 0.5, 0.6, 0.6],
+                "confidence": 0.42,
+                "class_name": "smoke",
+            }
+        ]
+    }
+    payload = {
+        "sequence_id": "1",
+        "alert_api_id": "9001",
+        "recorded_at": (now - timedelta(days=2)).isoformat(),
+        "algo_predictions": json.dumps(
+            {
+                "predictions": [
+                    {
+                        "xyxyn": [0.1, 0.1, 0.2, 0.2],
+                        "confidence": 0.95,
+                        "class_name": "smoke",
+                    }
+                ]
+            }
+        ),
+        "others_bboxes": json.dumps(others),
+    }
+
+    response = await authenticated_client.post(
+        "/detections/",
+        data=payload,
+        files={"file": ("image.jpg", mock_img, "image/jpeg")},
+    )
+    assert response.status_code == 201
+    created = response.json()
+    assert created["others_bboxes"] == others
+
+    # Round-trip via GET to confirm DB persistence + serialization.
+    fetched = await authenticated_client.get(f"/detections/{created['id']}")
+    assert fetched.status_code == 200
+    assert fetched.json()["others_bboxes"] == others
+
+
+@pytest.mark.asyncio
 async def test_get_detection(authenticated_client: AsyncClient):
     detection_id = 1
     response = await authenticated_client.get(f"/detections/{detection_id}")

--- a/annotation_api/src/tests/endpoints/test_sequence_annotations_auto_generation.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_annotations_auto_generation.py
@@ -173,7 +173,7 @@ async def test_auto_generation_uses_default_parameters(
         assert (
             call_args[1]["confidence_threshold"] == 0.0
         )  # Default (changed to include all predictions)
-        assert call_args[1]["iou_threshold"] == 0.3  # Default
+        assert call_args[1]["iou_threshold"] == 0.0  # Default
         assert call_args[1]["min_cluster_size"] == 1  # Default
 
 

--- a/annotation_api/src/tests/services/test_annotation_generation.py
+++ b/annotation_api/src/tests/services/test_annotation_generation.py
@@ -490,6 +490,25 @@ class TestUtilityFunctions:
         clusters = cluster_boxes_by_iou([], iou_threshold=0.5)
         assert clusters == []
 
+    def test_cluster_boxes_by_iou_zero_threshold_strict_overlap(self):
+        """At iou_threshold=0.0 the clustering uses `>` (strict positive
+        overlap), so disjoint boxes form separate clusters and only boxes
+        with any IoU > 0 collapse together. Without the strict operator
+        every box would land in the same cluster."""
+        boxes_with_ids = [
+            ([0.1, 0.1, 0.3, 0.3], "a"),
+            ([0.2, 0.2, 0.4, 0.4], "b"),  # overlaps a → same cluster
+            ([0.7, 0.7, 0.9, 0.9], "c"),  # disjoint → its own cluster
+            ([0.75, 0.75, 0.95, 0.95], "d"),  # overlaps c → same cluster
+        ]
+
+        clusters = cluster_boxes_by_iou(boxes_with_ids, iou_threshold=0.0)
+        assert len(clusters) == 2
+
+        cluster_ids = [{item[1] for item in cluster} for cluster in clusters]
+        assert {"a", "b"} in cluster_ids
+        assert {"c", "d"} in cluster_ids
+
 
 class TestAnnotationGenerationServiceConfiguration:
     """Test AnnotationGenerationService configuration and initialization."""

--- a/frontend/src/components/annotation/ImageOverlays.tsx
+++ b/frontend/src/components/annotation/ImageOverlays.tsx
@@ -59,6 +59,60 @@ export function BoundingBoxOverlay({ detection, imageInfo }: BoundingBoxOverlayP
 }
 
 /**
+ * Read-only overlay for sibling bboxes (Detection.others_bboxes): boxes the
+ * detector saw on the same image but that are not part of the tracked
+ * sequence. Rendered as dashed gray to clearly distinguish from primary
+ * predictions and user annotations — annotators use them only as a hint to
+ * spot missed smoke.
+ */
+interface SiblingBoundingBoxOverlayProps {
+  detection: Detection;
+  imageInfo: ImageInfo;
+}
+
+export function SiblingBoundingBoxOverlay({
+  detection,
+  imageInfo,
+}: SiblingBoundingBoxOverlayProps) {
+  const others = detection?.others_bboxes?.predictions;
+  if (!others || others.length === 0) return null;
+
+  return (
+    <>
+      {others
+        .map((prediction: AlgoPrediction, index: number) => {
+          if (!validateBoundingBox(prediction.xyxyn)) {
+            return null;
+          }
+
+          const { left, top, width, height } = normalizedToPixelBox(
+            prediction.xyxyn,
+            imageInfo
+          );
+
+          return (
+            <div
+              key={`sibling-bbox-${detection.id}-${index}`}
+              className="absolute border-2 border-dashed border-gray-400 pointer-events-none opacity-80"
+              style={{
+                left: `${left}px`,
+                top: `${top}px`,
+                width: `${width}px`,
+                height: `${height}px`,
+              }}
+            >
+              <div className="absolute -top-5 left-0 bg-gray-500/90 text-white text-[10px] px-1 rounded whitespace-nowrap">
+                sibling {(prediction.confidence * 100).toFixed(0)}%
+              </div>
+            </div>
+          );
+        })
+        .filter(Boolean)}
+    </>
+  );
+}
+
+/**
  * Component for rendering user annotation bounding boxes on detection images.
  * Shows smoke type classifications with appropriate colors and labels.
  */

--- a/frontend/src/components/annotation/ImageOverlays.tsx
+++ b/frontend/src/components/annotation/ImageOverlays.tsx
@@ -85,10 +85,7 @@ export function SiblingBoundingBoxOverlay({
             return null;
           }
 
-          const { left, top, width, height } = normalizedToPixelBox(
-            prediction.xyxyn,
-            imageInfo
-          );
+          const { left, top, width, height } = normalizedToPixelBox(prediction.xyxyn, imageInfo);
 
           return (
             <div

--- a/frontend/src/components/detection-annotation/DetectionAnnotationCanvas.tsx
+++ b/frontend/src/components/detection-annotation/DetectionAnnotationCanvas.tsx
@@ -7,7 +7,11 @@
 import { Detection } from '@/types/api';
 import { useDetectionImage } from '@/hooks/useDetectionImage';
 import { DrawnRectangle, CurrentDrawing, Point } from '@/utils/annotation';
-import { BoundingBoxOverlay, DrawingOverlay } from '@/components/annotation/ImageOverlays';
+import {
+  BoundingBoxOverlay,
+  DrawingOverlay,
+  SiblingBoundingBoxOverlay,
+} from '@/components/annotation/ImageOverlays';
 
 interface ImageInfo {
   width: number;
@@ -21,6 +25,7 @@ interface DetectionAnnotationCanvasProps {
   drawnRectangles: DrawnRectangle[];
   selectedRectangleId: string | null;
   showPredictions: boolean;
+  showSiblingBboxes?: boolean;
   currentDrawing: CurrentDrawing | null;
   // Image and container refs passed from parent
   containerRef: React.RefObject<HTMLDivElement>;
@@ -47,6 +52,7 @@ export function DetectionAnnotationCanvas({
   drawnRectangles,
   selectedRectangleId,
   showPredictions,
+  showSiblingBboxes = true,
   currentDrawing,
   containerRef,
   imgRef,
@@ -103,6 +109,9 @@ export function DetectionAnnotationCanvas({
       >
         {showPredictions && imageInfo && (
           <BoundingBoxOverlay detection={detection} imageInfo={imageInfo} />
+        )}
+        {showSiblingBboxes && imageInfo && (
+          <SiblingBoundingBoxOverlay detection={detection} imageInfo={imageInfo} />
         )}
       </div>
 

--- a/frontend/src/components/detection-annotation/DetectionAnnotationCanvas.tsx
+++ b/frontend/src/components/detection-annotation/DetectionAnnotationCanvas.tsx
@@ -110,7 +110,7 @@ export function DetectionAnnotationCanvas({
         {showPredictions && imageInfo && (
           <BoundingBoxOverlay detection={detection} imageInfo={imageInfo} />
         )}
-        {showSiblingBboxes && imageInfo && (
+        {showPredictions && showSiblingBboxes && imageInfo && (
           <SiblingBoundingBoxOverlay detection={detection} imageInfo={imageInfo} />
         )}
       </div>

--- a/frontend/src/components/detection-annotation/DetectionImageCard.tsx
+++ b/frontend/src/components/detection-annotation/DetectionImageCard.tsx
@@ -125,8 +125,10 @@ export function DetectionImageCard({
           <BoundingBoxOverlay detection={detection} imageInfo={imageInfo} />
         )}
 
-        {/* Sibling bboxes overlay (read-only hint for missed smoke) */}
-        {showSiblingBboxes && imageInfo && (
+        {/* Sibling bboxes overlay (read-only hint for missed smoke) —
+            gated on showPredictions so toggling predictions off hides
+            everything algorithmic at once. */}
+        {showPredictions && showSiblingBboxes && imageInfo && (
           <SiblingBoundingBoxOverlay detection={detection} imageInfo={imageInfo} />
         )}
 

--- a/frontend/src/components/detection-annotation/DetectionImageCard.tsx
+++ b/frontend/src/components/detection-annotation/DetectionImageCard.tsx
@@ -7,13 +7,18 @@ import { useState, useRef } from 'react';
 import { CheckCircle, AlertCircle, Clock } from 'lucide-react';
 import { Detection, DetectionAnnotation } from '@/types/api';
 import { useDetectionImage } from '@/hooks/useDetectionImage';
-import { BoundingBoxOverlay, UserAnnotationOverlay } from '@/components/annotation/ImageOverlays';
+import {
+  BoundingBoxOverlay,
+  SiblingBoundingBoxOverlay,
+  UserAnnotationOverlay,
+} from '@/components/annotation/ImageOverlays';
 
 interface DetectionImageCardProps {
   detection: Detection;
   onClick: () => void;
   isAnnotated?: boolean;
   showPredictions?: boolean;
+  showSiblingBboxes?: boolean;
   userAnnotation?: DetectionAnnotation | null;
 }
 
@@ -29,6 +34,7 @@ export function DetectionImageCard({
   onClick,
   isAnnotated = false,
   showPredictions = false,
+  showSiblingBboxes = true,
   userAnnotation = null,
 }: DetectionImageCardProps) {
   const { data: imageData, isLoading } = useDetectionImage(detection.id);
@@ -117,6 +123,11 @@ export function DetectionImageCard({
         {/* AI Predictions Overlay */}
         {showPredictions && detection.algo_predictions?.predictions && imageInfo && (
           <BoundingBoxOverlay detection={detection} imageInfo={imageInfo} />
+        )}
+
+        {/* Sibling bboxes overlay (read-only hint for missed smoke) */}
+        {showSiblingBboxes && imageInfo && (
+          <SiblingBoundingBoxOverlay detection={detection} imageInfo={imageInfo} />
         )}
 
         {/* User Annotations Overlay */}

--- a/frontend/src/components/sequence/SequencePlayer.tsx
+++ b/frontend/src/components/sequence/SequencePlayer.tsx
@@ -58,6 +58,9 @@ export default function SequencePlayer({
     offsetY: number;
   } | null>(null);
   const [showInstructionsModal, setShowInstructionsModal] = useState(false);
+  // Sibling boxes (Detection.others_bboxes) help spot missed smoke; ON by
+  // default but can be hidden if they clutter the frame.
+  const [showSiblingBboxes, setShowSiblingBboxes] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
 
@@ -260,6 +263,43 @@ export default function SequencePlayer({
       .filter(Boolean); // Remove null entries from invalid boxes
   };
 
+  // Render sibling bbox overlay (Detection.others_bboxes — read-only hint
+  // for missed smoke). Dashed gray to clearly distinguish from primary
+  // predictions.
+  const renderSiblingBoxes = () => {
+    const siblings = currentDetection?.others_bboxes?.predictions;
+    if (!imageInfo || !siblings || siblings.length === 0) return null;
+
+    return siblings
+      .map((prediction: AlgoPrediction, index: number) => {
+        const [x1, y1, x2, y2] = prediction.xyxyn;
+        if (x2 <= x1 || y2 <= y1) return null;
+
+        const left = imageInfo.offsetX + x1 * imageInfo.width;
+        const top = imageInfo.offsetY + y1 * imageInfo.height;
+        const width = (x2 - x1) * imageInfo.width;
+        const height = (y2 - y1) * imageInfo.height;
+
+        return (
+          <div
+            key={`sibling-${currentDetection.id}-${index}`}
+            className="absolute border-2 border-dashed border-gray-300 pointer-events-none opacity-80"
+            style={{
+              left: `${left}px`,
+              top: `${top}px`,
+              width: `${width}px`,
+              height: `${height}px`,
+            }}
+          >
+            <div className="absolute -top-5 left-0 bg-gray-500/90 text-white text-[10px] px-1 rounded whitespace-nowrap">
+              sibling {(prediction.confidence * 100).toFixed(0)}%
+            </div>
+          </div>
+        );
+      })
+      .filter(Boolean);
+  };
+
   // Only show loading spinner when image isn't loaded
   const showLoadingState = !currentImage?.loaded;
   const hasError = currentImage?.error;
@@ -357,6 +397,7 @@ export default function SequencePlayer({
             {imageInfo && !showLoadingState && (
               <div className="absolute inset-0 pointer-events-none z-20">
                 {renderBoundingBoxes()}
+                {showSiblingBboxes && renderSiblingBoxes()}
               </div>
             )}
           </>
@@ -417,13 +458,29 @@ export default function SequencePlayer({
                 </button>
               </div>
 
-              {/* Right - Predictions */}
-              <div className="flex-1 flex items-center justify-end space-x-2">
-                <Eye className="w-4 h-4" />
-                <span className="text-xs">
-                  {currentDetection.algo_predictions?.predictions?.length || 0} prediction
-                  {currentDetection.algo_predictions?.predictions?.length !== 1 ? 's' : ''}
-                </span>
+              {/* Right - Predictions + sibling toggle */}
+              <div className="flex-1 flex items-center justify-end space-x-3">
+                <div className="flex items-center space-x-2">
+                  <Eye className="w-4 h-4" />
+                  <span className="text-xs">
+                    {currentDetection.algo_predictions?.predictions?.length || 0} prediction
+                    {currentDetection.algo_predictions?.predictions?.length !== 1 ? 's' : ''}
+                  </span>
+                </div>
+                {(currentDetection.others_bboxes?.predictions?.length || 0) > 0 && (
+                  <label className="flex items-center cursor-pointer hover:bg-white/10 px-2 py-1 rounded transition-colors">
+                    <input
+                      type="checkbox"
+                      checked={showSiblingBboxes}
+                      onChange={e => setShowSiblingBboxes(e.target.checked)}
+                      className="w-3.5 h-3.5 mr-2 accent-gray-300"
+                    />
+                    <span className="text-xs">
+                      {currentDetection.others_bboxes?.predictions?.length} sibling
+                      {(currentDetection.others_bboxes?.predictions?.length || 0) > 1 ? 's' : ''}
+                    </span>
+                  </label>
+                )}
               </div>
             </div>
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -30,6 +30,10 @@ export interface Detection {
   created_at: string;
   recorded_at: string;
   algo_predictions: AlgoPredictions;
+  // Sibling boxes detected on the same image but not part of the tracked
+  // sequence. Read-only — annotators see them as a hint for missed smoke,
+  // and they are NOT fed into auto-annotation. Null on legacy detections.
+  others_bboxes?: AlgoPredictions | null;
   last_modified_at: string | null;
   confidence?: number;
 }


### PR DESCRIPTION
## Why
- The platform's `others_bboxes` (sibling boxes seen on the same image but
  outside the tracked sequence) was being concatenated into `bbox` and fed
  to auto-annotation, polluting AI-generated `sequences_bbox`.
- The auto-annotation IoU threshold of `0.3` silently dropped weakly-overlapping
  detections; visual review of recent sdis-40 data shows we want any positive
  overlap to merge.

## What changes
- New nullable `Detection.others_bboxes` JSONB column + Alembic migration.
  The platform import now routes `bbox` to `algo_predictions` (drives
  auto-annotation as before) and `others_bboxes` to the new column. Auto-
  annotation only ever reads `algo_predictions`.
- Default IoU clustering threshold dropped from `0.3` to `0.0` across the
  service, both endpoint payload schemas, the import CLI, and the
  annotation-management script. The clustering operator is also switched
  from `>=` to `>` so that "any positive overlap merges" works as intended
  at threshold `0.0` (otherwise every box would collapse into one cluster).
- Frontend renders `others_bboxes` as a read-only dashed-gray overlay
  (toggle ON by default in `SequencePlayer`, gated on `showPredictions` in
  the detection grid). Annotators can still spot missed smoke without those
  boxes leaking into the saved annotation.

## Out of scope
- `parse_platform_bboxes` was using `eval()`; switched to `ast.literal_eval`
  while we were touching the file. Broader audit of the script's untrusted
  input handling can be a separate PR.
- `SequencePlayer` keeps inline overlay rendering instead of reusing the
  shared overlay component (matches the existing `renderBoundingBoxes`
  pattern; both can be refactored together later).