### PR TITLE
feat(scripts): exclude unsure sequences from pull-seq-annotations

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
@@ -139,6 +139,9 @@ def fetch_sequences(
     the smoke-type filter, until we have ``max_sequences`` accepted (or we
     exhaust all pages). This matters for FP pulls (smoke_type=empty) where the
     first page can be entirely smoke sequences.
+
+    Sequences whose annotation is marked as unsure (``is_unsure=True``) are
+    excluded server-side and never pulled.
     """
     page = 1
     size = 100
@@ -148,6 +151,7 @@ def fetch_sequences(
             remote_api,
             token,
             processing_stage="seq_annotation_done",
+            is_unsure=False,
             page=page,
             size=size,
             include_annotation=True,


### PR DESCRIPTION
## What

`make pull-seq-annotations` (and the FP variant `make pull-fp`) no longer pulls sequences whose annotation is marked **unsure** (`is_unsure=True`).

## How

`fetch_sequences` now passes `is_unsure=False` to the remote `list_sequences` call, so unsure sequences are filtered out **server-side** and never paged in or transitioned to `in_review`. Both pipelines share `fetch_sequences`, so the filter applies to TP and FP pulls alike.

```diff
         resp = annotation_api.list_sequences(
             remote_api,
             token,
             processing_stage="seq_annotation_done",
+            is_unsure=False,
             page=page,
             size=size,
             include_annotation=True,
         )
```

The `/api/v1/sequences/` endpoint already supports the `is_unsure` filter. It requires the annotation join, which is gated by `processing_stage` being present — always the case here (`"seq_annotation_done"`), so the filter is guaranteed to apply.

## Verification

Verified **read-only** (GET-only, no stage-update PATCH, no mutations) against production `annotationapi.pyronear.org`:

| Set | Count |
|---|---|
| all `seq_annotation_done` | 12,206 |
| `is_unsure=True` (excluded) | 206 |
| `is_unsure=False` (pulled) | 12,000 |

`12,000 + 206 == 12,206` — the filter cleanly excludes exactly the unsure sequences. Exercising the real modified `fetch_sequences(max_sequences=5)` returned 5 sequences, all `is_unsure=False`.