### PR TITLE
feat(api): detection annotation box provenance (source field)

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -189,6 +189,7 @@ def convert_algo_predictions_to_annotation(
             "xyxyn": xyxyn,
             "class_name": class_name,
             "smoke_type": selected_smoke_type,
+            "source": {"origin": "engine"},
         }
         annotation_items.append(annotation_item)
 

--- a/annotation_api/src/app/schemas/annotation_validation.py
+++ b/annotation_api/src/app/schemas/annotation_validation.py
@@ -3,6 +3,7 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
+from enum import Enum
 from typing import List, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -15,6 +16,9 @@ __all__ = [
     "SequenceAnnotationData",
     "AlgoPrediction",
     "AlgoPredictions",
+    "AnnotationOrigin",
+    "Predictor",
+    "AnnotationSource",
     "DetectionAnnotationItem",
     "DetectionAnnotationData",
 ]
@@ -108,6 +112,43 @@ class AlgoPredictions(BaseModel):
     predictions: List[AlgoPrediction]
 
 
+class AnnotationOrigin(str, Enum):
+    """Who/what produced a detection-annotation box."""
+
+    ENGINE = "engine"
+    AUTO_ANNOTATION = "auto_annotation"
+    HUMAN = "human"
+
+
+class Predictor(BaseModel):
+    """Identifies the model that produced an auto_annotation box."""
+
+    name: str
+    version: str
+
+
+class AnnotationSource(BaseModel):
+    """Provenance of a detection-annotation box.
+
+    `predictor` is present iff `origin` is `auto_annotation`.
+    """
+
+    origin: AnnotationOrigin
+    predictor: Optional[Predictor] = None
+
+    @model_validator(mode="after")
+    def validate_predictor_matches_origin(self) -> "AnnotationSource":
+        has_predictor = self.predictor is not None
+        is_auto = self.origin == AnnotationOrigin.AUTO_ANNOTATION
+        if is_auto and not has_predictor:
+            raise ValueError("predictor is required when origin is 'auto_annotation'")
+        if not is_auto and has_predictor:
+            raise ValueError(
+                "predictor is only allowed when origin is 'auto_annotation'"
+            )
+        return self
+
+
 class DetectionAnnotationItem(BaseModel):
     """One reviewed box on a detection: either a smoke box (smoke_type set)
     or a false-positive box kept for traceability (false_positive_type set)."""
@@ -116,6 +157,9 @@ class DetectionAnnotationItem(BaseModel):
     class_name: str
     smoke_type: Optional[SmokeType] = Field(default=None)
     false_positive_type: Optional[FalsePositiveType] = Field(default=None)
+    source: AnnotationSource = Field(
+        default_factory=lambda: AnnotationSource(origin=AnnotationOrigin.HUMAN)
+    )
 
     @model_validator(mode="after")
     def validate_exactly_one_type(self) -> "DetectionAnnotationItem":

--- a/annotation_api/src/tests/endpoints/test_sequence_annotations.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_annotations.py
@@ -2127,6 +2127,27 @@ async def test_convert_algo_predictions_uses_per_object_smoke_types():
     assert {item["smoke_type"] for item in result["annotation"]} == {"industrial"}
 
 
+@pytest.mark.asyncio
+async def test_convert_algo_predictions_tags_source_engine():
+    """Pre-filled boxes from the engine's algo_predictions are tagged origin=engine."""
+    from app.api.api_v1.endpoints.sequence_annotations import (
+        convert_algo_predictions_to_annotation,
+    )
+
+    algo_predictions = {
+        "predictions": [
+            {"xyxyn": [0.1, 0.2, 0.4, 0.6], "confidence": 0.9, "class_name": "smoke"},
+            {"xyxyn": [0.5, 0.3, 0.8, 0.7], "confidence": 0.8, "class_name": "smoke"},
+        ]
+    }
+
+    result = convert_algo_predictions_to_annotation(algo_predictions, ["wildfire"])
+
+    assert len(result["annotation"]) == 2
+    for item in result["annotation"]:
+        assert item["source"] == {"origin": "engine"}
+
+
 # Contributor Tests
 
 

--- a/annotation_api/src/tests/schemas/test_annotation_validation.py
+++ b/annotation_api/src/tests/schemas/test_annotation_validation.py
@@ -5,9 +5,12 @@ from app.models import FalsePositiveType, SmokeType
 from app.schemas.annotation_validation import (
     AlgoPrediction,
     AlgoPredictions,
+    AnnotationOrigin,
+    AnnotationSource,
     BoundingBox,
     DetectionAnnotationData,
     DetectionAnnotationItem,
+    Predictor,
     SequenceAnnotationData,
     SequenceBBox,
 )
@@ -333,3 +336,76 @@ class TestEnumValidation:
                 xyxyn=[0.1, 0.2, 0.8, 0.9], class_name="smoke", smoke_type=smoke_type
             )
             assert item.smoke_type == smoke_type
+
+
+class TestAnnotationSource:
+    def test_engine_origin_without_predictor(self):
+        s = AnnotationSource(origin=AnnotationOrigin.ENGINE)
+        assert s.origin == AnnotationOrigin.ENGINE
+        assert s.predictor is None
+
+    def test_human_origin_without_predictor(self):
+        s = AnnotationSource(origin=AnnotationOrigin.HUMAN)
+        assert s.predictor is None
+
+    def test_auto_annotation_with_predictor(self):
+        s = AnnotationSource(
+            origin=AnnotationOrigin.AUTO_ANNOTATION,
+            predictor=Predictor(name="pyronear-yolov11s", version="1.4.0"),
+        )
+        assert s.predictor.name == "pyronear-yolov11s"
+        assert s.predictor.version == "1.4.0"
+
+    def test_auto_annotation_without_predictor_is_invalid(self):
+        with pytest.raises(ValidationError) as exc_info:
+            AnnotationSource(origin=AnnotationOrigin.AUTO_ANNOTATION)
+        assert "predictor" in str(exc_info.value)
+
+    def test_engine_with_predictor_is_invalid(self):
+        with pytest.raises(ValidationError) as exc_info:
+            AnnotationSource(
+                origin=AnnotationOrigin.ENGINE,
+                predictor=Predictor(name="pyro-engine", version="1.0"),
+            )
+        assert "predictor" in str(exc_info.value)
+
+    def test_human_with_predictor_is_invalid(self):
+        with pytest.raises(ValidationError) as exc_info:
+            AnnotationSource(
+                origin=AnnotationOrigin.HUMAN,
+                predictor=Predictor(name="x", version="1"),
+            )
+        assert "predictor" in str(exc_info.value)
+
+
+class TestDetectionAnnotationItemSource:
+    def test_source_defaults_to_human_when_omitted(self):
+        item = DetectionAnnotationItem(
+            xyxyn=[0.1, 0.2, 0.8, 0.9],
+            class_name="smoke",
+            smoke_type=SmokeType.WILDFIRE,
+        )
+        assert item.source.origin == AnnotationOrigin.HUMAN
+        assert item.source.predictor is None
+
+    def test_source_engine_accepted_from_dict(self):
+        item = DetectionAnnotationItem(
+            xyxyn=[0.1, 0.2, 0.8, 0.9],
+            class_name="smoke",
+            smoke_type=SmokeType.WILDFIRE,
+            source={"origin": "engine"},
+        )
+        assert item.source.origin == AnnotationOrigin.ENGINE
+
+    def test_source_auto_annotation_accepted_from_dict(self):
+        item = DetectionAnnotationItem(
+            xyxyn=[0.1, 0.2, 0.8, 0.9],
+            class_name="smoke",
+            smoke_type=SmokeType.WILDFIRE,
+            source={
+                "origin": "auto_annotation",
+                "predictor": {"name": "pyronear-yolov11s", "version": "1.4.0"},
+            },
+        )
+        assert item.source.origin == AnnotationOrigin.AUTO_ANNOTATION
+        assert item.source.predictor.version == "1.4.0"


### PR DESCRIPTION
## What
Adds a structured `source` provenance field to each detection-annotation box, so the origin of every box is recorded.

```jsonc
source: { origin: "engine" }                                              // pyro-engine / alert-api prediction
source: { origin: "auto_annotation", predictor: { name, version } }       // offline auto-annotate model
source: { origin: "human" }                                               // drawn / edited by a person
```

- `AnnotationOrigin` enum (`engine` | `auto_annotation` | `human`), `Predictor` (`name`, `version`), `AnnotationSource` models in `annotation_validation.py`.
- Validator: `predictor` present **iff** `origin == auto_annotation`.
- `DetectionAnnotationItem.source` defaults to `{ origin: human }`, so legacy boxes without provenance are never attributed to a model.
- The server-side pre-fill (`convert_algo_predictions_to_annotation`, from #150) now tags its boxes `{ origin: engine }` (they come from the engine's `algo_predictions`).

## Why
Foundation for DB-native, model-assisted detection review: the review UI needs to tell apart the engine's original predictions, the auto-annotate model's predictions, and human edits. This is **Chunk 0** of that design (`docs/specs/2026-07-17-detection-review-db-native-design.md`); follow-ups: local↔remote sync (#157), retire FiftyOne (#158).

## Notes
- No DB migration — `annotation` is JSONB; this is a Pydantic schema + code-path change.
- No behavior change for existing clients (the field defaults to `human`).

## Tests
- New unit tests for `AnnotationSource` (valid/invalid origin×predictor combos) and `DetectionAnnotationItem` default.
- Regression test that pre-filled boxes are tagged `engine`.
- Full suite green: 390 passed.