### PR TITLE
feat(scripts): add --force-url to platform import

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/platform/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import.py
@@ -232,7 +232,7 @@ def make_cli_parser() -> argparse.ArgumentParser:
         help="Preview actions without executing them",
     )
     parser.add_argument(
-        "--prefer-url",
+        "--force-url",
         action="store_true",
         help=(
             "Skip the server-side bucket-key copy and post detections via "
@@ -906,7 +906,7 @@ def main() -> None:
                     max_detection_workers=worker_config.detection_per_sequence,
                     suppress_logs=suppress_logs,
                     source_api=source_api,
-                    prefer_url=args.prefer_url,
+                    force_url=args.force_url,
                 )
 
                 # Capture import statistics in main stats and get successfully imported sequence IDs

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import.py
@@ -231,6 +231,15 @@ def make_cli_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Preview actions without executing them",
     )
+    parser.add_argument(
+        "--prefer-url",
+        action="store_true",
+        help=(
+            "Skip the server-side bucket-key copy and post detections via "
+            "the /from-url endpoint instead. Useful for local dev where the "
+            "annotation API can't see the platform's S3 bucket (e.g. LocalStack)."
+        ),
+    )
 
     # Concurrency control
     parser.add_argument(
@@ -897,6 +906,7 @@ def main() -> None:
                     max_detection_workers=worker_config.detection_per_sequence,
                     suppress_logs=suppress_logs,
                     source_api=source_api,
+                    prefer_url=args.prefer_url,
                 )
 
                 # Capture import statistics in main stats and get successfully imported sequence IDs

--- a/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
@@ -317,7 +317,7 @@ def _process_single_detection(
     annotation_sequence_id: int,
     max_retries: int = 3,
     base_delay: float = 5.0,
-    prefer_url: bool = False,
+    force_url: bool = False,
 ) -> Dict[str, Any]:
     """
     Process a single detection: download image and create detection in API.
@@ -347,9 +347,9 @@ def _process_single_detection(
     # Only platform-fetch records carry a platform bucket_key. Clone-from-
     # annotation records intentionally omit detection_bucket_key because their
     # key lives in the source annotation bucket, not the platform bucket.
-    # `prefer_url` forces the URL fallback even when bucket_key is set — useful
+    # `force_url` forces the URL fallback even when bucket_key is set — useful
     # for local dev where the API can't reach the platform's S3 bucket.
-    source_key = None if prefer_url else record.get("detection_bucket_key")
+    source_key = None if force_url else record.get("detection_bucket_key")
     source_url = record.get("detection_url")
 
     for attempt in range(max_retries + 1):
@@ -422,7 +422,7 @@ def post_sequence_to_annotation_api(
     auth_token: str,
     max_detection_workers: int = 4,
     source_api: str = "pyronear_french",
-    prefer_url: bool = False,
+    force_url: bool = False,
 ) -> Dict:
     """
     Post a sequence and its detections to the annotation API.
@@ -478,7 +478,7 @@ def post_sequence_to_annotation_api(
             annotation_api_url,
             auth_token,
             annotation_sequence_id,
-            prefer_url=prefer_url,
+            force_url=force_url,
         )
         if result["success"]:
             successful_detections = 1
@@ -497,7 +497,7 @@ def post_sequence_to_annotation_api(
                     annotation_api_url,
                     auth_token,
                     annotation_sequence_id,
-                    prefer_url=prefer_url,
+                    force_url=force_url,
                 ): record
                 for record in sequence_records
             }
@@ -534,7 +534,7 @@ def post_records_to_annotation_api(
     max_detection_workers: int = 4,
     suppress_logs: bool = True,
     source_api: str = "pyronear_french",
-    prefer_url: bool = False,
+    force_url: bool = False,
 ) -> Dict:
     """
     Post multiple sequences and their detections to the annotation API.
@@ -588,9 +588,9 @@ def post_records_to_annotation_api(
                 annotation_api_url,
                 sequence_records,
                 auth_token,
-                max_detection_workers,
-                source_api,
-                prefer_url,
+                max_detection_workers=max_detection_workers,
+                source_api=source_api,
+                force_url=force_url,
             ): (platform_sequence_id, sequence_records)
             for platform_sequence_id, sequence_records in grouped_records.items()
         }

--- a/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
@@ -317,6 +317,7 @@ def _process_single_detection(
     annotation_sequence_id: int,
     max_retries: int = 3,
     base_delay: float = 5.0,
+    prefer_url: bool = False,
 ) -> Dict[str, Any]:
     """
     Process a single detection: download image and create detection in API.
@@ -346,7 +347,9 @@ def _process_single_detection(
     # Only platform-fetch records carry a platform bucket_key. Clone-from-
     # annotation records intentionally omit detection_bucket_key because their
     # key lives in the source annotation bucket, not the platform bucket.
-    source_key = record.get("detection_bucket_key")
+    # `prefer_url` forces the URL fallback even when bucket_key is set — useful
+    # for local dev where the API can't reach the platform's S3 bucket.
+    source_key = None if prefer_url else record.get("detection_bucket_key")
     source_url = record.get("detection_url")
 
     for attempt in range(max_retries + 1):
@@ -419,6 +422,7 @@ def post_sequence_to_annotation_api(
     auth_token: str,
     max_detection_workers: int = 4,
     source_api: str = "pyronear_french",
+    prefer_url: bool = False,
 ) -> Dict:
     """
     Post a sequence and its detections to the annotation API.
@@ -470,7 +474,11 @@ def post_sequence_to_annotation_api(
     if len(sequence_records) == 1:
         # Single detection - process directly to avoid thread overhead
         result = _process_single_detection(
-            sequence_records[0], annotation_api_url, auth_token, annotation_sequence_id
+            sequence_records[0],
+            annotation_api_url,
+            auth_token,
+            annotation_sequence_id,
+            prefer_url=prefer_url,
         )
         if result["success"]:
             successful_detections = 1
@@ -489,6 +497,7 @@ def post_sequence_to_annotation_api(
                     annotation_api_url,
                     auth_token,
                     annotation_sequence_id,
+                    prefer_url=prefer_url,
                 ): record
                 for record in sequence_records
             }
@@ -525,6 +534,7 @@ def post_records_to_annotation_api(
     max_detection_workers: int = 4,
     suppress_logs: bool = True,
     source_api: str = "pyronear_french",
+    prefer_url: bool = False,
 ) -> Dict:
     """
     Post multiple sequences and their detections to the annotation API.
@@ -580,6 +590,7 @@ def post_records_to_annotation_api(
                 auth_token,
                 max_detection_workers,
                 source_api,
+                prefer_url,
             ): (platform_sequence_id, sequence_records)
             for platform_sequence_id, sequence_records in grouped_records.items()
         }


### PR DESCRIPTION
## Why
The platform import normally hands detections off via `/from-bucket-key`,
which has the API server do a same-region S3 copy from the platform's
bucket. That path can't work against a local stack where the API only
sees LocalStack — every detection fails with "Source object not found".

## What changes
- New `--force-url` flag on the import script. When set, the bucket-key
  branch is skipped and detections go through `/from-url` instead, which
  makes the API download the image over HTTPS and re-upload it to its own
  bucket. Slower but works anywhere the platform's presigned URLs resolve.
- Plumbed through `post_records_to_annotation_api` ->
  `post_sequence_to_annotation_api` -> `_process_single_detection`.

## Out of scope
- Codex flagged that `/from-url` does no host allowlist / size limit on
  the user-provided URL. That's a pre-existing SSRF/DoS concern unrelated
  to this flag (the same surface exists today for clone-from-annotation
  records that already only carry a URL). Worth its own hardening PR.