### PR TITLE
feat(make): add READ_ONLY_SOURCE to pull-seq-annotations

### DIFF
--- a/annotation_api/Makefile
+++ b/annotation_api/Makefile
@@ -161,13 +161,16 @@ push-annotations:
 # Pull seq_annotation_done sequences locally (moves remote stage to in_review).
 # Object-split sequences are merged into one folder per camera view (see manifest.json);
 # MAX_SEQUENCES caps merged folders, not raw sequences.
-# Usage: make pull-seq-annotations [MAX_SEQUENCES=20] [SMOKE_TYPE=wildfire] [DATA_ROOT=outputs/seq_annotation_done]
+# Set READ_ONLY_SOURCE=1 to leave the remote untouched (skips the PATCH that
+# transitions the pulled sequences to in_review) — for test/debug export.
+# Usage: make pull-seq-annotations [MAX_SEQUENCES=20] [SMOKE_TYPE=wildfire] [DATA_ROOT=outputs/seq_annotation_done] [READ_ONLY_SOURCE=1]
 pull-seq-annotations:
 	uv run python -m scripts.data_transfer.ingestion.platform.pull_sequence_annotations \
 		--remote-api $(REMOTE_API) \
 		--max-sequences $(MAX_SEQUENCES) \
 		--output-dir $(DATA_ROOT) \
 		--smoke-type $(SMOKE_TYPE) \
+		$(if $(filter-out 0,$(READ_ONLY_SOURCE)),--no-stage-update) \
 		--loglevel $(LOGLEVEL)
 
 # Auto-fill missing boxes using the pyronear YOLO11s model.


### PR DESCRIPTION
## What
Add a `READ_ONLY_SOURCE` toggle to the `pull-seq-annotations` make target. When set to `1`, it passes `--no-stage-update` to the underlying script, which skips the PATCH that transitions the pulled sequences `seq_annotation_done -> in_review` on the remote.

## Why
`pull-seq-annotations` mutates remote state by default (marks pulled sequences `in_review`). For local test/debug hydration you often want to export the frames without touching the remote. The `--no-stage-update` flag already exists in `pull_sequence_annotations.py`; this just exposes it through the Makefile, mirroring the existing `READ_ONLY_SOURCE` convention on `pull-sequences`.

## Usage
```bash
# Read-only: remote left untouched
make pull-seq-annotations MAX_SEQUENCES=20 SMOKE_TYPE=wildfire READ_ONLY_SOURCE=1

# Default (unchanged): marks pulled sequences in_review
make pull-seq-annotations MAX_SEQUENCES=20 SMOKE_TYPE=wildfire
```

## Notes
- Uses the same `$(if $(filter-out 0,$(READ_ONLY_SOURCE)),...)` guard as `pull-sequences`, so `READ_ONLY_SOURCE=0` correctly counts as disabled.
- Default behavior is unchanged; the flag is only added when explicitly requested.
- Verified via `make -n`: flag present only with `READ_ONLY_SOURCE=1`.