### PR TITLE
feat(api): validate sequence annotation completeness on seq_annotation_done

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/push_sequence_annotations.py
@@ -342,12 +342,15 @@ def main() -> None:
             stats["skipped_remote_downstream"] += 1
             continue
 
-        # Build payload from local annotation
+        # Build payload from local annotation. is_unsure must travel with the
+        # annotation: the remote completeness validation exempts unsure rows,
+        # and the detection review pull excludes them (is_unsure=False filter).
         payload = {
             "sequence_id": remote_seq_id,
             "annotation": remapped_annotation,
             "processing_stage": SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE.value,
             "has_missed_smoke": local_ann.get("has_missed_smoke", False),
+            "is_unsure": local_ann.get("is_unsure", False),
         }
 
         try:

--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -417,6 +417,44 @@ async def validate_detection_ids(
         )
 
 
+def validate_annotation_completeness(
+    annotation_data: SequenceAnnotationData,
+    processing_stage: SequenceAnnotationProcessingStage,
+    is_unsure: bool,
+) -> None:
+    """Reject seq_annotation_done annotations with unclassified objects.
+
+    Mirrors the frontend gate (hasUserAnnotations): every sequences_bbox must
+    either be smoke with a smoke_type set or carry at least one
+    false_positive_type. Unsure annotations are exempt, matching the frontend
+    which lets unsure submissions bypass the completeness check.
+
+    Raises:
+        HTTPException: 422 listing the indices of unclassified sequences_bbox
+    """
+    if (
+        processing_stage != SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE
+        or is_unsure
+    ):
+        return
+
+    incomplete = [
+        i
+        for i, bbox in enumerate(annotation_data.sequences_bbox)
+        if (bbox.smoke_type is None if bbox.is_smoke else not bbox.false_positive_types)
+    ]
+    if incomplete:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Annotation is incomplete for processing_stage=seq_annotation_done: "
+                f"sequences_bbox at indices {incomplete} must have smoke_type set "
+                "(is_smoke=true) or at least one false_positive_type (is_smoke=false). "
+                "Mark the annotation as unsure to bypass this check."
+            ),
+        )
+
+
 @router.post("/", status_code=status.HTTP_201_CREATED)
 async def create_sequence_annotation(
     create_data: SequenceAnnotationCreate = Body(...),
@@ -451,6 +489,11 @@ async def create_sequence_annotation(
 
     # Validate that all detection_ids exist in the database
     await validate_detection_ids(create_data.annotation, annotations.session)
+
+    # Reject unclassified objects when the annotation claims seq_annotation_done
+    validate_annotation_completeness(
+        create_data.annotation, create_data.processing_stage, create_data.is_unsure
+    )
 
     # Use CRUD method which handles contribution tracking with proper conditional logic
     sequence_annotation = await annotations.create(create_data, current_user.id)
@@ -730,6 +773,21 @@ async def update_sequence_annotation(
     # Validate detection_ids if annotation is being updated
     if payload.annotation is not None:
         await validate_detection_ids(payload.annotation, annotations.session)
+
+    # Reject unclassified objects when the resulting row would sit at
+    # seq_annotation_done (covers stage-only PATCHes by validating the stored
+    # payload, and annotation-only PATCHes on rows already at that stage)
+    target_is_unsure = (
+        payload.is_unsure if payload.is_unsure is not None else existing.is_unsure
+    )
+    target_annotation_data = (
+        payload.annotation
+        if payload.annotation is not None
+        else SequenceAnnotationData(**existing.annotation)
+    )
+    validate_annotation_completeness(
+        target_annotation_data, target_processing_stage, target_is_unsure
+    )
 
     # Check if processing_stage is being updated to "annotated" for auto-creation logic
     was_annotated_before = (

--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -17,6 +17,7 @@ from fastapi import (
 )
 from fastapi_pagination import Page, Params, create_page
 from fastapi_pagination.ext.sqlalchemy import apaginate
+from pydantic import ValidationError
 from sqlalchemy import asc, desc, select, text, or_
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -780,14 +781,34 @@ async def update_sequence_annotation(
     target_is_unsure = (
         payload.is_unsure if payload.is_unsure is not None else existing.is_unsure
     )
-    target_annotation_data = (
-        payload.annotation
-        if payload.annotation is not None
-        else SequenceAnnotationData(**existing.annotation)
-    )
-    validate_annotation_completeness(
-        target_annotation_data, target_processing_stage, target_is_unsure
-    )
+    if (
+        target_processing_stage
+        == SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE
+        and not target_is_unsure
+    ):
+        if payload.annotation is not None:
+            target_annotation_data = payload.annotation
+        else:
+            # Stored payloads may predate stricter bbox validation; surface an
+            # actionable 422 instead of a 500 when they no longer parse.
+            try:
+                target_annotation_data = SequenceAnnotationData(**existing.annotation)
+            except ValidationError as exc:
+                logger.error(
+                    f"Stored annotation for sequence annotation {annotation_id} "
+                    f"failed validation during stage update: {exc}"
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(
+                        "Stored annotation payload is invalid and cannot be "
+                        "promoted to seq_annotation_done; resubmit the "
+                        "annotation in the same request"
+                    ),
+                ) from exc
+        validate_annotation_completeness(
+            target_annotation_data, target_processing_stage, target_is_unsure
+        )
 
     # Check if processing_stage is being updated to "annotated" for auto-creation logic
     was_annotated_before = (

--- a/annotation_api/src/tests/endpoints/test_sequence_annotations.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_annotations.py
@@ -2702,3 +2702,165 @@ async def test_sequence_annotation_update_edge_cases(
     assert "lens_flare" in fp_types
     assert "other" in fp_types
     assert len(fp_types) == 3  # No duplicates
+
+
+# ---------------------------------------------------------------------------
+# Completeness validation for seq_annotation_done (#151)
+# Every sequences_bbox must be classified (smoke with a smoke_type, or at
+# least one false_positive_type) before an annotation may carry the
+# seq_annotation_done stage, unless it is marked unsure.
+# ---------------------------------------------------------------------------
+
+
+def _completeness_payload(sequences_bbox: list, stage: str, is_unsure: bool = False):
+    return {
+        "sequence_id": 1,
+        "has_missed_smoke": False,
+        "is_unsure": is_unsure,
+        "annotation": {"sequences_bbox": sequences_bbox},
+        "processing_stage": stage,
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+
+
+_UNCLASSIFIED_BBOX = {
+    "is_smoke": False,
+    "false_positive_types": [],
+    "bboxes": [{"detection_id": 1, "xyxyn": [0.1, 0.1, 0.2, 0.2]}],
+}
+
+_SMOKE_WITHOUT_TYPE_BBOX = {
+    "is_smoke": True,
+    "false_positive_types": [],
+    "bboxes": [{"detection_id": 1, "xyxyn": [0.1, 0.1, 0.2, 0.2]}],
+}
+
+_COMPLETE_SMOKE_BBOX = {
+    "is_smoke": True,
+    "smoke_type": "wildfire",
+    "false_positive_types": [],
+    "bboxes": [{"detection_id": 1, "xyxyn": [0.1, 0.1, 0.2, 0.2]}],
+}
+
+_COMPLETE_FP_BBOX = {
+    "is_smoke": False,
+    "false_positive_types": ["antenna"],
+    "bboxes": [{"detection_id": 2, "xyxyn": [0.5, 0.5, 0.6, 0.6]}],
+}
+
+
+@pytest.mark.asyncio
+async def test_create_seq_annotation_done_rejects_unclassified_object(
+    authenticated_client: AsyncClient, sequence_session, detection_session
+):
+    payload = _completeness_payload(
+        [_COMPLETE_SMOKE_BBOX, _UNCLASSIFIED_BBOX], stage="seq_annotation_done"
+    )
+    response = await authenticated_client.post("/annotations/sequences/", json=payload)
+    assert response.status_code == 422, response.text
+    assert "incomplete" in response.json()["detail"]
+    assert "[1]" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_seq_annotation_done_rejects_smoke_without_type(
+    authenticated_client: AsyncClient, sequence_session, detection_session
+):
+    payload = _completeness_payload(
+        [_SMOKE_WITHOUT_TYPE_BBOX], stage="seq_annotation_done"
+    )
+    response = await authenticated_client.post("/annotations/sequences/", json=payload)
+    assert response.status_code == 422, response.text
+    assert "incomplete" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_seq_annotation_done_accepts_complete_annotation(
+    authenticated_client: AsyncClient, sequence_session, detection_session
+):
+    payload = _completeness_payload(
+        [_COMPLETE_SMOKE_BBOX, _COMPLETE_FP_BBOX], stage="seq_annotation_done"
+    )
+    response = await authenticated_client.post("/annotations/sequences/", json=payload)
+    assert response.status_code == 201, response.text
+
+
+@pytest.mark.asyncio
+async def test_create_seq_annotation_done_allows_incomplete_when_unsure(
+    authenticated_client: AsyncClient, sequence_session, detection_session
+):
+    payload = _completeness_payload(
+        [_UNCLASSIFIED_BBOX], stage="seq_annotation_done", is_unsure=True
+    )
+    response = await authenticated_client.post("/annotations/sequences/", json=payload)
+    assert response.status_code == 201, response.text
+
+
+@pytest.mark.asyncio
+async def test_create_incomplete_annotation_allowed_in_earlier_stages(
+    authenticated_client: AsyncClient, sequence_session, detection_session
+):
+    payload = _completeness_payload(
+        [_UNCLASSIFIED_BBOX, _SMOKE_WITHOUT_TYPE_BBOX], stage="under_annotation"
+    )
+    response = await authenticated_client.post("/annotations/sequences/", json=payload)
+    assert response.status_code == 201, response.text
+
+
+@pytest.mark.asyncio
+async def test_patch_stage_only_to_seq_annotation_done_validates_stored_annotation(
+    authenticated_client: AsyncClient, sequence_session, detection_session
+):
+    # Incomplete annotation parked at under_annotation is fine
+    payload = _completeness_payload([_UNCLASSIFIED_BBOX], stage="under_annotation")
+    response = await authenticated_client.post("/annotations/sequences/", json=payload)
+    assert response.status_code == 201, response.text
+    annotation_id = response.json()["id"]
+
+    # Stage-only PATCH must validate the stored payload and refuse
+    response = await authenticated_client.patch(
+        f"/annotations/sequences/{annotation_id}",
+        json={"processing_stage": "seq_annotation_done"},
+    )
+    assert response.status_code == 422, response.text
+    assert "incomplete" in response.json()["detail"]
+
+    # Completing the annotation in the same PATCH goes through
+    response = await authenticated_client.patch(
+        f"/annotations/sequences/{annotation_id}",
+        json={
+            "processing_stage": "seq_annotation_done",
+            "annotation": {"sequences_bbox": [_COMPLETE_FP_BBOX]},
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["processing_stage"] == "seq_annotation_done"
+
+
+@pytest.mark.asyncio
+async def test_patch_annotation_on_seq_annotation_done_rejects_incomplete(
+    authenticated_client: AsyncClient, sequence_session, detection_session
+):
+    payload = _completeness_payload([_COMPLETE_SMOKE_BBOX], stage="seq_annotation_done")
+    response = await authenticated_client.post("/annotations/sequences/", json=payload)
+    assert response.status_code == 201, response.text
+    annotation_id = response.json()["id"]
+
+    # Replacing the payload with an unclassified object must be refused while
+    # the row stays at seq_annotation_done
+    response = await authenticated_client.patch(
+        f"/annotations/sequences/{annotation_id}",
+        json={"annotation": {"sequences_bbox": [_UNCLASSIFIED_BBOX]}},
+    )
+    assert response.status_code == 422, response.text
+    assert "incomplete" in response.json()["detail"]
+
+    # Marking it unsure in the same PATCH lifts the gate
+    response = await authenticated_client.patch(
+        f"/annotations/sequences/{annotation_id}",
+        json={
+            "annotation": {"sequences_bbox": [_UNCLASSIFIED_BBOX]},
+            "is_unsure": True,
+        },
+    )
+    assert response.status_code == 200, response.text

--- a/annotation_api/src/tests/endpoints/test_sequence_annotations.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_annotations.py
@@ -2864,3 +2864,42 @@ async def test_patch_annotation_on_seq_annotation_done_rejects_incomplete(
         },
     )
     assert response.status_code == 200, response.text
+
+
+@pytest.mark.asyncio
+async def test_patch_stage_to_seq_annotation_done_with_unparseable_stored_annotation(
+    authenticated_client: AsyncClient, sequence_session, detection_session
+):
+    # Legacy rows can hold payloads that predate the stricter bbox validation
+    # (e.g. null [0,0,0,0] boxes). Promoting such a row with a stage-only
+    # PATCH must yield an actionable 422, not a 500 from the stored-payload
+    # parse.
+    legacy = models.SequenceAnnotation(
+        sequence_id=1,
+        has_smoke=True,
+        has_false_positives=False,
+        has_missed_smoke=False,
+        is_unsure=False,
+        annotation={
+            "sequences_bbox": [
+                {
+                    "is_smoke": True,
+                    "smoke_type": "wildfire",
+                    "false_positive_types": [],
+                    "bboxes": [{"detection_id": 1, "xyxyn": [0, 0, 0, 0]}],
+                }
+            ]
+        },
+        processing_stage=models.SequenceAnnotationProcessingStage.UNDER_ANNOTATION,
+        created_at=datetime.now(UTC),
+    )
+    sequence_session.add(legacy)
+    await sequence_session.commit()
+    await sequence_session.refresh(legacy)
+
+    response = await authenticated_client.patch(
+        f"/annotations/sequences/{legacy.id}",
+        json={"processing_stage": "seq_annotation_done"},
+    )
+    assert response.status_code == 422, response.text
+    assert "Stored annotation" in response.json()["detail"]


### PR DESCRIPTION
Closes #151

## What

Server-side enforcement of the annotation-completeness invariant that previously lived only in the frontend: a sequence annotation may not sit at `seq_annotation_done` with unclassified objects unless it is marked unsure.

A `sequences_bbox` entry counts as classified when:
- `is_smoke = true` **and** `smoke_type` is set, or
- `false_positive_types` is non-empty.

Violations return `422` listing the offending indices.

## Why

The frontend is not the only writer (`push_sequence_annotations.py`, `update_annotation_stage.py`, raw clients), and the detection-review pipeline trusts the stage blindly: `collect_annotation_bboxes()` exports an unreviewed object (`is_smoke=false`, no FP types) as `fp_unlabeled`, and `apply_fiftyone_review.py` can then write that wrong label back at stage `annotated` — the same classification-fidelity failure class as #148/#150.

## How

- New `validate_annotation_completeness()` in `sequence_annotations.py`, called from both POST and PATCH handlers.
- Validates the **target state**: stage-only PATCHes validate the stored payload; annotation-only PATCHes on rows already at `seq_annotation_done` are validated too.
- Unsure annotations are exempt, mirroring the frontend gate (`hasUserAnnotations` / `isAnnotationComplete`), which unsure submissions bypass.
- Internal flows (bulk annotate, group propagation) call the CRUD layer directly and always produce labeled payloads; they are unaffected.

## Tests

7 new endpoint tests covering: rejection on create (unclassified object, smoke without type), acceptance of complete payloads, unsure exemption, earlier stages unaffected, stage-only PATCH validating stored payload, and annotation-only PATCH on a `seq_annotation_done` row.

Full suite: 387 passed. New mypy/ruff findings vs `main`: none (pre-existing baseline unchanged).

## Note for deployment

Legacy rows already at/near `seq_annotation_done` with incomplete payloads will start failing stage-only PATCHes — likely desirable, but worth a quick audit of production data before merging (see issue caveats).
