### PR TITLE
feat: add unlabeled false positive type

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/platform/export_dataset.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/export_dataset.py
@@ -218,6 +218,7 @@ FALSE_POSITIVE_TYPES: List[str] = [
     "tree",
     "water_body",
     "other",
+    "unlabeled",
 ]
 
 ALL_CLASSES: List[str] = SMOKE_TYPES + FALSE_POSITIVE_TYPES

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import_yolo_sequence.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import_yolo_sequence.py
@@ -51,6 +51,7 @@ FALSE_POSITIVE_TYPES = [
     "tree",
     "water_body",
     "other",
+    "unlabeled",
 ]
 ALL_CLASSES = SMOKE_TYPES + FALSE_POSITIVE_TYPES
 

--- a/annotation_api/src/app/models.py
+++ b/annotation_api/src/app/models.py
@@ -132,6 +132,7 @@ class FalsePositiveType(str, Enum):
     OTHER = (
         "other"  # Any other source of false positive not covered by specific categories
     )
+    UNLABELED = "unlabeled"  # False positive discarded by auto-annotation without a specific category assigned
 
 
 class AnnotationType(str, Enum):

--- a/frontend/src/components/sequence-annotation/SequenceAnnotationGrid.tsx
+++ b/frontend/src/components/sequence-annotation/SequenceAnnotationGrid.tsx
@@ -68,6 +68,7 @@ export const SequenceAnnotationGrid: React.FC<SequenceAnnotationGridProps> = ({
       tree: 'E',
       water_body: 'W',
       other: 'X',
+      unlabeled: 'N',
     };
     return keyMap[type];
   };

--- a/frontend/src/components/sequence-annotation/SequenceAnnotationGrid.tsx
+++ b/frontend/src/components/sequence-annotation/SequenceAnnotationGrid.tsx
@@ -68,7 +68,7 @@ export const SequenceAnnotationGrid: React.FC<SequenceAnnotationGridProps> = ({
       tree: 'E',
       water_body: 'W',
       other: 'X',
-      unlabeled: 'N',
+      unlabeled: 'M',
     };
     return keyMap[type];
   };

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -182,7 +182,8 @@ export type FalsePositiveType =
   | 'sky'
   | 'tree'
   | 'water_body'
-  | 'other';
+  | 'other'
+  | 'unlabeled';
 
 export type ProcessingStage =
   | 'imported'

--- a/frontend/src/utils/annotation/annotationHandlers.ts
+++ b/frontend/src/utils/annotation/annotationHandlers.ts
@@ -214,6 +214,7 @@ export const getTypeIndexForKey = (key: string): number => {
     e: FALSE_POSITIVE_TYPES.indexOf('tree'), // 't' taken by trail
     w: FALSE_POSITIVE_TYPES.indexOf('water_body'),
     x: FALSE_POSITIVE_TYPES.indexOf('other'), // 'o' taken by road
+    n: FALSE_POSITIVE_TYPES.indexOf('unlabeled'), // auto-annotation, no specific category
   };
 
   return keyMap[key] ?? -1;

--- a/frontend/src/utils/annotation/annotationHandlers.ts
+++ b/frontend/src/utils/annotation/annotationHandlers.ts
@@ -214,7 +214,7 @@ export const getTypeIndexForKey = (key: string): number => {
     e: FALSE_POSITIVE_TYPES.indexOf('tree'), // 't' taken by trail
     w: FALSE_POSITIVE_TYPES.indexOf('water_body'),
     x: FALSE_POSITIVE_TYPES.indexOf('other'), // 'o' taken by road
-    n: FALSE_POSITIVE_TYPES.indexOf('unlabeled'), // auto-annotation, no specific category
+    m: FALSE_POSITIVE_TYPES.indexOf('unlabeled'), // 'n' reserved for missed-smoke "no"
   };
 
   return keyMap[key] ?? -1;

--- a/frontend/src/utils/annotation/sequenceUtils.ts
+++ b/frontend/src/utils/annotation/sequenceUtils.ts
@@ -212,6 +212,7 @@ export const getKeyForFalsePositiveType = (type: string): string => {
     tree: 'E',
     water_body: 'W',
     other: 'X',
+    unlabeled: 'N',
   };
   return keyMap[type] || '';
 };

--- a/frontend/src/utils/annotation/sequenceUtils.ts
+++ b/frontend/src/utils/annotation/sequenceUtils.ts
@@ -212,7 +212,7 @@ export const getKeyForFalsePositiveType = (type: string): string => {
     tree: 'E',
     water_body: 'W',
     other: 'X',
-    unlabeled: 'N',
+    unlabeled: 'M',
   };
   return keyMap[type] || '';
 };

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -180,6 +180,7 @@ export const PROCESSING_STAGE_LABELS = {
  * @property {string} tree - Trees or vegetation
  * @property {string} water_body - Lakes, rivers, or other water bodies
  * @property {string} other - Other unspecified false positive types
+ * @property {string} unlabeled - False positive discarded by auto-annotation without a specific category
  *
  * @example
  * ```typescript
@@ -204,6 +205,7 @@ export const FALSE_POSITIVE_TYPES = [
   'tree',
   'water_body',
   'other',
+  'unlabeled',
 ] as const;
 
 /**

--- a/frontend/src/utils/modelAccuracy.ts
+++ b/frontend/src/utils/modelAccuracy.ts
@@ -239,6 +239,7 @@ export const getFalsePositiveEmoji = (type: string): string => {
     tree: '🌳',
     water_body: '🌊',
     other: '❓',
+    unlabeled: '🏷️',
   };
   return emojiMap[type] || '❓';
 };


### PR DESCRIPTION
- Adds a new `unlabeled` value to the `FalsePositiveType` enum, for false positives discarded by auto-annotation without a specific category assigned (e.g. the temporal model flags a FP and outputs it).
- Mirrors the type everywhere the others are declared: backend enum + YOLO export/import class lists, frontend type union, FP-type constants, emoji, and keyboard shortcut.
- Uses `M` as the keyboard shortcut since `N` is already reserved globally for the missed-smoke "no" action.