### PR TITLE
feat(platform): predictor-driven, object-split platform import

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,43 @@ make import-platform DATE_FROM=2025-03-04 DATE_END=2025-03-04 MAX_SEQUENCES=10
 - To use an alert-id filter, call the underlying script directly with `--sequence-list alerts_id_list.txt`.
 - Use `LOGLEVEL=debug` if you need more detail during imports.
 
+### Predictor-split import (one annotation sequence per detected object)
+
+`import_predictor_split` runs the pyro-engine predictor over each sequence and
+splits it into **one annotation sequence per detected smoke plume** (porting
+pyro-api's bbox-overlap association). Detections carry the predictor's boxes as
+`algo_predictions`, plus the other objects' boxes on the same frame as
+`others_bboxes` (read-only context for judging missed smoke). The date range is
+walked **one day at a time** (inclusive of both ends) and is **resumable**:
+already-imported objects are skipped, so re-running the same command continues
+where it left off.
+
+Requires the sister repos (set in `annotation_api/.env` or pass as flags):
+
+```
+PYRO_DATASET_DIR=/path/to/pyro-dataset
+PYRO_ENGINE_DIR=/path/to/pyro-engine
+```
+
+```bash
+cd annotation_api
+# Long unattended run (detached) — full date range, day by day:
+nohup uv run python -m scripts.data_transfer.ingestion.platform.import_predictor_split \
+  --date-from 2025-07-01 --date-end 2026-06-01 \
+  --url-api-annotation https://annotationapi.pyronear.org \
+  --pyro-dataset-dir "$PYRO_DATASET_DIR" --pyro-engine-dir "$PYRO_ENGINE_DIR" \
+  --loglevel info > /tmp/predsplit.log 2>&1 &
+
+# Or via Make (reads PYRO_DATASET_DIR / PYRO_ENGINE_DIR from the environment):
+make import-platform-predictor-split DATE_FROM=2025-07-01 DATE_END=2026-06-01
+```
+
+- `--max-workers N` — concurrent detection uploads per object (default 8; the upload is the throughput bottleneck).
+- `--max-sequences N` — cap on new platform sequences imported across the run (0 = all).
+- `--reset` — delete previously-imported synthetic sequences before importing (clean re-run).
+- `--dry-run` — fetch + predict + cluster without POSTing.
+- The target org is selected by the `PLATFORM_LOGIN` account in `.env` (there is no org flag). The run is robust to transient API/network errors (per-request timeout + retry) and skips+logs a failing day rather than aborting (non-zero exit lists skipped days).
+
 ### Prerequisites
 
 **Services must be running first:**

--- a/annotation_api/Makefile
+++ b/annotation_api/Makefile
@@ -347,6 +347,20 @@ import-platform-filtered:
 		--max-workers $(MAX_WORKERS) \
 		--loglevel $(LOGLEVEL)
 
+# Predictor-split import: fetch 30 images/sequence, run the pyro-engine predictor,
+# split each platform sequence into one annotation sequence per detected object
+# (pyro-api logic) and POST predictor-derived detections.
+# Requires env vars PYRO_DATASET_DIR and PYRO_ENGINE_DIR.
+import-platform-predictor-split:
+	@if [ -z "$(DATE_FROM)" ]; then \
+		echo "ERROR: set DATE_FROM=YYYY-MM-DD (and optionally DATE_END)"; exit 1; \
+	fi
+	uv run python -m scripts.data_transfer.ingestion.platform.import_predictor_split \
+		--date-from $(DATE_FROM) --date-end $(DATE_END) \
+		--url-api-annotation $(REMOTE_API) \
+		--max-sequences $(MAX_SEQUENCES) \
+		--loglevel $(LOGLEVEL)
+
 .PHONY: help lint fix docker-build start stop clean test test-specific \
 	migrate migrate-up \
 	pull-sequences push-annotations \
@@ -354,4 +368,4 @@ import-platform-filtered:
 	pull-fp visual-check-fp apply-review-fp \
 	export-dataset import-yolo-sequence import-local-yolo \
 	update-stage-remote update-stage-local \
-	import-platform import-platform-filtered assign-groups
+	import-platform import-platform-filtered import-platform-predictor-split assign-groups

--- a/annotation_api/Makefile
+++ b/annotation_api/Makefile
@@ -359,6 +359,7 @@ import-platform-predictor-split:
 		--date-from $(DATE_FROM) --date-end $(DATE_END) \
 		--url-api-annotation $(REMOTE_API) \
 		--max-sequences $(MAX_SEQUENCES) \
+		--max-workers $(MAX_WORKERS) \
 		--loglevel $(LOGLEVEL)
 
 .PHONY: help lint fix docker-build start stop clean test test-specific \

--- a/annotation_api/Makefile
+++ b/annotation_api/Makefile
@@ -332,6 +332,21 @@ import-platform:
 		--max-workers $(MAX_WORKERS) \
 		--loglevel $(LOGLEVEL)
 
+# Filtered import: registry dedup + pyro-engine Predictor filter, then import 30
+# detections per kept sequence into the annotation API.
+# Requires env vars PYRO_DATASET_DIR and PYRO_ENGINE_DIR (point to the local
+# checkouts of pyro-dataset and pyro-engine respectively).
+import-platform-filtered:
+	@if [ -z "$(DATE_FROM)" ]; then \
+		echo "ERROR: set DATE_FROM=YYYY-MM-DD (and optionally DATE_END)"; exit 1; \
+	fi
+	uv run python -m scripts.data_transfer.ingestion.platform.import_filtered \
+		--date-from $(DATE_FROM) --date-end $(DATE_END) \
+		--url-api-annotation $(REMOTE_API) \
+		--max-sequences $(MAX_SEQUENCES) \
+		--max-workers $(MAX_WORKERS) \
+		--loglevel $(LOGLEVEL)
+
 .PHONY: help lint fix docker-build start stop clean test test-specific \
 	migrate migrate-up \
 	pull-sequences push-annotations \
@@ -339,4 +354,4 @@ import-platform:
 	pull-fp visual-check-fp apply-review-fp \
 	export-dataset import-yolo-sequence import-local-yolo \
 	update-stage-remote update-stage-local \
-	import-platform assign-groups
+	import-platform import-platform-filtered assign-groups

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import_filtered.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import_filtered.py
@@ -171,6 +171,16 @@ def make_cli_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--skip-group-assignment",
+        action="store_true",
+        help=(
+            "Skip the final assign_groups step. By default the orchestrator "
+            "calls POST /sequence_groups/assign after a successful import so "
+            "the freshly-imported sequences are placed in groups (the import "
+            "step itself does not touch groups)."
+        ),
+    )
+    parser.add_argument(
         "--loglevel",
         default="info",
         help="Logging level (default: info).",
@@ -310,6 +320,33 @@ def collect_kept_alert_ids(temp_dir: Path) -> List[int]:
     return kept
 
 
+def step_assign_groups(args: argparse.Namespace) -> None:
+    """Step 5: trigger POST /sequence_groups/assign on the annotation API.
+
+    `import.py` writes sequences + detections + annotations but does NOT
+    populate sequence groups; without this call the freshly-imported
+    sequences land in the API with no group set, which downstream UIs
+    surface as "no group". `assign_groups.py` is the documented post-import
+    step that fills that gap.
+    """
+    if args.skip_group_assignment:
+        logging.info("--skip-group-assignment: not invoking assign_groups")
+        return
+    annotation_api_dir = Path(__file__).resolve().parents[4]
+    cmd: list = [
+        "uv",
+        "run",
+        "python",
+        "-m",
+        "scripts.data_transfer.ingestion.platform.assign_groups",
+        "--url-api-annotation",
+        args.url_api_annotation,
+        "--loglevel",
+        args.loglevel,
+    ]
+    _run(cmd, label="assign-groups", cwd=annotation_api_dir)
+
+
 def step_push_to_annotation_api(
     args: argparse.Namespace, kept_ids: List[int]
 ) -> None:
@@ -413,6 +450,8 @@ def main() -> int:
         kept_ids = collect_kept_alert_ids(temp_dir)
         logging.info(f"Predictor kept {len(kept_ids)} sequence(s)")
         step_push_to_annotation_api(args, kept_ids)
+        if kept_ids and not args.dry_run:
+            step_assign_groups(args)
         success = True
         return 0
     finally:

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import_filtered.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import_filtered.py
@@ -161,6 +161,16 @@ def make_cli_parser() -> argparse.ArgumentParser:
         help="Forward --dry-run to the import step (no actual POSTs).",
     )
     parser.add_argument(
+        "--force-url",
+        action="store_true",
+        help=(
+            "Forward --force-url to import.py: post detection images via the "
+            "/from-url endpoint instead of the server-side bucket-key copy. "
+            "Required for local dev where the annotation API cannot see the "
+            "platform's S3 bucket (e.g. against LocalStack)."
+        ),
+    )
+    parser.add_argument(
         "--loglevel",
         default="info",
         help="Logging level (default: info).",
@@ -340,13 +350,18 @@ def step_push_to_annotation_api(
             str(args.detections_limit),
             "--max-workers",
             str(args.max_workers),
+            # Always pass --max-sequences so the orchestrator's default (0 =
+            # "all kept", per its own help text) wins over import.py's own
+            # default of 10, which would silently truncate the kept list.
+            "--max-sequences",
+            str(args.max_sequences),
             "--loglevel",
             args.loglevel,
         ]
-        if args.max_sequences > 0:
-            cmd += ["--max-sequences", str(args.max_sequences)]
         if args.dry_run:
             cmd.append("--dry-run")
+        if args.force_url:
+            cmd.append("--force-url")
         _run(cmd, label="import-api", cwd=annotation_api_dir)
     finally:
         list_file.unlink(missing_ok=True)

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import_filtered.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import_filtered.py
@@ -1,0 +1,365 @@
+"""
+Orchestrator: filter + import platform sequences via the pyro-engine predictor.
+
+Pipeline (per date range):
+  1. Light fetch: shell out to pyro-dataset's `fetch_all_platform_sequences.py`
+     with `--detections-limit 10` into a temp directory, skipping sequences
+     already known to the local wildfire/fp registries.
+  2. Predictor filter: shell out to pyro-dataset's
+     `predict_and_filter_sequences.py` (via pyro-engine's venv, which carries
+     the heavy `pyro_predictor` / `ncnn` / `onnxruntime` deps). Dropped
+     sequences are moved into `<temp>/dropped/`.
+  3. Collect the `alert_api_id`s of the kept sequences from
+     `<temp>/predictions.csv`.
+  4. Heavy import: invoke the standard `import.py` with
+     `--sequence-list <kept-ids> --detections-limit 30`, which re-fetches a
+     30-image payload per kept sequence and POSTs it to the annotation API
+     (which handles its own dedup, image upload, and auto-generation of
+     sequence annotations).
+  5. On success, delete the temp directory. On failure or with
+     `--keep-temp`, leave it for inspection.
+
+Sister-repo paths (`pyro-dataset`, `pyro-engine`) come from env vars
+`PYRO_DATASET_DIR` / `PYRO_ENGINE_DIR` (overridable via CLI flags).
+
+Usage:
+  uv run python -m scripts.data_transfer.ingestion.platform.import_filtered \\
+    --date-from 2025-03-04 --date-end 2025-03-04 \\
+    --url-api-annotation http://localhost:5050 \\
+    --max-sequences 10
+
+Or via the Makefile:
+  make import-platform-filtered DATE_FROM=2025-03-04 DATE_END=2025-03-04 MAX_SEQUENCES=10
+"""
+
+import argparse
+import csv
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+
+def _path_from_env(env_name: str) -> Optional[Path]:
+    value = os.getenv(env_name)
+    return Path(value).expanduser() if value else None
+
+
+def valid_date(s: str) -> str:
+    """Argparse type: validate YYYY-MM-DD format, return the original string."""
+    try:
+        datetime.strptime(s, "%Y-%m-%d")
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"not a valid date: {s!r} (expected YYYY-MM-DD)"
+        ) from exc
+    return s
+
+
+def make_cli_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--date-from",
+        type=valid_date,
+        required=True,
+        help="Start date (YYYY-MM-DD, inclusive).",
+    )
+    parser.add_argument(
+        "--date-end",
+        type=valid_date,
+        default=None,
+        help="End date (YYYY-MM-DD, exclusive in fetch step). Defaults to today.",
+    )
+    parser.add_argument(
+        "--max-sequences",
+        type=int,
+        default=0,
+        help="Cap the number of kept sequences pushed to the annotation API (0 = no cap).",
+    )
+
+    # Predictor parameters
+    parser.add_argument(
+        "--predictor-n-consecutive",
+        type=int,
+        default=6,
+        help="Sliding-window size passed to the Predictor (default: 6).",
+    )
+    parser.add_argument(
+        "--predictor-conf-threshold",
+        type=float,
+        default=0.1,
+        help="Confidence threshold for the Predictor (default: 0.1).",
+    )
+    parser.add_argument(
+        "--predictor-detections-limit",
+        type=int,
+        default=10,
+        help="Number of images per sequence fetched for the predictor pass (default: 10).",
+    )
+
+    # Annotation API import parameters (forwarded to import.py)
+    parser.add_argument(
+        "--detections-limit",
+        type=int,
+        default=30,
+        help="Detections per sequence sent to the annotation API for kept sequences (default: 30).",
+    )
+    parser.add_argument(
+        "--url-api-annotation",
+        type=str,
+        default="http://localhost:5050",
+        help="Annotation API URL.",
+    )
+    parser.add_argument(
+        "--url-api-platform",
+        type=str,
+        default="https://alertapi.pyronear.org",
+        help="Platform API URL.",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=4,
+        help="Max workers forwarded to import.py (default: 4).",
+    )
+
+    # Sister-repo paths
+    parser.add_argument(
+        "--pyro-dataset-dir",
+        type=Path,
+        default=_path_from_env("PYRO_DATASET_DIR"),
+        help="Path to the pyro-dataset repo (or set PYRO_DATASET_DIR).",
+    )
+    parser.add_argument(
+        "--pyro-engine-dir",
+        type=Path,
+        default=_path_from_env("PYRO_ENGINE_DIR"),
+        help="Path to the pyro-engine repo (or set PYRO_ENGINE_DIR).",
+    )
+
+    parser.add_argument(
+        "--keep-temp",
+        action="store_true",
+        help="Do not delete the temp directory on success (debugging).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Forward --dry-run to the import step (no actual POSTs).",
+    )
+    parser.add_argument(
+        "--loglevel",
+        default="info",
+        help="Logging level (default: info).",
+    )
+    return parser
+
+
+def _validate_paths(args: argparse.Namespace) -> None:
+    if args.pyro_dataset_dir is None:
+        raise SystemExit(
+            "PYRO_DATASET_DIR is not set and --pyro-dataset-dir was not provided"
+        )
+    if args.pyro_engine_dir is None:
+        raise SystemExit(
+            "PYRO_ENGINE_DIR is not set and --pyro-engine-dir was not provided"
+        )
+    fetch_script = (
+        args.pyro_dataset_dir
+        / "scripts/platform_train_loop/fetch_all_platform_sequences.py"
+    )
+    predict_script = (
+        args.pyro_dataset_dir
+        / "scripts/platform_train_loop/predict_and_filter_sequences.py"
+    )
+    pyro_dataset_python = args.pyro_dataset_dir / ".venv/bin/python"
+    pyro_engine_python = args.pyro_engine_dir / ".venv/bin/python"
+    pyro_predictor_src = args.pyro_engine_dir / "pyro-predictor"
+    for path in (
+        fetch_script,
+        predict_script,
+        pyro_dataset_python,
+        pyro_engine_python,
+        pyro_predictor_src,
+    ):
+        if not path.exists():
+            raise SystemExit(f"Expected path does not exist: {path}")
+
+
+def _run(cmd: list, label: str, cwd: Optional[Path] = None,
+         env: Optional[dict] = None) -> None:
+    logging.info(f"[{label}] {' '.join(str(c) for c in cmd)}")
+    result = subprocess.run(cmd, cwd=cwd, env=env)
+    if result.returncode != 0:
+        raise RuntimeError(f"[{label}] exited with code {result.returncode}")
+
+
+def step_fetch_light(args: argparse.Namespace, temp_dir: Path) -> None:
+    """Step 1: download the predictor-only payload via fetch_all_platform_sequences.py.
+
+    The pyro-dataset fetch script reads `PLATFORM_API_ENDPOINT` and the four
+    PLATFORM_*_LOGIN/PASSWORD vars from os.environ (it does not load a .env
+    on its own). We inject PLATFORM_API_ENDPOINT from --url-api-platform so
+    the orchestrator's single CLI flag wins over any divergent .env value.
+    """
+    script = (
+        args.pyro_dataset_dir
+        / "scripts/platform_train_loop/fetch_all_platform_sequences.py"
+    )
+    python = args.pyro_dataset_dir / ".venv/bin/python"
+    env = {**os.environ, "PLATFORM_API_ENDPOINT": args.url_api_platform}
+    cmd: list = [
+        str(python),
+        str(script),
+        "--date-from",
+        args.date_from,
+        "--date-end",
+        args.date_end,
+        "--save-dir",
+        str(temp_dir),
+        "--detections-limit",
+        str(args.predictor_detections_limit),
+        "--loglevel",
+        args.loglevel,
+    ]
+    _run(cmd, label="fetch", cwd=args.pyro_dataset_dir, env=env)
+
+
+def step_predict(args: argparse.Namespace, temp_dir: Path) -> None:
+    """Step 2: run the predictor + move dropped folders, via pyro-engine's venv."""
+    script = (
+        args.pyro_dataset_dir
+        / "scripts/platform_train_loop/predict_and_filter_sequences.py"
+    )
+    python = args.pyro_engine_dir / ".venv/bin/python"
+    pythonpath = str(args.pyro_engine_dir / "pyro-predictor")
+    env = {**os.environ, "PYTHONPATH": pythonpath}
+    cmd: list = [
+        str(python),
+        str(script),
+        "--save-dir",
+        str(temp_dir),
+        "--n-consecutive",
+        str(args.predictor_n_consecutive),
+        "--conf-threshold",
+        str(args.predictor_conf_threshold),
+        "--loglevel",
+        args.loglevel,
+    ]
+    _run(cmd, label="predict", env=env)
+
+
+def collect_kept_alert_ids(temp_dir: Path) -> List[int]:
+    """Step 3: parse predictions.csv -> list of platform alert_api_ids for kept sequences."""
+    csv_path = temp_dir / "predictions.csv"
+    if not csv_path.exists():
+        logging.info(f"No {csv_path} found — predictor produced no output")
+        return []
+    kept: List[int] = []
+    with open(csv_path) as f:
+        for row in csv.DictReader(f):
+            if row.get("status") != "kept":
+                continue
+            raw = row.get("sequence_id", "")
+            try:
+                kept.append(int(raw))
+            except ValueError:
+                logging.warning(f"Skipping non-integer sequence_id={raw!r} in {csv_path}")
+    return kept
+
+
+def step_push_to_annotation_api(
+    args: argparse.Namespace, kept_ids: List[int]
+) -> None:
+    """Step 4: invoke import.py with --sequence-list to import only kept sequences."""
+    if not kept_ids:
+        logging.info("No kept sequences after predictor — skipping annotation API push")
+        return
+    # Pass kept ids via a temp file so we never bump into shell-arg length limits.
+    list_file = Path(tempfile.mkstemp(prefix="kept_ids_", suffix=".txt")[1])
+    try:
+        list_file.write_text("\n".join(str(i) for i in kept_ids) + "\n")
+        logging.info(
+            f"Importing {len(kept_ids)} kept sequence(s) into annotation API "
+            f"({args.url_api_annotation})"
+        )
+        # platform/ → ingestion/ → data_transfer/ → scripts/ → annotation_api/
+        annotation_api_dir = Path(__file__).resolve().parents[4]
+        cmd: list = [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "scripts.data_transfer.ingestion.platform.import",
+            "--date-from",
+            args.date_from,
+            "--date-end",
+            args.date_end,
+            "--url-api-annotation",
+            args.url_api_annotation,
+            "--url-api-platform",
+            args.url_api_platform,
+            "--sequence-list",
+            str(list_file),
+            "--detections-limit",
+            str(args.detections_limit),
+            "--max-workers",
+            str(args.max_workers),
+            "--loglevel",
+            args.loglevel,
+        ]
+        if args.max_sequences > 0:
+            cmd += ["--max-sequences", str(args.max_sequences)]
+        if args.dry_run:
+            cmd.append("--dry-run")
+        _run(cmd, label="import-api", cwd=annotation_api_dir)
+    finally:
+        list_file.unlink(missing_ok=True)
+
+
+def main() -> int:
+    args = make_cli_parser().parse_args()
+    logging.basicConfig(
+        level=args.loglevel.upper(),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    if args.date_end is None:
+        args.date_end = datetime.now().date().strftime("%Y-%m-%d")
+
+    _validate_paths(args)
+
+    temp_dir = Path(tempfile.mkdtemp(prefix="import_filtered_"))
+    logging.info(f"Temp dir: {temp_dir}")
+    success = False
+    try:
+        step_fetch_light(args, temp_dir)
+        step_predict(args, temp_dir)
+        kept_ids = collect_kept_alert_ids(temp_dir)
+        logging.info(f"Predictor kept {len(kept_ids)} sequence(s)")
+        step_push_to_annotation_api(args, kept_ids)
+        success = True
+        return 0
+    finally:
+        if success and not args.keep_temp:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+            logging.info(f"Cleaned up temp dir {temp_dir}")
+        else:
+            logging.info(f"Temp dir kept at {temp_dir}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import_filtered.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import_filtered.py
@@ -40,7 +40,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import List, Optional
 
@@ -188,12 +188,14 @@ def _validate_paths(args: argparse.Namespace) -> None:
     pyro_dataset_python = args.pyro_dataset_dir / ".venv/bin/python"
     pyro_engine_python = args.pyro_engine_dir / ".venv/bin/python"
     pyro_predictor_src = args.pyro_engine_dir / "pyro-predictor"
+    pyro_predictor_data = pyro_predictor_src / "data"
     for path in (
         fetch_script,
         predict_script,
         pyro_dataset_python,
         pyro_engine_python,
         pyro_predictor_src,
+        pyro_predictor_data,
     ):
         if not path.exists():
             raise SystemExit(f"Expected path does not exist: {path}")
@@ -202,9 +204,14 @@ def _validate_paths(args: argparse.Namespace) -> None:
 def _run(cmd: list, label: str, cwd: Optional[Path] = None,
          env: Optional[dict] = None) -> None:
     logging.info(f"[{label}] {' '.join(str(c) for c in cmd)}")
-    result = subprocess.run(cmd, cwd=cwd, env=env)
-    if result.returncode != 0:
-        raise RuntimeError(f"[{label}] exited with code {result.returncode}")
+    try:
+        subprocess.run(cmd, cwd=cwd, env=env, check=True)
+    except OSError as exc:
+        raise RuntimeError(f"[{label}] failed to start (cwd={cwd}): {cmd}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"[{label}] exited with code {exc.returncode} (cwd={cwd}): {cmd}"
+        ) from exc
 
 
 def step_fetch_light(args: argparse.Namespace, temp_dir: Path) -> None:
@@ -245,8 +252,8 @@ def step_predict(args: argparse.Namespace, temp_dir: Path) -> None:
         / "scripts/platform_train_loop/predict_and_filter_sequences.py"
     )
     python = args.pyro_engine_dir / ".venv/bin/python"
-    pythonpath = str(args.pyro_engine_dir / "pyro-predictor")
-    env = {**os.environ, "PYTHONPATH": pythonpath}
+    pyro_predictor_src = args.pyro_engine_dir / "pyro-predictor"
+    env = {**os.environ, "PYTHONPATH": str(pyro_predictor_src)}
     cmd: list = [
         str(python),
         str(script),
@@ -256,6 +263,8 @@ def step_predict(args: argparse.Namespace, temp_dir: Path) -> None:
         str(args.predictor_n_consecutive),
         "--conf-threshold",
         str(args.predictor_conf_threshold),
+        "--model-folder",
+        str(pyro_predictor_src / "data"),
         "--loglevel",
         args.loglevel,
     ]
@@ -269,15 +278,25 @@ def collect_kept_alert_ids(temp_dir: Path) -> List[int]:
         logging.info(f"No {csv_path} found — predictor produced no output")
         return []
     kept: List[int] = []
-    with open(csv_path) as f:
-        for row in csv.DictReader(f):
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        required = {"status", "sequence_id"}
+        missing = required - set(reader.fieldnames or [])
+        if missing:
+            raise RuntimeError(
+                f"{csv_path} missing required column(s): {sorted(missing)}"
+            )
+        # `enumerate` from 2 so the row number matches the file (header is line 1).
+        for line_no, row in enumerate(reader, start=2):
             if row.get("status") != "kept":
                 continue
-            raw = row.get("sequence_id", "")
+            raw = row.get("sequence_id")
             try:
-                kept.append(int(raw))
-            except ValueError:
-                logging.warning(f"Skipping non-integer sequence_id={raw!r} in {csv_path}")
+                kept.append(int(raw))  # type: ignore[arg-type]
+            except (TypeError, ValueError) as exc:
+                raise RuntimeError(
+                    f"{csv_path}:{line_no} invalid sequence_id for kept row: {raw!r}"
+                ) from exc
     return kept
 
 
@@ -289,7 +308,10 @@ def step_push_to_annotation_api(
         logging.info("No kept sequences after predictor — skipping annotation API push")
         return
     # Pass kept ids via a temp file so we never bump into shell-arg length limits.
-    list_file = Path(tempfile.mkstemp(prefix="kept_ids_", suffix=".txt")[1])
+    # Close mkstemp's fd immediately to avoid leaking it if a later step raises.
+    fd, list_path = tempfile.mkstemp(prefix="kept_ids_", suffix=".txt")
+    os.close(fd)
+    list_file = Path(list_path)
     try:
         list_file.write_text("\n".join(str(i) for i in kept_ids) + "\n")
         logging.info(
@@ -330,6 +352,33 @@ def step_push_to_annotation_api(
         list_file.unlink(missing_ok=True)
 
 
+def _normalize_date_range(args: argparse.Namespace) -> None:
+    """
+    Reconcile --date-from / --date-end with the fetch script's *exclusive*
+    `--date-end` semantics. The Makefile defaults `DATE_END ?= DATE_FROM`,
+    so `make import-platform-filtered DATE_FROM=X` arrives here with
+    date_end == date_from, which would otherwise yield a zero-day window.
+    Treat date_end == date_from as a "single day" request by bumping
+    date_end by one day. Reject end-before-start as a user error.
+    """
+    if args.date_end is None:
+        args.date_end = datetime.now().date().strftime("%Y-%m-%d")
+        return
+    start = datetime.strptime(args.date_from, "%Y-%m-%d").date()
+    end = datetime.strptime(args.date_end, "%Y-%m-%d").date()
+    if end < start:
+        raise SystemExit(
+            f"--date-end ({end}) is before --date-from ({start})"
+        )
+    if end == start:
+        bumped = start + timedelta(days=1)
+        logging.info(
+            f"--date-end == --date-from ({start}); treating as a single-day "
+            f"fetch by bumping --date-end to {bumped} (exclusive)"
+        )
+        args.date_end = bumped.strftime("%Y-%m-%d")
+
+
 def main() -> int:
     args = make_cli_parser().parse_args()
     logging.basicConfig(
@@ -337,9 +386,7 @@ def main() -> int:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
 
-    if args.date_end is None:
-        args.date_end = datetime.now().date().strftime("%Y-%m-%d")
-
+    _normalize_date_range(args)
     _validate_paths(args)
 
     temp_dir = Path(tempfile.mkdtemp(prefix="import_filtered_"))
@@ -355,8 +402,12 @@ def main() -> int:
         return 0
     finally:
         if success and not args.keep_temp:
-            shutil.rmtree(temp_dir, ignore_errors=True)
-            logging.info(f"Cleaned up temp dir {temp_dir}")
+            try:
+                shutil.rmtree(temp_dir)
+            except OSError as exc:
+                logging.warning(f"Failed to clean up temp dir {temp_dir}: {exc}")
+            else:
+                logging.info(f"Cleaned up temp dir {temp_dir}")
         else:
             logging.info(f"Temp dir kept at {temp_dir}")
 

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
@@ -51,6 +51,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
@@ -607,6 +608,30 @@ def _build_sequence_payload(
     return shared.transform_sequence_data(record, SOURCE_API)
 
 
+def _with_retry(fn, *, what: str, attempts: int = 3, base_delay: float = 3.0):
+    """Call `fn`, retrying transient annotation-API errors (5xx and network/
+    timeout, which surface as AnnotationAPIError with status_code None).
+
+    Non-transient errors (e.g. 409 already-exists, 422 validation) are raised
+    immediately so callers can handle them.
+    """
+    for attempt in range(attempts):
+        try:
+            return fn()
+        except AnnotationAPIError as exc:
+            transient = exc.status_code in (502, 503, 504) or exc.status_code is None
+            if transient and attempt < attempts - 1:
+                delay = base_delay * (2**attempt)
+                logging.warning(
+                    f"{what}: transient error ({exc}) — retrying in {delay:.0f}s "
+                    f"({attempt + 1}/{attempts - 1})"
+                )
+                time.sleep(delay)
+                continue
+            raise
+    raise AssertionError("unreachable")  # loop always returns or raises
+
+
 def post_object(
     args: argparse.Namespace,
     token: str,
@@ -658,8 +683,9 @@ def post_object(
         return True
 
     try:
-        annotation_sequence = create_sequence(
-            args.url_api_annotation, token, sequence_data
+        annotation_sequence = _with_retry(
+            lambda: create_sequence(args.url_api_annotation, token, sequence_data),
+            what=f"create_sequence(alert_id={alert_id})",
         )
     except AnnotationAPIError as exc:
         if exc.status_code == 409:
@@ -720,12 +746,15 @@ def post_object(
             logging.warning(f"Cannot read {row['filepath_image']}: {exc}")
             continue
         try:
-            created = create_detection(
-                args.url_api_annotation,
-                token,
-                detection_data,
-                image_bytes,
-                member.image_filename,
+            created = _with_retry(
+                lambda: create_detection(
+                    args.url_api_annotation,
+                    token,
+                    detection_data,
+                    image_bytes,
+                    member.image_filename,
+                ),
+                what=f"create_detection(det={row['detection_id']})",
             )
             posted += 1
             # Remember the annotation-API detection id + its box so we can build

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
@@ -937,6 +937,12 @@ def process_day(
             camera_azimuth, is_wildfire = _refetch_sequence_fields(
                 args, platform_token, sid, refetch_cache
             )
+            # NOTE: object_index is the positional enumeration of clustered
+            # objects. The (sid, object_index) dedup key is therefore only
+            # stable across runs while the predictor/clustering output is stable.
+            # If the model or clustering params change, the same physical plume
+            # may get a different index → on resume it can be re-imported as a
+            # duplicate or skipped. Use --reset for a clean rebuild in that case.
             for object_index, obj in enumerate(objects):
                 if (sid, object_index) in imported_objs:
                     logging.debug(

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
@@ -21,7 +21,9 @@ Pipeline (per day):
      `alert_api_id = alert_id_base + platform_id*1000 + object_index`, per-object
      cone azimuth), POST one Detection per (frame, box) carrying the predictor box as
      `algo_predictions` (image bytes uploaded from the locally-fetched file), then
-     trigger server-side annotation auto-generation.
+     write the sequence annotation as a SINGLE bbox track (= this object). We do
+     NOT use the server's IoU auto-generation, which would re-fragment one
+     drifting/tiny-box object into several tracks.
   5. Assign groups, then clean up the temp dir.
 
 Unlike `import_filtered.py`, detections carry OUR predictor's boxes (not the
@@ -58,11 +60,11 @@ from tqdm import tqdm
 from . import client as platform_client
 from . import shared
 from .object_clustering import cluster_objects, object_cone_azimuth
-from .annotation_management import create_simple_sequence_annotation
 from app.clients.annotation_api import (
     AnnotationAPIError,
     create_detection,
     create_sequence,
+    create_sequence_annotation,
     delete_sequence,
     get_auth_token,
     list_sequences,
@@ -163,26 +165,6 @@ def make_cli_parser() -> argparse.ArgumentParser:
             "Base offset for synthetic sequence alert_api_ids "
             "(default: 1e9), kept disjoint from real platform ids."
         ),
-    )
-
-    # Annotation API auto-generation
-    parser.add_argument(
-        "--confidence-threshold",
-        type=float,
-        default=0.0,
-        help="Auto-gen confidence threshold forwarded to the API (default: 0.0).",
-    )
-    parser.add_argument(
-        "--iou-threshold",
-        type=float,
-        default=0.3,
-        help="Auto-gen IoU threshold forwarded to the API (default: 0.3).",
-    )
-    parser.add_argument(
-        "--min-cluster-size",
-        type=int,
-        default=1,
-        help="Auto-gen min cluster size forwarded to the API (default: 1).",
     )
 
     # URLs
@@ -684,6 +666,7 @@ def post_object(
 
     posted = 0
     hard_failure = False
+    track_bboxes: List[dict] = []
     for member in members:
         row = meta.images.get(member.image_filename)
         if row is None:
@@ -691,10 +674,11 @@ def post_object(
                 f"No CSV row for image {member.image_filename}; skipping detection"
             )
             continue
+        xyxyn = [float(c) for c in member.box[:4]]
         predictions = shared._sanitize_predictions(
             [
                 {
-                    "xyxyn": [float(c) for c in member.box[:4]],
+                    "xyxyn": xyxyn,
                     "confidence": float(member.box[4]),
                     "class_name": "smoke",
                 }
@@ -714,7 +698,7 @@ def post_object(
             logging.warning(f"Cannot read {row['filepath_image']}: {exc}")
             continue
         try:
-            create_detection(
+            created = create_detection(
                 args.url_api_annotation,
                 token,
                 detection_data,
@@ -722,6 +706,9 @@ def post_object(
                 member.image_filename,
             )
             posted += 1
+            # Remember the annotation-API detection id + its box so we can build
+            # ONE annotation track for this object (see below).
+            track_bboxes.append({"detection_id": created["id"], "xyxyn": xyxyn})
         except AnnotationAPIError as exc:
             logging.warning(
                 f"Detection {row['detection_id']} (seq {new_seq_id}) failed: {exc}"
@@ -739,26 +726,44 @@ def post_object(
         _safe_delete_sequence(args, token, new_seq_id)
         return False
 
-    # Trigger server-side annotation auto-generation for this object's detections.
-    ann_result = create_simple_sequence_annotation(
-        sequence_id=new_seq_id,
-        annotation_api_url=args.url_api_annotation,
-        config={
-            "confidence_threshold": args.confidence_threshold,
-            "iou_threshold": args.iou_threshold,
-            "min_cluster_size": args.min_cluster_size,
+    # Write the annotation ourselves as a SINGLE bbox track = this object.
+    # We deliberately do NOT use the server's empty-bbox auto-generation: that
+    # re-clusters the detections by IoU and fragments one drifting/tiny-box
+    # object into several tracks. Since the object split already happened
+    # upstream (object_clustering), every detection here belongs to the same
+    # object, so it is exactly one track (is_smoke, conservative, for review).
+    annotation_payload = {
+        "sequence_id": new_seq_id,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": True,
+                    "false_positive_types": [],
+                    "bboxes": track_bboxes,
+                }
+            ]
         },
-        dry_run=args.dry_run,
-    )
-    if not ann_result.get("annotation_created"):
+        "processing_stage": "ready_to_annotate",
+        "has_missed_smoke": False,
+        "has_smoke": True,
+        "has_false_positives": False,
+        "false_positive_types": [],
+        "smoke_types": [],
+        "is_unsure": False,
+    }
+    try:
+        create_sequence_annotation(args.url_api_annotation, token, annotation_payload)
+    except AnnotationAPIError as exc:
         logging.warning(
-            f"seq {sid} object {object_index}: annotation auto-gen failed "
+            f"seq {sid} object {object_index}: annotation POST failed ({exc}) "
             f"— deleting sequence {new_seq_id} for retry"
         )
         _safe_delete_sequence(args, token, new_seq_id)
         return False
 
-    logging.info(f"seq {sid} object {object_index}: posted {posted} detection(s)")
+    logging.info(
+        f"seq {sid} object {object_index}: posted {posted} detection(s), 1 track"
+    )
     return True
 
 

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
@@ -53,6 +53,7 @@ import sys
 import tempfile
 import time
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
@@ -123,6 +124,13 @@ def make_cli_parser() -> argparse.ArgumentParser:
         type=int,
         default=30,
         help="Images per sequence fetched & predicted (default: 30).",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=8,
+        help="Concurrent detection uploads per object to the annotation API "
+        "(default: 8; 1 = serial).",
     )
 
     # Predictor
@@ -697,16 +705,15 @@ def post_object(
         raise
     new_seq_id = annotation_sequence["id"]
 
-    posted = 0
-    hard_failure = False
-    track_bboxes: List[dict] = []
-    for member in members:
+    def _post_member(member) -> Optional[dict]:
+        """POST one detection; return its {detection_id, xyxyn} bbox, or None on
+        skip/failure (so the caller treats a shortfall as incomplete)."""
         row = meta.images.get(member.image_filename)
         if row is None:
             logging.warning(
                 f"No CSV row for image {member.image_filename}; skipping detection"
             )
-            continue
+            return None
         xyxyn = [float(c) for c in member.box[:4]]
         predictions = shared._sanitize_predictions(
             [
@@ -718,7 +725,7 @@ def post_object(
             ]
         )
         if not predictions:
-            continue
+            return None
         detection_data = {
             "sequence_id": new_seq_id,
             "alert_api_id": row["detection_id"],
@@ -744,7 +751,7 @@ def post_object(
             image_bytes = Path(row["filepath_image"]).read_bytes()
         except OSError as exc:
             logging.warning(f"Cannot read {row['filepath_image']}: {exc}")
-            continue
+            return None
         try:
             created = _with_retry(
                 lambda: create_detection(
@@ -756,24 +763,38 @@ def post_object(
                 ),
                 what=f"create_detection(det={row['detection_id']})",
             )
-            posted += 1
-            # Remember the annotation-API detection id + its box so we can build
-            # ONE annotation track for this object (see below).
-            track_bboxes.append({"detection_id": created["id"], "xyxyn": xyxyn})
         except AnnotationAPIError as exc:
             logging.warning(
                 f"Detection {row['detection_id']} (seq {new_seq_id}) failed: {exc}"
             )
-            hard_failure = True
+            return None
+        return {"detection_id": created["id"], "xyxyn": xyxyn}
+
+    # Post this object's detections concurrently (image upload is the dominant
+    # cost; serial posting is the throughput bottleneck for the run). An
+    # UNEXPECTED worker exception must not strand the already-created sequence
+    # (the object-level dedup would then skip it forever), so delete it first.
+    workers = min(max(1, args.max_workers), len(members))
+    try:
+        if workers <= 1:
+            results = [_post_member(m) for m in members]
+        else:
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                results = list(executor.map(_post_member, members))
+    except Exception:
+        _safe_delete_sequence(args, token, new_seq_id)
+        raise
+    track_bboxes: List[dict] = [r for r in results if r is not None]
+    posted = len(track_bboxes)
 
     # Roll back an incomplete object so it is not left half-imported (which the
     # object-level dedup would otherwise treat as "done" and never retry).
     # Any shortfall vs the member count (POST error, unreadable image, dropped
     # prediction) is treated as incomplete, so a retry re-creates it cleanly.
-    if posted < len(members) or hard_failure:
+    if posted < len(members):
         logging.warning(
             f"seq {sid} object {object_index}: incomplete "
-            f"({posted}/{len(members)} detections, hard_failure={hard_failure}) "
+            f"({posted}/{len(members)} detections) "
             f"— deleting sequence {new_seq_id} for retry"
         )
         _safe_delete_sequence(args, token, new_seq_id)
@@ -806,7 +827,9 @@ def post_object(
     }
     try:
         create_sequence_annotation(args.url_api_annotation, token, annotation_payload)
-    except AnnotationAPIError as exc:
+    except Exception as exc:
+        # Any failure here (API error or unexpected) must delete the sequence so
+        # it is not stranded annotation-less and skipped forever by the dedup.
         logging.warning(
             f"seq {sid} object {object_index}: annotation POST failed ({exc}) "
             f"— deleting sequence {new_seq_id} for retry"

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
@@ -53,6 +53,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
 from dotenv import load_dotenv
+from tqdm import tqdm
 
 from . import client as platform_client
 from . import shared
@@ -809,7 +810,9 @@ def process_day(
         )
         logging.info(f"Day {day_from}: {len(kept_sids)} kept sequence(s)")
 
-        for sid in kept_sids:
+        for sid in tqdm(
+            kept_sids, desc=f"{day_from} sequences", unit="seq", leave=False
+        ):
             # Budget: stop taking NEW platform sequences once the cap is hit.
             if (
                 max_new_sids is not None
@@ -911,7 +914,7 @@ def main() -> int:
     )
 
     created_any = False
-    for day in days:
+    for day in tqdm(days, desc="Days", unit="day"):
         if max_new_sids is not None and len(imported_run_sids) >= max_new_sids:
             logging.info("Reached --max-sequences cap; stopping.")
             break

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
@@ -739,7 +739,9 @@ def post_object(
 
     # Roll back an incomplete object so it is not left half-imported (which the
     # object-level dedup would otherwise treat as "done" and never retry).
-    if posted == 0 or hard_failure:
+    # Any shortfall vs the member count (POST error, unreadable image, dropped
+    # prediction) is treated as incomplete, so a retry re-creates it cleanly.
+    if posted < len(members) or hard_failure:
         logging.warning(
             f"seq {sid} object {object_index}: incomplete "
             f"({posted}/{len(members)} detections, hard_failure={hard_failure}) "
@@ -930,7 +932,8 @@ def main() -> int:
     _validate_paths(args)
     logging.info(f"Processing {len(days)} day(s): {days[0]} .. {days[-1]}")
 
-    # Annotation API auth (sequences + detections).
+    # Annotation API auth (sequences + detections). Re-fetched per day inside the
+    # loop too, so a multi-day run never outlives the token's TTL.
     login, password = shared.get_annotation_credentials(args.url_api_annotation)
     token = get_auth_token(args.url_api_annotation, login, password)
 
@@ -940,33 +943,49 @@ def main() -> int:
     # Pre-load (sid, object_index) keys already in the dataset (object-level dedup).
     imported_objs = load_imported_object_keys(args, token)
 
-    platform_token = _platform_token(args)
     refetch_cache: Dict[int, Tuple[Optional[float], Optional[str]]] = {}
     imported_run_sids: Set[int] = set()
     max_new_sids = (
         args.max_sequences if args.max_sequences and args.max_sequences > 0 else None
     )
 
-    created_any = False
+    failed_days: List[str] = []
     for day in tqdm(days, desc="Days", unit="day"):
         if max_new_sids is not None and len(imported_run_sids) >= max_new_sids:
             logging.info("Reached --max-sequences cap; stopping.")
             break
-        if process_day(
-            args,
-            day,
-            token,
-            platform_token,
-            refetch_cache,
-            imported_objs,
-            imported_run_sids,
-            max_new_sids,
-        ):
-            created_any = True
+        # Refresh both tokens each day so a long run never hits an expired token.
+        try:
+            token = get_auth_token(args.url_api_annotation, login, password)
+            platform_token = _platform_token(args)
+            created = process_day(
+                args,
+                day,
+                token,
+                platform_token,
+                refetch_cache,
+                imported_objs,
+                imported_run_sids,
+                max_new_sids,
+            )
+        except Exception as exc:
+            # One bad day (fetch/predict/network) must not abort a 335-day run.
+            logging.error(f"Day {day} failed: {exc} — skipping", exc_info=True)
+            failed_days.append(day.strftime("%Y-%m-%d"))
+            continue
+        # Assign groups after each productive day so an interruption never leaves
+        # already-imported sequences ungrouped.
+        if created and not args.dry_run:
+            try:
+                step_assign_groups(args)
+            except Exception as exc:
+                logging.error(f"assign_groups after {day} failed: {exc}")
 
-    if created_any and not args.dry_run:
-        step_assign_groups(args)
-    return 0
+    if failed_days:
+        logging.warning(
+            f"{len(failed_days)} day(s) failed and were skipped: {failed_days}"
+        )
+    return 1 if failed_days else 0
 
 
 if __name__ == "__main__":

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
@@ -20,9 +20,10 @@ Pipeline (per day):
   4. Post: for each object, create ONE annotation-API Sequence (synthetic
      `alert_api_id = alert_id_base + platform_id*1000 + object_index`, per-object
      cone azimuth), POST one Detection per (frame, box) carrying the predictor box as
-     `algo_predictions` (image bytes uploaded from the locally-fetched file), then
-     write the sequence annotation as a SINGLE bbox track (= this object). We do
-     NOT use the server's IoU auto-generation, which would re-fragment one
+     `algo_predictions` and the OTHER objects' boxes on the same frame as
+     `others_bboxes` (read-only context for judging missed smoke), then write the
+     sequence annotation as a SINGLE bbox track (= this object). We do NOT use
+     the server's IoU auto-generation, which would re-fragment one
      drifting/tiny-box object into several tracks.
   5. Assign groups, then clean up the temp dir.
 
@@ -50,6 +51,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
@@ -614,10 +616,15 @@ def post_object(
     obj,
     camera_azimuth: Optional[float],
     is_wildfire: Optional[str],
+    boxes_by_image: Dict[str, List[Tuple[int, List[float]]]],
 ) -> bool:
-    """Create one annotation sequence + its detections + trigger auto-gen.
+    """Create one annotation sequence + its detections + the single-object track.
 
-    Returns True on success (sequence created & at least attempted detections).
+    `boxes_by_image` maps each image filename to the list of
+    `(object_index, box)` for every object detected on that frame, so each
+    detection can carry the OTHER objects' boxes on the same image in
+    `others_bboxes` (read-only context the annotator needs to judge missed
+    smoke). Returns True on success.
     """
     members = obj.members
     sequence_data = _build_sequence_payload(meta, sid, camera_azimuth, is_wildfire)
@@ -692,6 +699,21 @@ def post_object(
             "recorded_at": row["recorded_at"],
             "algo_predictions": {"predictions": predictions},
         }
+        # Other objects' boxes on this same frame -> others_bboxes (read-only
+        # context so the annotator can judge missed smoke across objects).
+        other_preds = shared._sanitize_predictions(
+            [
+                {
+                    "xyxyn": [float(c) for c in box[:4]],
+                    "confidence": float(box[4]),
+                    "class_name": "smoke",
+                }
+                for oi, box in boxes_by_image.get(member.image_filename, [])
+                if oi != object_index
+            ]
+        )
+        if other_preds:
+            detection_data["others_bboxes"] = {"predictions": other_preds}
         try:
             image_bytes = Path(row["filepath_image"]).read_bytes()
         except OSError as exc:
@@ -852,6 +874,12 @@ def process_day(
             if not objects:
                 logging.info(f"seq {sid}: no objects after clustering — dropped")
                 continue
+            # Index every object's boxes by frame so each detection can carry the
+            # OTHER objects' boxes on that frame as others_bboxes.
+            boxes_by_image: Dict[str, List[Tuple[int, List[float]]]] = defaultdict(list)
+            for oi, o in enumerate(objects):
+                for m in o.members:
+                    boxes_by_image[m.image_filename].append((oi, m.box))
             camera_azimuth, is_wildfire = _refetch_sequence_fields(
                 args, platform_token, sid, refetch_cache
             )
@@ -870,6 +898,7 @@ def process_day(
                     obj,
                     camera_azimuth,
                     is_wildfire,
+                    boxes_by_image,
                 ):
                     imported_objs.add((sid, object_index))
                     imported_run_sids.add(sid)

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import_predictor_split.py
@@ -1,0 +1,936 @@
+"""
+Orchestrator: import platform sequences as predictor-derived, object-split
+annotation sequences.
+
+The date range is walked ONE CALENDAR DAY AT A TIME (inclusive of both
+--date-from and --date-end): day 1 is fetched, predicted and pushed in full
+before day 2 starts. Before any work, the set of platform sequences already in
+the dataset is loaded (by reversing the synthetic alert_api_id scheme) so
+already-imported sequences are skipped rather than re-fetched/re-pushed.
+
+Pipeline (per day):
+  1. Fetch: shell out to pyro-dataset's `fetch_all_platform_sequences.py` with
+     `--detections-limit 30` into a temp dir (single pass — images + sequences.csv).
+  2. Predict: shell out to `predictor_runner.py` via pyro-engine's venv to get the
+     predictor's per-frame *smoothed* boxes for every fetched image
+     (`predictor_boxes.jsonl`).
+  3. Split: for each kept platform sequence, replay pyro-api's detection->sequence
+     association rule (`object_clustering.cluster_objects`) over the predictor boxes,
+     carving the sequence into one *object* per detected smoke plume.
+  4. Post: for each object, create ONE annotation-API Sequence (synthetic
+     `alert_api_id = alert_id_base + platform_id*1000 + object_index`, per-object
+     cone azimuth), POST one Detection per (frame, box) carrying the predictor box as
+     `algo_predictions` (image bytes uploaded from the locally-fetched file), then
+     trigger server-side annotation auto-generation.
+  5. Assign groups, then clean up the temp dir.
+
+Unlike `import_filtered.py`, detections carry OUR predictor's boxes (not the
+platform's tracked bbox), and one platform sequence may yield several annotation
+sequences. `is_wildfire` / `camera_azimuth` are re-fetched from the platform API
+because pyro-dataset's CSV does not carry a usable value for them.
+
+Sister-repo paths come from `PYRO_DATASET_DIR` / `PYRO_ENGINE_DIR`.
+
+Usage:
+  uv run python -m scripts.data_transfer.ingestion.platform.import_predictor_split \\
+    --date-from 2025-03-04 --url-api-annotation http://localhost:5050 --max-sequences 2
+
+Or via the Makefile:
+  make import-platform-predictor-split DATE_FROM=2025-03-04 MAX_SEQUENCES=2
+"""
+
+import argparse
+import csv
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+from dotenv import load_dotenv
+
+from . import client as platform_client
+from . import shared
+from .object_clustering import cluster_objects, object_cone_azimuth
+from .annotation_management import create_simple_sequence_annotation
+from app.clients.annotation_api import (
+    AnnotationAPIError,
+    create_detection,
+    create_sequence,
+    delete_sequence,
+    get_auth_token,
+    list_sequences,
+)
+
+load_dotenv()
+
+DEFAULT_ALERT_ID_BASE = 1_000_000_000
+SOURCE_API = "pyronear_french"
+
+
+def _path_from_env(env_name: str) -> Optional[Path]:
+    value = os.getenv(env_name)
+    return Path(value).expanduser() if value else None
+
+
+def valid_date(s: str) -> str:
+    """Argparse type: validate YYYY-MM-DD, return the original string."""
+    try:
+        datetime.strptime(s, "%Y-%m-%d")
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"not a valid date: {s!r} (expected YYYY-MM-DD)"
+        ) from exc
+    return s
+
+
+def make_cli_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--date-from",
+        type=valid_date,
+        required=True,
+        help="Start date (YYYY-MM-DD, inclusive).",
+    )
+    parser.add_argument(
+        "--date-end",
+        type=valid_date,
+        default=None,
+        help="End date (YYYY-MM-DD, INCLUSIVE; looped day by day). Defaults to today.",
+    )
+    parser.add_argument(
+        "--max-sequences",
+        type=int,
+        default=0,
+        help="Cap on NEW platform sequences imported across the whole run (0 = no cap).",
+    )
+    parser.add_argument(
+        "--detections-limit",
+        type=int,
+        default=30,
+        help="Images per sequence fetched & predicted (default: 30).",
+    )
+
+    # Predictor
+    parser.add_argument(
+        "--predictor-n-consecutive",
+        type=int,
+        default=6,
+        help="Sliding-window size for the predictor (default: 6).",
+    )
+    parser.add_argument(
+        "--predictor-conf-threshold",
+        type=float,
+        default=0.1,
+        help="Predictor confidence threshold for kept/dropped (default: 0.1).",
+    )
+
+    # Object clustering (pyro-api thresholds)
+    parser.add_argument(
+        "--min-dets",
+        type=int,
+        default=3,
+        help="Min overlapping detections to spawn an object (default: 3).",
+    )
+    parser.add_argument(
+        "--min-interval-seconds",
+        type=int,
+        default=300,
+        help="Spawn-pool time window in seconds (default: 300).",
+    )
+    parser.add_argument(
+        "--relaxation-seconds",
+        type=int,
+        default=7200,
+        help="Open-object match window in seconds (default: 7200).",
+    )
+
+    # Synthetic id namespace
+    parser.add_argument(
+        "--alert-id-base",
+        type=int,
+        default=DEFAULT_ALERT_ID_BASE,
+        help=(
+            "Base offset for synthetic sequence alert_api_ids "
+            "(default: 1e9), kept disjoint from real platform ids."
+        ),
+    )
+
+    # Annotation API auto-generation
+    parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=0.0,
+        help="Auto-gen confidence threshold forwarded to the API (default: 0.0).",
+    )
+    parser.add_argument(
+        "--iou-threshold",
+        type=float,
+        default=0.3,
+        help="Auto-gen IoU threshold forwarded to the API (default: 0.3).",
+    )
+    parser.add_argument(
+        "--min-cluster-size",
+        type=int,
+        default=1,
+        help="Auto-gen min cluster size forwarded to the API (default: 1).",
+    )
+
+    # URLs
+    parser.add_argument(
+        "--url-api-annotation",
+        type=str,
+        default="http://localhost:5050",
+        help="Annotation API URL.",
+    )
+    parser.add_argument(
+        "--url-api-platform",
+        type=str,
+        default="https://alertapi.pyronear.org",
+        help="Platform API URL.",
+    )
+
+    # Sister repos
+    parser.add_argument(
+        "--pyro-dataset-dir",
+        type=Path,
+        default=_path_from_env("PYRO_DATASET_DIR"),
+        help="Path to the pyro-dataset repo (or set PYRO_DATASET_DIR).",
+    )
+    parser.add_argument(
+        "--pyro-engine-dir",
+        type=Path,
+        default=_path_from_env("PYRO_ENGINE_DIR"),
+        help="Path to the pyro-engine repo (or set PYRO_ENGINE_DIR).",
+    )
+
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help=(
+            "Delete previously-imported synthetic sequences "
+            "(source_api=pyronear_french, alert_api_id >= --alert-id-base) "
+            "before importing, for a clean idempotent re-run."
+        ),
+    )
+    parser.add_argument(
+        "--keep-temp",
+        action="store_true",
+        help="Do not delete the temp directory on success (debugging).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Do everything except POST/DELETE to the annotation API.",
+    )
+    parser.add_argument(
+        "--skip-group-assignment",
+        action="store_true",
+        help="Skip the final POST /sequence_groups/assign step.",
+    )
+    parser.add_argument(
+        "--loglevel", default="info", help="Logging level (default: info)."
+    )
+    return parser
+
+
+# --------------------------------------------------------------------------- #
+# Setup helpers
+# --------------------------------------------------------------------------- #
+def _validate_paths(args: argparse.Namespace) -> None:
+    if args.pyro_dataset_dir is None:
+        raise SystemExit(
+            "PYRO_DATASET_DIR is not set and --pyro-dataset-dir was not provided"
+        )
+    if args.pyro_engine_dir is None:
+        raise SystemExit(
+            "PYRO_ENGINE_DIR is not set and --pyro-engine-dir was not provided"
+        )
+    fetch_script = (
+        args.pyro_dataset_dir
+        / "scripts/platform_train_loop/fetch_all_platform_sequences.py"
+    )
+    runner = Path(__file__).resolve().parent / "predictor_runner.py"
+    required = [
+        fetch_script,
+        args.pyro_dataset_dir / ".venv/bin/python",
+        args.pyro_engine_dir / ".venv/bin/python",
+        args.pyro_engine_dir / "pyro-predictor",
+        args.pyro_engine_dir / "pyro-predictor/data",
+        runner,
+    ]
+    for path in required:
+        if not path.exists():
+            raise SystemExit(f"Expected path does not exist: {path}")
+
+
+def _run(
+    cmd: list, label: str, cwd: Optional[Path] = None, env: Optional[dict] = None
+) -> None:
+    logging.info(f"[{label}] {' '.join(str(c) for c in cmd)}")
+    try:
+        subprocess.run(cmd, cwd=cwd, env=env, check=True)
+    except OSError as exc:
+        raise RuntimeError(f"[{label}] failed to start (cwd={cwd}): {cmd}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"[{label}] exited with code {exc.returncode} (cwd={cwd}): {cmd}"
+        ) from exc
+
+
+def _iter_days(args: argparse.Namespace) -> List[date]:
+    """Return every day to process, INCLUSIVE of --date-from and --date-end.
+
+    The orchestrator processes one day at a time (fetch -> predict -> push), so
+    a "from xx to yy" request walks each calendar day in [xx, yy]. --date-end
+    defaults to today. Rejects end-before-start.
+    """
+    start = datetime.strptime(args.date_from, "%Y-%m-%d").date()
+    end = (
+        datetime.strptime(args.date_end, "%Y-%m-%d").date()
+        if args.date_end
+        else datetime.now().date()
+    )
+    if end < start:
+        raise SystemExit(f"--date-end ({end}) is before --date-from ({start})")
+    days: List[date] = []
+    current = start
+    while current <= end:
+        days.append(current)
+        current += timedelta(days=1)
+    return days
+
+
+# --------------------------------------------------------------------------- #
+# Pipeline steps
+# --------------------------------------------------------------------------- #
+def step_fetch(
+    args: argparse.Namespace, temp_dir: Path, date_from: str, date_end: str
+) -> None:
+    """Step 1: download `--detections-limit` images per sequence + sequences.csv.
+
+    `date_end` is exclusive (the fetch script's convention); callers pass a
+    single-day window (`date_from`, `date_from + 1 day`).
+    """
+    script = (
+        args.pyro_dataset_dir
+        / "scripts/platform_train_loop/fetch_all_platform_sequences.py"
+    )
+    python = args.pyro_dataset_dir / ".venv/bin/python"
+    env = {**os.environ, "PLATFORM_API_ENDPOINT": args.url_api_platform}
+    # Disable the fetch script's LOCAL wildfire/fp registry dedup by pointing it
+    # at non-existent files: that dedup targets the pyro-dataset training set,
+    # not the annotation API. This importer dedups against the annotation API
+    # itself (see load_imported_object_keys), so the fetcher must not silently
+    # drop sequences that merely happen to be in a local registry.
+    no_registry = temp_dir / "__no_registry__.json"
+    cmd = [
+        str(python),
+        str(script),
+        "--date-from",
+        date_from,
+        "--date-end",
+        date_end,
+        "--save-dir",
+        str(temp_dir),
+        "--detections-limit",
+        str(args.detections_limit),
+        "--wildfire-registry",
+        str(no_registry),
+        "--fp-registry",
+        str(no_registry),
+        "--loglevel",
+        args.loglevel,
+    ]
+    _run(cmd, label="fetch", cwd=args.pyro_dataset_dir, env=env)
+
+
+def step_predict(args: argparse.Namespace, temp_dir: Path) -> Path:
+    """Step 2: run predictor_runner.py inside pyro-engine's venv -> JSONL."""
+    runner = Path(__file__).resolve().parent / "predictor_runner.py"
+    python = args.pyro_engine_dir / ".venv/bin/python"
+    pyro_predictor_src = args.pyro_engine_dir / "pyro-predictor"
+    out_path = temp_dir / "predictor_boxes.jsonl"
+    env = {**os.environ, "PYTHONPATH": str(pyro_predictor_src)}
+    cmd = [
+        str(python),
+        str(runner),
+        "--save-dir",
+        str(temp_dir),
+        "--out",
+        str(out_path),
+        "--n-consecutive",
+        str(args.predictor_n_consecutive),
+        "--conf-threshold",
+        str(args.predictor_conf_threshold),
+        "--model-folder",
+        str(pyro_predictor_src / "data"),
+        "--loglevel",
+        args.loglevel,
+    ]
+    _run(cmd, label="predict", env=env)
+    return out_path
+
+
+def step_assign_groups(args: argparse.Namespace) -> None:
+    """Step 5: trigger POST /sequence_groups/assign on the annotation API."""
+    if args.skip_group_assignment:
+        logging.info("--skip-group-assignment: not invoking assign_groups")
+        return
+    annotation_api_dir = Path(__file__).resolve().parents[4]
+    cmd = [
+        "uv",
+        "run",
+        "python",
+        "-m",
+        "scripts.data_transfer.ingestion.platform.assign_groups",
+        "--url-api-annotation",
+        args.url_api_annotation,
+        "--loglevel",
+        args.loglevel,
+    ]
+    _run(cmd, label="assign-groups", cwd=annotation_api_dir)
+
+
+# --------------------------------------------------------------------------- #
+# Data loading / joining
+# --------------------------------------------------------------------------- #
+def _parse_dt(value: str) -> datetime:
+    """Parse a platform ISO datetime to a naive UTC datetime.
+
+    Timezone-aware inputs are converted to UTC before the tzinfo is dropped, so
+    naive comparisons in clustering use a single, consistent wall clock.
+    """
+    text = value.strip().replace("Z", "+00:00")
+    dt = datetime.fromisoformat(text)
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+class SequenceMeta:
+    """Platform sequence metadata + per-image detection lookup, from sequences.csv."""
+
+    def __init__(self, first_row: dict) -> None:
+        self.camera_name = first_row.get("camera_name")
+        self.camera_id = _to_int(first_row.get("camera_id"))
+        self.organization_name = first_row.get("organization_name")
+        self.organization_id = _to_int(first_row.get("organization_id"))
+        self.camera_lat = _to_float(first_row.get("camera_lat"))
+        self.camera_lon = _to_float(first_row.get("camera_lon"))
+        self.camera_angle_of_view = _to_float(first_row.get("camera_angle_of_view"))
+        self.sequence_started_at = first_row.get("sequence_started_at")
+        self.sequence_last_seen_at = first_row.get("sequence_last_seen_at")
+        # image_filename (basename) -> detection lookup
+        self.images: Dict[str, dict] = {}
+
+    def add_image(self, row: dict) -> None:
+        filepath = row.get("filepath_image")
+        if not filepath:
+            return
+        filename = Path(filepath).name
+        if filename in self.images:
+            logging.warning(
+                f"Duplicate image filename {filename} in sequences.csv — keeping first"
+            )
+            return
+        self.images[filename] = {
+            "filepath_image": filepath,
+            "recorded_at": row.get("detection_created_at"),
+            "detection_id": _to_int(row.get("detection_id")),
+        }
+
+
+def _to_int(value) -> Optional[int]:
+    try:
+        return int(float(value)) if value not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_float(value) -> Optional[float]:
+    try:
+        return float(value) if value not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
+def load_sequences_csv(temp_dir: Path) -> Dict[int, SequenceMeta]:
+    """Index sequences.csv by platform sequence_id -> SequenceMeta."""
+    csv_path = temp_dir / "sequences.csv"
+    metas: Dict[int, SequenceMeta] = {}
+    if not csv_path.exists():
+        logging.warning(f"{csv_path} not found — fetch produced no images")
+        return metas
+    with open(csv_path, newline="") as f:
+        for row in csv.DictReader(f):
+            sid = _to_int(row.get("sequence_id"))
+            if sid is None:
+                continue
+            meta = metas.get(sid)
+            if meta is None:
+                meta = SequenceMeta(row)
+                metas[sid] = meta
+            meta.add_image(row)
+    return metas
+
+
+def load_predictor_boxes(jsonl_path: Path) -> Dict[int, dict]:
+    """Load predictor_boxes.jsonl into platform sequence_id -> record."""
+    records: Dict[int, dict] = {}
+    if not jsonl_path.exists():
+        logging.warning(f"{jsonl_path} not found — predictor produced no output")
+        return records
+    with open(jsonl_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            sid = _to_int(obj.get("sequence_id"))
+            if sid is not None:
+                records[sid] = obj
+    return records
+
+
+# --------------------------------------------------------------------------- #
+# Platform re-fetch (camera_azimuth + is_wildfire)
+# --------------------------------------------------------------------------- #
+def _platform_token(args: argparse.Namespace) -> Optional[str]:
+    login = os.getenv("PLATFORM_LOGIN")
+    password = os.getenv("PLATFORM_PASSWORD")
+    if not login or not password:
+        logging.warning(
+            "PLATFORM_LOGIN/PLATFORM_PASSWORD unset — cannot re-fetch "
+            "camera_azimuth/is_wildfire; falling back to CSV/None"
+        )
+        return None
+    try:
+        return platform_client.get_api_access_token(
+            api_endpoint=args.url_api_platform, username=login, password=password
+        )
+    except Exception as exc:
+        logging.warning(f"Platform authentication failed: {exc}")
+        return None
+
+
+def _refetch_sequence_fields(
+    args: argparse.Namespace,
+    token: Optional[str],
+    sid: int,
+    cache: Dict[int, Tuple[Optional[float], Optional[str]]],
+) -> Tuple[Optional[float], Optional[str]]:
+    """Return (camera_azimuth, is_wildfire) for a platform sequence id, cached."""
+    if sid in cache:
+        return cache[sid]
+    camera_azimuth: Optional[float] = None
+    is_wildfire: Optional[str] = None
+    if token is not None:
+        try:
+            seq = platform_client.get_sequence(args.url_api_platform, sid, token)
+            camera_azimuth = _to_float(seq.get("camera_azimuth"))
+            is_wildfire = seq.get("is_wildfire")
+        except Exception as exc:
+            logging.warning(f"Re-fetch of platform sequence {sid} failed: {exc}")
+    cache[sid] = (camera_azimuth, is_wildfire)
+    return camera_azimuth, is_wildfire
+
+
+# --------------------------------------------------------------------------- #
+# Posting
+# --------------------------------------------------------------------------- #
+def _iter_synthetic_sequences(args: argparse.Namespace, token: str):
+    """Yield (sequence_dict) for every synthetic sequence (alert_api_id >= base).
+
+    Collects each page fully before yielding so callers may delete while
+    iterating without skipping rows (paginating forward over a shrinking set
+    would otherwise miss items).
+    """
+    collected = []
+    page = 1
+    while True:
+        result = list_sequences(
+            args.url_api_annotation, token, source_api=SOURCE_API, page=page, size=100
+        )
+        items = result.get("items", [])
+        for seq in items:
+            if (seq.get("alert_api_id") or 0) >= args.alert_id_base:
+                collected.append(seq)
+        if page >= result.get("pages", 1) or not items:
+            break
+        page += 1
+    return collected
+
+
+def reset_synthetic_sequences(args: argparse.Namespace, token: str) -> None:
+    """Delete previously-imported synthetic sequences for a clean re-run."""
+    sequences = _iter_synthetic_sequences(args, token)
+    deleted = 0
+    for seq in sequences:
+        if not args.dry_run:
+            delete_sequence(args.url_api_annotation, token, seq["id"])
+        deleted += 1
+    logging.info(f"--reset: deleted {deleted} synthetic sequence(s)")
+
+
+def load_imported_object_keys(
+    args: argparse.Namespace, token: str
+) -> Set[Tuple[int, int]]:
+    """Set of (platform_sid, object_index) already imported as synthetic sequences.
+
+    Reverses the synthetic id scheme (``alert_api_id = base + sid*1000 + idx``)
+    so a run skips re-importing objects that are already in the dataset. Working
+    at object granularity (not just sid) lets a previously-partial import be
+    completed: only the missing objects are re-created.
+    """
+    keys: Set[Tuple[int, int]] = set()
+    for seq in _iter_synthetic_sequences(args, token):
+        offset = (seq.get("alert_api_id") or 0) - args.alert_id_base
+        keys.add((offset // 1000, offset % 1000))
+    logging.info(f"{len(keys)} object(s) already in the dataset")
+    return keys
+
+
+def _build_sequence_payload(
+    meta: SequenceMeta,
+    sid: int,
+    camera_azimuth: Optional[float],
+    is_wildfire: Optional[str],
+) -> dict:
+    """Build the transform_sequence_data input record from CSV + re-fetched fields."""
+    record = {
+        "camera_azimuth": camera_azimuth,
+        "sequence_id": sid,
+        "camera_name": meta.camera_name,
+        "camera_id": meta.camera_id,
+        "organization_name": meta.organization_name,
+        "organization_id": meta.organization_id,
+        "sequence_is_wildfire": is_wildfire,
+        "camera_lat": meta.camera_lat,
+        "camera_lon": meta.camera_lon,
+        "sequence_started_at": meta.sequence_started_at,
+        "sequence_last_seen_at": meta.sequence_last_seen_at,
+    }
+    return shared.transform_sequence_data(record, SOURCE_API)
+
+
+def post_object(
+    args: argparse.Namespace,
+    token: str,
+    meta: SequenceMeta,
+    sid: int,
+    object_index: int,
+    obj,
+    camera_azimuth: Optional[float],
+    is_wildfire: Optional[str],
+) -> bool:
+    """Create one annotation sequence + its detections + trigger auto-gen.
+
+    Returns True on success (sequence created & at least attempted detections).
+    """
+    members = obj.members
+    sequence_data = _build_sequence_payload(meta, sid, camera_azimuth, is_wildfire)
+    sequence_data["alert_api_id"] = args.alert_id_base + sid * 1000 + object_index
+
+    cone_azimuth = (
+        object_cone_azimuth(obj, camera_azimuth, meta.camera_angle_of_view)
+        if camera_azimuth is not None
+        else None
+    )
+    if cone_azimuth is not None:
+        sequence_data["azimuth"] = int(round(cone_azimuth)) % 360
+
+    # Per-object temporal extent from the member frames (raw ISO strings preserved).
+    member_rows = [meta.images.get(m.image_filename) for m in members]
+    recorded_strs = [
+        (r["recorded_at"], _parse_dt(r["recorded_at"]))
+        for r in member_rows
+        if r and r.get("recorded_at")
+    ]
+    if recorded_strs:
+        sequence_data["recorded_at"] = min(recorded_strs, key=lambda x: x[1])[0]
+        sequence_data["last_seen_at"] = max(recorded_strs, key=lambda x: x[1])[0]
+
+    alert_id = sequence_data["alert_api_id"]
+    logging.info(
+        f"seq {sid} object {object_index}: alert_api_id={alert_id}, "
+        f"{len(members)} detection(s), azimuth={sequence_data.get('azimuth')}"
+    )
+    if args.dry_run:
+        return True
+
+    try:
+        annotation_sequence = create_sequence(
+            args.url_api_annotation, token, sequence_data
+        )
+    except AnnotationAPIError as exc:
+        if exc.status_code == 409:
+            logging.warning(
+                f"seq {sid} object {object_index}: alert_api_id={alert_id} already "
+                f"exists — skipping (use --reset for a clean re-run)"
+            )
+            return False
+        raise
+    new_seq_id = annotation_sequence["id"]
+
+    posted = 0
+    hard_failure = False
+    for member in members:
+        row = meta.images.get(member.image_filename)
+        if row is None:
+            logging.warning(
+                f"No CSV row for image {member.image_filename}; skipping detection"
+            )
+            continue
+        predictions = shared._sanitize_predictions(
+            [
+                {
+                    "xyxyn": [float(c) for c in member.box[:4]],
+                    "confidence": float(member.box[4]),
+                    "class_name": "smoke",
+                }
+            ]
+        )
+        if not predictions:
+            continue
+        detection_data = {
+            "sequence_id": new_seq_id,
+            "alert_api_id": row["detection_id"],
+            "recorded_at": row["recorded_at"],
+            "algo_predictions": {"predictions": predictions},
+        }
+        try:
+            image_bytes = Path(row["filepath_image"]).read_bytes()
+        except OSError as exc:
+            logging.warning(f"Cannot read {row['filepath_image']}: {exc}")
+            continue
+        try:
+            create_detection(
+                args.url_api_annotation,
+                token,
+                detection_data,
+                image_bytes,
+                member.image_filename,
+            )
+            posted += 1
+        except AnnotationAPIError as exc:
+            logging.warning(
+                f"Detection {row['detection_id']} (seq {new_seq_id}) failed: {exc}"
+            )
+            hard_failure = True
+
+    # Roll back an incomplete object so it is not left half-imported (which the
+    # object-level dedup would otherwise treat as "done" and never retry).
+    if posted == 0 or hard_failure:
+        logging.warning(
+            f"seq {sid} object {object_index}: incomplete "
+            f"({posted}/{len(members)} detections, hard_failure={hard_failure}) "
+            f"— deleting sequence {new_seq_id} for retry"
+        )
+        _safe_delete_sequence(args, token, new_seq_id)
+        return False
+
+    # Trigger server-side annotation auto-generation for this object's detections.
+    ann_result = create_simple_sequence_annotation(
+        sequence_id=new_seq_id,
+        annotation_api_url=args.url_api_annotation,
+        config={
+            "confidence_threshold": args.confidence_threshold,
+            "iou_threshold": args.iou_threshold,
+            "min_cluster_size": args.min_cluster_size,
+        },
+        dry_run=args.dry_run,
+    )
+    if not ann_result.get("annotation_created"):
+        logging.warning(
+            f"seq {sid} object {object_index}: annotation auto-gen failed "
+            f"— deleting sequence {new_seq_id} for retry"
+        )
+        _safe_delete_sequence(args, token, new_seq_id)
+        return False
+
+    logging.info(f"seq {sid} object {object_index}: posted {posted} detection(s)")
+    return True
+
+
+def _safe_delete_sequence(args: argparse.Namespace, token: str, seq_id: int) -> None:
+    """Delete a sequence, swallowing errors (rollback is best-effort)."""
+    try:
+        delete_sequence(args.url_api_annotation, token, seq_id)
+    except AnnotationAPIError as exc:
+        logging.warning(f"Rollback delete of sequence {seq_id} failed: {exc}")
+
+
+# --------------------------------------------------------------------------- #
+# Per-day processing
+# --------------------------------------------------------------------------- #
+def process_day(
+    args: argparse.Namespace,
+    day: date,
+    token: str,
+    platform_token: Optional[str],
+    refetch_cache: Dict[int, Tuple[Optional[float], Optional[str]]],
+    imported_objs: Set[Tuple[int, int]],
+    imported_run_sids: Set[int],
+    max_new_sids: Optional[int],
+) -> bool:
+    """Fetch + predict + push one calendar day. Returns True if anything was created.
+
+    Dedup is at OBJECT granularity: an object whose ``(sid, object_index)`` is
+    already in `imported_objs` (the dataset) is skipped, so a previously-partial
+    platform sequence is completed rather than blocked. `imported_run_sids`
+    tracks platform sequences imported during this run for the --max-sequences
+    budget (`max_new_sids`).
+    """
+    day_from = day.strftime("%Y-%m-%d")
+    day_end = (day + timedelta(days=1)).strftime("%Y-%m-%d")  # exclusive
+    temp_dir = Path(tempfile.mkdtemp(prefix=f"import_predictor_split_{day_from}_"))
+    logging.info(f"=== Day {day_from} === temp dir: {temp_dir}")
+    created_any = False
+    try:
+        step_fetch(args, temp_dir, day_from, day_end)
+        jsonl_path = step_predict(args, temp_dir)
+
+        metas = load_sequences_csv(temp_dir)
+        predictor_records = load_predictor_boxes(jsonl_path)
+
+        kept_sids = sorted(
+            sid
+            for sid, rec in predictor_records.items()
+            if rec.get("status") == "kept" and sid in metas
+        )
+        logging.info(f"Day {day_from}: {len(kept_sids)} kept sequence(s)")
+
+        for sid in kept_sids:
+            # Budget: stop taking NEW platform sequences once the cap is hit.
+            if (
+                max_new_sids is not None
+                and sid not in imported_run_sids
+                and len(imported_run_sids) >= max_new_sids
+            ):
+                logging.info("Reached --max-sequences cap; stopping.")
+                break
+
+            meta = metas[sid]
+            rec = predictor_records[sid]
+            # Attach the parsed recorded_at to each frame for clustering.
+            frames = []
+            for frame in rec.get("frames", []):
+                row = meta.images.get(frame.get("image_filename"))
+                if row is None or not row.get("recorded_at"):
+                    continue
+                frames.append(
+                    {
+                        "frame_idx": frame.get("frame_idx", 0),
+                        "image_filename": frame["image_filename"],
+                        "recorded_at": _parse_dt(row["recorded_at"]),
+                        "boxes": frame.get("boxes", []),
+                    }
+                )
+            objects = cluster_objects(
+                frames,
+                min_dets=args.min_dets,
+                min_interval_seconds=args.min_interval_seconds,
+                relaxation_seconds=args.relaxation_seconds,
+            )
+            if not objects:
+                logging.info(f"seq {sid}: no objects after clustering — dropped")
+                continue
+            camera_azimuth, is_wildfire = _refetch_sequence_fields(
+                args, platform_token, sid, refetch_cache
+            )
+            for object_index, obj in enumerate(objects):
+                if (sid, object_index) in imported_objs:
+                    logging.debug(
+                        f"seq {sid} object {object_index}: already in dataset — skipping"
+                    )
+                    continue
+                if post_object(
+                    args,
+                    token,
+                    meta,
+                    sid,
+                    object_index,
+                    obj,
+                    camera_azimuth,
+                    is_wildfire,
+                ):
+                    imported_objs.add((sid, object_index))
+                    imported_run_sids.add(sid)
+                    created_any = True
+        return created_any
+    finally:
+        if args.keep_temp:
+            logging.info(f"Temp dir kept at {temp_dir}")
+        else:
+            try:
+                shutil.rmtree(temp_dir)
+            except OSError as exc:
+                logging.warning(f"Failed to clean up temp dir {temp_dir}: {exc}")
+            else:
+                logging.info(f"Cleaned up temp dir {temp_dir}")
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def main() -> int:
+    args = make_cli_parser().parse_args()
+    logging.basicConfig(
+        level=args.loglevel.upper(),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    days = _iter_days(args)
+    _validate_paths(args)
+    logging.info(f"Processing {len(days)} day(s): {days[0]} .. {days[-1]}")
+
+    # Annotation API auth (sequences + detections).
+    login, password = shared.get_annotation_credentials(args.url_api_annotation)
+    token = get_auth_token(args.url_api_annotation, login, password)
+
+    if args.reset:
+        reset_synthetic_sequences(args, token)
+
+    # Pre-load (sid, object_index) keys already in the dataset (object-level dedup).
+    imported_objs = load_imported_object_keys(args, token)
+
+    platform_token = _platform_token(args)
+    refetch_cache: Dict[int, Tuple[Optional[float], Optional[str]]] = {}
+    imported_run_sids: Set[int] = set()
+    max_new_sids = (
+        args.max_sequences if args.max_sequences and args.max_sequences > 0 else None
+    )
+
+    created_any = False
+    for day in days:
+        if max_new_sids is not None and len(imported_run_sids) >= max_new_sids:
+            logging.info("Reached --max-sequences cap; stopping.")
+            break
+        if process_day(
+            args,
+            day,
+            token,
+            platform_token,
+            refetch_cache,
+            imported_objs,
+            imported_run_sids,
+            max_new_sids,
+        ):
+            created_any = True
+
+    if created_any and not args.dry_run:
+        step_assign_groups(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/annotation_api/scripts/data_transfer/ingestion/platform/object_clustering.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/object_clustering.py
@@ -1,0 +1,216 @@
+"""
+Offline port of pyro-api's detection -> sequence association logic.
+
+The alert platform (`pyro-api`) turns a stream of per-frame bounding boxes into
+one *sequence per detected object*: an incoming box joins an existing open
+sequence when it spatially overlaps that sequence's most-recent box, otherwise a
+brand-new sequence is spawned once enough overlapping un-assigned boxes have
+accumulated within a short time window. We replay that exact rule offline over
+the (already complete) set of predictor boxes for a single platform sequence so
+that one platform sequence is split into one annotation-API sequence per object.
+
+Reference implementation:
+  - `pyro-api/src/app/api/api_v1/endpoints/detections.py`
+      `_bboxes_overlap`            (intersection area > 0, no IoU threshold)
+      candidate match / spawn loop (lines ~420-491)
+  - `pyro-api/src/app/services/cones.py` `resolve_cone`
+  - thresholds: `pyro-api/src/app/core/config.py`
+      SEQUENCE_RELAXATION_SECONDS = 7200  (open-sequence match window)
+      SEQUENCE_MIN_INTERVAL_SECONDS = 300 (spawn pool window)
+      SEQUENCE_MIN_INTERVAL_DETS = 3      (min overlapping dets to spawn)
+
+Offline note: all frames of one platform sequence already share a camera/pose,
+so the per-camera filtering collapses; the 2h relaxation window is effectively
+always satisfied, while the 5min/3-detection spawn rule still shapes how many
+distinct objects are carved out. The thresholds remain parameters so the
+behaviour can be tightened.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional, Sequence, Tuple
+
+# Defaults mirror pyro-api/src/app/core/config.py
+SEQUENCE_RELAXATION_SECONDS = 7200
+SEQUENCE_MIN_INTERVAL_SECONDS = 300
+SEQUENCE_MIN_INTERVAL_DETS = 3
+
+# A box is [x1, y1, x2, y2, conf], normalised to [0, 1].
+Box = Sequence[float]
+
+
+@dataclass(eq=False)
+class Detection:
+    """A single predictor box on a single frame.
+
+    `eq=False` keeps identity-based equality so the pending-pool removal
+    (`d not in window`) compares object identity, not value — two value-equal
+    boxes (same frame/timestamp/coords) are never confused.
+    """
+
+    frame_idx: int
+    recorded_at: datetime
+    image_filename: str
+    box: List[float]
+
+
+@dataclass
+class TrackedObject:
+    """An object = an ordered chain of overlapping detections across frames."""
+
+    members: List[Detection] = field(default_factory=list)
+
+    @property
+    def last(self) -> Detection:
+        return self.members[-1]
+
+    @property
+    def last_box(self) -> List[float]:
+        return self.members[-1].box
+
+    @property
+    def last_seen(self) -> datetime:
+        return self.members[-1].recorded_at
+
+    @property
+    def started_at(self) -> datetime:
+        return self.members[0].recorded_at
+
+
+def bboxes_overlap(left: Box, right: Box) -> bool:
+    """True iff the two boxes have a strictly positive 2D intersection.
+
+    Port of pyro-api `_bboxes_overlap` (detections.py:90) — note there is NO IoU
+    threshold; any pixel overlap counts. The confidence element is ignored.
+    """
+    lx_min, ly_min, lx_max, ly_max = left[0], left[1], left[2], left[3]
+    rx_min, ry_min, rx_max, ry_max = right[0], right[1], right[2], right[3]
+    inter_w = min(lx_max, rx_max) - max(lx_min, rx_min)
+    inter_h = min(ly_max, ry_max) - max(ly_min, ry_min)
+    return inter_w > 0 and inter_h > 0
+
+
+def resolve_cone(
+    azimuth: float, boxes: Sequence[Box], aov: float
+) -> Tuple[float, float]:
+    """Port of pyro-api `cones.resolve_cone` (cones.py:11).
+
+    Keys on the box with the largest `xmax` (``max(boxes, key=itemgetter(2))`` in
+    the original — this is what the code does, despite the misleading docstring
+    that says "most confident"). Returns ``(cone_azimuth, cone_angle)`` derived
+    from the *camera* azimuth and angle-of-view.
+    """
+    best = max(boxes, key=lambda b: b[2])
+    xmin, xmax = best[0], best[2]
+    cone_azimuth = round(azimuth + aov * ((xmin + xmax) / 2 - 0.5), 1) % 360
+    cone_angle = round(aov * (xmax - xmin), 1)
+    return cone_azimuth, cone_angle
+
+
+def _flatten(frames: Sequence[dict]) -> List[Detection]:
+    """Flatten per-frame box lists into ordered single-box detections.
+
+    `frames` is the predictor output for one sequence:
+        [{"frame_idx": int, "recorded_at": datetime,
+          "image_filename": str, "boxes": [[x1,y1,x2,y2,conf], ...]}, ...]
+    Frames with no boxes contribute nothing. Items are ordered by
+    (recorded_at, frame_idx) so the replay is temporal.
+    """
+    items: List[Detection] = []
+    for frame in frames:
+        for box in frame.get("boxes", []):
+            if not box:
+                continue
+            items.append(
+                Detection(
+                    frame_idx=frame["frame_idx"],
+                    recorded_at=frame["recorded_at"],
+                    image_filename=frame["image_filename"],
+                    box=list(box),
+                )
+            )
+    items.sort(key=lambda d: (d.recorded_at, d.frame_idx))
+    return items
+
+
+def cluster_objects(
+    frames: Sequence[dict],
+    *,
+    min_dets: int = SEQUENCE_MIN_INTERVAL_DETS,
+    min_interval_seconds: int = SEQUENCE_MIN_INTERVAL_SECONDS,
+    relaxation_seconds: int = SEQUENCE_RELAXATION_SECONDS,
+) -> List[TrackedObject]:
+    """Replay pyro-api's association rule offline; return one object per chain.
+
+    For each detection (in temporal order):
+      1. Try to attach it to an OPEN object whose last box overlaps, scanning
+         open objects most-recently-seen first (pyro-api orders candidates by
+         `last_seen_at` desc and breaks on the first overlap, detections.py:421).
+      2. Otherwise, collect the un-assigned detections within the trailing
+         `min_interval_seconds` window that overlap the current box — INCLUDING
+         the current detection in the count (detections.py:448-472) — and spawn a
+         new object when that set reaches `min_dets`. Below the threshold the
+         detection stays pending and may seed/join a later object.
+
+    Detections that never reach the spawn threshold are dropped, exactly as
+    pyro-api never materialises a sequence for fewer than `min_dets` overlapping
+    detections.
+    """
+    items = _flatten(frames)
+    open_objects: List[TrackedObject] = []
+    pending: List[Detection] = []
+
+    for det in items:
+        # 1. attach to an existing open object (most-recent-seen first)
+        candidates = sorted(
+            (
+                obj
+                for obj in open_objects
+                if (det.recorded_at - obj.last_seen).total_seconds()
+                <= relaxation_seconds
+            ),
+            key=lambda obj: obj.last_seen,
+            reverse=True,
+        )
+        matched: Optional[TrackedObject] = None
+        for obj in candidates:
+            if bboxes_overlap(obj.last_box, det.box):
+                matched = obj
+                break
+
+        if matched is not None:
+            matched.members.append(det)
+            continue
+
+        # 2. otherwise, try to spawn a new object from overlapping pending dets
+        window = [
+            d
+            for d in pending
+            if (det.recorded_at - d.recorded_at).total_seconds() <= min_interval_seconds
+            and bboxes_overlap(d.box, det.box)
+        ]
+        window.append(det)  # the current detection counts toward the threshold
+        if len(window) >= min_dets:
+            window.sort(key=lambda d: (d.recorded_at, d.frame_idx))
+            open_objects.append(TrackedObject(members=window))
+            pending = [d for d in pending if d not in window]
+        else:
+            pending.append(det)
+
+    return open_objects
+
+
+def object_cone_azimuth(
+    obj: TrackedObject, camera_azimuth: float, angle_of_view: Optional[float]
+) -> Optional[float]:
+    """Per-object azimuth, derived from the *camera* azimuth (never the
+    platform's `sequence_azimuth`), using the object's first detection box —
+    mirroring pyro-api which keys the cone on `first_det.bbox` (detections.py:474).
+
+    Returns None when angle-of-view is unavailable so the caller can fall back to
+    the plain camera azimuth.
+    """
+    if angle_of_view is None:
+        return None
+    cone_azimuth, _ = resolve_cone(camera_azimuth, [obj.members[0].box], angle_of_view)
+    return cone_azimuth

--- a/annotation_api/scripts/data_transfer/ingestion/platform/object_clustering.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/object_clustering.py
@@ -119,7 +119,10 @@ def _flatten(frames: Sequence[dict]) -> List[Detection]:
     items: List[Detection] = []
     for frame in frames:
         for box in frame.get("boxes", []):
-            if not box:
+            # Each box must be [x1, y1, x2, y2, conf]; guard the shape so a
+            # malformed predictor row is skipped rather than crashing later on
+            # box[4] access.
+            if not box or len(box) < 5:
                 continue
             items.append(
                 Detection(

--- a/annotation_api/scripts/data_transfer/ingestion/platform/predictor_runner.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/predictor_runner.py
@@ -1,0 +1,244 @@
+"""
+Run the Pyronear engine predictor over fetched sequence folders and emit the
+per-frame smoothed bounding boxes as JSONL.
+
+This script is the box-extracting counterpart to pyro-dataset's
+`predict_and_filter_sequences.py`: instead of only recording a kept/dropped
+verdict per sequence, it records, for every frame, the predictor's
+temporally-smoothed `output_predictions` so the orchestrator can rebuild
+objects from them and POST predictor-derived detections.
+
+It MUST run inside the pyro-engine virtualenv (which carries the heavy
+`pyro_predictor` / `ncnn` / `onnxruntime` deps) and therefore imports nothing
+from the annotation_api package — the orchestrator invokes it as a subprocess:
+
+    PYTHONPATH=$PYRO_ENGINE_DIR/pyro-predictor \
+    $PYRO_ENGINE_DIR/.venv/bin/python /abs/path/to/predictor_runner.py \
+      --save-dir <temp> --out <temp>/predictor_boxes.jsonl \
+      --n-consecutive 6 --conf-threshold 0.1 \
+      --model-folder $PYRO_ENGINE_DIR/pyro-predictor/data
+
+Output (`--out`): one JSON object per sequence, e.g.
+    {"sequence_id": "16851", "n_images": 30, "max_conf": 0.42, "status": "kept",
+     "frames": [{"frame_idx": 0,
+                 "image_filename": "pyronear_org_cam-123_2025-03-04T10-02-55.jpg",
+                 "boxes": [[0.41, 0.30, 0.55, 0.44, 0.42]]},
+                {"frame_idx": 1, "image_filename": "...", "boxes": []}]}
+
+The smoothed boxes are read from the predictor's per-camera state after each
+`predict()` call: `predictor._states[cam_id]["last_predictions"][-1][2]`, which
+is the `output_predictions` list ([x1, y1, x2, y2, conf], normalised, <=5 boxes).
+This is a private attribute; the index is stable on both the local checkout and
+origin/main of pyro-engine (predictor.py:139 / :153).
+"""
+
+import argparse
+import json
+import logging
+import re
+from pathlib import Path
+from typing import List
+
+from PIL import Image
+from pyro_predictor import Predictor  # type: ignore[import-not-found]  # runs in pyro-engine venv
+
+SEQUENCE_DIR_RE = re.compile(r"_sequence-(\d+)$")
+
+
+def make_cli_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--save-dir",
+        type=Path,
+        required=True,
+        help="Root dir containing the sequence folders (the fetch --save-dir).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Output JSONL path (one object per sequence).",
+    )
+    parser.add_argument(
+        "--n-consecutive",
+        type=int,
+        default=6,
+        help="Sliding-window size passed as nb_consecutive_frames to Predictor.",
+    )
+    parser.add_argument(
+        "--conf-threshold",
+        type=float,
+        default=0.1,
+        help="Confidence threshold; sequences with max conf strictly below are 'dropped'.",
+    )
+    parser.add_argument(
+        "--model-folder",
+        type=Path,
+        required=True,
+        help="Path passed as Classifier(model_folder=...).",
+    )
+    parser.add_argument(
+        "--dropped-subdir",
+        type=str,
+        default="dropped",
+        help="Subdir under --save-dir to exclude from scanning.",
+    )
+    parser.add_argument("-log", "--loglevel", default="info", help="Logging level.")
+    return parser
+
+
+def find_sequence_dirs(root: Path, exclude: Path) -> List[Path]:
+    """Every dir under `root` named `*_sequence-<id>`, excluding `exclude`."""
+    results: List[Path] = []
+    exclude_abs = exclude.resolve()
+    for path in root.rglob("*"):
+        if not path.is_dir() or not SEQUENCE_DIR_RE.search(path.name):
+            continue
+        try:
+            resolved = path.resolve()
+            if exclude_abs in resolved.parents or resolved == exclude_abs:
+                continue
+        except OSError:
+            continue
+        results.append(path)
+    return sorted(results)
+
+
+def list_images(sequence_dir: Path) -> List[Path]:
+    images_dir = sequence_dir / "images"
+    if not images_dir.is_dir():
+        return []
+    return sorted(
+        p for p in images_dir.iterdir() if p.suffix.lower() in {".jpg", ".jpeg", ".png"}
+    )
+
+
+def _smoothed_boxes(predictor: Predictor, cam_id: str) -> List[List[float]]:
+    """Read the just-appended frame's smoothed `output_predictions`.
+
+    Returns [] defensively if the predictor state is missing/empty or shaped
+    unexpectedly, so a single odd frame never aborts the whole run.
+    """
+    try:
+        last_predictions = predictor._states[cam_id]["last_predictions"]
+        if not last_predictions:
+            return []
+        output_predictions = last_predictions[-1][2]
+        return [list(box) for box in output_predictions]
+    except (KeyError, IndexError, TypeError) as exc:
+        logging.debug(f"Could not read smoothed boxes for cam_id={cam_id}: {exc}")
+        return []
+
+
+def predict_sequence(
+    predictor: Predictor, sequence_dir: Path, sequence_id: str
+) -> tuple[List[dict], float, int]:
+    """Run the predictor over a sequence; return (frame_records, max_conf, n_failed).
+
+    A fresh `cam_id` per sequence allocates fresh sliding-window state in the
+    predictor's internal `_states` dict (same convention as
+    predict_and_filter_sequences.py). `n_failed` counts frames whose inference
+    raised, so the caller can distinguish "no smoke" from "inference broke".
+    """
+    frames: List[dict] = []
+    max_conf = 0.0
+    n_failed = 0
+    for frame_idx, image_path in enumerate(list_images(sequence_dir)):
+        boxes: List[List[float]] = []
+        try:
+            with Image.open(image_path) as im:
+                im.load()
+                conf = predictor.predict(im, cam_id=sequence_id)
+            boxes = _smoothed_boxes(predictor, sequence_id)
+        except Exception as exc:
+            logging.warning(f"Inference failed on {image_path}: {exc}")
+            conf = 0.0
+            n_failed += 1
+        if conf > max_conf:
+            max_conf = conf
+        frames.append(
+            {
+                "frame_idx": frame_idx,
+                "image_filename": image_path.name,
+                "boxes": boxes,
+            }
+        )
+    return frames, max_conf, n_failed
+
+
+def main() -> int:
+    args = make_cli_parser().parse_args()
+    logging.basicConfig(level=args.loglevel.upper())
+
+    save_dir: Path = args.save_dir
+    if not save_dir.is_dir():
+        logging.error(f"--save-dir {save_dir} does not exist or is not a directory")
+        return 1
+
+    dropped_root = save_dir / args.dropped_subdir
+    sequence_dirs = find_sequence_dirs(save_dir, exclude=dropped_root)
+    logging.info(
+        f"Found {len(sequence_dirs)} sequence(s) under {save_dir}; "
+        f"predictor: nb_consecutive_frames={args.n_consecutive}, "
+        f"conf_thresh={args.conf_threshold}"
+    )
+
+    predictor = Predictor(
+        conf_thresh=args.conf_threshold,
+        nb_consecutive_frames=args.n_consecutive,
+        verbose=False,
+        model_folder=str(args.model_folder),
+    )
+
+    kept = 0
+    dropped = 0
+    total_frames = 0
+    total_failed = 0
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w") as out_file:
+        for sequence_dir in sequence_dirs:
+            match = SEQUENCE_DIR_RE.search(sequence_dir.name)
+            sequence_id = match.group(1) if match else sequence_dir.name
+            frames, max_conf, n_failed = predict_sequence(
+                predictor, sequence_dir, sequence_id
+            )
+            n_images = len(frames)
+            total_frames += n_images
+            total_failed += n_failed
+            if n_images == 0:
+                status = "dropped_no_images"
+            elif n_failed == n_images:
+                status = "error"  # every frame's inference raised
+            elif max_conf < args.conf_threshold:
+                status = "dropped"
+            else:
+                status = "kept"
+            kept += status == "kept"
+            dropped += status != "kept"
+            out_file.write(
+                json.dumps(
+                    {
+                        "sequence_id": sequence_id,
+                        "n_images": n_images,
+                        "max_conf": round(max_conf, 4),
+                        "status": status,
+                        "frames": frames,
+                    }
+                )
+                + "\n"
+            )
+
+    logging.info(f"Done — kept={kept}, dropped={dropped}, out={args.out}")
+    # Systemic failure (e.g. model failed to load / wrong runtime): every frame
+    # raised. Exit non-zero so the orchestrator aborts instead of treating the
+    # run as "nothing detected".
+    if total_frames > 0 and total_failed == total_frames:
+        logging.error(
+            f"All {total_frames} frame(s) failed inference — aborting (exit 1)"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/annotation_api/scripts/data_transfer/ingestion/platform/predictor_runner.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/predictor_runner.py
@@ -41,6 +41,7 @@ from typing import List
 
 from PIL import Image
 from pyro_predictor import Predictor  # type: ignore[import-not-found]  # runs in pyro-engine venv
+from tqdm import tqdm
 
 SEQUENCE_DIR_RE = re.compile(r"_sequence-(\d+)$")
 
@@ -196,7 +197,7 @@ def main() -> int:
     total_failed = 0
     args.out.parent.mkdir(parents=True, exist_ok=True)
     with open(args.out, "w") as out_file:
-        for sequence_dir in sequence_dirs:
+        for sequence_dir in tqdm(sequence_dirs, desc="Predicting", unit="seq"):
             match = SEQUENCE_DIR_RE.search(sequence_dir.name)
             sequence_id = match.group(1) if match else sequence_dir.name
             frames, max_conf, n_failed = predict_sequence(

--- a/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
@@ -78,6 +78,11 @@ def parse_args() -> argparse.Namespace:
         help="Only pull sequences whose annotation smoke_types includes this value (use 'any' to include all smoke types, 'empty' to only include sequences with no smoke_types)",
     )
     parser.add_argument(
+        "--no-stage-update",
+        action="store_true",
+        help="Skip the remote PATCH that transitions seq_annotation_done -> in_review (read-only export)",
+    )
+    parser.add_argument(
         "--loglevel",
         default="info",
         choices=["debug", "info", "warning", "error"],
@@ -269,18 +274,19 @@ def main() -> None:
             else:
                 label_path.write_text("")
 
-        # update remote stage to in_review
-        try:
-            remote_ann = ann
-            annotation_api.update_sequence_annotation(
-                args.remote_api,
-                token,
-                remote_ann["id"],
-                {"processing_stage": "in_review"},
-            )
-        except Exception as exc:
-            logging.warning("Failed to set sequence %s to in_review: %s", seq_id, exc)
-            return ("stage_update_failed", seq_id)
+        # update remote stage to in_review (skipped in read-only export mode)
+        if not args.no_stage_update:
+            try:
+                remote_ann = ann
+                annotation_api.update_sequence_annotation(
+                    args.remote_api,
+                    token,
+                    remote_ann["id"],
+                    {"processing_stage": "in_review"},
+                )
+            except Exception as exc:
+                logging.warning("Failed to set sequence %s to in_review: %s", seq_id, exc)
+                return ("stage_update_failed", seq_id)
 
         return ("ok", seq_id)
 

--- a/annotation_api/scripts/data_transfer/ingestion/platform/sequence_fetching.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/sequence_fetching.py
@@ -365,13 +365,16 @@ def fetch_all_sequences_within(
                     sequences.extend(future.result())
                     progress_bar.advance(task)
 
-    # Optionally filter sequences by alert_api_id
+    # Optionally filter sequences by alert_api_id.
+    # The raw platform sequences expose this value as the `id` field; the
+    # `alert_api_id` rename happens later in shared.py when records are
+    # formatted for the annotation API, so we cannot read it back here.
     if selected_sequence_list:
         pre_filter_count = len(sequences)
         sequences = [
             sequence
             for sequence in sequences
-            if sequence.get("alert_api_id") in selected_sequence_list
+            if sequence.get("id") in selected_sequence_list
         ]
         filtered_out = pre_filter_count - len(sequences)
         console.print(

--- a/annotation_api/src/app/clients/annotation_api.py
+++ b/annotation_api/src/app/clients/annotation_api.py
@@ -170,6 +170,11 @@ def _make_request(
         headers.update(_get_auth_headers(auth_token))
         kwargs["headers"] = headers
 
+        # Default (connect, read) timeout so a hung/half-open connection raises a
+        # RequestException (handled below) instead of blocking the caller
+        # forever. Callers may override by passing their own `timeout`.
+        kwargs.setdefault("timeout", (10, 120))
+
         response = requests.request(method, url, **kwargs)
 
         # Don't raise for status here - we'll handle it in _handle_response


### PR DESCRIPTION
## What & why

Adds a new platform→annotation ingestion pipeline that runs **our own
pyro-engine predictor** over fetched sequences and splits each platform
sequence into **one annotation sequence per detected smoke plume** (porting
pyro-api's detection→sequence association). Detections carry the predictor's
boxes — not the platform's tracked bbox — so the annotation dataset reflects the
model we actually ship, already segmented by object and ready for human review.

The branch also includes `import_filtered.py` (registry-dedup + predictor-filter
orchestrator that reuses the existing `import.py` POST path) and a small
`--no-stage-update` read-only export flag on `pull_sequence_annotations`.

## Pipeline (`import_predictor_split.py`)

Walks the date range **one day at a time** (inclusive), and per day:
1. **Fetch** N images/sequence via pyro-dataset's fetch script (local registry
   dedup disabled — this importer dedups against the annotation API instead).
2. **Predict** in the pyro-engine venv (`predictor_runner.py`), emitting each
   frame's temporally-smoothed boxes as JSONL.
3. **Split** into objects (`object_clustering.py`, pure-Python port of pyro-api:
   bbox-overlap chaining, ≥3-overlap spawn, cone azimuth from `camera_azimuth`).
4. **Post** per object: one Sequence (synthetic `alert_api_id =
   base + platform_id*1000 + object_index`, per-object cone azimuth), one
   Detection per frame (predictor box as `algo_predictions`, the other objects'
   boxes as `others_bboxes` for missed-smoke review), and a single explicit
   `is_smoke` annotation track. Uploads run concurrently (`--max-workers`).
5. **assign_groups** per productive day.

## Design & robustness

- **One object = one annotation track** (we bypass the server's IoU auto-gen,
  which fragmented a single drifting/tiny-box plume into several tracks).
- **Object-level dedup** by reversing the synthetic `alert_api_id` → resumable;
  re-running continues where it left off (`--reset` for a clean rebuild).
- **Transactional**: any partial/failed object deletes its sequence (cascade)
  so the dedup never skips a stranded sequence forever.
- **Long-run hardening**: per-request HTTP timeout + transient retry, per-day
  token refresh, a failing day is skipped+logged (non-zero exit lists them),
  parallel uploads (the upload was the throughput bottleneck).

## Validation

Full **336-day** run against prod completed cleanly: **0 failed days, 0 retries,
0 rollbacks, 0 tracebacks**. 4,171 sequences fetched, ~25% dropped by the model,
**3,764 annotation objects from 2,757 platform sequences**. Multi-object split,
`others_bboxes`, and single-track annotations all verified in the API.
~73 s/day after parallelization (POST 288 s → ~66 s on a representative day).

## Usage

```bash
cd annotation_api
make import-platform-predictor-split DATE_FROM=2025-07-01 DATE_END=2026-06-01
# or the direct nohup form (see README "Admin Workflow")
```

Requires `PYRO_DATASET_DIR` / `PYRO_ENGINE_DIR`; the target org is selected by
the `PLATFORM_LOGIN` account.

## Known limitation

`object_index` is positional, so the resume dedup is only stable while the
predictor/clustering output is stable; after a model/params change use `--reset`
for a clean rebuild (documented in code).

## Files

- `import_predictor_split.py` (orchestrator), `object_clustering.py`,
  `predictor_runner.py` — new
- `import_filtered.py` — new (parallel registry-dedup + predictor-filter pipeline)
- `annotation_api/src/app/clients/annotation_api.py` — default request timeout
- `Makefile`, `README.md`, `pull_sequence_annotations.py` — targets / docs / flag
