### PR TITLE
feat(sequence-groups): 3+ member filter, size sort, and zoomed crop view

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
@@ -99,9 +99,12 @@ async def list_sequence_groups(
         )
         # Inner-join so small groups (no row in the subquery) drop out.
         .join(member_count_subq, member_count_subq.c.group_id == SequenceGroup.id)
-        # Biggest groups first, then newest within each size.
+        # Biggest groups first, then newest within each size. `id` is a final
+        # deterministic tie-breaker so paginated offsets stay stable.
         .order_by(
-            desc(member_count_subq.c.member_count), desc(SequenceGroup.created_at)
+            desc(member_count_subq.c.member_count),
+            desc(SequenceGroup.created_at),
+            desc(SequenceGroup.id),
         )
     )
     if labeled is True:

--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
@@ -71,8 +71,8 @@ async def list_sequence_groups(
     session: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user),
 ) -> Page[SequenceGroupListItem]:
-    # Singletons (size-1 groups) are excluded from the list because the
-    # whole point of this page is to find groups worth bulk-annotating.
+    # Small groups (fewer than 3 members) are excluded from the list because
+    # the whole point of this page is to find groups worth bulk-annotating.
     member_count_subq = (
         select(
             Sequence.sequence_group_id.label("group_id"),
@@ -80,7 +80,7 @@ async def list_sequence_groups(
         )
         .where(Sequence.sequence_group_id.is_not(None))
         .group_by(Sequence.sequence_group_id)
-        .having(func.count(Sequence.id) >= 2)
+        .having(func.count(Sequence.id) >= 3)
         .subquery()
     )
     query = (
@@ -97,9 +97,12 @@ async def list_sequence_groups(
             SequenceGroup.created_at,
             member_count_subq.c.member_count,
         )
-        # Inner-join so singletons (no row in the subquery) drop out.
+        # Inner-join so small groups (no row in the subquery) drop out.
         .join(member_count_subq, member_count_subq.c.group_id == SequenceGroup.id)
-        .order_by(desc(SequenceGroup.created_at))
+        # Biggest groups first, then newest within each size.
+        .order_by(
+            desc(member_count_subq.c.member_count), desc(SequenceGroup.created_at)
+        )
     )
     if labeled is True:
         query = query.where(

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -24,6 +24,8 @@ from httpx import AsyncClient
 from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.models import Sequence
+
 
 async def _set_seq_metadata(
     session: AsyncSession,
@@ -81,6 +83,92 @@ async def _seed_two_member_group(
         )
     await session.commit()
     return group_id
+
+
+async def _seed_group_with_members(
+    session: AsyncSession,
+    *,
+    n_members: int,
+    created_at: datetime,
+    alert_api_id_start: int,
+) -> int:
+    """Insert a SequenceGroup with `n_members` member sequences (each with a
+    distinct alert_api_id) and return its id."""
+    group_id = (
+        await session.exec(
+            text(
+                """
+                INSERT INTO sequence_groups
+                    (camera_id, azimuth, representative_bbox, is_validated,
+                     created_at)
+                VALUES
+                    (1, 0, CAST(:bbox AS jsonb), false, :created_at)
+                RETURNING id
+                """
+            ).bindparams(
+                bbox='{"xyxyn":[0.1,0.1,0.4,0.4],"confidence":0.9}',
+                created_at=created_at,
+            )
+        )
+    ).scalar_one()
+    for i in range(n_members):
+        session.add(
+            Sequence(
+                source_api="pyronear_french",
+                alert_api_id=alert_api_id_start + i,
+                created_at=created_at,
+                recorded_at=created_at,
+                last_seen_at=created_at,
+                camera_name="cam",
+                camera_id=1,
+                is_wildfire_alertapi="wildfire_smoke",
+                organisation_name="org",
+                lat=0.0,
+                lon=0.0,
+                organisation_id=1,
+                sequence_group_id=group_id,
+            )
+        )
+    await session.commit()
+    return group_id
+
+
+@pytest.mark.asyncio
+async def test_list_groups_hides_small_groups_and_sorts_by_size(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """The list endpoint returns only groups with 3+ members, ordered by
+    member count descending."""
+    big = await _seed_group_with_members(
+        async_session,
+        n_members=4,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        alert_api_id_start=100,
+    )
+    medium = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        alert_api_id_start=200,
+    )
+    small = await _seed_group_with_members(
+        async_session,
+        n_members=2,
+        created_at=datetime(2026, 1, 3, tzinfo=timezone.utc),
+        alert_api_id_start=300,
+    )
+
+    resp = await authenticated_client.get("/sequence_groups/")
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+
+    ids = [item["id"] for item in items]
+    assert small not in ids  # 2-member group is hidden
+    assert ids == [big, medium]  # 4 members sort before 3 members
+    counts = {item["id"]: item["member_count"] for item in items}
+    assert counts[big] == 4
+    assert counts[medium] == 3
 
 
 def _annotation_payload(*, stage: str, smoke_type: str) -> dict:

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -183,15 +183,21 @@ function MemberCard({
               <Loader2 className="animate-spin w-5 h-5 text-gray-400" />
             )}
           </div>
-          {/* Zoomed crop so small objects stay legible. */}
+          {/* Zoomed crop so small objects stay legible. Falls back to the
+              plain frame when neither a prediction nor the group region
+              yields a valid box to zoom into. */}
           <div className="relative aspect-video bg-gray-100 overflow-hidden flex items-center justify-center">
             {image?.url ? (
-              <>
-                <BboxCrop url={image.url} box={cropBox} />
-                <span className="absolute bottom-1 right-1 z-10 px-1 rounded bg-black/50 text-white text-[10px] leading-tight pointer-events-none">
-                  zoom
-                </span>
-              </>
+              isValidBox(cropBox) ? (
+                <>
+                  <BboxCrop url={image.url} box={cropBox} />
+                  <span className="absolute bottom-1 right-1 z-10 px-1 rounded bg-black/50 text-white text-[10px] leading-tight pointer-events-none">
+                    zoom
+                  </span>
+                </>
+              ) : (
+                <img src={image.url} alt="" className="w-full h-full object-cover" />
+              )
             ) : (
               <Loader2 className="animate-spin w-5 h-5 text-gray-400" />
             )}

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -34,6 +34,38 @@ function memberIsAnnotated(m: SequenceGroupMember): boolean {
   );
 }
 
+type Bbox = [number, number, number, number];
+
+function isValidBox([x1, y1, x2, y2]: Bbox): boolean {
+  return x2 > x1 && y2 > y1;
+}
+
+// Zoomed view of a single image centered on `box`. The same (already cached)
+// detection image is reused and magnified with a CSS transform — no second
+// fetch, no canvas — so small objects are legible next to the full frame.
+function BboxCrop({ url, box }: { url: string; box: Bbox }) {
+  const [x1, y1, x2, y2] = box;
+  const cx = (x1 + x2) / 2;
+  const cy = (y1 + y2) / 2;
+  // Show the box plus a margin of one box-size on each side (region ≈ 3×),
+  // then zoom so the whole region fits the cell; cap at 8× for tiny boxes.
+  const regionW = Math.min(1, Math.max(x2 - x1, 0.001) * 3);
+  const regionH = Math.min(1, Math.max(y2 - y1, 0.001) * 3);
+  const zoom = Math.min(1 / regionW, 1 / regionH, 8);
+
+  return (
+    <img
+      src={url}
+      alt=""
+      className="absolute inset-0 w-full h-full object-cover"
+      style={{
+        transformOrigin: `${cx * 100}% ${cy * 100}%`,
+        transform: `translate(${(0.5 - cx) * 100}%, ${(0.5 - cy) * 100}%) scale(${zoom})`,
+      }}
+    />
+  );
+}
+
 function MemberCard({
   member,
   groupId,
@@ -55,6 +87,18 @@ function MemberCard({
   });
 
   const predictions: AlgoPrediction[] = member.first_detection_algo_predictions?.predictions ?? [];
+
+  // Crop target: the tracked prediction(s) for this frame (the actual object),
+  // falling back to the group reference region when the frame has none.
+  const validPreds = predictions.filter(p => isValidBox(p.xyxyn));
+  const cropBox: Bbox = validPreds.length
+    ? [
+        Math.min(...validPreds.map(p => p.xyxyn[0])),
+        Math.min(...validPreds.map(p => p.xyxyn[1])),
+        Math.max(...validPreds.map(p => p.xyxyn[2])),
+        Math.max(...validPreds.map(p => p.xyxyn[3])),
+      ]
+    : groupBbox.xyxyn;
 
   return (
     <div
@@ -88,54 +132,70 @@ function MemberCard({
         className="block hover:bg-blue-50"
         title="Open the per-sequence annotation page"
       >
-        <div className="relative aspect-video bg-gray-100 overflow-hidden flex items-center justify-center">
-          {image?.url ? (
-            <>
-              <img
-                src={image.url}
-                alt={`seq ${member.sequence_id}`}
-                className="w-full h-full object-cover"
-                onLoad={() => setImgLoaded(true)}
-              />
-              {imgLoaded && (
-                <>
-                  {predictions.map((p, i) => {
-                    const [x1, y1, x2, y2] = p.xyxyn;
-                    if (x2 <= x1 || y2 <= y1) return null;
-                    return (
-                      <div
-                        key={`pred-${i}`}
-                        className="absolute border-2 border-red-500 pointer-events-none"
-                        style={{
-                          left: `${x1 * 100}%`,
-                          top: `${y1 * 100}%`,
-                          width: `${(x2 - x1) * 100}%`,
-                          height: `${(y2 - y1) * 100}%`,
-                        }}
-                      />
-                    );
-                  })}
-                  {(() => {
-                    const [gx1, gy1, gx2, gy2] = groupBbox.xyxyn;
-                    if (gx2 <= gx1 || gy2 <= gy1) return null;
-                    return (
-                      <div
-                        className="absolute border-2 border-dashed border-yellow-400 pointer-events-none"
-                        style={{
-                          left: `${gx1 * 100}%`,
-                          top: `${gy1 * 100}%`,
-                          width: `${(gx2 - gx1) * 100}%`,
-                          height: `${(gy2 - gy1) * 100}%`,
-                        }}
-                      />
-                    );
-                  })()}
-                </>
-              )}
-            </>
-          ) : (
-            <Loader2 className="animate-spin w-5 h-5 text-gray-400" />
-          )}
+        <div className="grid grid-cols-2">
+          {/* Full frame with bbox overlays. */}
+          <div className="relative aspect-video bg-gray-100 overflow-hidden flex items-center justify-center border-r border-gray-200">
+            {image?.url ? (
+              <>
+                <img
+                  src={image.url}
+                  alt={`seq ${member.sequence_id}`}
+                  className="w-full h-full object-cover"
+                  onLoad={() => setImgLoaded(true)}
+                />
+                {imgLoaded && (
+                  <>
+                    {predictions.map((p, i) => {
+                      const [x1, y1, x2, y2] = p.xyxyn;
+                      if (x2 <= x1 || y2 <= y1) return null;
+                      return (
+                        <div
+                          key={`pred-${i}`}
+                          className="absolute border-2 border-red-500 pointer-events-none"
+                          style={{
+                            left: `${x1 * 100}%`,
+                            top: `${y1 * 100}%`,
+                            width: `${(x2 - x1) * 100}%`,
+                            height: `${(y2 - y1) * 100}%`,
+                          }}
+                        />
+                      );
+                    })}
+                    {(() => {
+                      const [gx1, gy1, gx2, gy2] = groupBbox.xyxyn;
+                      if (gx2 <= gx1 || gy2 <= gy1) return null;
+                      return (
+                        <div
+                          className="absolute border-2 border-dashed border-fuchsia-500 pointer-events-none"
+                          style={{
+                            left: `${gx1 * 100}%`,
+                            top: `${gy1 * 100}%`,
+                            width: `${(gx2 - gx1) * 100}%`,
+                            height: `${(gy2 - gy1) * 100}%`,
+                          }}
+                        />
+                      );
+                    })()}
+                  </>
+                )}
+              </>
+            ) : (
+              <Loader2 className="animate-spin w-5 h-5 text-gray-400" />
+            )}
+          </div>
+          {/* Zoomed crop so small objects stay legible. */}
+          <div className="relative aspect-video bg-gray-100 overflow-hidden flex items-center justify-center">
+            {image?.url ? (
+              <>
+                <BboxCrop url={image.url} box={cropBox} />
+                <span className="absolute bottom-1 right-1 z-10 px-1 rounded bg-black/50 text-white text-[10px] leading-tight pointer-events-none">
+                  zoom
+                </span>
+              </>
+            ) : (
+              <Loader2 className="animate-spin w-5 h-5 text-gray-400" />
+            )}
+          </div>
         </div>
         <div className="px-2 py-1 text-xs text-gray-700">
           <div className="font-medium">seq #{member.sequence_id}</div>
@@ -250,9 +310,10 @@ export default function SequenceGroupAnnotatePage() {
             tracked prediction (per-sequence)
           </span>
           <span className="inline-flex items-center gap-2">
-            <span className="inline-block w-4 h-3 border-2 border-dashed border-yellow-400" />
+            <span className="inline-block w-4 h-3 border-2 border-dashed border-fuchsia-500" />
             group reference region
           </span>
+          <span>Each row shows the full frame and a zoomed crop of the detected object.</span>
           <span>Click a thumbnail to annotate the sequence.</span>
           <span>The X removes a sequence from this group.</span>
           {group.is_validated && (
@@ -269,7 +330,7 @@ export default function SequenceGroupAnnotatePage() {
           This group has no members.
         </div>
       ) : (
-        <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <section className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           {group.members.map(m => (
             <MemberCard
               key={m.sequence_id}

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -47,7 +47,7 @@ export default function SequenceGroupsListPage() {
       <header className="mb-4">
         <h1 className="text-2xl font-semibold">Sequence groups</h1>
         <p className="text-sm text-gray-600 mt-1">
-          {total} group{total === 1 ? '' : 's'} with 2 or more members. Click a row to review
+          {total} group{total === 1 ? '' : 's'} with 3 or more members. Click a row to review
           membership; annotate one member from the per-sequence page and the labels propagate to the
           rest if the group has been validated.
         </p>
@@ -91,8 +91,8 @@ export default function SequenceGroupsListPage() {
                 <td colSpan={7} className="px-3 py-8 text-center text-gray-500">
                   {filter === 'unlabeled'
                     ? 'No unlabeled multi-sequence groups yet. Run ' +
-                      'make assign-groups after an import; single-sequence ' +
-                      'groups are intentionally hidden here.'
+                      'make assign-groups after an import; groups with ' +
+                      'fewer than 3 sequences are intentionally hidden here.'
                     : 'No groups match this filter.'}
                 </td>
               </tr>


### PR DESCRIPTION
- List only groups with at least 3 sequences (was 2+), ordered by member count descending, then newest, with `id` as a stable pagination tie-breaker.
- Group page now shows each member's full frame beside a zoomed crop centered on the detected object, so small objects stay legible; reference-region overlay recolored to magenta.
- Frontend copy updated to the new threshold; backend test covers the filter and size ordering.