### PR TITLE
feat(scripts): read-only clone mode for pull-sequences (--skip-source-stage-update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ make pull-sequences MAX_SEQUENCES=10 CLONE_STAGE=ready_to_annotate
 - `MAX_SEQUENCES` caps how many sequences you pull; use `0` for all.
 - `CLONE_STAGE` defaults to `ready_to_annotate`; set to `under_annotation`, `seq_annotation_done`, `needs_manual`, or `no_annotation` to grab those stages.
 - To restrict by `alert_api_id`, call the underlying script directly with `--sequence-list <file_or_csv>`.
+- The pull normally marks the cloned sequences `under_annotation` on the remote to claim them. To hydrate a local API for testing **without mutating the remote**, add `READ_ONLY_SOURCE=1` (passes `--skip-source-stage-update` to the underlying script).
 
 **Step 2 — Annotate sequences locally**
 

--- a/annotation_api/Makefile
+++ b/annotation_api/Makefile
@@ -138,7 +138,7 @@ pull-sequences:
 		--url-api-annotation $(LOCAL_API) \
 		--max-sequences $(MAX_SEQUENCES) \
 		--clone-processing-stage $(CLONE_STAGE) \
-		$(if $(READ_ONLY_SOURCE),--skip-source-stage-update) \
+		$(if $(filter-out 0,$(READ_ONLY_SOURCE)),--skip-source-stage-update) \
 		--loglevel $(LOGLEVEL)
 	$(MAKE) assign-groups
 

--- a/annotation_api/Makefile
+++ b/annotation_api/Makefile
@@ -129,13 +129,16 @@ migrate-up:
 # Duplicate N sequences from the remote annotation API into the local one,
 # then run assign-groups so newly-pulled sequences get clustered and inherit
 # any existing group's label automatically.
-# Usage: make pull-sequences [MAX_SEQUENCES=10] [CLONE_STAGE=ready_to_annotate]
+# Set READ_ONLY_SOURCE=1 to leave the remote untouched (skips the PATCH that
+# parks the cloned sequences at under_annotation) — for test/debug hydration.
+# Usage: make pull-sequences [MAX_SEQUENCES=10] [CLONE_STAGE=ready_to_annotate] [READ_ONLY_SOURCE=1]
 pull-sequences:
 	uv run python -m scripts.data_transfer.ingestion.platform.import \
 		--source-annotation-url $(REMOTE_API) \
 		--url-api-annotation $(LOCAL_API) \
 		--max-sequences $(MAX_SEQUENCES) \
 		--clone-processing-stage $(CLONE_STAGE) \
+		$(if $(READ_ONLY_SOURCE),--skip-source-stage-update) \
 		--loglevel $(LOGLEVEL)
 	$(MAKE) assign-groups
 

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import.py
@@ -235,6 +235,16 @@ def make_cli_parser() -> argparse.ArgumentParser:
         help="Preview actions without executing them",
     )
     parser.add_argument(
+        "--skip-source-stage-update",
+        action="store_true",
+        help=(
+            "In clone mode, skip the PATCH that marks the cloned sequences as "
+            "under_annotation on the source API. Makes the clone read-only "
+            "against the source (useful to hydrate a local API for testing "
+            "without mutating remote state)."
+        ),
+    )
+    parser.add_argument(
         "--force-url",
         action="store_true",
         help=(
@@ -800,7 +810,11 @@ def main() -> None:
                 step_manager.complete_step(False, f"Annotation clone failed: {e}")
                 error_collector.print_summary(console, "Annotation Clone Errors")
                 sys.exit(1)
-            if not args.dry_run:
+            if args.skip_source_stage_update:
+                console.print(
+                    "[blue]ℹ️  --skip-source-stage-update: source annotations left untouched[/]"
+                )
+            elif not args.dry_run:
                 update_source_annotations_stage(
                     args.source_annotation_url,
                     source_sequence_ids,


### PR DESCRIPTION
Closes #152

## What

Adds `--skip-source-stage-update` to `import.py` clone mode, exposed as `READ_ONLY_SOURCE=1` on `make pull-sequences`, making it possible to hydrate a local API from the remote **without mutating remote state**.

## Why

Clone mode always PATCHes every cloned sequence's annotation on the *source* API to `under_annotation` (the workflow-A claim step). That is correct for production annotators but makes read-only test/debug hydration impossible:

- there was no flag to skip the claim,
- `--dry-run` skips the claim but also skips the import itself,
- the equivalent `--no-stage-update` flag exists only in `pull_sequence_annotations.py` (pipeline B).

## How

- New argparse flag guarding the `update_source_annotations_stage()` call; a console line reports when the claim is skipped.
- `make pull-sequences READ_ONLY_SOURCE=1` passes the flag through.
- README workflow-A notes document the default claim behavior and the opt-out.

## Verification

- `--help` lists the flag (module import + argparse wiring exercised).
- `make -n pull-sequences READ_ONLY_SOURCE=1` includes `--skip-source-stage-update`; without the variable it does not.
- `ruff check` clean. The pytest suite does not exercise `import.py` (no existing coverage for its CLI), matching the repo convention for script flags.
