### PR TITLE
feat(scripts): merge object-split sequences into single review folders at pull time

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Once sequence annotations are in `seq_annotation_done` on the remote API, refine
 make pull-seq-annotations MAX_SEQUENCES=20 SMOKE_TYPE=wildfire
 ```
 - Set `MAX_SEQUENCES=0` to pull all; override `SMOKE_TYPE` (or call the script directly without `--smoke-type`) to pull every smoke type.
+- Object-split sequences (predictor-split import) are merged back into one folder per camera view: siblings of the same platform alert share a folder, and alerts from the same camera/azimuth less than 2h apart are chained (camera azimuth is fetched from the platform API using `PLATFORM_LOGIN`/`PLATFORM_PASSWORD`; without credentials only siblings merge). Each frame is downloaded once with the union of all objects' boxes, and a `manifest.json` maps results back to every member sequence. `MAX_SEQUENCES` counts merged folders. Alerts with a sibling still under annotation are deferred to a later pull.
 - TLS is verified by default; pass `--skip-ssl-verify` to the underlying script if you trust the host and need to silence self-signed cert issues.
 
 **Step 2 — `auto-annotate`**: auto-fill missing boxes with the pyronear YOLO11s sensitive-detector model (downloads on first run):

--- a/annotation_api/Makefile
+++ b/annotation_api/Makefile
@@ -159,6 +159,8 @@ push-annotations:
 # --- 1B. Detection annotation workflow ---
 
 # Pull seq_annotation_done sequences locally (moves remote stage to in_review).
+# Object-split sequences are merged into one folder per camera view (see manifest.json);
+# MAX_SEQUENCES caps merged folders, not raw sequences.
 # Usage: make pull-seq-annotations [MAX_SEQUENCES=20] [SMOKE_TYPE=wildfire] [DATA_ROOT=outputs/seq_annotation_done]
 pull-seq-annotations:
 	uv run python -m scripts.data_transfer.ingestion.platform.pull_sequence_annotations \

--- a/annotation_api/scripts/data_transfer/ingestion/platform/apply_fiftyone_review.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/apply_fiftyone_review.py
@@ -10,9 +10,16 @@ Rules:
   and set only those detections' annotations to bbox_annotation.
 
 Assumes exported data layout: outputs/seq_annotation_done/seq_<alert_api_id>/images/detection_<id>.jpg
+
+Folders holding a ``manifest.json`` (written by ``pull_sequence_annotations.py``) contain several
+remote sequences merged for review (object-split siblings and/or chained alerts). The manifest maps
+each image to the member sequences' own detection ids; the rules above then apply per member:
+an "issue" frame only sends the members having a detection on that frame to needs_manual, the black
+separator sends every member, and a clean folder marks every member annotated.
 """
 
 import argparse
+import json
 import logging
 import os
 import re
@@ -47,13 +54,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--username",
         type=str,
-        default=os.getenv("MAIN_ANNOTATION_LOGIN", os.getenv("ANNOTATOR_LOGIN", "admin")),
+        default=os.getenv(
+            "MAIN_ANNOTATION_LOGIN", os.getenv("ANNOTATOR_LOGIN", "admin")
+        ),
         help="Remote API username",
     )
     parser.add_argument(
         "--password",
         type=str,
-        default=os.getenv("MAIN_ANNOTATION_PASSWORD", os.getenv("ANNOTATOR_PASSWORD", "admin12345")),
+        default=os.getenv(
+            "MAIN_ANNOTATION_PASSWORD", os.getenv("ANNOTATOR_PASSWORD", "admin12345")
+        ),
         help="Remote API password",
     )
     parser.add_argument(
@@ -112,7 +123,9 @@ def group_reviews(dataset: fo.Dataset) -> Dict[int, Dict[str, Set[int]]]:
       "all_frames": set(all detection_ids)
     }
     """
-    per_seq: Dict[int, Dict[str, Set[int] | bool]] = defaultdict(lambda: {"issue_frames": set(), "whole_issue": False, "all_frames": set()})
+    per_seq: Dict[int, Dict[str, Set[int] | bool]] = defaultdict(
+        lambda: {"issue_frames": set(), "whole_issue": False, "all_frames": set()}
+    )
 
     for sample in dataset:
         alert_id = parse_alert_id(sample.filepath)
@@ -165,18 +178,31 @@ def fetch_all_sequences(remote_api: str, token: str) -> Dict[int, Dict]:
     return lookup
 
 
-def update_sequence_stage(remote_api: str, token: str, seq_id: int, stage: str, dry_run: bool) -> bool:
-    ann_resp = annotation_api.list_sequence_annotations(remote_api, token, sequence_id=seq_id, page=1, size=1)
+def update_sequence_stage(
+    remote_api: str, token: str, seq_id: int, stage: str, dry_run: bool
+) -> bool:
+    ann_resp = annotation_api.list_sequence_annotations(
+        remote_api, token, sequence_id=seq_id, page=1, size=1
+    )
     items = ann_resp.get("items", []) if isinstance(ann_resp, dict) else ann_resp
     if not items:
         logging.warning("Sequence %s has no annotation row to update", seq_id)
         return False
     ann_id = items[0]["id"]
     if dry_run:
-        logging.info("[DRY-RUN] Would set sequence_id=%s annotation_id=%s stage=%s", seq_id, ann_id, stage)
+        logging.info(
+            "[DRY-RUN] Would set sequence_id=%s annotation_id=%s stage=%s",
+            seq_id,
+            ann_id,
+            stage,
+        )
         return True
-    annotation_api.update_sequence_annotation(remote_api, token, ann_id, {"processing_stage": stage})
-    logging.info("Updated sequence_id=%s annotation_id=%s stage=%s", seq_id, ann_id, stage)
+    annotation_api.update_sequence_annotation(
+        remote_api, token, ann_id, {"processing_stage": stage}
+    )
+    logging.info(
+        "Updated sequence_id=%s annotation_id=%s stage=%s", seq_id, ann_id, stage
+    )
     return True
 
 
@@ -188,7 +214,9 @@ def update_detection_stage(
     dry_run: bool,
     annotation_data: Optional[List[Dict]] = None,
 ) -> bool:
-    ann_resp = annotation_api.list_detection_annotations(remote_api, token, detection_id=det_id, page=1, size=1)
+    ann_resp = annotation_api.list_detection_annotations(
+        remote_api, token, detection_id=det_id, page=1, size=1
+    )
     items = ann_resp.get("items", []) if isinstance(ann_resp, dict) else ann_resp
     if not items:
         logging.warning("Detection %s has no annotation row to update", det_id)
@@ -207,7 +235,9 @@ def update_detection_stage(
     if annotation_data is not None:
         payload["annotation"] = {"annotation": annotation_data}
     annotation_api.update_detection_annotation(remote_api, token, ann_id, payload)
-    logging.debug("Updated detection_id=%s annotation_id=%s stage=%s", det_id, ann_id, stage)
+    logging.debug(
+        "Updated detection_id=%s annotation_id=%s stage=%s", det_id, ann_id, stage
+    )
     return True
 
 
@@ -243,15 +273,27 @@ def ensure_detection_annotations(
     missing = [det_id for det_id in detection_ids if det_id not in annotated_dets]
     if not missing or dry_run:
         if dry_run and missing:
-            logging.info("[DRY-RUN] Would create %d detection annotations", len(missing))
+            logging.info(
+                "[DRY-RUN] Would create %d detection annotations", len(missing)
+            )
         return missing
 
     def _create_one(det_id: int) -> None:
         try:
-            ann_payload = {"annotation": annotation_map[det_id]} if annotation_map and det_id in annotation_map else {"annotation": []}
-            annotation_api.create_detection_annotation(remote_api, token, det_id, ann_payload, default_stage)
+            ann_payload = (
+                {"annotation": annotation_map[det_id]}
+                if annotation_map and det_id in annotation_map
+                else {"annotation": []}
+            )
+            annotation_api.create_detection_annotation(
+                remote_api, token, det_id, ann_payload, default_stage
+            )
         except Exception as exc:  # noqa: BLE001
-            logging.error("Failed to create detection annotation for detection_id=%s: %s", det_id, exc)
+            logging.error(
+                "Failed to create detection annotation for detection_id=%s: %s",
+                det_id,
+                exc,
+            )
 
     with ThreadPoolExecutor(max_workers=8) as pool:
         pool.map(_create_one, missing)
@@ -318,11 +360,21 @@ def delete_detection_annotations_for_sequence(
 SMOKE_CLASSES = ["wildfire", "industrial", "other"]
 
 
-def load_yolo_annotation(labels_root: Path, alert_id: int, det_id: int) -> Optional[List[Dict]]:
+def load_yolo_annotation(
+    labels_root: Path, alert_id: int, det_id: int
+) -> Optional[List[Dict]]:
     """
     Load YOLO label file for a detection and convert to DetectionAnnotationData items.
     """
-    lbl_path = labels_root / f"seq_{alert_id}" / "labels" / f"detection_{det_id}.txt"
+    return load_yolo_label_file(
+        labels_root / f"seq_{alert_id}" / "labels" / f"detection_{det_id}.txt"
+    )
+
+
+def load_yolo_label_file(lbl_path: Path) -> Optional[List[Dict]]:
+    """
+    Load a YOLO label file and convert to DetectionAnnotationData items.
+    """
     if not lbl_path.exists() or lbl_path.stat().st_size == 0:
         return None
 
@@ -344,7 +396,11 @@ def load_yolo_annotation(labels_root: Path, alert_id: int, det_id: int) -> Optio
                 y2 = cy + h / 2.0
                 # clip to [0,1]
                 xyxyn = [max(0.0, min(1.0, v)) for v in (x1, y1, x2, y2)]
-                smoke_type = SMOKE_CLASSES[cls_id] if 0 <= cls_id < len(SMOKE_CLASSES) else "other"
+                smoke_type = (
+                    SMOKE_CLASSES[cls_id]
+                    if 0 <= cls_id < len(SMOKE_CLASSES)
+                    else "other"
+                )
                 items.append(
                     {
                         "xyxyn": xyxyn,
@@ -357,6 +413,114 @@ def load_yolo_annotation(labels_root: Path, alert_id: int, det_id: int) -> Optio
         return None
 
     return items if items else None
+
+
+def load_manifest(labels_root: Path, alert_id: int) -> Optional[Dict]:
+    """Return the merged-folder manifest written by pull_sequence_annotations.py, if any."""
+    manifest_path = labels_root / f"seq_{alert_id}" / "manifest.json"
+    if not manifest_path.exists():
+        return None
+    try:
+        return json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        logging.error("Failed to read manifest %s: %s", manifest_path, exc)
+        return None
+
+
+def process_one_group(
+    alert_id: int,
+    info: Dict,
+    manifest: Dict,
+    remote_api: str,
+    token: str,
+    labels_root: Path,
+    dry_run: bool,
+    fp_mode: bool = False,
+) -> str:
+    """Process a merged folder: apply the review to every member sequence listed
+    in the manifest. An issue frame only affects the members that have a
+    detection on it. Returns the folder-level status string."""
+    frames: Dict[str, Dict] = manifest.get("frames", {})
+    issue_files = {f"detection_{det_id}.jpg" for det_id in info["issue_frames"]}
+    whole_issue = info["whole_issue"]
+
+    for member in manifest.get("members", []):
+        seq_id = member["sequence_id"]
+
+        # Map this member's own detection ids to the canonical (deduplicated) frame files.
+        det_to_file: Dict[int, str] = {}
+        for filename, frame in frames.items():
+            det_id = frame.get("detections", {}).get(str(seq_id))
+            if det_id is not None:
+                det_to_file[det_id] = filename
+
+        # Remove any existing detection annotations so we can recreate from labels cleanly
+        delete_detection_annotations_for_sequence(remote_api, token, seq_id, dry_run)
+
+        detections = list_all_detections(remote_api, token, seq_id)
+        detection_ids = [d["id"] for d in detections]
+        annotation_map: Dict[int, List[Dict]] = {}
+        for det_id in detection_ids:
+            frame_file = det_to_file.get(det_id)
+            if frame_file is None:
+                continue
+            lbl_path = (
+                labels_root
+                / f"seq_{alert_id}"
+                / "labels"
+                / frame_file.replace(".jpg", ".txt")
+            )
+            data = load_yolo_label_file(lbl_path)
+            if data is not None:
+                annotation_map[det_id] = data
+        ensure_detection_annotations(
+            remote_api,
+            token,
+            seq_id,
+            detection_ids,
+            default_stage="bbox_annotation",
+            dry_run=dry_run,
+            annotation_map=annotation_map,
+        )
+
+        member_issue_dets = [
+            det_id
+            for det_id, filename in det_to_file.items()
+            if filename in issue_files
+        ]
+
+        if whole_issue or member_issue_dets:
+            update_sequence_stage(remote_api, token, seq_id, "needs_manual", dry_run)
+            target_dets = list(det_to_file) if whole_issue else member_issue_dets
+            updates: List[tuple] = [
+                (det_id, "bbox_annotation", annotation_map.get(det_id))
+                for det_id in target_dets
+            ]
+            updated_set = set(target_dets)
+            updates.extend(
+                (det_id, "annotated", ann_payload)
+                for det_id, ann_payload in annotation_map.items()
+                if det_id not in updated_set
+            )
+        else:
+            update_sequence_stage(remote_api, token, seq_id, "annotated", dry_run)
+            # In FP mode, push empty annotations (no bboxes); otherwise push the YOLO labels
+            updates = [
+                (det_id, "annotated", [] if fp_mode else annotation_map.get(det_id))
+                for det_id in det_to_file
+            ]
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            pool.map(
+                lambda update: update_detection_stage(
+                    remote_api, token, update[0], update[1], dry_run, update[2]
+                ),
+                updates,
+            )
+
+    if whole_issue:
+        return "whole_issue"
+    return "partial_issue" if issue_files else "ok"
 
 
 def process_one_sequence(
@@ -377,9 +541,15 @@ def process_one_sequence(
     seq_id = seq["id"]
 
     # Remove any existing detection annotations so we can recreate from labels cleanly
-    deleted_count = delete_detection_annotations_for_sequence(remote_api, token, seq_id, dry_run)
+    deleted_count = delete_detection_annotations_for_sequence(
+        remote_api, token, seq_id, dry_run
+    )
     if dry_run and deleted_count:
-        logging.info("[DRY-RUN] Would delete %s detection annotations for sequence_id=%s", deleted_count, seq_id)
+        logging.info(
+            "[DRY-RUN] Would delete %s detection annotations for sequence_id=%s",
+            deleted_count,
+            seq_id,
+        )
 
     # Load detections and ensure annotations exist for them
     detections = list_all_detections(remote_api, token, seq_id)
@@ -390,8 +560,13 @@ def process_one_sequence(
         if data is not None:
             annotation_map[det["id"]] = data
     ensure_detection_annotations(
-        remote_api, token, seq_id, detection_ids,
-        default_stage="bbox_annotation", dry_run=dry_run, annotation_map=annotation_map,
+        remote_api,
+        token,
+        seq_id,
+        detection_ids,
+        default_stage="bbox_annotation",
+        dry_run=dry_run,
+        annotation_map=annotation_map,
     )
 
     issue_frames = info["issue_frames"]
@@ -404,7 +579,11 @@ def process_one_sequence(
             # In FP mode, push empty annotations (no bboxes); otherwise push the YOLO labels
             pool.map(
                 lambda det_id: update_detection_stage(
-                    remote_api, token, det_id, "annotated", dry_run,
+                    remote_api,
+                    token,
+                    det_id,
+                    "annotated",
+                    dry_run,
                     [] if fp_mode else annotation_map.get(det_id),
                 ),
                 all_frames,
@@ -416,7 +595,10 @@ def process_one_sequence(
     target_dets: List[int] = list(all_frames) if whole_issue else list(issue_frames)
 
     # Build list of (det_id, stage, annotation_data) for all detections
-    updates: List[tuple] = [(det_id, "bbox_annotation", annotation_map.get(det_id)) for det_id in target_dets]
+    updates: List[tuple] = [
+        (det_id, "bbox_annotation", annotation_map.get(det_id))
+        for det_id in target_dets
+    ]
     updated_set = set(target_dets)
     for det_id, ann_payload in annotation_map.items():
         if det_id not in updated_set:
@@ -424,7 +606,9 @@ def process_one_sequence(
 
     with ThreadPoolExecutor(max_workers=8) as pool:
         pool.map(
-            lambda args: update_detection_stage(remote_api, token, args[0], args[1], dry_run, args[2]),
+            lambda args: update_detection_stage(
+                remote_api, token, args[0], args[1], dry_run, args[2]
+            ),
             updates,
         )
 
@@ -433,7 +617,9 @@ def process_one_sequence(
 
 def main() -> None:
     args = parse_args()
-    logging.basicConfig(level=args.loglevel.upper(), format="%(levelname)s - %(message)s")
+    logging.basicConfig(
+        level=args.loglevel.upper(), format="%(levelname)s - %(message)s"
+    )
 
     dataset = fo.load_dataset(args.dataset_name)
     reviews = group_reviews(dataset)
@@ -449,15 +635,41 @@ def main() -> None:
     if args.max_sequences:
         items = items[: args.max_sequences]
 
-    results: Dict[str, int] = {"ok": 0, "whole_issue": 0, "partial_issue": 0, "not_found": 0, "errors": 0}
+    results: Dict[str, int] = {
+        "ok": 0,
+        "whole_issue": 0,
+        "partial_issue": 0,
+        "not_found": 0,
+        "errors": 0,
+    }
+
+    def process_one(alert_id: int, info: Dict) -> str:
+        manifest = load_manifest(args.labels_root, alert_id)
+        if manifest is not None:
+            return process_one_group(
+                alert_id,
+                info,
+                manifest,
+                args.remote_api,
+                token,
+                args.labels_root,
+                args.dry_run,
+                args.fp_mode,
+            )
+        return process_one_sequence(
+            alert_id,
+            info,
+            seq_lookup,
+            args.remote_api,
+            token,
+            args.labels_root,
+            args.dry_run,
+            args.fp_mode,
+        )
 
     with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
         future_map = {
-            executor.submit(
-                process_one_sequence,
-                alert_id, info, seq_lookup,
-                args.remote_api, token, args.labels_root, args.dry_run, args.fp_mode,
-            ): alert_id
+            executor.submit(process_one, alert_id, info): alert_id
             for alert_id, info in items
         }
         for future in as_completed(future_map):

--- a/annotation_api/scripts/data_transfer/ingestion/platform/apply_fiftyone_review.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/apply_fiftyone_review.py
@@ -498,8 +498,8 @@ def process_one_group(
             ]
             updated_set = set(target_dets)
             updates.extend(
-                (det_id, "annotated", ann_payload)
-                for det_id, ann_payload in annotation_map.items()
+                (det_id, "annotated", annotation_map.get(det_id))
+                for det_id in det_to_file
                 if det_id not in updated_set
             )
         else:

--- a/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
@@ -1,12 +1,33 @@
 """
 Pull sequences annotated on remote API (processing_stage=seq_annotation_done), download images/labels,
 save locally, and transition remote annotations to in_review.
+
+Sequences imported by the predictor-split pipeline (one annotation sequence per detected object,
+synthetic ``alert_api_id = base + platform_id * 1000 + object_index``) are merged back into a single
+review folder so each frame is reviewed only once:
+
+- Siblings (objects of the same platform alert) always share one folder; frames are deduplicated by
+  ``recorded_at`` and each label file carries the union of every object's boxes on that frame.
+- Alerts from the same camera with the same camera azimuth (re-fetched from the platform API) are
+  chained into the same folder while the gap between two consecutive alerts is below
+  ``--merge-gap-hours``. Without platform credentials, merging degrades to siblings-only.
+- If any sibling of a platform alert is not annotated yet (imported/ready_to_annotate/
+  under_annotation), the whole alert is deferred to a later pull so its frames are never pulled
+  twice. Unsure or smoke-type-filtered siblings do not block their alert.
+
+Each folder gets a ``manifest.json`` describing member sequences and the frame -> per-sequence
+detection mapping; ``apply_fiftyone_review.py`` uses it to push review results back to every member.
+
+``--max-sequences`` caps the number of merged folders (groups), not raw sequences.
 """
 
 import argparse
+import json
 import logging
 import os
+from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -15,10 +36,19 @@ from dotenv import load_dotenv
 
 from app.clients import annotation_api
 
+from . import client as platform_client
+
 load_dotenv()
 
 SMOKE_CLASSES = ["wildfire", "industrial", "other"]
 CLASS_ID = {name: idx for idx, name in enumerate(SMOKE_CLASSES)}
+
+# Stages that mean a sibling sequence still awaits sequence-level annotation.
+UNLABELED_STAGES = {"imported", "ready_to_annotate", "under_annotation"}
+
+# A cluster groups the object-split sequences of one platform alert:
+# {"sid": Optional[int], "members": List[sequence dict]}
+Cluster = Dict
 
 
 def parse_args() -> argparse.Namespace:
@@ -48,10 +78,28 @@ def parse_args() -> argparse.Namespace:
         help="Remote API password",
     )
     parser.add_argument(
+        "--platform-api",
+        type=str,
+        default="https://alertapi.pyronear.org",
+        help="Platform API base URL (used to re-fetch camera_azimuth for cross-alert merging)",
+    )
+    parser.add_argument(
+        "--alert-id-base",
+        type=int,
+        default=1_000_000_000,
+        help="Base offset of synthetic alert_api_ids created by the predictor-split import",
+    )
+    parser.add_argument(
+        "--merge-gap-hours",
+        type=float,
+        default=2.0,
+        help="Max gap between two alerts of the same camera/azimuth to merge them into one folder",
+    )
+    parser.add_argument(
         "--max-sequences",
         type=int,
         default=0,
-        help="Optional cap on number of sequences to pull (0 = all)",
+        help="Optional cap on number of merged folders (groups) to pull (0 = all)",
     )
     parser.add_argument(
         "--max-workers",
@@ -95,6 +143,13 @@ def ensure_dir(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
 
 
+def parse_dt(value: str) -> datetime:
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
 def to_yolo(bbox: List[float]) -> List[float]:
     x1, y1, x2, y2 = bbox
     cx = (x1 + x2) / 2
@@ -104,10 +159,21 @@ def to_yolo(bbox: List[float]) -> List[float]:
     return [cx, cy, w, h]
 
 
-def write_label(label_path: Path, bbox: List[float], class_name: str) -> None:
-    cid = CLASS_ID.get(class_name, 0)
-    yolo = to_yolo(bbox)
-    label_path.write_text(f"{cid} " + " ".join(f"{v:.6f}" for v in yolo) + "\n")
+def write_labels(label_path: Path, boxes: List[Tuple[str, List[float]]]) -> None:
+    """Write one YOLO line per (class_name, xyxyn) box; empty file when no boxes."""
+    lines = []
+    for class_name, bbox in boxes:
+        cid = CLASS_ID.get(class_name, 0)
+        yolo = to_yolo(bbox)
+        lines.append(f"{cid} " + " ".join(f"{v:.6f}" for v in yolo))
+    label_path.write_text("\n".join(lines) + ("\n" if lines else ""))
+
+
+def decode_platform_id(alert_api_id: Optional[int], base: int) -> Optional[int]:
+    """Reverse the synthetic id scheme (alert_api_id = base + platform_id*1000 + object_index)."""
+    if alert_api_id is None or alert_api_id < base:
+        return None
+    return (alert_api_id - base) // 1000
 
 
 def _passes_smoke_filter(seq: Dict, smoke_type: Optional[str]) -> bool:
@@ -132,13 +198,11 @@ def _passes_smoke_filter(seq: Dict, smoke_type: Optional[str]) -> bool:
 def fetch_sequences(
     remote_api: str,
     token: str,
-    max_sequences: int,
     smoke_type: Optional[str] = None,
 ) -> List[Dict]:
-    """Page through seq_annotation_done sequences, keeping only those that pass
-    the smoke-type filter, until we have ``max_sequences`` accepted (or we
-    exhaust all pages). This matters for FP pulls (smoke_type=empty) where the
-    first page can be entirely smoke sequences.
+    """Page through ALL seq_annotation_done sequences that pass the smoke-type
+    filter. Everything must be fetched before grouping so siblings and chained
+    alerts are never split across pulls (--max-sequences caps groups, not rows).
 
     Sequences whose annotation is marked as unsure (``is_unsure=True``) are
     excluded server-side and never pulled.
@@ -161,8 +225,6 @@ def fetch_sequences(
             if not _passes_smoke_filter(item, smoke_type):
                 continue
             accepted.append(item)
-            if max_sequences and len(accepted) >= max_sequences:
-                return accepted
         if page >= resp.get("pages", 1):
             break
         page += 1
@@ -177,6 +239,179 @@ def get_sequence_annotation(remote_api: str, token: str, seq_id: int) -> Optiona
     return items[0] if items else None
 
 
+def list_all_detections(remote_api: str, token: str, seq_id: int) -> List[Dict]:
+    page = 1
+    detections: List[Dict] = []
+    while True:
+        resp = annotation_api.list_detections(
+            remote_api, token, sequence_id=seq_id, page=page, size=100
+        )
+        detections.extend(resp.get("items", []))
+        if page >= resp.get("pages", 1):
+            break
+        page += 1
+    return detections
+
+
+# --------------------------------------------------------------------------- #
+# Grouping
+# --------------------------------------------------------------------------- #
+def build_clusters(sequences: List[Dict], base: int) -> List[Cluster]:
+    """Bucket sequences by decoded platform alert id; legacy ids become singletons."""
+    by_sid: Dict[int, List[Dict]] = defaultdict(list)
+    clusters: List[Cluster] = []
+    for seq in sequences:
+        sid = decode_platform_id(seq.get("alert_api_id"), base)
+        if sid is None:
+            clusters.append({"sid": None, "members": [seq]})
+        else:
+            by_sid[sid].append(seq)
+    clusters.extend({"sid": sid, "members": members} for sid, members in by_sid.items())
+    return clusters
+
+
+def cluster_start(cluster: Cluster) -> datetime:
+    return min(parse_dt(s["recorded_at"]) for s in cluster["members"])
+
+
+def cluster_end(cluster: Cluster) -> datetime:
+    return max(
+        parse_dt(s.get("last_seen_at") or s["recorded_at"]) for s in cluster["members"]
+    )
+
+
+def fetch_camera_azimuths(
+    platform_api: str, sids: List[int]
+) -> Dict[int, Optional[float]]:
+    """Fetch camera_azimuth per platform alert id (the annotation API only stores
+    the per-object cone azimuth, which differs between objects of one pose)."""
+    login = os.getenv("PLATFORM_LOGIN")
+    password = os.getenv("PLATFORM_PASSWORD")
+    if not sids:
+        return {}
+    if not login or not password:
+        logging.warning(
+            "PLATFORM_LOGIN/PLATFORM_PASSWORD unset - cannot fetch camera_azimuth; "
+            "merging siblings of the same alert only"
+        )
+        return {}
+    try:
+        token = platform_client.get_api_access_token(
+            api_endpoint=platform_api, username=login, password=password
+        )
+    except Exception as exc:  # noqa: BLE001
+        logging.warning(
+            "Platform authentication failed (%s); merging siblings only", exc
+        )
+        return {}
+
+    azimuths: Dict[int, Optional[float]] = {}
+    for sid in sids:
+        try:
+            seq = platform_client.get_sequence(platform_api, sid, token)
+            raw = seq.get("camera_azimuth")
+            azimuths[sid] = float(raw) if raw is not None else None
+        except Exception as exc:  # noqa: BLE001
+            logging.warning("Failed to fetch platform sequence %s: %s", sid, exc)
+            azimuths[sid] = None
+    return azimuths
+
+
+def chain_clusters(
+    clusters: List[Cluster],
+    azimuths: Dict[int, Optional[float]],
+    max_gap: timedelta,
+) -> List[List[Cluster]]:
+    """Chain alert clusters sharing (camera_id, camera azimuth) while the gap
+    between one alert's end and the next one's start stays under ``max_gap``.
+    Clusters without a known camera azimuth stay alone."""
+    groups: List[List[Cluster]] = []
+    keyed: Dict[Tuple[int, int], List[Cluster]] = defaultdict(list)
+    for cluster in clusters:
+        sid = cluster["sid"]
+        azimuth = azimuths.get(sid) if sid is not None else None
+        if azimuth is None:
+            groups.append([cluster])
+            continue
+        camera_id = cluster["members"][0]["camera_id"]
+        keyed[(camera_id, int(round(azimuth)) % 360)].append(cluster)
+
+    for chain_candidates in keyed.values():
+        chain_candidates.sort(key=cluster_start)
+        current = [chain_candidates[0]]
+        current_end = cluster_end(chain_candidates[0])
+        for nxt in chain_candidates[1:]:
+            if cluster_start(nxt) - current_end <= max_gap:
+                current.append(nxt)
+                current_end = max(current_end, cluster_end(nxt))
+            else:
+                groups.append(current)
+                current = [nxt]
+                current_end = cluster_end(nxt)
+        groups.append(current)
+
+    groups.sort(key=lambda group: min(cluster_start(c) for c in group))
+    return groups
+
+
+def find_blocking_siblings(
+    remote_api: str, token: str, cluster: Cluster, base: int
+) -> List[str]:
+    """Return descriptions of sibling sequences (same platform alert) that are
+    still awaiting sequence annotation. Unsure or already-reviewed siblings do
+    not block; neither do seq_annotation_done siblings excluded by the smoke
+    filter (they belong to another review pipeline)."""
+    sid = cluster["sid"]
+    members = cluster["members"]
+    known_ids = {s["id"] for s in members}
+    camera_id = members[0]["camera_id"]
+    window_start = cluster_start(cluster) - timedelta(hours=12)
+    window_end = cluster_end(cluster) + timedelta(hours=12)
+
+    blocking: List[str] = []
+    page = 1
+    while True:
+        resp = annotation_api.list_sequences(
+            remote_api,
+            token,
+            camera_id=camera_id,
+            recorded_at_gte=window_start.isoformat(),
+            recorded_at_lte=window_end.isoformat(),
+            include_annotation=True,
+            page=page,
+            size=100,
+        )
+        for item in resp.get("items", []):
+            if item["id"] in known_ids:
+                continue
+            if decode_platform_id(item.get("alert_api_id"), base) != sid:
+                continue
+            ann = item.get("annotation")
+            if ann is None:
+                blocking.append(f"sequence {item['id']} (no annotation)")
+            elif ann.get("is_unsure"):
+                logging.info(
+                    "Alert %s: sibling sequence %s is unsure; pulling without it",
+                    sid,
+                    item["id"],
+                )
+            elif ann.get("processing_stage") in UNLABELED_STAGES:
+                blocking.append(
+                    f"sequence {item['id']} (stage {ann.get('processing_stage')})"
+                )
+            elif ann.get("processing_stage") == "seq_annotation_done":
+                logging.info(
+                    "Alert %s: sibling sequence %s filtered out (smoke types %s); pulling without it",
+                    sid,
+                    item["id"],
+                    ann.get("smoke_types"),
+                )
+        if page >= resp.get("pages", 1):
+            break
+        page += 1
+    return blocking
+
+
 def main() -> None:
     args = parse_args()
     logging.basicConfig(
@@ -184,24 +419,58 @@ def main() -> None:
     )
 
     token = annotation_api.get_auth_token(args.remote_api, args.username, args.password)
-    sequences = fetch_sequences(
-        args.remote_api,
-        token,
-        args.max_sequences,
-        smoke_type=args.smoke_type,
-    )
+    sequences = fetch_sequences(args.remote_api, token, smoke_type=args.smoke_type)
     logging.info(f"Found {len(sequences)} sequence(s) with stage seq_annotation_done")
-    logging.info("Processing with %s worker(s)", args.max_workers)
+
+    clusters = build_clusters(sequences, args.alert_id_base)
+    sids = sorted({c["sid"] for c in clusters if c["sid"] is not None})
+    azimuths = fetch_camera_azimuths(args.platform_api, sids)
+    groups = chain_clusters(clusters, azimuths, timedelta(hours=args.merge_gap_hours))
+    logging.info(
+        "Grouped %s sequence(s) into %s folder(s)", len(sequences), len(groups)
+    )
+
+    if args.max_sequences:
+        groups = groups[: args.max_sequences]
+
+    # Defer alerts whose siblings are still being annotated, so their frames are
+    # pulled once, complete, in a later run.
+    deferred = 0
+    final_groups: List[List[Dict]] = []
+    for group in groups:
+        kept: List[Dict] = []
+        for cluster in group:
+            if cluster["sid"] is not None:
+                blocking = find_blocking_siblings(
+                    args.remote_api, token, cluster, args.alert_id_base
+                )
+                if blocking:
+                    deferred += 1
+                    logging.info(
+                        "Deferring alert %s: waiting for %s",
+                        cluster["sid"],
+                        "; ".join(blocking),
+                    )
+                    continue
+            kept.extend(cluster["members"])
+        if kept:
+            final_groups.append(kept)
+    if deferred:
+        logging.info("Deferred %s incomplete alert(s) to a later pull", deferred)
+    logging.info(
+        "Pulling %s folder(s) with %s worker(s)", len(final_groups), args.max_workers
+    )
 
     base = Path(args.output_dir)
     ensure_dir(base)
 
-    def process_sequence(seq: Dict) -> Tuple[str, int]:
+    def prepare_member(seq: Dict) -> Optional[Tuple[Dict, Dict, List[Dict]]]:
+        """Fetch the member's annotation and detections; None if it must be skipped."""
         seq_id = seq["id"]
         ann = get_sequence_annotation(args.remote_api, token, seq_id)
         if not ann:
             logging.warning("No annotation for sequence %s, skipping", seq_id)
-            return ("no_annotation", seq_id)
+            return None
 
         # Re-check against the freshly fetched annotation; the page payload is only a prefilter.
         smoke_types = ann.get("smoke_types", [])
@@ -212,7 +481,7 @@ def main() -> None:
                     seq_id,
                     smoke_types,
                 )
-                return ("filter_skip", seq_id)
+                return None
         elif args.smoke_type and args.smoke_type != "any":
             if args.smoke_type not in smoke_types:
                 logging.info(
@@ -221,103 +490,156 @@ def main() -> None:
                     smoke_types,
                     args.smoke_type,
                 )
-                return ("filter_skip", seq_id)
+                return None
         elif args.smoke_type == "any":
             if not smoke_types:
                 logging.info("Skipping sequence %s (no smoke_types)", seq_id)
-                return ("filter_skip", seq_id)
+                return None
 
-        det_resp = annotation_api.list_detections(
-            args.remote_api, token, sequence_id=seq_id, page=1, size=100
-        )
-        detections = det_resp.get("items", [])
+        detections = list_all_detections(args.remote_api, token, seq_id)
+        return (seq, ann, detections)
 
-        seq_dir = base / f"seq_{seq.get('alert_api_id', seq_id)}"
+    def process_group(group: List[Dict]) -> Tuple[str, List[int]]:
+        group = sorted(group, key=lambda s: s.get("alert_api_id") or s["id"])
+        members = [m for m in (prepare_member(seq) for seq in group) if m]
+        if not members:
+            return ("filter_skip", [s["id"] for s in group])
+
+        first_seq = members[0][0]
+        seq_dir = base / f"seq_{first_seq.get('alert_api_id') or first_seq['id']}"
         img_dir = seq_dir / "images"
         lbl_dir = seq_dir / "labels"
         ensure_dir(img_dir)
         ensure_dir(lbl_dir)
 
-        ann_bboxes = {}
-        for sb in ann.get("annotation", {}).get("sequences_bbox", []):
-            class_name = sb.get("smoke_type", "wildfire")
-            for bbox in sb.get("bboxes", []):
-                det_key = bbox.get("detection_id")
-                if det_key is not None:
-                    ann_bboxes[det_key] = {
-                        "xyxyn": bbox.get("xyxyn", []),
-                        "class_name": class_name,
-                    }
-        for det in detections:
-            det_id = det["id"]
-            image_url = annotation_api.get_detection_url(args.remote_api, token, det_id)
-            img_name = f"detection_{det_id}.jpg"
-            img_path = img_dir / img_name
-            label_path = lbl_dir / (img_name.replace(".jpg", ".txt"))
+        # Deduplicate frames across members by recorded_at: the first member seen
+        # for a timestamp provides the canonical image; every member's box on that
+        # frame lands in the same label file.
+        frames: Dict[datetime, Dict] = {}
+        boxes: Dict[str, List[Tuple[str, List[float]]]] = defaultdict(list)
+        for seq, ann, detections in members:
+            ann_bboxes = {}
+            for sb in ann.get("annotation", {}).get("sequences_bbox", []):
+                class_name = sb.get("smoke_type", "wildfire")
+                for bbox in sb.get("bboxes", []):
+                    det_key = bbox.get("detection_id")
+                    if det_key is not None:
+                        ann_bboxes[det_key] = {
+                            "xyxyn": bbox.get("xyxyn", []),
+                            "class_name": class_name,
+                        }
+            for det in detections:
+                det_id = det["id"]
+                frame = frames.setdefault(
+                    parse_dt(det["recorded_at"]),
+                    {
+                        "canonical_det_id": det_id,
+                        "filename": f"detection_{det_id}.jpg",
+                        "recorded_at": det["recorded_at"],
+                        "detections": {},
+                    },
+                )
+                frame["detections"][seq["id"]] = det_id
+                # Match by annotation detection_id (primary) then fall back to alert_api_id if present.
+                bbox = ann_bboxes.get(det_id) or ann_bboxes.get(det.get("alert_api_id"))
+                if bbox and bbox.get("xyxyn"):
+                    boxes[frame["filename"]].append(
+                        (bbox.get("class_name", "wildfire"), bbox["xyxyn"])
+                    )
 
+        manifest_frames: Dict[str, Dict] = {}
+        for key in sorted(frames):
+            frame = frames[key]
+            det_id = frame["canonical_det_id"]
+            img_name = frame["filename"]
             try:
+                image_url = annotation_api.get_detection_url(
+                    args.remote_api, token, det_id
+                )
                 resp = requests.get(
                     image_url, timeout=30, verify=not args.skip_ssl_verify
                 )
                 resp.raise_for_status()
-                img_path.write_bytes(resp.content)
-            except Exception as exc:
+                (img_dir / img_name).write_bytes(resp.content)
+            except Exception as exc:  # noqa: BLE001
                 logging.error(
                     "Failed to download image for detection %s: %s", det_id, exc
                 )
                 continue
+            write_labels(lbl_dir / img_name.replace(".jpg", ".txt"), boxes[img_name])
+            manifest_frames[img_name] = {
+                "recorded_at": frame["recorded_at"],
+                "detections": {
+                    str(seq_id): d_id for seq_id, d_id in frame["detections"].items()
+                },
+            }
 
-            # Match by annotation detection_id (primary) then fall back to alert_api_id if present.
-            bbox = ann_bboxes.get(det_id) or ann_bboxes.get(det.get("alert_api_id"))
-            if bbox:
-                write_label(
-                    label_path,
-                    bbox.get("xyxyn", []),
-                    bbox.get("class_name", "wildfire"),
-                )
-            else:
-                label_path.write_text("")
+        manifest = {
+            "version": 1,
+            "members": [
+                {
+                    "sequence_id": seq["id"],
+                    "alert_api_id": seq.get("alert_api_id"),
+                    "annotation_id": ann["id"],
+                    "platform_sequence_id": decode_platform_id(
+                        seq.get("alert_api_id"), args.alert_id_base
+                    ),
+                }
+                for seq, ann, _ in members
+            ],
+            "frames": manifest_frames,
+        }
+        (seq_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
 
-        # update remote stage to in_review (skipped in read-only export mode)
+        # update remote stages to in_review only once the folder is fully written
+        # (skipped in read-only export mode)
+        status = "ok"
         if not args.no_stage_update:
-            try:
-                remote_ann = ann
-                annotation_api.update_sequence_annotation(
-                    args.remote_api,
-                    token,
-                    remote_ann["id"],
-                    {"processing_stage": "in_review"},
-                )
-            except Exception as exc:
-                logging.warning("Failed to set sequence %s to in_review: %s", seq_id, exc)
-                return ("stage_update_failed", seq_id)
+            for seq, ann, _ in members:
+                try:
+                    annotation_api.update_sequence_annotation(
+                        args.remote_api,
+                        token,
+                        ann["id"],
+                        {"processing_stage": "in_review"},
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logging.warning(
+                        "Failed to set sequence %s to in_review: %s", seq["id"], exc
+                    )
+                    status = "stage_update_failed"
 
-        return ("ok", seq_id)
+        return (status, [seq["id"] for seq, _, _ in members])
 
     results: Dict[str, int] = {
         "ok": 0,
         "filter_skip": 0,
-        "no_annotation": 0,
         "stage_update_failed": 0,
         "errors": 0,
     }
 
     with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
-        future_map = {executor.submit(process_sequence, seq): seq for seq in sequences}
+        future_map = {
+            executor.submit(process_group, group): group for group in final_groups
+        }
         for future in as_completed(future_map):
             try:
                 status, _ = future.result()
                 results[status] = results.get(status, 0) + 1
             except Exception as exc:  # noqa: BLE001
                 results["errors"] = results.get("errors", 0) + 1
-                seq = future_map[future]
-                logging.error("Unhandled error on sequence %s: %s", seq.get("id"), exc)
+                group = future_map[future]
+                logging.error(
+                    "Unhandled error on group %s: %s",
+                    [s.get("id") for s in group],
+                    exc,
+                )
 
     logging.info(
-        "Finished: ok=%s, skipped_filter=%s, no_annotation=%s, stage_update_failed=%s, errors=%s",
+        "Finished: ok=%s, skipped_filter=%s, deferred=%s, stage_update_failed=%s, errors=%s",
         results["ok"],
         results["filter_skip"],
-        results["no_annotation"],
+        deferred,
         results["stage_update_failed"],
         results["errors"],
     )

--- a/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
@@ -430,14 +430,14 @@ def main() -> None:
         "Grouped %s sequence(s) into %s folder(s)", len(sequences), len(groups)
     )
 
-    if args.max_sequences:
-        groups = groups[: args.max_sequences]
-
     # Defer alerts whose siblings are still being annotated, so their frames are
-    # pulled once, complete, in a later run.
+    # pulled once, complete, in a later run. Deferred groups do not count against
+    # --max-sequences, so blocked groups never starve eligible ones.
     deferred = 0
     final_groups: List[List[Dict]] = []
     for group in groups:
+        if args.max_sequences and len(final_groups) >= args.max_sequences:
+            break
         kept: List[Dict] = []
         for cluster in group:
             if cluster["sid"] is not None:


### PR DESCRIPTION
- Pulling `seq_annotation_done` sequences now merges the per-object split sequences of one platform alert (and alerts from the same camera/azimuth less than 2h apart) into one folder, so each frame is reviewed once in FiftyOne instead of once per detected object.
- Frames are deduplicated by `recorded_at` with label files carrying the union of all objects' boxes; a `manifest.json` per folder maps results back to every member sequence.
- `apply_fiftyone_review` uses the manifest to update members individually: an issue frame only reopens the members with a detection on it; folders without a manifest keep the legacy behavior.
- Alerts with a sibling still under annotation are deferred to a later pull; `MAX_SEQUENCES` now caps merged folders.