### PR TITLE
fix(api): keep per-object smoke_type in sequence-to-detection propagation

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -1,9 +1,10 @@
 # Copyright (C) 2025, Pyronear.
 
 import logging
+from collections import defaultdict
 from datetime import datetime, UTC
 from enum import Enum
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from fastapi import (
     APIRouter,
@@ -99,15 +100,48 @@ def derive_smoke_types(annotation_data: SequenceAnnotationData) -> List[str]:
     return unique_types
 
 
+def _bbox_iou(box1: List[float], box2: List[float]) -> float:
+    """Intersection over union of two xyxyn boxes."""
+    x1 = max(box1[0], box2[0])
+    y1 = max(box1[1], box2[1])
+    x2 = min(box1[2], box2[2])
+    y2 = min(box1[3], box2[3])
+    inter = max(0.0, x2 - x1) * max(0.0, y2 - y1)
+    area1 = max(0.0, box1[2] - box1[0]) * max(0.0, box1[3] - box1[1])
+    area2 = max(0.0, box2[2] - box2[0]) * max(0.0, box2[3] - box2[1])
+    union = area1 + area2 - inter
+    return inter / union if union > 0 else 0.0
+
+
+def collect_object_boxes_by_detection(
+    annotation: Optional[dict],
+) -> Dict[int, List[Tuple[List[float], str]]]:
+    """Map detection_id -> [(xyxyn, smoke_type), ...] from a sequence
+    annotation's sequences_bbox, keeping each smoke object's own type."""
+    object_boxes: Dict[int, List[Tuple[List[float], str]]] = defaultdict(list)
+    for seq_bbox in (annotation or {}).get("sequences_bbox", []):
+        if not seq_bbox.get("is_smoke") or not seq_bbox.get("smoke_type"):
+            continue
+        for bbox in seq_bbox.get("bboxes", []):
+            detection_id = bbox.get("detection_id")
+            xyxyn = bbox.get("xyxyn")
+            if detection_id is not None and isinstance(xyxyn, list) and len(xyxyn) == 4:
+                object_boxes[detection_id].append((xyxyn, seq_bbox["smoke_type"]))
+    return object_boxes
+
+
 def convert_algo_predictions_to_annotation(
-    algo_predictions: Optional[dict], smoke_types: Optional[List[str]] = None
+    algo_predictions: Optional[dict],
+    smoke_types: Optional[List[str]] = None,
+    object_boxes: Optional[List[Tuple[List[float], str]]] = None,
 ) -> dict:
     """
     Convert detection algo_predictions to detection annotation format.
 
     Args:
         algo_predictions: Model predictions in format {"predictions": [{"xyxyn": [...], "confidence": float, "class_name": str}]}
-        smoke_types: Optional list of smoke types from sequence annotation. Uses first smoke type if available, defaults to "wildfire"
+        smoke_types: Optional list of smoke types from sequence annotation. Fallback when a prediction matches no object box; uses the first type, defaults to "wildfire"
+        object_boxes: Optional per-detection [(xyxyn, smoke_type), ...] from the sequence annotation's sequences_bbox. Each prediction takes the type of the exactly-matching object box (best IoU as fallback) so multi-type sequences keep per-object types
 
     Returns:
         Annotation dict in format {"annotation": [{"xyxyn": [...], "class_name": str, "smoke_type": str}]}
@@ -132,11 +166,24 @@ def convert_algo_predictions_to_annotation(
         if not isinstance(xyxyn, list) or len(xyxyn) != 4:
             continue
 
-        # Convert to annotation format with user-selected smoke type or default wildfire
-        # Use first smoke type from sequence annotation if available, otherwise default to wildfire
-        selected_smoke_type = "wildfire"  # Default fallback
+        # Sequence-wide fallback: first smoke type if available, else wildfire
+        selected_smoke_type = "wildfire"
         if smoke_types and len(smoke_types) > 0:
             selected_smoke_type = smoke_types[0]
+
+        # Per-object type: object boxes come from algo_predictions untouched,
+        # so an exact coordinate match identifies the annotated object; best
+        # IoU covers boxes whose geometry drifted (e.g. external tooling)
+        if object_boxes:
+            best_iou = 0.0
+            for object_xyxyn, object_smoke_type in object_boxes:
+                if object_xyxyn == xyxyn:
+                    selected_smoke_type = object_smoke_type
+                    break
+                iou = _bbox_iou(object_xyxyn, xyxyn)
+                if iou > best_iou:
+                    best_iou = iou
+                    selected_smoke_type = object_smoke_type
 
         annotation_item = {
             "xyxyn": xyxyn,
@@ -236,6 +283,7 @@ async def auto_create_detection_annotations(
     has_false_positives: bool,
     session: AsyncSession,
     smoke_types: Optional[List[str]] = None,
+    annotation: Optional[dict] = None,
 ) -> None:
     """
     Automatically create detection annotations for all detections in a sequence.
@@ -253,6 +301,7 @@ async def auto_create_detection_annotations(
         has_false_positives: Whether sequence annotation indicates false positives
         session: Database session
         smoke_types: Optional list of smoke types from sequence annotation for true positive sequences
+        annotation: Optional sequence annotation data (sequences_bbox) used to keep each object's own smoke_type on the pre-populated boxes
     """
     # Determine the appropriate processing stage based on sequence annotation
     if not has_missed_smoke and has_false_positives and not has_smoke:
@@ -287,6 +336,7 @@ async def auto_create_detection_annotations(
     # Prepare batch data for bulk insert
     new_annotations = []
     current_time = datetime.now(UTC)
+    object_boxes_by_detection = collect_object_boxes_by_detection(annotation)
 
     for detection in detections:
         # Skip if annotation already exists
@@ -295,9 +345,12 @@ async def auto_create_detection_annotations(
 
         # Determine annotation data based on sequence type
         if has_smoke and not has_missed_smoke and not has_false_positives:
-            # True positive sequence: pre-populate with model predictions using user-selected smoke types
+            # True positive sequence: pre-populate with model predictions,
+            # keeping each annotated object's own smoke type
             annotation_data = convert_algo_predictions_to_annotation(
-                detection.algo_predictions, smoke_types
+                detection.algo_predictions,
+                smoke_types,
+                object_boxes_by_detection.get(detection.id),
             )
         else:
             # All other cases: start with empty annotation
@@ -415,6 +468,7 @@ async def create_sequence_annotation(
             has_false_positives=sequence_annotation.has_false_positives,
             session=annotations.session,
             smoke_types=sequence_annotation.smoke_types,
+            annotation=sequence_annotation.annotation,
         )
         # Commit the detection annotations
         await annotations.session.commit()
@@ -712,6 +766,7 @@ async def update_sequence_annotation(
             has_false_positives=updated_annotation.has_false_positives,
             session=annotations.session,
             smoke_types=updated_annotation.smoke_types,
+            annotation=updated_annotation.annotation,
         )
         # Commit the detection annotations
         await annotations.session.commit()

--- a/annotation_api/src/tests/endpoints/test_detection_annotation_workflow.py
+++ b/annotation_api/src/tests/endpoints/test_detection_annotation_workflow.py
@@ -1038,8 +1038,14 @@ async def test_smoke_type_propagation_from_sequence_to_detection_annotations(
         len(sequence_detection_annotations) >= 2
     ), "Should have detection annotations for both detections"
 
-    # Step 4: Verify smoke type propagation - should use first smoke type from sequence annotation
-    for detection_annotation in sequence_detection_annotations[:2]:  # Check first 2
+    # Step 4: Verify per-object smoke type propagation - each detection's
+    # pre-populated box takes the type of the object annotated on that
+    # detection instead of the sequence-wide first smoke type
+    expected_smoke_types = {
+        detection_ids[0]: "industrial",
+        detection_ids[1]: "other",
+    }
+    for detection_annotation in sequence_detection_annotations:
         annotation_data = detection_annotation["annotation"]
         assert (
             "annotation" in annotation_data
@@ -1053,10 +1059,10 @@ async def test_smoke_type_propagation_from_sequence_to_detection_annotations(
                 len(annotations) > 0
             ), "True positive sequence should have predictions pre-populated"
 
-            # Verify that smoke_type is "industrial" (first smoke type) instead of defaulting to "wildfire"
+            expected = expected_smoke_types[detection_annotation["detection_id"]]
             assert (
-                annotations[0]["smoke_type"] == "industrial"
-            ), f"Should use sequence annotation smoke type 'industrial', got '{annotations[0]['smoke_type']}'"
+                annotations[0]["smoke_type"] == expected
+            ), f"Should use the object's own smoke type '{expected}', got '{annotations[0]['smoke_type']}'"
             assert (
                 annotations[0]["class_name"] == "smoke"
             ), "Should have smoke prediction"

--- a/annotation_api/src/tests/endpoints/test_sequence_annotations.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_annotations.py
@@ -1733,6 +1733,96 @@ async def test_true_positive_sequence_pre_populated_detection_annotations(
 
 
 @pytest.mark.asyncio
+async def test_true_positive_sequence_keeps_per_object_smoke_types(
+    authenticated_client: AsyncClient, sequence_session
+):
+    """Regression test: a sequence with objects of different smoke types must
+    propagate each object's own type to the pre-populated detection boxes
+    instead of stamping smoke_types[0] on every box."""
+
+    algo_predictions = {
+        "predictions": [
+            {"xyxyn": [0.1, 0.2, 0.4, 0.6], "confidence": 0.92, "class_name": "smoke"},
+            {"xyxyn": [0.5, 0.3, 0.8, 0.7], "confidence": 0.85, "class_name": "smoke"},
+        ]
+    }
+
+    detection_payload = {
+        "sequence_id": "1",
+        "alert_api_id": "3002",
+        "recorded_at": "2024-01-15T10:25:00",
+        "algo_predictions": json.dumps(algo_predictions),
+    }
+
+    import io
+
+    img = Image.new("RGB", (100, 100), color="orange")
+    img_bytes = io.BytesIO()
+    img.save(img_bytes, format="JPEG")
+    img_bytes.seek(0)
+
+    files = {"file": ("test.jpg", img_bytes, "image/jpeg")}
+    response = await authenticated_client.post(
+        "/detections", data=detection_payload, files=files
+    )
+    assert response.status_code == 201
+    detection_id = response.json()["id"]
+
+    # Two smoke objects with different types, each referencing one prediction box
+    mixed_types_payload = {
+        "sequence_id": 1,
+        "has_missed_smoke": False,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": True,
+                    "smoke_type": "wildfire",
+                    "false_positive_types": [],
+                    "bboxes": [
+                        {"detection_id": detection_id, "xyxyn": [0.1, 0.2, 0.4, 0.6]}
+                    ],
+                },
+                {
+                    "is_smoke": True,
+                    "smoke_type": "industrial",
+                    "false_positive_types": [],
+                    "bboxes": [
+                        {"detection_id": detection_id, "xyxyn": [0.5, 0.3, 0.8, 0.7]}
+                    ],
+                },
+            ]
+        },
+        "processing_stage": models.SequenceAnnotationProcessingStage.ANNOTATED.value,
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+
+    response = await authenticated_client.post(
+        "/annotations/sequences/", json=mixed_types_payload
+    )
+    assert response.status_code == 201
+    assert response.json()["smoke_types"] == ["wildfire", "industrial"]
+
+    response = await authenticated_client.get("/annotations/detections/?sequence_id=1")
+    assert response.status_code == 200
+    detection_annotation = next(
+        (
+            ann
+            for ann in response.json()["items"]
+            if ann["detection_id"] == detection_id
+        ),
+        None,
+    )
+    assert detection_annotation is not None
+
+    boxes = {
+        tuple(item["xyxyn"]): item["smoke_type"]
+        for item in detection_annotation["annotation"]["annotation"]
+    }
+    assert boxes[(0.1, 0.2, 0.4, 0.6)] == "wildfire"
+    assert boxes[(0.5, 0.3, 0.8, 0.7)] == "industrial"
+
+
+@pytest.mark.asyncio
 async def test_true_positive_sequence_empty_predictions_fallback(
     authenticated_client: AsyncClient, sequence_session
 ):
@@ -1987,6 +2077,54 @@ async def test_convert_algo_predictions_to_annotation_helper():
     assert len(result["annotation"]) == 1
     assert result["annotation"][0]["class_name"] == "smoke"  # Default value
     assert result["annotation"][0]["smoke_type"] == "wildfire"
+
+
+@pytest.mark.asyncio
+async def test_convert_algo_predictions_uses_per_object_smoke_types():
+    """Object boxes from the sequence annotation drive per-box smoke types:
+    exact coordinate match first, best IoU as fallback, sequence-wide first
+    type when a prediction overlaps no object box."""
+    from app.api.api_v1.endpoints.sequence_annotations import (
+        convert_algo_predictions_to_annotation,
+    )
+
+    algo_predictions = {
+        "predictions": [
+            {"xyxyn": [0.1, 0.2, 0.4, 0.6], "confidence": 0.92, "class_name": "smoke"},
+            {"xyxyn": [0.5, 0.3, 0.8, 0.7], "confidence": 0.85, "class_name": "smoke"},
+            {
+                "xyxyn": [0.51, 0.31, 0.79, 0.69],
+                "confidence": 0.7,
+                "class_name": "smoke",
+            },
+            {
+                "xyxyn": [0.05, 0.85, 0.1, 0.95],
+                "confidence": 0.6,
+                "class_name": "smoke",
+            },
+        ]
+    }
+    object_boxes = [
+        ([0.1, 0.2, 0.4, 0.6], "wildfire"),
+        ([0.5, 0.3, 0.8, 0.7], "industrial"),
+    ]
+
+    result = convert_algo_predictions_to_annotation(
+        algo_predictions, ["wildfire", "industrial"], object_boxes
+    )
+    items = result["annotation"]
+    assert [item["smoke_type"] for item in items] == [
+        "wildfire",  # exact match on the wildfire object box
+        "industrial",  # exact match on the industrial object box
+        "industrial",  # near-duplicate box resolved by best IoU
+        "wildfire",  # no overlap with any object box -> smoke_types[0]
+    ]
+
+    # Without object boxes, the legacy sequence-wide fallback applies
+    result = convert_algo_predictions_to_annotation(
+        algo_predictions, ["industrial", "wildfire"]
+    )
+    assert {item["smoke_type"] for item in result["annotation"]} == {"industrial"}
 
 
 # Contributor Tests


### PR DESCRIPTION
- `auto_create_detection_annotations` applied `smoke_types[0]` to every pre-populated detection box, so sequences containing objects of different smoke types (e.g. one wildfire + one industrial) were mislabeled at the detection level.
- Each prediction now inherits the type of the `sequences_bbox` object whose box matches it: exact coordinate match first (object boxes come from `algo_predictions` untouched), best IoU as a robustness fallback, and the sequence-wide first type only when a prediction overlaps no object box.
- Adds a unit test on `convert_algo_predictions_to_annotation` (exact / IoU / no-overlap paths) and an end-to-end regression test (mixed wildfire+industrial sequence); both fail before the fix.

Fixes #142