### PR TITLE
feat(api): propagate unsure flag across validated group

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -793,14 +793,33 @@ async def _propagate_to_group_if_validated(
     annotation_data = SequenceAnnotationData(**sequence_annotation.annotation)
     derived = derive_group_label_from_annotation(annotation_data)
     if derived is None:
-        # No label signal we can carry over (e.g. is_smoke=True clusters
-        # with no smoke_type set). Group state stays as it is; the per-seq
-        # annotation still saves. If this turns out to mask real conflicts
-        # we'll surface it as a separate validation step at save time.
-        return None
-    smoke_type, fp_type = derived
-    new_smoke = smoke_type.value if smoke_type else None
-    new_fp = fp_type.value if fp_type else None
+        if not sequence_annotation.is_unsure:
+            # No label signal we can carry over (e.g. is_smoke=True clusters
+            # with no smoke_type set). Group state stays as it is; the per-seq
+            # annotation still saves. If this turns out to mask real conflicts
+            # we'll surface it as a separate validation step at save time.
+            return None
+        # Unsure submission with no label: spread the uncertainty across the
+        # group instead of dropping it. Refuse if the group is already labeled
+        # so we don't silently wipe a real smoke/FP label.
+        if group.smoke_type is not None or group.false_positive_type is not None:
+            existing = (
+                f"smoke/{group.smoke_type}"
+                if group.smoke_type is not None
+                else f"FP/{group.false_positive_type}"
+            )
+            message = (
+                f"Group {group.id} already labeled {existing}; this unsure "
+                "annotation was saved on this sequence but not propagated."
+            )
+            logger.warning(message)
+            return message
+        smoke_type, fp_type = None, None
+        new_smoke, new_fp = None, None
+    else:
+        smoke_type, fp_type = derived
+        new_smoke = smoke_type.value if smoke_type else None
+        new_fp = fp_type.value if fp_type else None
 
     # Refuse to silently flip the group's label if a previous member's
     # annotation already set a different one. The new annotation is kept
@@ -826,8 +845,11 @@ async def _propagate_to_group_if_validated(
     group.smoke_type = new_smoke
     group.false_positive_type = new_fp
     group.is_unsure = sequence_annotation.is_unsure
-    group.labeled_at = datetime.now(UTC)
-    group.labeled_by_user_id = current_user_id
+    # labeled_at must stay null when there is no label (ck constraint), which
+    # is the case for an unsure-only propagation.
+    if new_smoke is not None or new_fp is not None:
+        group.labeled_at = datetime.now(UTC)
+        group.labeled_by_user_id = current_user_id
     group.updated_at = datetime.now(UTC)
     session.add(group)
 

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -190,6 +190,17 @@ def _annotation_payload(*, stage: str, smoke_type: str) -> dict:
     }
 
 
+def _unsure_payload(*, stage: str) -> dict:
+    """An unsure submission carries no label (empty sequences_bbox)."""
+    return {
+        "sequence_id": 1,  # overwritten per call
+        "has_missed_smoke": False,
+        "is_unsure": True,
+        "annotation": {"sequences_bbox": []},
+        "processing_stage": stage,
+    }
+
+
 @pytest.mark.asyncio
 async def test_assign_groups_creates_group_for_unmatched_sequence(
     authenticated_client: AsyncClient,
@@ -426,6 +437,73 @@ async def test_propagation_skips_locked_members(
     assert len(items) == 1
     assert items[0]["processing_stage"] == "annotated"
     assert items[0]["smoke_types"] == ["industrial"]
+
+
+@pytest.mark.asyncio
+async def test_propagation_fans_out_unsure_flag(
+    authenticated_client: AsyncClient,
+    sequence_session: AsyncSession,
+    detection_session: AsyncSession,
+):
+    """Validated group, no existing label → saving seq 1 as unsure marks the
+    group unsure and fans the unsure flag out to the other unlocked member in
+    SEQ_ANNOTATION_DONE."""
+    group_id = await _seed_two_member_group(
+        sequence_session, [1, 2], is_validated=True
+    )
+
+    payload = _unsure_payload(stage="seq_annotation_done")
+    payload["sequence_id"] = 1
+    resp = await authenticated_client.post("/annotations/sequences/", json=payload)
+    assert resp.status_code == 201
+    assert resp.json().get("group_propagation_warning") is None
+
+    group_payload = (
+        await authenticated_client.get(f"/sequence_groups/{group_id}")
+    ).json()
+    assert group_payload["is_unsure"] is True
+    assert group_payload["smoke_type"] is None
+    assert group_payload["false_positive_type"] is None
+
+    other = await authenticated_client.get("/annotations/sequences/?sequence_id=2")
+    items = other.json()["items"]
+    assert len(items) == 1
+    assert items[0]["is_unsure"] is True
+    assert items[0]["processing_stage"] == "seq_annotation_done"
+
+
+@pytest.mark.asyncio
+async def test_propagation_warns_when_unsure_hits_labeled_group(
+    authenticated_client: AsyncClient,
+    sequence_session: AsyncSession,
+    detection_session: AsyncSession,
+):
+    """A group already labeled `industrial` → marking seq 1 unsure returns a
+    warning, leaves the group label untouched, and does not propagate."""
+    group_id = await _seed_two_member_group(
+        sequence_session,
+        [1, 2],
+        is_validated=True,
+        smoke_type="industrial",
+    )
+
+    payload = _unsure_payload(stage="seq_annotation_done")
+    payload["sequence_id"] = 1
+    resp = await authenticated_client.post("/annotations/sequences/", json=payload)
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["group_propagation_warning"] is not None
+    assert "industrial" in body["group_propagation_warning"]
+
+    group_payload = (
+        await authenticated_client.get(f"/sequence_groups/{group_id}")
+    ).json()
+    assert group_payload["smoke_type"] == "industrial"
+    assert group_payload["is_unsure"] is False
+
+    # No fan-out to seq 2.
+    other = await authenticated_client.get("/annotations/sequences/?sequence_id=2")
+    assert other.json()["total"] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- In a validated sequence group, marking one sequence *unsure* and saving it without a label now fans the unsure state out to the group and its other unlabeled members (set to `SEQ_ANNOTATION_DONE`), instead of silently dropping it.
- Refuses with a warning if the group already carries a smoke/FP label, so an unsure submission never wipes a real label.
- Fixes the `labeled_at` consistency check by leaving `labeled_at` null when there is no label (unsure-only propagation).
- Adds tests covering the fan-out and the refuse-on-existing-label cases.

Known follow-up (deferred): resolving an unsure group with a real label later won't overwrite the locked unsure members — separate from this change.