### PR TITLE
fix: preserve object classes and FP boxes across the TP review pipeline

### DIFF
--- a/annotation_api/docker-compose-dev.yml
+++ b/annotation_api/docker-compose-dev.yml
@@ -72,6 +72,7 @@ services:
       - ./src/alembic.ini:/app/alembic.ini
       - ./src/migrations:/app/migrations
       - ./src/tests:/app/tests
+      - ./scripts:/app/scripts
     command: "sh -c 'alembic upgrade head && uvicorn app.main:app --reload --host 0.0.0.0 --port 5050 --proxy-headers'"
     restart: always
     healthcheck:

--- a/annotation_api/pyproject.toml
+++ b/annotation_api/pyproject.toml
@@ -70,3 +70,5 @@ allow-direct-references = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+# make the scripts/ namespace package importable from tests
+pythonpath = ["."]

--- a/annotation_api/scripts/data_transfer/ingestion/platform/apply_fiftyone_review.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/apply_fiftyone_review.py
@@ -33,6 +33,8 @@ from dotenv import load_dotenv
 
 from app.clients import annotation_api
 
+from .label_classes import class_id_to_name, fp_type_from_class_name, is_fp_class_id
+
 load_dotenv()
 
 
@@ -357,9 +359,6 @@ def delete_detection_annotations_for_sequence(
     return len(ann_ids)
 
 
-SMOKE_CLASSES = ["wildfire", "industrial", "other"]
-
-
 def load_yolo_annotation(
     labels_root: Path, alert_id: int, det_id: int
 ) -> Optional[List[Dict]]:
@@ -396,18 +395,30 @@ def load_yolo_label_file(lbl_path: Path) -> Optional[List[Dict]]:
                 y2 = cy + h / 2.0
                 # clip to [0,1]
                 xyxyn = [max(0.0, min(1.0, v)) for v in (x1, y1, x2, y2)]
-                smoke_type = (
-                    SMOKE_CLASSES[cls_id]
-                    if 0 <= cls_id < len(SMOKE_CLASSES)
-                    else "other"
-                )
-                items.append(
-                    {
-                        "xyxyn": xyxyn,
-                        "class_name": smoke_type,
-                        "smoke_type": smoke_type,
-                    }
-                )
+                class_name = class_id_to_name(cls_id)
+                if class_name is None:
+                    # unknown ids keep the legacy fallback to the "other" smoke type
+                    items.append(
+                        {"xyxyn": xyxyn, "class_name": "other", "smoke_type": "other"}
+                    )
+                elif is_fp_class_id(cls_id):
+                    # FP boxes are kept on the detection for traceability,
+                    # flagged with their false_positive_type (never as smoke)
+                    items.append(
+                        {
+                            "xyxyn": xyxyn,
+                            "class_name": class_name,
+                            "false_positive_type": fp_type_from_class_name(class_name),
+                        }
+                    )
+                else:
+                    items.append(
+                        {
+                            "xyxyn": xyxyn,
+                            "class_name": class_name,
+                            "smoke_type": class_name,
+                        }
+                    )
     except Exception as exc:  # noqa: BLE001
         logging.error("Failed to read label file %s: %s", lbl_path, exc)
         return None

--- a/annotation_api/scripts/data_transfer/ingestion/platform/auto_annotate.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/auto_annotate.py
@@ -1,9 +1,12 @@
 """
-Auto-annotate exported sequences by running the YOLO11s (pyronear) classifier and replacing label files with predictions.
+Auto-annotate exported sequences by running the YOLO11s (pyronear) classifier and replacing smoke label boxes with predictions.
 
-- Works on YOLO-style labels in each sequence directory.
-- Groups existing boxes to focus predictions on known objects.
-- Overwrites each label file with the new class=1 boxes that intersect grouped objects (empty if none).
+- Works on YOLO-style labels in each sequence directory (class ids from label_classes.py).
+- Groups existing smoke boxes to focus predictions on known objects; each kept
+  prediction inherits the smoke class of the group it overlaps.
+- False-positive boxes (fp_* classes) are never replaced: they are written back
+  unchanged and never validate a model prediction.
+- Overwrites each label file with kept predictions + untouched FP boxes (empty if none).
 - Uses the pyronear YOLO11s model (onnx by default) downloaded from Hugging Face.
 """
 
@@ -19,6 +22,8 @@ import cv2
 import numpy as np
 from PIL import Image
 from tqdm import tqdm
+
+from .label_classes import FP_CLASS_ID_START
 
 
 MODEL_REPO = "pyronear/yolo11s_sensitive-detector"
@@ -132,11 +137,12 @@ class DownloadProgressBar(tqdm):
 
 def read_file(label_path: Path, default_conf: float = 1.0) -> np.ndarray:
     """
-    Read YOLO txt into [x1,y1,x2,y2,conf] array.
+    Read YOLO txt into [x1,y1,x2,y2,cls,conf] array.
     Supports 'cls cx cy w h' and 'cls cx cy w h conf' (matching write_bboxes_to_label_file).
+    The confidence stays in the last column so nms() keeps sorting by it.
     """
     if not label_path.exists() or label_path.stat().st_size == 0:
-        return np.zeros((0, 5), dtype=np.float64)
+        return np.zeros((0, 6), dtype=np.float64)
 
     boxes = []
     for raw in label_path.read_text().splitlines():
@@ -145,23 +151,23 @@ def read_file(label_path: Path, default_conf: float = 1.0) -> np.ndarray:
             continue
         parts = raw.split()
         if len(parts) == 5:
-            _, cx, cy, w, h = parts
+            cls, cx, cy, w, h = parts
             conf = default_conf
         elif len(parts) == 6:
             # Must match write_bboxes_to_label_file: "cls cx cy w h conf"
-            _, cx, cy, w, h, conf = parts
+            cls, cx, cy, w, h, conf = parts
         else:
             continue
         bbox_xyxy = xywh2xyxy(
             np.array([float(cx), float(cy), float(w), float(h)], dtype=np.float64)
         )
         x1, y1, x2, y2 = bbox_xyxy.tolist()
-        boxes.append([x1, y1, x2, y2, float(conf)])
+        boxes.append([x1, y1, x2, y2, float(int(cls)), float(conf)])
 
     return (
         np.array(boxes, dtype=np.float64)
         if boxes
-        else np.zeros((0, 5), dtype=np.float64)
+        else np.zeros((0, 6), dtype=np.float64)
     )
 
 
@@ -172,11 +178,11 @@ def group_and_merge_boxes(
     Cluster boxes into persistent object groups.
     """
     if boxes.size == 0:
-        return np.empty((0, 5), dtype=boxes.dtype), {}
+        return np.empty((0, boxes.shape[1]), dtype=boxes.dtype), {}
 
     main_bboxes = nms(boxes.copy(), overlapThresh=iou_nms)
     if len(main_bboxes) == 0:
-        return np.empty((0, 5), dtype=boxes.dtype), {}
+        return np.empty((0, boxes.shape[1]), dtype=boxes.dtype), {}
 
     ious = box_iou(boxes[:, :4], main_bboxes[:, :4])
     X, Y = np.where(ious > threshold)
@@ -210,24 +216,24 @@ def group_and_merge_boxes(
     return final_main, groups
 
 
-def write_bboxes_to_label_file(
-    label_file: Path, bbox_list: List[np.ndarray], class_id: int = 1
-) -> None:
+def write_bboxes_to_label_file(label_file: Path, bbox_list: List[np.ndarray]) -> None:
     """
     Overwrite label file with normalized YOLO lines (cls cx cy w h conf).
-    bbox_list entries are arrays (N,5) in xyxy+conf. If empty, file is truncated.
+    bbox_list entries are arrays (N,6) in xyxy+cls+conf. If empty, file is truncated.
     """
     lines: List[str] = []
     for arr in bbox_list:
         if arr.size == 0:
             continue
         for b in arr:
-            x1, y1, x2, y2, score = b
+            x1, y1, x2, y2, class_id, score = b
             x_c = (x1 + x2) / 2.0
             y_c = (y1 + y2) / 2.0
             w = x2 - x1
             h = y2 - y1
-            lines.append(f"{class_id} {x_c:.6f} {y_c:.6f} {w:.6f} {h:.6f} {score:.6f}")
+            lines.append(
+                f"{int(class_id)} {x_c:.6f} {y_c:.6f} {w:.6f} {h:.6f} {score:.6f}"
+            )
 
     label_file.parent.mkdir(parents=True, exist_ok=True)
     with label_file.open("w") as f:
@@ -389,18 +395,26 @@ class Classifier:
 
 
 def _format_boxes(boxes: np.ndarray, max_rows: int = 20) -> str:
-    """Compact pretty-printer for an (N, 5) xyxy+conf array used in debug logs."""
+    """Compact pretty-printer for (N, 5) xyxy+conf / (N, 6) xyxy+cls+conf debug logs."""
     if boxes.size == 0:
         return "  <none>"
     lines = []
     for i, b in enumerate(boxes[:max_rows]):
-        x1, y1, x2, y2, c = b.tolist()
+        vals = b.tolist()
+        x1, y1, x2, y2 = vals[:4]
+        cls_part = f" cls={int(vals[4])}" if len(vals) >= 6 else ""
         lines.append(
-            f"  [{i:02d}] x1={x1:.4f} y1={y1:.4f} x2={x2:.4f} y2={y2:.4f} conf={c:.4f}"
+            f"  [{i:02d}] x1={x1:.4f} y1={y1:.4f} x2={x2:.4f} y2={y2:.4f}{cls_part} conf={vals[-1]:.4f}"
         )
     if boxes.shape[0] > max_rows:
         lines.append(f"  ... ({boxes.shape[0] - max_rows} more)")
     return "\n".join(lines)
+
+
+def majority_class(class_values: np.ndarray) -> int:
+    """Most frequent class id in a group's seed boxes (smallest id on ties)."""
+    ids, counts = np.unique(class_values.astype(int), return_counts=True)
+    return int(ids[counts == counts.max()].min())
 
 
 def process_sequence(
@@ -420,19 +434,26 @@ def process_sequence(
     logging.info("[%s] === START === %d frames", seq_dir.name, len(imgs))
 
     # ----- Step 2: aggregate existing labels -----
-    all_boxes = np.zeros((0, 5), dtype=np.float64)
+    # Smoke boxes seed the persistent groups; FP boxes (fp_* classes) are kept
+    # aside per frame and passed through unchanged.
+    smoke_boxes = np.zeros((0, 6), dtype=np.float64)
+    fp_per_frame: Dict[str, np.ndarray] = {}
     per_frame_counts: List[Tuple[str, int]] = []
     for img_path in imgs:
         label_path = lbl_dir / (img_path.stem + ".txt")
         box = read_file(label_path)
         per_frame_counts.append((img_path.stem, box.shape[0]))
         if box.shape[0] > 0:
-            all_boxes = np.concatenate([all_boxes, box])
+            is_fp = box[:, 4] >= FP_CLASS_ID_START
+            fp_per_frame[img_path.stem] = box[is_fp]
+            smoke_boxes = np.concatenate([smoke_boxes, box[~is_fp]])
 
+    total_fp = sum(arr.shape[0] for arr in fp_per_frame.values())
     logging.info(
-        "[%s] step 2: aggregated %d existing boxes across %d/%d frames with labels",
+        "[%s] step 2: aggregated %d smoke boxes (+%d FP boxes kept as-is) across %d/%d frames with labels",
         seq_dir.name,
-        all_boxes.shape[0],
+        smoke_boxes.shape[0],
+        total_fp,
         sum(1 for _, n in per_frame_counts if n > 0),
         len(imgs),
     )
@@ -440,22 +461,25 @@ def process_sequence(
         for stem, n in per_frame_counts:
             logging.debug("[%s]   frame %s: %d existing box(es)", seq_dir.name, stem, n)
         logging.debug(
-            "[%s] step 2: all_boxes (xyxy+conf, normalized):\n%s",
+            "[%s] step 2: smoke_boxes (xyxy+cls+conf, normalized):\n%s",
             seq_dir.name,
-            _format_boxes(all_boxes),
+            _format_boxes(smoke_boxes),
         )
 
-    if all_boxes.shape[0] == 0:
+    if smoke_boxes.shape[0] == 0:
         logging.info(
-            "[%s] no seed labels — skipping (auto-annotate only enriches existing labels)",
+            "[%s] no smoke seed labels — skipping (auto-annotate only enriches smoke labels)",
             seq_dir.name,
         )
         return 0
 
-    # ----- Step 3: cluster boxes into persistent groups -----
+    # ----- Step 3: cluster smoke boxes into persistent groups -----
     main_bboxes, grouped = group_and_merge_boxes(
-        all_boxes, iou_nms=iou_nms, threshold=iou_assign
+        smoke_boxes, iou_nms=iou_nms, threshold=iou_assign
     )
+    group_class = {
+        gid: majority_class(gboxes[:, 4]) for gid, gboxes in grouped.items()
+    }
     logging.info(
         "[%s] step 3: clustered into %d persistent group(s) (iou_nms=%.2f, iou_assign=%.2f)",
         seq_dir.name,
@@ -479,9 +503,12 @@ def process_sequence(
             )
 
     # ----- Steps 4-6: per-frame inference, filter by group overlap, write -----
-    # Strategy: drop the seed labels and write only the model's predictions that
-    # overlap at least one persistent group. The seed labels are used solely to
-    # localize the smoke region (via the clusters built in step 3).
+    # Strategy: drop the smoke seed labels and write only the model's predictions
+    # that overlap at least one persistent group; each kept prediction inherits
+    # the class of its best-overlapping group. The smoke seeds are used solely to
+    # localize the objects (via the clusters built in step 3). FP boxes never
+    # form groups (a prediction overlapping only an FP zone is dropped) and are
+    # re-written untouched.
     changed = 0
     total_raw = 0
     total_after_conf = 0
@@ -514,25 +541,34 @@ def process_sequence(
             _format_boxes(preds),
         )
 
-        # Step 5: keep only predictions overlapping any persistent group.
+        # Step 5: keep only predictions overlapping any persistent smoke group,
+        # assigning each one the class of its best-overlapping group.
         # box_iou(preds, group_boxes) returns shape (M_group, N_preds);
         # max over axis 0 gives the best-IoU per prediction against this group.
-        keep_any = np.zeros(preds.shape[0], dtype=bool)
+        best_iou = np.zeros(preds.shape[0], dtype=np.float64)
+        pred_class = np.zeros(preds.shape[0], dtype=np.float64)
         if preds.shape[0]:
             for gid, group_boxes in grouped.items():
-                ious = box_iou(preds[:, :4], group_boxes[:, :4])
-                hits = ious.max(0) > 0
+                ious = box_iou(preds[:, :4], group_boxes[:, :4]).max(0)
                 if logging.getLogger().isEnabledFor(logging.DEBUG):
                     logging.debug(
                         "[%s] frame %s step 5: group %d → %d/%d preds overlap",
                         seq_dir.name,
                         img_path.stem,
                         gid,
-                        int(hits.sum()),
+                        int((ious > 0).sum()),
                         preds.shape[0],
                     )
-                keep_any |= hits
-        new_bbox = preds[keep_any, :] if preds.shape[0] else np.zeros((0, 5))
+                better = ious > best_iou
+                pred_class[better] = group_class[gid]
+                best_iou = np.maximum(best_iou, ious)
+        keep_any = best_iou > 0
+        if preds.shape[0]:
+            new_bbox = np.column_stack(
+                [preds[keep_any, :4], pred_class[keep_any], preds[keep_any, 4]]
+            )
+        else:
+            new_bbox = np.zeros((0, 6))
         total_kept += new_bbox.shape[0]
         logging.debug(
             "[%s] frame %s step 5: %d pred(s) kept after group-overlap filter:\n%s",
@@ -542,8 +578,9 @@ def process_sequence(
             _format_boxes(new_bbox),
         )
 
-        # Step 6: overwrite label file with model preds only
-        write_bboxes_to_label_file(label_path, [new_bbox], class_id=1)
+        # Step 6: overwrite label file with kept model preds + untouched FP boxes
+        fp_rows = fp_per_frame.get(img_path.stem, np.zeros((0, 6)))
+        write_bboxes_to_label_file(label_path, [new_bbox, fp_rows])
         if new_bbox.shape[0]:
             changed += 1
 

--- a/annotation_api/scripts/data_transfer/ingestion/platform/auto_annotate.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/auto_annotate.py
@@ -151,18 +151,18 @@ def read_file(label_path: Path, default_conf: float = 1.0) -> np.ndarray:
             continue
         parts = raw.split()
         if len(parts) == 5:
-            cls, cx, cy, w, h = parts
             conf = default_conf
         elif len(parts) == 6:
             # Must match write_bboxes_to_label_file: "cls cx cy w h conf"
-            cls, cx, cy, w, h, conf = parts
+            conf = float(parts[5])
         else:
             continue
+        cls, cx, cy, w, h = parts[:5]
         bbox_xyxy = xywh2xyxy(
             np.array([float(cx), float(cy), float(w), float(h)], dtype=np.float64)
         )
         x1, y1, x2, y2 = bbox_xyxy.tolist()
-        boxes.append([x1, y1, x2, y2, float(int(cls)), float(conf)])
+        boxes.append([x1, y1, x2, y2, float(int(cls)), conf])
 
     return (
         np.array(boxes, dtype=np.float64)
@@ -477,9 +477,7 @@ def process_sequence(
     main_bboxes, grouped = group_and_merge_boxes(
         smoke_boxes, iou_nms=iou_nms, threshold=iou_assign
     )
-    group_class = {
-        gid: majority_class(gboxes[:, 4]) for gid, gboxes in grouped.items()
-    }
+    group_class = {gid: majority_class(gboxes[:, 4]) for gid, gboxes in grouped.items()}
     logging.info(
         "[%s] step 3: clustered into %d persistent group(s) (iou_nms=%.2f, iou_assign=%.2f)",
         seq_dir.name,

--- a/annotation_api/scripts/data_transfer/ingestion/platform/label_classes.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/label_classes.py
@@ -1,0 +1,76 @@
+"""
+Shared YOLO class registry for the TP review pipeline label files.
+
+The class integer written in ``seq_*/labels/*.txt`` is a contract between
+``pull_sequence_annotations.py``, ``auto_annotate.py``,
+``visual_check_fiftyone.py`` and ``apply_fiftyone_review.py``:
+
+- ids 0-2: smoke objects, one id per ``SmokeType`` value
+- ids 3+:  false-positive objects, one id per ``FalsePositiveType`` value,
+  named ``fp_<type>``
+
+Ids are persisted in label files across pipeline runs: both lists are
+append-only and must never be reordered. A sync test
+(``src/tests/scripts/test_label_classes.py``) guards them against the app
+enums.
+"""
+
+from typing import Optional
+
+FP_CLASS_PREFIX = "fp_"
+
+SMOKE_CLASSES = ["wildfire", "industrial", "other"]
+
+FP_CLASSES = [
+    "fp_antenna",
+    "fp_building",
+    "fp_cliff",
+    "fp_dark",
+    "fp_dust",
+    "fp_high_cloud",
+    "fp_low_cloud",
+    "fp_lens_flare",
+    "fp_lens_droplet",
+    "fp_light",
+    "fp_rain",
+    "fp_trail",
+    "fp_road",
+    "fp_sky",
+    "fp_tree",
+    "fp_water_body",
+    "fp_other",
+    "fp_unlabeled",
+]
+
+CLASS_NAMES = SMOKE_CLASSES + FP_CLASSES
+CLASS_ID = {name: idx for idx, name in enumerate(CLASS_NAMES)}
+FP_CLASS_ID_START = len(SMOKE_CLASSES)
+
+FP_FALLBACK_CLASS = "fp_unlabeled"
+
+
+def is_fp_class_id(class_id: int) -> bool:
+    return class_id >= FP_CLASS_ID_START
+
+
+def class_id_to_name(class_id: int) -> Optional[str]:
+    """Name for a persisted class id, or None for an unknown id."""
+    if 0 <= class_id < len(CLASS_NAMES):
+        return CLASS_NAMES[class_id]
+    return None
+
+
+def smoke_class_name(smoke_type: Optional[str]) -> str:
+    """YOLO class name for a smoke object (unknown/missing types map to wildfire)."""
+    return smoke_type if smoke_type in SMOKE_CLASSES else SMOKE_CLASSES[0]
+
+
+def fp_class_name(fp_type: Optional[str]) -> str:
+    """YOLO class name for a false-positive object (unknown/missing types map to fp_unlabeled)."""
+    name = f"{FP_CLASS_PREFIX}{fp_type}" if fp_type else FP_FALLBACK_CLASS
+    return name if name in CLASS_ID else FP_FALLBACK_CLASS
+
+
+def fp_type_from_class_name(name: str) -> str:
+    """FalsePositiveType value encoded in an ``fp_*`` class name."""
+    return name[len(FP_CLASS_PREFIX) :]

--- a/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
@@ -558,9 +558,7 @@ def main() -> None:
                 if not frame_bboxes and det.get("alert_api_id") is not None:
                     frame_bboxes = ann_bboxes.get(det["alert_api_id"], [])
                 for bbox in frame_bboxes:
-                    boxes[frame["filename"]].append(
-                        (bbox["class_name"], bbox["xyxyn"])
-                    )
+                    boxes[frame["filename"]].append((bbox["class_name"], bbox["xyxyn"]))
 
         manifest_frames: Dict[str, Dict] = {}
         for key in sorted(frames):

--- a/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
@@ -37,11 +37,9 @@ from dotenv import load_dotenv
 from app.clients import annotation_api
 
 from . import client as platform_client
+from .label_classes import CLASS_ID, fp_class_name, smoke_class_name
 
 load_dotenv()
-
-SMOKE_CLASSES = ["wildfire", "industrial", "other"]
-CLASS_ID = {name: idx for idx, name in enumerate(SMOKE_CLASSES)}
 
 # Stages that mean a sibling sequence still awaits sequence-level annotation.
 UNLABELED_STAGES = {"imported", "ready_to_annotate", "under_annotation"}
@@ -167,6 +165,30 @@ def write_labels(label_path: Path, boxes: List[Tuple[str, List[float]]]) -> None
         yolo = to_yolo(bbox)
         lines.append(f"{cid} " + " ".join(f"{v:.6f}" for v in yolo))
     label_path.write_text("\n".join(lines) + ("\n" if lines else ""))
+
+
+def collect_annotation_bboxes(annotation: Dict) -> Dict[int, List[Dict]]:
+    """Collect every annotated object's boxes, keyed by detection_id.
+
+    Each frame gets a list so that distinct objects sharing a frame are all
+    exported (#140). Smoke objects keep their annotated smoke type;
+    false-positive objects (is_smoke=False) are exported under their
+    ``fp_<type>`` class instead of being coerced into a smoke label (#141).
+    """
+    bboxes: Dict[int, List[Dict]] = defaultdict(list)
+    for sb in annotation.get("sequences_bbox", []):
+        if sb.get("is_smoke"):
+            class_name = smoke_class_name(sb.get("smoke_type"))
+        else:
+            fp_types = sb.get("false_positive_types") or []
+            class_name = fp_class_name(fp_types[0] if fp_types else None)
+        for bbox in sb.get("bboxes", []):
+            det_key = bbox.get("detection_id")
+            if det_key is not None and bbox.get("xyxyn"):
+                bboxes[det_key].append(
+                    {"xyxyn": bbox["xyxyn"], "class_name": class_name}
+                )
+    return bboxes
 
 
 def decode_platform_id(alert_api_id: Optional[int], base: int) -> Optional[int]:
@@ -518,16 +540,7 @@ def main() -> None:
         frames: Dict[datetime, Dict] = {}
         boxes: Dict[str, List[Tuple[str, List[float]]]] = defaultdict(list)
         for seq, ann, detections in members:
-            ann_bboxes = {}
-            for sb in ann.get("annotation", {}).get("sequences_bbox", []):
-                class_name = sb.get("smoke_type", "wildfire")
-                for bbox in sb.get("bboxes", []):
-                    det_key = bbox.get("detection_id")
-                    if det_key is not None:
-                        ann_bboxes[det_key] = {
-                            "xyxyn": bbox.get("xyxyn", []),
-                            "class_name": class_name,
-                        }
+            ann_bboxes = collect_annotation_bboxes(ann.get("annotation", {}))
             for det in detections:
                 det_id = det["id"]
                 frame = frames.setdefault(
@@ -541,10 +554,12 @@ def main() -> None:
                 )
                 frame["detections"][seq["id"]] = det_id
                 # Match by annotation detection_id (primary) then fall back to alert_api_id if present.
-                bbox = ann_bboxes.get(det_id) or ann_bboxes.get(det.get("alert_api_id"))
-                if bbox and bbox.get("xyxyn"):
+                frame_bboxes = ann_bboxes.get(det_id, [])
+                if not frame_bboxes and det.get("alert_api_id") is not None:
+                    frame_bboxes = ann_bboxes.get(det["alert_api_id"], [])
+                for bbox in frame_bboxes:
                     boxes[frame["filename"]].append(
-                        (bbox.get("class_name", "wildfire"), bbox["xyxyn"])
+                        (bbox["class_name"], bbox["xyxyn"])
                     )
 
         manifest_frames: Dict[str, Dict] = {}

--- a/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/pull_sequence_annotations.py
@@ -178,15 +178,17 @@ def collect_annotation_bboxes(annotation: Dict) -> Dict[int, List[Dict]]:
     bboxes: Dict[int, List[Dict]] = defaultdict(list)
     for sb in annotation.get("sequences_bbox", []):
         if sb.get("is_smoke"):
-            class_name = smoke_class_name(sb.get("smoke_type"))
+            class_names = [smoke_class_name(sb.get("smoke_type"))]
         else:
-            fp_types = sb.get("false_positive_types") or []
-            class_name = fp_class_name(fp_types[0] if fp_types else None)
+            # one label per assigned FP type so no classification is lost
+            fp_types = sb.get("false_positive_types") or [None]
+            class_names = list(dict.fromkeys(fp_class_name(t) for t in fp_types))
         for bbox in sb.get("bboxes", []):
             det_key = bbox.get("detection_id")
             if det_key is not None and bbox.get("xyxyn"):
-                bboxes[det_key].append(
+                bboxes[det_key].extend(
                     {"xyxyn": bbox["xyxyn"], "class_name": class_name}
+                    for class_name in class_names
                 )
     return bboxes
 

--- a/annotation_api/scripts/data_transfer/ingestion/platform/visual_check_fiftyone.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/visual_check_fiftyone.py
@@ -1,6 +1,9 @@
 """
 Load exported sequences (images + YOLO labels) into FiftyOne for visual review.
 
+Smoke boxes and false-positive boxes (fp_* classes) are shown in two separate
+label fields ("smoke" and "false_positive") so reviewers can tell them apart.
+
 Defaults to reading from outputs/seq_annotation_done/seq_*/{images,labels}.
 Only deletes an existing dataset with the same name (safe by default).
 """
@@ -12,8 +15,7 @@ from typing import List, Tuple
 import fiftyone as fo
 from PIL import Image
 
-
-SMOKE_CLASSES = ["wildfire", "industrial", "other"]
+from .label_classes import class_id_to_name, is_fp_class_id
 
 
 def parse_args() -> argparse.Namespace:
@@ -61,7 +63,8 @@ def yolo_line_to_bbox(parts: List[str]) -> Tuple[int, float, float, float, float
 
 def build_sample(img_path: Path, label_path: Path, conf_th: float) -> fo.Sample:
     sample = fo.Sample(filepath=str(img_path))
-    detections = []
+    smoke_detections = []
+    fp_detections = []
 
     if label_path.exists() and label_path.stat().st_size > 0:
         with label_path.open() as f:
@@ -75,17 +78,21 @@ def build_sample(img_path: Path, label_path: Path, conf_th: float) -> fo.Sample:
                 cls_id, x, y, w, h, conf = yolo_line_to_bbox(parts)
                 if conf < conf_th:
                     continue
-                label = SMOKE_CLASSES[cls_id] if cls_id < len(SMOKE_CLASSES) else str(cls_id)
-                detections.append(
-                    fo.Detection(
-                        label=label,
-                        bounding_box=[x, y, w, h],
-                        confidence=conf,
-                    )
+                label = class_id_to_name(cls_id) or str(cls_id)
+                detection = fo.Detection(
+                    label=label,
+                    bounding_box=[x, y, w, h],
+                    confidence=conf,
                 )
+                if is_fp_class_id(cls_id):
+                    fp_detections.append(detection)
+                else:
+                    smoke_detections.append(detection)
 
-    if detections:
-        sample["detections"] = fo.Detections(detections=detections)
+    if smoke_detections:
+        sample["smoke"] = fo.Detections(detections=smoke_detections)
+    if fp_detections:
+        sample["false_positive"] = fo.Detections(detections=fp_detections)
     return sample
 
 

--- a/annotation_api/scripts/data_transfer/ingestion/platform/visual_check_fiftyone.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/visual_check_fiftyone.py
@@ -19,7 +19,9 @@ from .label_classes import class_id_to_name, is_fp_class_id
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Open exported sequences in FiftyOne for visual check.")
+    parser = argparse.ArgumentParser(
+        description="Open exported sequences in FiftyOne for visual check."
+    )
     parser.add_argument(
         "--data-root",
         type=Path,
@@ -48,7 +50,9 @@ def ensure_black_image(path: Path) -> Path:
     return path
 
 
-def yolo_line_to_bbox(parts: List[str]) -> Tuple[int, float, float, float, float, float]:
+def yolo_line_to_bbox(
+    parts: List[str],
+) -> Tuple[int, float, float, float, float, float]:
     """
     Parse YOLO line: cls cx cy w h [conf]
     Returns (cls_id, x, y, w, h, conf)
@@ -103,7 +107,10 @@ def main() -> None:
     if args.dataset_name in fo.list_datasets():
         fo.delete_dataset(args.dataset_name)
 
-    seq_image_dirs = sorted((p for p in args.data_root.glob("seq_*") if (p / "images").exists()), key=lambda p: p.name)
+    seq_image_dirs = sorted(
+        (p for p in args.data_root.glob("seq_*") if (p / "images").exists()),
+        key=lambda p: p.name,
+    )
     samples: List[fo.Sample] = []
 
     for seq_dir in seq_image_dirs:

--- a/annotation_api/src/app/api/api_v1/endpoints/detection_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/detection_annotations.py
@@ -103,6 +103,7 @@ async def create_detection_annotation(
 
 @router.get("/")
 async def list_annotations(
+    detection_id: Optional[int] = Query(None, description="Filter by detection ID"),
     sequence_id: Optional[int] = Query(None, description="Filter by sequence ID"),
     camera_id: Optional[int] = Query(None, description="Filter by camera ID"),
     organisation_id: Optional[int] = Query(
@@ -137,6 +138,7 @@ async def list_annotations(
     """
     List detection annotations with filtering, pagination and ordering.
 
+    - **detection_id**: Filter annotations by detection ID
     - **sequence_id**: Filter annotations by sequence ID (through detection relationship)
     - **camera_id**: Filter annotations by camera ID (through detection -> sequence relationship)
     - **organisation_id**: Filter annotations by organisation ID (through detection -> sequence relationship)
@@ -171,6 +173,9 @@ async def list_annotations(
         query = query.join(Detection)
 
     # Apply filtering conditions
+    if detection_id is not None:
+        query = query.where(DetectionAnnotation.detection_id == detection_id)
+
     if sequence_id is not None:
         query = query.where(Detection.sequence_id == sequence_id)
 

--- a/annotation_api/src/app/clients/annotation_api.py
+++ b/annotation_api/src/app/clients/annotation_api.py
@@ -680,6 +680,7 @@ def list_detection_annotations(base_url: str, auth_token: str, **params) -> Dict
         base_url: Base URL of the annotation API
         auth_token: JWT authentication token
         **params: Query parameters for filtering and pagination:
+            - detection_id: Filter by detection ID
             - sequence_id: Filter by sequence ID (through detection relationship)
             - camera_id: Filter by camera ID (through detection -> sequence relationship)
             - organisation_id: Filter by organisation ID (through detection -> sequence relationship)

--- a/annotation_api/src/app/schemas/annotation_validation.py
+++ b/annotation_api/src/app/schemas/annotation_validation.py
@@ -5,7 +5,7 @@
 
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.models import FalsePositiveType, SmokeType
 
@@ -109,9 +109,21 @@ class AlgoPredictions(BaseModel):
 
 
 class DetectionAnnotationItem(BaseModel):
+    """One reviewed box on a detection: either a smoke box (smoke_type set)
+    or a false-positive box kept for traceability (false_positive_type set)."""
+
     xyxyn: List[float] = Field(..., min_length=4, max_length=4)
     class_name: str
-    smoke_type: SmokeType
+    smoke_type: Optional[SmokeType] = Field(default=None)
+    false_positive_type: Optional[FalsePositiveType] = Field(default=None)
+
+    @model_validator(mode="after")
+    def validate_exactly_one_type(self) -> "DetectionAnnotationItem":
+        if (self.smoke_type is None) == (self.false_positive_type is None):
+            raise ValueError(
+                "Exactly one of smoke_type or false_positive_type must be set"
+            )
+        return self
 
     @field_validator("xyxyn")
     @classmethod

--- a/annotation_api/src/tests/schemas/test_annotation_validation.py
+++ b/annotation_api/src/tests/schemas/test_annotation_validation.py
@@ -246,6 +246,39 @@ class TestDetectionAnnotationItem:
         error_details = str(exc_info.value)
         assert "y1 must be <= y2" in error_details
 
+    def test_valid_false_positive_item(self):
+        item = DetectionAnnotationItem(
+            xyxyn=[0.1, 0.2, 0.8, 0.9],
+            class_name="fp_antenna",
+            false_positive_type=FalsePositiveType.ANTENNA,
+        )
+        assert item.smoke_type is None
+        assert item.false_positive_type == FalsePositiveType.ANTENNA
+
+    def test_all_false_positive_types(self):
+        for fp_type in FalsePositiveType:
+            item = DetectionAnnotationItem(
+                xyxyn=[0.1, 0.2, 0.8, 0.9],
+                class_name=f"fp_{fp_type.value}",
+                false_positive_type=fp_type,
+            )
+            assert item.false_positive_type == fp_type
+
+    def test_rejects_neither_type_set(self):
+        with pytest.raises(ValidationError) as exc_info:
+            DetectionAnnotationItem(xyxyn=[0.1, 0.2, 0.8, 0.9], class_name="smoke")
+        assert "Exactly one of smoke_type or false_positive_type" in str(exc_info.value)
+
+    def test_rejects_both_types_set(self):
+        with pytest.raises(ValidationError) as exc_info:
+            DetectionAnnotationItem(
+                xyxyn=[0.1, 0.2, 0.8, 0.9],
+                class_name="smoke",
+                smoke_type=SmokeType.WILDFIRE,
+                false_positive_type=FalsePositiveType.ANTENNA,
+            )
+        assert "Exactly one of smoke_type or false_positive_type" in str(exc_info.value)
+
 
 class TestDetectionAnnotationData:
     def test_valid_detection_annotation_data(self):

--- a/annotation_api/src/tests/scripts/test_apply_fiftyone_review.py
+++ b/annotation_api/src/tests/scripts/test_apply_fiftyone_review.py
@@ -1,0 +1,48 @@
+from app.schemas.annotation_validation import DetectionAnnotationItem
+
+from scripts.data_transfer.ingestion.platform.apply_fiftyone_review import (
+    load_yolo_label_file,
+)
+from scripts.data_transfer.ingestion.platform.label_classes import CLASS_ID
+
+
+class TestLoadYoloLabelFile:
+    def test_smoke_and_fp_lines_decode_to_distinct_items(self, tmp_path):
+        lbl = tmp_path / "detection_1.txt"
+        lbl.write_text(
+            "1 0.15 0.15 0.10 0.10 0.800000\n"
+            f"{CLASS_ID['fp_antenna']} 0.55 0.55 0.10 0.10\n"
+        )
+        items = load_yolo_label_file(lbl)
+        assert items is not None and len(items) == 2
+
+        smoke, fp = items
+        assert smoke["smoke_type"] == "industrial"
+        assert "false_positive_type" not in smoke
+        assert fp["false_positive_type"] == "antenna"
+        assert fp["class_name"] == "fp_antenna"
+        assert "smoke_type" not in fp
+
+    def test_items_validate_against_detection_annotation_schema(self, tmp_path):
+        lbl = tmp_path / "detection_1.txt"
+        lbl.write_text(
+            "0 0.15 0.15 0.10 0.10\n"
+            f"{CLASS_ID['fp_unlabeled']} 0.55 0.55 0.10 0.10 1.000000\n"
+        )
+        items = load_yolo_label_file(lbl)
+        assert items is not None
+        validated = [DetectionAnnotationItem(**item) for item in items]
+        assert validated[0].smoke_type is not None
+        assert validated[1].false_positive_type is not None
+
+    def test_unknown_class_id_falls_back_to_other_smoke(self, tmp_path):
+        lbl = tmp_path / "detection_1.txt"
+        lbl.write_text("99 0.15 0.15 0.10 0.10\n")
+        items = load_yolo_label_file(lbl)
+        assert items is not None
+        assert items[0]["smoke_type"] == "other"
+
+    def test_empty_file_returns_none(self, tmp_path):
+        lbl = tmp_path / "detection_1.txt"
+        lbl.write_text("")
+        assert load_yolo_label_file(lbl) is None

--- a/annotation_api/src/tests/scripts/test_auto_annotate.py
+++ b/annotation_api/src/tests/scripts/test_auto_annotate.py
@@ -1,0 +1,61 @@
+import numpy as np
+
+from scripts.data_transfer.ingestion.platform.auto_annotate import (
+    group_and_merge_boxes,
+    majority_class,
+    read_file,
+    write_bboxes_to_label_file,
+)
+from scripts.data_transfer.ingestion.platform.label_classes import FP_CLASS_ID_START
+
+
+class TestReadWriteRoundTrip:
+    def test_read_file_keeps_class_ids(self, tmp_path):
+        lbl = tmp_path / "detection_1.txt"
+        lbl.write_text("0 0.15 0.15 0.10 0.10\n3 0.55 0.55 0.10 0.10 0.900000\n")
+        rows = read_file(lbl)
+        assert rows.shape == (2, 6)
+        assert rows[0, 4] == 0 and rows[0, 5] == 1.0  # default conf
+        assert rows[1, 4] == 3 and rows[1, 5] == 0.9
+
+    def test_write_then_read_round_trip(self, tmp_path):
+        lbl = tmp_path / "detection_1.txt"
+        rows = np.array(
+            [
+                [0.1, 0.1, 0.2, 0.2, 1.0, 0.75],
+                [0.5, 0.5, 0.6, 0.6, float(FP_CLASS_ID_START), 1.0],
+            ]
+        )
+        write_bboxes_to_label_file(lbl, [rows])
+        back = read_file(lbl)
+        assert back.shape == (2, 6)
+        np.testing.assert_allclose(back, rows, atol=1e-5)
+
+    def test_write_empty_truncates(self, tmp_path):
+        lbl = tmp_path / "detection_1.txt"
+        lbl.write_text("0 0.15 0.15 0.10 0.10\n")
+        write_bboxes_to_label_file(lbl, [np.zeros((0, 6))])
+        assert lbl.stat().st_size == 0
+
+
+class TestMajorityClass:
+    def test_majority(self):
+        assert majority_class(np.array([1.0, 1.0, 2.0])) == 1
+
+    def test_tie_is_deterministic_smallest_id(self):
+        assert majority_class(np.array([2.0, 1.0, 2.0, 1.0])) == 1
+
+
+class TestGroupClassSeeding:
+    def test_groups_carry_seed_classes(self):
+        # Two spatially distinct objects across frames, different classes.
+        boxes = np.array(
+            [
+                [0.10, 0.10, 0.20, 0.20, 0.0, 1.0],
+                [0.11, 0.11, 0.21, 0.21, 0.0, 1.0],
+                [0.70, 0.70, 0.80, 0.80, 1.0, 1.0],
+            ]
+        )
+        _, grouped = group_and_merge_boxes(boxes, iou_nms=0.0, threshold=0.0)
+        classes = sorted(majority_class(g[:, 4]) for g in grouped.values())
+        assert classes == [0, 1]

--- a/annotation_api/src/tests/scripts/test_label_classes.py
+++ b/annotation_api/src/tests/scripts/test_label_classes.py
@@ -1,0 +1,47 @@
+from app.models import FalsePositiveType, SmokeType
+
+from scripts.data_transfer.ingestion.platform import label_classes as lc
+
+
+class TestClassRegistrySync:
+    def test_smoke_classes_cover_smoke_type_enum(self):
+        assert set(lc.SMOKE_CLASSES) == {t.value for t in SmokeType}
+
+    def test_fp_classes_cover_false_positive_type_enum(self):
+        fp_types = {lc.fp_type_from_class_name(name) for name in lc.FP_CLASSES}
+        assert fp_types == {t.value for t in FalsePositiveType}
+
+    def test_fp_classes_all_prefixed(self):
+        assert all(name.startswith(lc.FP_CLASS_PREFIX) for name in lc.FP_CLASSES)
+
+    def test_class_ids_unique_and_roundtrip(self):
+        assert len(lc.CLASS_ID) == len(lc.CLASS_NAMES)
+        for name, class_id in lc.CLASS_ID.items():
+            assert lc.class_id_to_name(class_id) == name
+
+    def test_smoke_and_fp_id_ranges(self):
+        for name in lc.SMOKE_CLASSES:
+            assert not lc.is_fp_class_id(lc.CLASS_ID[name])
+        for name in lc.FP_CLASSES:
+            assert lc.is_fp_class_id(lc.CLASS_ID[name])
+
+    def test_legacy_smoke_ids_are_stable(self):
+        # Ids 0-2 are persisted in label folders pulled before the registry
+        # existed; they must never change.
+        assert lc.CLASS_NAMES[:3] == ["wildfire", "industrial", "other"]
+
+
+class TestHelpers:
+    def test_smoke_class_name(self):
+        assert lc.smoke_class_name("industrial") == "industrial"
+        assert lc.smoke_class_name(None) == "wildfire"
+        assert lc.smoke_class_name("bogus") == "wildfire"
+
+    def test_fp_class_name(self):
+        assert lc.fp_class_name("antenna") == "fp_antenna"
+        assert lc.fp_class_name(None) == "fp_unlabeled"
+        assert lc.fp_class_name("bogus") == "fp_unlabeled"
+
+    def test_class_id_to_name_unknown(self):
+        assert lc.class_id_to_name(len(lc.CLASS_NAMES)) is None
+        assert lc.class_id_to_name(-1) is None

--- a/annotation_api/src/tests/scripts/test_label_classes.py
+++ b/annotation_api/src/tests/scripts/test_label_classes.py
@@ -30,6 +30,31 @@ class TestClassRegistrySync:
         # existed; they must never change.
         assert lc.CLASS_NAMES[:3] == ["wildfire", "industrial", "other"]
 
+    def test_fp_class_order_is_stable(self):
+        # Ids 3+ are persisted in label folders on disk; the order is the
+        # contract and must stay append-only (a mid-list insert would shift
+        # every id after it and silently corrupt old folders).
+        assert lc.FP_CLASSES == [
+            "fp_antenna",
+            "fp_building",
+            "fp_cliff",
+            "fp_dark",
+            "fp_dust",
+            "fp_high_cloud",
+            "fp_low_cloud",
+            "fp_lens_flare",
+            "fp_lens_droplet",
+            "fp_light",
+            "fp_rain",
+            "fp_trail",
+            "fp_road",
+            "fp_sky",
+            "fp_tree",
+            "fp_water_body",
+            "fp_other",
+            "fp_unlabeled",
+        ]
+
 
 class TestHelpers:
     def test_smoke_class_name(self):

--- a/annotation_api/src/tests/scripts/test_pipeline_e2e.py
+++ b/annotation_api/src/tests/scripts/test_pipeline_e2e.py
@@ -1,0 +1,444 @@
+"""End-to-end test of the TP review pipeline against the dev API stack.
+
+Seeds fake sequences covering the label-corruption scenarios (#139/#140/#141),
+then runs the real pipeline stages in order:
+
+    seed -> pull_sequence_annotations (real, in-process)
+         -> auto_annotate.process_sequence (fake model, no ONNX download)
+         -> apply_fiftyone_review.process_one_group (real, FiftyOne bypassed)
+
+and asserts the label files, the stage transitions and the detection
+annotations pushed back to the API.
+
+Only runs inside the docker test stack (`make test`) where the API is served
+on localhost:5050; skipped elsewhere.
+"""
+
+import io
+import json
+import sys
+import time
+from datetime import datetime, timedelta, UTC
+
+import numpy as np
+import pytest
+import requests
+from PIL import Image
+
+API = "http://localhost:5050"
+LOGIN = {"username": "admin", "password": "admin12345"}
+
+# Prediction boxes shared by seeding and the fake model
+P_LEFT = [0.10, 0.10, 0.20, 0.20]
+P_RIGHT = [0.60, 0.60, 0.70, 0.70]
+
+now = datetime.now(UTC)
+
+
+def _api_up() -> bool:
+    try:
+        return requests.get(f"{API}/status", timeout=2).status_code == 200
+    except requests.RequestException:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _api_up(), reason="requires the dev API stack (run via make test)"
+)
+
+
+def _token() -> str:
+    """Authenticate against the live API.
+
+    Retried because the DB-reset fixture invalidates the running server's
+    asyncpg prepared-statement cache: the first request after a schema reset
+    can 500 once (InvalidCachedStatementError) before SQLAlchemy clears the
+    cache and everything recovers.
+    """
+    response = None
+    for _ in range(10):
+        response = requests.post(f"{API}/api/v1/auth/login", json=LOGIN, timeout=10)
+        if response.status_code == 200:
+            return response.json()["access_token"]
+        time.sleep(0.3)
+    raise AssertionError(f"login kept failing: {response.status_code} {response.text}")
+
+
+def _headers(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _post_with_retry(url: str, *, prepare: dict | None = None, **kwargs):
+    """POST with one retry on the transient InvalidCachedStatementError 500
+    (see _token docstring); the failed statement is rolled back server-side,
+    so retrying cannot double-insert. ``prepare`` maps file-like kwargs to
+    reset before each attempt."""
+    for attempt in range(2):
+        for stream in (prepare or {}).values():
+            stream.seek(0)
+        response = requests.post(url, timeout=10, **kwargs)
+        if (
+            response.status_code < 500
+            or "InvalidCachedStatementError" not in response.text
+        ):
+            return response
+    return response
+
+
+def _create_sequence(token: str, alert_api_id: int, camera_id: int) -> int:
+    response = _post_with_retry(
+        f"{API}/api/v1/sequences/",
+        headers=_headers(token),
+        data={
+            "source_api": "pyronear_french",
+            "alert_api_id": str(alert_api_id),
+            "camera_name": f"e2e_cam_{camera_id}",
+            "camera_id": str(camera_id),
+            "organisation_name": "e2e_org",
+            "organisation_id": "1",
+            "lat": "0.0",
+            "lon": "0.0",
+            "recorded_at": (now - timedelta(hours=1)).isoformat(),
+            "last_seen_at": now.isoformat(),
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def _create_detection(
+    token: str,
+    sequence_id: int,
+    alert_api_id: int,
+    minutes_ago: int,
+    predictions: list,
+) -> int:
+    img = Image.new("RGB", (64, 64), color="gray")
+    img_bytes = io.BytesIO()
+    img.save(img_bytes, format="JPEG")
+    img_bytes.seek(0)
+    response = _post_with_retry(
+        f"{API}/api/v1/detections/",
+        prepare={"image": img_bytes},
+        headers=_headers(token),
+        data={
+            "sequence_id": str(sequence_id),
+            "alert_api_id": str(alert_api_id),
+            "recorded_at": (now - timedelta(minutes=minutes_ago)).isoformat(),
+            "algo_predictions": json.dumps(
+                {
+                    "predictions": [
+                        {"xyxyn": box, "confidence": 0.9, "class_name": "smoke"}
+                        for box in predictions
+                    ]
+                }
+            ),
+        },
+        files={"file": ("e2e.jpg", img_bytes, "image/jpeg")},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def _create_seq_annotation(
+    token: str, sequence_id: int, sequences_bbox: list, is_unsure: bool = False
+) -> int:
+    response = _post_with_retry(
+        f"{API}/api/v1/annotations/sequences/",
+        headers=_headers(token),
+        json={
+            "sequence_id": sequence_id,
+            "has_missed_smoke": False,
+            "is_unsure": is_unsure,
+            "annotation": {"sequences_bbox": sequences_bbox},
+            "processing_stage": "seq_annotation_done",
+            "created_at": now.isoformat(),
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def _get_seq_annotation(token: str, sequence_id: int) -> dict:
+    response = requests.get(
+        f"{API}/api/v1/annotations/sequences/",
+        headers=_headers(token),
+        params={"sequence_id": sequence_id},
+        timeout=10,
+    )
+    assert response.status_code == 200, response.text
+    items = response.json()["items"]
+    assert items, f"no sequence annotation for sequence {sequence_id}"
+    return items[0]
+
+
+def _get_detection_annotations(token: str, sequence_id: int) -> list:
+    response = requests.get(
+        f"{API}/api/v1/annotations/detections/",
+        headers=_headers(token),
+        params={"sequence_id": sequence_id},
+        timeout=10,
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["items"]
+
+
+def _run_pull(output_dir, monkeypatch) -> None:
+    """Run the real pull script in-process; presigned S3 URLs point at the
+    host-oriented proxy (localhost:4566), so rewrite them to the in-network
+    localstack host before downloading."""
+    from scripts.data_transfer.ingestion.platform import (
+        pull_sequence_annotations as pull,
+    )
+
+    real_get = requests.get
+
+    def _rewriting_get(url, **kwargs):
+        return real_get(url.replace("localhost:4566", "localstack:4566"), **kwargs)
+
+    monkeypatch.setattr(pull.requests, "get", _rewriting_get)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pull_sequence_annotations",
+            "--remote-api",
+            API,
+            "--output-dir",
+            str(output_dir),
+            "--loglevel",
+            "warning",
+        ],
+    )
+    pull.main()
+
+
+class _FakeModel:
+    """Deterministic stand-in for the YOLO11s classifier: one prediction near
+    each seeded object box plus a stray box overlapping nothing."""
+
+    def __call__(self, pil_img) -> np.ndarray:
+        return np.array(
+            [
+                [0.11, 0.11, 0.19, 0.19, 0.90],  # overlaps P_LEFT
+                [0.61, 0.61, 0.69, 0.69, 0.80],  # overlaps P_RIGHT
+                [0.40, 0.85, 0.45, 0.90, 0.70],  # stray, overlaps nothing
+            ]
+        )
+
+
+def _smoke_object(smoke_type: str, boxes_by_detection: dict) -> dict:
+    return {
+        "is_smoke": True,
+        "smoke_type": smoke_type,
+        "false_positive_types": [],
+        "bboxes": [
+            {"detection_id": det_id, "xyxyn": box}
+            for det_id, box in boxes_by_detection.items()
+        ],
+    }
+
+
+def _fp_object(fp_types: list, boxes_by_detection: dict) -> dict:
+    return {
+        "is_smoke": False,
+        "false_positive_types": fp_types,
+        "bboxes": [
+            {"detection_id": det_id, "xyxyn": box}
+            for det_id, box in boxes_by_detection.items()
+        ],
+    }
+
+
+def _read_labels(seq_dir, detection_id: int) -> list:
+    """Return [(class_id, [cx, cy, w, h]), ...] for one frame's label file."""
+    label_path = seq_dir / "labels" / f"detection_{detection_id}.txt"
+    assert label_path.exists(), f"missing label file {label_path}"
+    rows = []
+    for raw in label_path.read_text().splitlines():
+        parts = raw.split()
+        rows.append((int(parts[0]), [float(v) for v in parts[1:5]]))
+    return rows
+
+
+async def test_pipeline_end_to_end(tmp_path, monkeypatch, test_user):
+    from scripts.data_transfer.ingestion.platform.apply_fiftyone_review import (
+        load_manifest,
+        process_one_group,
+    )
+    from scripts.data_transfer.ingestion.platform.auto_annotate import (
+        process_sequence,
+    )
+    from scripts.data_transfer.ingestion.platform.label_classes import CLASS_ID
+
+    token = _token()
+
+    # --- Seed: 4 fake sequences covering the corruption scenarios ------------
+    # 1. collision: wildfire + industrial objects on the SAME frames (#140/#139)
+    seq_collision = _create_sequence(token, alert_api_id=501, camera_id=501)
+    collision_dets = [
+        _create_detection(token, seq_collision, 50100 + i, 50 - i, [P_LEFT, P_RIGHT])
+        for i in range(2)
+    ]
+    _create_seq_annotation(
+        token,
+        seq_collision,
+        [
+            _smoke_object("wildfire", {d: P_LEFT for d in collision_dets}),
+            _smoke_object("industrial", {d: P_RIGHT for d in collision_dets}),
+        ],
+    )
+
+    # 2. mixed: wildfire + FP antenna on the same frame (#141)
+    seq_mixed = _create_sequence(token, alert_api_id=502, camera_id=502)
+    mixed_det = _create_detection(token, seq_mixed, 50200, 40, [P_LEFT, P_RIGHT])
+    _create_seq_annotation(
+        token,
+        seq_mixed,
+        [
+            _smoke_object("wildfire", {mixed_det: P_LEFT}),
+            _fp_object(["antenna"], {mixed_det: P_RIGHT}),
+        ],
+    )
+
+    # 3. FP with multiple types -> one label line per type
+    seq_fp = _create_sequence(token, alert_api_id=503, camera_id=503)
+    fp_det = _create_detection(token, seq_fp, 50300, 30, [P_LEFT])
+    _create_seq_annotation(
+        token, seq_fp, [_fp_object(["antenna", "road"], {fp_det: P_LEFT})]
+    )
+
+    # 4. unsure -> must never be pulled
+    seq_unsure = _create_sequence(token, alert_api_id=504, camera_id=504)
+    unsure_det = _create_detection(token, seq_unsure, 50400, 20, [P_LEFT])
+    _create_seq_annotation(
+        token,
+        seq_unsure,
+        [_smoke_object("wildfire", {unsure_det: P_LEFT})],
+        is_unsure=True,
+    )
+
+    # --- Stage 1: pull ------------------------------------------------------
+    _run_pull(tmp_path, monkeypatch)
+
+    collision_dir = tmp_path / "seq_501"
+    mixed_dir = tmp_path / "seq_502"
+    fp_dir = tmp_path / "seq_503"
+    assert not (tmp_path / "seq_504").exists(), "unsure sequence must not be pulled"
+
+    # collision: both objects on every shared frame, with their own classes
+    for det_id in collision_dets:
+        rows = _read_labels(collision_dir, det_id)
+        assert sorted(cls for cls, _ in rows) == [
+            CLASS_ID["wildfire"],
+            CLASS_ID["industrial"],
+        ]
+
+    # mixed: FP box exported as fp_antenna, never as a smoke class
+    rows = _read_labels(mixed_dir, mixed_det)
+    assert sorted(cls for cls, _ in rows) == [
+        CLASS_ID["wildfire"],
+        CLASS_ID["fp_antenna"],
+    ]
+
+    # multi-type FP: one line per assigned type, same box
+    rows = _read_labels(fp_dir, fp_det)
+    assert sorted(cls for cls, _ in rows) == [
+        CLASS_ID["fp_antenna"],
+        CLASS_ID["fp_road"],
+    ]
+
+    # pull transitions the pulled sequences (and only them) to in_review
+    for seq_id in (seq_collision, seq_mixed, seq_fp):
+        assert _get_seq_annotation(token, seq_id)["processing_stage"] == "in_review"
+    assert (
+        _get_seq_annotation(token, seq_unsure)["processing_stage"]
+        == "seq_annotation_done"
+    )
+
+    # --- Stage 2: auto-annotate (fake model) --------------------------------
+    for seq_dir in (collision_dir, mixed_dir):
+        process_sequence(
+            seq_dir, _FakeModel(), conf_th=0.05, iou_nms=0.0, iou_assign=0.0
+        )
+
+    # collision: kept predictions inherit each seed group's class; stray dropped
+    for det_id in collision_dets:
+        rows = _read_labels(collision_dir, det_id)
+        assert len(rows) == 2, "stray prediction must be dropped"
+        classes = {cls: box for cls, box in rows}
+        assert set(classes) == {CLASS_ID["wildfire"], CLASS_ID["industrial"]}
+        # the left prediction is the wildfire one, the right the industrial one
+        assert classes[CLASS_ID["wildfire"]][0] < 0.5
+        assert classes[CLASS_ID["industrial"]][0] > 0.5
+
+    # mixed: FP box untouched; the model prediction over the FP zone is
+    # dropped (FP never validates a prediction), the wildfire one is kept
+    rows = _read_labels(mixed_dir, mixed_det)
+    classes = {cls: box for cls, box in rows}
+    assert set(classes) == {CLASS_ID["wildfire"], CLASS_ID["fp_antenna"]}
+    fp_box = classes[CLASS_ID["fp_antenna"]]
+    assert fp_box == [pytest.approx(v) for v in [0.65, 0.65, 0.10, 0.10]]
+
+    # --- Stage 3: apply-review (clean folder, FiftyOne bypassed) ------------
+    for alert_id, seq_id, dets in (
+        (502, seq_mixed, [mixed_det]),
+        (501, seq_collision, collision_dets),
+    ):
+        manifest = load_manifest(tmp_path, alert_id)
+        assert manifest is not None
+        info = {"issue_frames": set(), "whole_issue": False, "all_frames": set(dets)}
+        status = process_one_group(
+            alert_id, info, manifest, API, token, tmp_path, dry_run=False
+        )
+        assert status == "ok"
+        assert _get_seq_annotation(token, seq_id)["processing_stage"] == "annotated"
+
+    # mixed sequence: detection annotation carries the smoke box AND the FP box
+    det_annotations = _get_detection_annotations(token, seq_mixed)
+    assert len(det_annotations) == 1
+    assert det_annotations[0]["processing_stage"] == "annotated"
+    items = det_annotations[0]["annotation"]["annotation"]
+    smoke_items = [i for i in items if i.get("smoke_type")]
+    fp_items = [i for i in items if i.get("false_positive_type")]
+    assert [i["smoke_type"] for i in smoke_items] == ["wildfire"]
+    assert [i["false_positive_type"] for i in fp_items] == ["antenna"]
+
+    # collision sequence: both smoke types survive the round trip
+    for annotation in _get_detection_annotations(token, seq_collision):
+        types = sorted(i["smoke_type"] for i in annotation["annotation"]["annotation"])
+        assert types == ["industrial", "wildfire"]
+
+    # --- Stage 3b: apply-review with an issue-tagged frame -------------------
+    # Runs in the same test so the schema is reset only once per uvicorn
+    # lifetime (each reset invalidates the live server's asyncpg statement
+    # cache; see _token). The sequences above are now in_review, so this
+    # second pull only fetches the new one.
+    seq_issue = _create_sequence(token, alert_api_id=601, camera_id=601)
+    det_ok = _create_detection(token, seq_issue, 60100, 15, [P_LEFT])
+    det_bad = _create_detection(token, seq_issue, 60101, 10, [P_LEFT])
+    _create_seq_annotation(
+        token, seq_issue, [_smoke_object("wildfire", {det_ok: P_LEFT, det_bad: P_LEFT})]
+    )
+
+    _run_pull(tmp_path, monkeypatch)
+
+    manifest = load_manifest(tmp_path, 601)
+    assert manifest is not None
+    info = {
+        "issue_frames": {det_bad},
+        "whole_issue": False,
+        "all_frames": {det_ok, det_bad},
+    }
+    status = process_one_group(601, info, manifest, API, token, tmp_path, dry_run=False)
+    assert status == "partial_issue"
+
+    # the issue frame sends the sequence to needs_manual; only the flagged
+    # detection goes back to bbox_annotation
+    assert _get_seq_annotation(token, seq_issue)["processing_stage"] == "needs_manual"
+    stages = {
+        annotation["detection_id"]: annotation["processing_stage"]
+        for annotation in _get_detection_annotations(token, seq_issue)
+    }
+    assert stages[det_bad] == "bbox_annotation"
+    assert stages[det_ok] == "annotated"

--- a/annotation_api/src/tests/scripts/test_pull_sequence_annotations.py
+++ b/annotation_api/src/tests/scripts/test_pull_sequence_annotations.py
@@ -58,7 +58,9 @@ class TestCollectAnnotationBboxes:
     def test_smoke_object_without_type_falls_back_to_wildfire(self):
         annotation = {
             "sequences_bbox": [
-                _smoke_object(None, [{"detection_id": 2, "xyxyn": [0.1, 0.1, 0.2, 0.2]}])
+                _smoke_object(
+                    None, [{"detection_id": 2, "xyxyn": [0.1, 0.1, 0.2, 0.2]}]
+                )
             ]
         }
         boxes = collect_annotation_bboxes(annotation)

--- a/annotation_api/src/tests/scripts/test_pull_sequence_annotations.py
+++ b/annotation_api/src/tests/scripts/test_pull_sequence_annotations.py
@@ -1,0 +1,109 @@
+from scripts.data_transfer.ingestion.platform.pull_sequence_annotations import (
+    collect_annotation_bboxes,
+    write_labels,
+)
+
+
+def _smoke_object(smoke_type, bboxes):
+    return {"is_smoke": True, "smoke_type": smoke_type, "bboxes": bboxes}
+
+
+def _fp_object(fp_types, bboxes):
+    return {
+        "is_smoke": False,
+        "smoke_type": None,
+        "false_positive_types": fp_types,
+        "bboxes": bboxes,
+    }
+
+
+class TestCollectAnnotationBboxes:
+    def test_two_objects_sharing_a_frame_are_both_kept(self):
+        # Regression for #140: same detection_id must not overwrite.
+        annotation = {
+            "sequences_bbox": [
+                _smoke_object(
+                    "wildfire", [{"detection_id": 1, "xyxyn": [0.1, 0.1, 0.2, 0.2]}]
+                ),
+                _smoke_object(
+                    "industrial", [{"detection_id": 1, "xyxyn": [0.6, 0.6, 0.7, 0.7]}]
+                ),
+            ]
+        }
+        boxes = collect_annotation_bboxes(annotation)
+        assert len(boxes[1]) == 2
+        assert {b["class_name"] for b in boxes[1]} == {"wildfire", "industrial"}
+
+    def test_false_positive_object_gets_fp_class(self):
+        # Regression for #141: FP objects must not become wildfire labels.
+        annotation = {
+            "sequences_bbox": [
+                _fp_object(
+                    ["antenna"], [{"detection_id": 5, "xyxyn": [0.1, 0.1, 0.2, 0.2]}]
+                )
+            ]
+        }
+        boxes = collect_annotation_bboxes(annotation)
+        assert boxes[5][0]["class_name"] == "fp_antenna"
+
+    def test_false_positive_without_type_falls_back_to_unlabeled(self):
+        annotation = {
+            "sequences_bbox": [
+                _fp_object([], [{"detection_id": 5, "xyxyn": [0.1, 0.1, 0.2, 0.2]}])
+            ]
+        }
+        boxes = collect_annotation_bboxes(annotation)
+        assert boxes[5][0]["class_name"] == "fp_unlabeled"
+
+    def test_smoke_object_without_type_falls_back_to_wildfire(self):
+        annotation = {
+            "sequences_bbox": [
+                _smoke_object(None, [{"detection_id": 2, "xyxyn": [0.1, 0.1, 0.2, 0.2]}])
+            ]
+        }
+        boxes = collect_annotation_bboxes(annotation)
+        assert boxes[2][0]["class_name"] == "wildfire"
+
+    def test_mixed_smoke_and_fp_on_same_frame(self):
+        annotation = {
+            "sequences_bbox": [
+                _smoke_object(
+                    "wildfire", [{"detection_id": 9, "xyxyn": [0.1, 0.1, 0.2, 0.2]}]
+                ),
+                _fp_object(
+                    ["road"], [{"detection_id": 9, "xyxyn": [0.5, 0.5, 0.6, 0.6]}]
+                ),
+            ]
+        }
+        boxes = collect_annotation_bboxes(annotation)
+        assert {b["class_name"] for b in boxes[9]} == {"wildfire", "fp_road"}
+
+    def test_boxes_without_detection_id_or_coordinates_are_skipped(self):
+        annotation = {
+            "sequences_bbox": [
+                _smoke_object(
+                    "wildfire",
+                    [
+                        {"detection_id": None, "xyxyn": [0.1, 0.1, 0.2, 0.2]},
+                        {"detection_id": 3, "xyxyn": []},
+                    ],
+                )
+            ]
+        }
+        assert collect_annotation_bboxes(annotation) == {}
+
+
+class TestWriteLabels:
+    def test_writes_smoke_and_fp_class_ids(self, tmp_path):
+        label_path = tmp_path / "detection_1.txt"
+        write_labels(
+            label_path,
+            [
+                ("wildfire", [0.1, 0.1, 0.3, 0.3]),
+                ("fp_antenna", [0.5, 0.5, 0.7, 0.7]),
+            ],
+        )
+        lines = label_path.read_text().splitlines()
+        assert len(lines) == 2
+        assert lines[0].split()[0] == "0"
+        assert int(lines[1].split()[0]) >= 3

--- a/annotation_api/src/tests/scripts/test_pull_sequence_annotations.py
+++ b/annotation_api/src/tests/scripts/test_pull_sequence_annotations.py
@@ -46,6 +46,19 @@ class TestCollectAnnotationBboxes:
         boxes = collect_annotation_bboxes(annotation)
         assert boxes[5][0]["class_name"] == "fp_antenna"
 
+    def test_false_positive_with_multiple_types_exports_one_box_per_type(self):
+        annotation = {
+            "sequences_bbox": [
+                _fp_object(
+                    ["antenna", "road"],
+                    [{"detection_id": 5, "xyxyn": [0.1, 0.1, 0.2, 0.2]}],
+                )
+            ]
+        }
+        boxes = collect_annotation_bboxes(annotation)
+        assert [b["class_name"] for b in boxes[5]] == ["fp_antenna", "fp_road"]
+        assert boxes[5][0]["xyxyn"] == boxes[5][1]["xyxyn"]
+
     def test_false_positive_without_type_falls_back_to_unlabeled(self):
         annotation = {
             "sequences_bbox": [

--- a/frontend/src/components/annotation/ImageOverlays.tsx
+++ b/frontend/src/components/annotation/ImageOverlays.tsx
@@ -133,8 +133,9 @@ export function UserAnnotationOverlay({
     <>
       {detectionAnnotation.annotation.annotation
         .map((annotationBbox, index) => {
-          // Validate bounding box before rendering
-          if (!validateBoundingBox(annotationBbox.xyxyn)) {
+          // Validate bounding box before rendering; false-positive items
+          // (no smoke_type) are not part of the smoke overlay
+          if (!validateBoundingBox(annotationBbox.xyxyn) || !annotationBbox.smoke_type) {
             return null;
           }
 

--- a/frontend/src/components/detection-sequence/ImageModal.tsx
+++ b/frontend/src/components/detection-sequence/ImageModal.tsx
@@ -201,13 +201,14 @@ export function ImageModal({
 
     // Always update rectangles based on annotation (even if detection didn't change)
     if (existingAnnotation?.annotation?.annotation) {
-      const existingRects: DrawnRectangle[] = existingAnnotation.annotation.annotation.map(
-        (item, index) => ({
+      // false-positive items (no smoke_type) are not editable smoke rectangles
+      const existingRects: DrawnRectangle[] = existingAnnotation.annotation.annotation
+        .filter(item => item.smoke_type != null)
+        .map((item, index) => ({
           id: `existing-${index}`,
           xyxyn: item.xyxyn,
-          smokeType: item.smoke_type,
-        })
-      );
+          smokeType: item.smoke_type as SmokeType,
+        }));
       setDrawnRectangles(existingRects);
     } else {
       setDrawnRectangles([]);

--- a/frontend/src/pages/DetectionSequenceAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionSequenceAnnotatePage.tsx
@@ -381,10 +381,16 @@ export default function DetectionSequenceAnnotatePage() {
           smoke_type: rect.smokeType,
         }));
 
+        // Preserve false-positive items: they are not editable rectangles
+        // (filtered out of the modal) and must survive a smoke-box edit
+        const falsePositiveItems = (existingAnnotation.annotation?.annotation ?? []).filter(
+          item => item.false_positive_type != null
+        );
+
         // Update existing annotation with proper annotation data and 'annotated' stage
         const payload = {
           annotation: {
-            annotation: annotationItems,
+            annotation: [...annotationItems, ...falsePositiveItems],
           },
           processing_stage: 'annotated' as const,
         };

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -101,7 +101,9 @@ export interface DetectionAnnotation {
 export interface DetectionAnnotationBbox {
   xyxyn: [number, number, number, number];
   class_name: string;
-  smoke_type: SmokeType;
+  // exactly one of smoke_type / false_positive_type is set
+  smoke_type?: SmokeType | null;
+  false_positive_type?: FalsePositiveType | null;
 }
 
 export interface DetectionAnnotationData {

--- a/frontend/src/utils/annotation/validationUtils.ts
+++ b/frontend/src/utils/annotation/validationUtils.ts
@@ -185,7 +185,8 @@ export const validateDetectionAnnotation = (annotation: DetectionAnnotation): Va
       }
 
       const validSmokeTypes = ['wildfire', 'industrial', 'other'];
-      if (!validSmokeTypes.includes(item.smoke_type)) {
+      // false-positive items carry false_positive_type instead of smoke_type
+      if (!item.false_positive_type && !validSmokeTypes.includes(item.smoke_type ?? '')) {
         errors.push(`Annotation item ${index} has invalid smoke type: ${item.smoke_type}`);
       }
     });


### PR DESCRIPTION
- `pull-seq-annotations` dropped one of two objects sharing a frame (dict keyed by `detection_id`) and exported false-positive objects as class 0 wildfire; boxes are now collected per frame as lists and FP objects get a dedicated `fp_<type>` class (one label line per assigned type).
- `auto-annotate` hardcoded `class_id=1` on every kept prediction, discarding the human smoke_type; predictions now inherit the majority class of their seed group, and FP boxes pass through untouched (they never validate a prediction).
- Class ids are now a shared registry (`label_classes.py`, ids 0-2 smoke / 3-20 `fp_*`) used consistently by pull, auto-annotate, visual-check (two FiftyOne fields: `smoke` / `false_positive`) and apply-review, which pushes FP boxes back as `false_positive_type` detection items for traceability.
- `DetectionAnnotationItem` accepts either `smoke_type` or `false_positive_type` (exactly one); the frontend preserves FP items when editing smoke boxes.

Note: running `make apply-review` with FP boxes requires the updated backend to be deployed first, otherwise validation rejects the payload.

Fixes #139, fixes #140, fixes #141. Supersedes #147.