### PR TITLE
feat(scripts): object-split the platform import from platform boxes

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/platform/annotation_management.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/annotation_management.py
@@ -40,7 +40,9 @@ from app.clients.annotation_api import (
     list_sequence_annotations,
     create_sequence_annotation,
     update_sequence_annotation,
+    delete_sequence,
 )
+from .object_split import build_single_track_annotation
 from app.models import SequenceAnnotationProcessingStage
 from app.schemas.annotation_validation import SequenceAnnotationData
 
@@ -375,7 +377,9 @@ def create_placeholder_sequence_annotation(
     }
 
     try:
-        existing_annotation_id = check_existing_annotation(annotation_api_url, sequence_id)
+        existing_annotation_id = check_existing_annotation(
+            annotation_api_url, sequence_id
+        )
         empty_annotation_data = SequenceAnnotationData(sequences_bbox=[])
 
         if create_annotation_from_data(
@@ -397,7 +401,9 @@ def create_placeholder_sequence_annotation(
                 f"with stage {processing_stage.value}"
             )
         else:
-            error_msg = f"Failed to create placeholder annotation for sequence {sequence_id}"
+            error_msg = (
+                f"Failed to create placeholder annotation for sequence {sequence_id}"
+            )
             logging.error(error_msg)
             result["errors"].append(error_msg)
         return result
@@ -406,3 +412,65 @@ def create_placeholder_sequence_annotation(
         logging.error(error_msg)
         result["errors"].append(error_msg)
         return result
+
+
+def annotate_split_sequence(
+    seq_result: Dict[str, Any],
+    annotation_api_url: str,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Write the single-track annotation for one imported object sequence.
+
+    If the object's detections were only partially imported, delete the
+    sequence instead (a half-imported object would 409 on the next run and
+    never be completed), and report the rollback as an error.
+    """
+    sequence_id = seq_result["sequence_id"]
+    result: Dict[str, Any] = {
+        "sequence_id": sequence_id,
+        "annotation_created": False,
+        "annotation_id": None,
+        "errors": [],
+        "final_stage": None,
+    }
+
+    if seq_result["failed_detections"] > 0:
+        login, password = shared.get_annotation_credentials(annotation_api_url)
+        try:
+            token = get_auth_token(
+                annotation_api_url, username=login, password=password
+            )
+            delete_sequence(annotation_api_url, token, sequence_id)
+        except Exception as exc:
+            logging.warning(f"Rollback delete of sequence {sequence_id} failed: {exc}")
+        result["errors"].append(
+            f"sequence {sequence_id} rolled back: "
+            f"{seq_result['failed_detections']}/{seq_result['total_detections']} detections failed"
+        )
+        return result
+
+    annotation_data = build_single_track_annotation(
+        seq_result.get("detection_results", [])
+    )
+    existing_annotation_id = check_existing_annotation(annotation_api_url, sequence_id)
+    if create_annotation_from_data(
+        annotation_api_url,
+        sequence_id,
+        annotation_data,
+        dry_run,
+        existing_annotation_id,
+        SequenceAnnotationProcessingStage.READY_TO_ANNOTATE,
+        config=None,
+    ):
+        result["annotation_created"] = True
+        result["annotation_id"] = (
+            existing_annotation_id if existing_annotation_id else "new"
+        )
+        result["final_stage"] = (
+            SequenceAnnotationProcessingStage.READY_TO_ANNOTATE.value
+        )
+    else:
+        result["errors"].append(
+            f"Failed to create annotation for sequence {sequence_id}"
+        )
+    return result

--- a/annotation_api/scripts/data_transfer/ingestion/platform/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/import.py
@@ -76,10 +76,12 @@ from rich.progress import (
 from .progress_management import ErrorCollector, StepManager, LogSuppressor
 from .worker_config import WorkerConfig
 from .sequence_fetching import fetch_all_sequences_within
+from . import object_split
 from .annotation_management import (
     valid_date,
-    create_simple_sequence_annotation,
+    create_simple_sequence_annotation,  # noqa: F401 - kept for now, dies with clone mode in PR2
     create_placeholder_sequence_annotation,
+    annotate_split_sequence,
 )
 from . import shared
 from . import client as platform_client
@@ -887,6 +889,14 @@ def main() -> None:
                 error_collector.print_summary(console, "Platform Data Fetching Errors")
                 sys.exit(1)
 
+            records, split_stats = object_split.split_all_records(records)
+            console.print(
+                f"[blue]🔀 Object split: {split_stats['platform_sequences']} platform sequence(s) → "
+                f"{split_stats['objects']} object sequence(s) "
+                f"({split_stats['sibling_objects']} sibling(s), "
+                f"{split_stats['fallback_sequences']} fallback)[/]"
+            )
+
         if not records and not args.dry_run:
             msg = (
                 "No records fetched from source annotation API"
@@ -1008,38 +1018,46 @@ def main() -> None:
             ),
         )
 
-        # Prepare annotation configuration
-        annotation_config = {
+        # Annotation configuration - unused now that the platform path uses
+        # annotate_split_sequence (no auto-generation config); the CLI flags
+        # are removed in PR2 along with clone mode.
+        annotation_config = {  # noqa: F841
             "confidence_threshold": args.confidence_threshold,
             "iou_threshold": args.iou_threshold,
             "min_cluster_size": args.min_cluster_size,
         }
 
+        platform_seq_results = []
+        if not clone_from_annotation and not args.dry_run:
+            platform_seq_results = [
+                r for r in result.get("sequence_results", []) if not r.get("skipped")
+            ]
+
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=worker_config.annotation_processing
         ) as executor:
             # Submit all sequence annotation tasks
-            future_to_sequence_id = {
-                (
+            if not clone_from_annotation:
+                future_to_sequence_id = {
                     executor.submit(
-                        create_simple_sequence_annotation,
-                        sequence_id=sequence_id,
+                        annotate_split_sequence,
+                        seq_result=seq_result,
                         annotation_api_url=args.url_api_annotation,
-                        config=annotation_config,
                         dry_run=args.dry_run,
-                        processing_stage=SequenceAnnotationProcessingStage.READY_TO_ANNOTATE,
-                    )
-                    if not clone_from_annotation
-                    else executor.submit(
+                    ): seq_result["sequence_id"]
+                    for seq_result in platform_seq_results
+                }
+            else:
+                future_to_sequence_id = {
+                    executor.submit(
                         create_placeholder_sequence_annotation,
                         sequence_id=sequence_id,
                         annotation_api_url=args.url_api_annotation,
                         processing_stage=SequenceAnnotationProcessingStage.READY_TO_ANNOTATE,
                         dry_run=args.dry_run,
-                    )
-                ): sequence_id
-                for sequence_id in sequence_ids
-            }
+                    ): sequence_id
+                    for sequence_id in sequence_ids
+                }
 
             # Collect results with progress tracking
             with LogSuppressor(suppress=suppress_logs):

--- a/annotation_api/scripts/data_transfer/ingestion/platform/object_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/object_split.py
@@ -1,0 +1,94 @@
+"""
+Split one platform sequence's records into one record group per smoke object.
+
+The platform's detections already carry every object's boxes (`bbox` for the
+tracked object, `others_bboxes` for its siblings — see issue #166). We cluster
+all boxes across frames with `object_clustering.cluster_objects` (the offline
+port of pyro-api's association rule) and emit, per object, rewritten copies of
+the platform records. Because each copy carries the object's own
+`sequence_id`, the existing posting pipeline
+(`shared.post_records_to_annotation_api`) imports each object as its own
+annotation sequence with no changes.
+
+ID scheme: the PRIMARY object (the cluster with the most boxes sourced from
+the platform's own `bbox` field; ties broken by earliest first detection)
+keeps the raw platform sequence id so past plain imports dedup naturally via
+the 409-skip. Siblings get
+`alert_id_base + platform_sequence_id * 1000 + object_index`.
+"""
+
+from datetime import datetime
+from typing import List, Set, Tuple
+
+from .object_clustering import TrackedObject
+
+DEFAULT_ALERT_ID_BASE = 1_000_000_000
+
+# (frame_key, (x1, y1, x2, y2)) identifying one box on one frame
+BoxKey = Tuple[str, Tuple[float, float, float, float]]
+
+
+def _parse_dt(value: str) -> datetime:
+    """Parse a platform ISO timestamp (tolerating a trailing Z)."""
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+
+def _frame_key(record: dict) -> str:
+    return str(record["detection_id"])
+
+
+def build_frames(sequence_records: List[dict]) -> Tuple[List[dict], Set[BoxKey]]:
+    """Build `cluster_objects` frames plus the set of `bbox`-sourced box keys.
+
+    Each frame merges the record's own `detection_bboxes` and its
+    `detection_others_bboxes` — clustering ignores the source, but primary
+    selection needs to know which boxes came from the platform's `bbox` field.
+    """
+    frames: List[dict] = []
+    primary_keys: Set[BoxKey] = set()
+    ordered = sorted(
+        sequence_records, key=lambda r: _parse_dt(r["detection_created_at"])
+    )
+    for idx, record in enumerate(ordered):
+        key = _frame_key(record)
+        own = [list(b) for b in record.get("detection_bboxes") or [] if len(b) >= 5]
+        others = [
+            list(b) for b in record.get("detection_others_bboxes") or [] if len(b) >= 5
+        ]
+        for box in own:
+            primary_keys.add((key, tuple(box[:4])))
+        frames.append(
+            {
+                "frame_idx": idx,
+                "recorded_at": _parse_dt(record["detection_created_at"]),
+                "image_filename": key,
+                "boxes": own + others,
+            }
+        )
+    return frames, primary_keys
+
+
+def select_primary_index(
+    objects: List[TrackedObject], primary_keys: Set[BoxKey]
+) -> int:
+    """Index of the primary object: most `bbox`-sourced boxes, earliest start on ties."""
+
+    def bbox_sourced_count(obj: TrackedObject) -> int:
+        return sum(
+            1
+            for m in obj.members
+            if (m.image_filename, tuple(m.box[:4])) in primary_keys
+        )
+
+    return min(
+        range(len(objects)),
+        key=lambda i: (-bbox_sourced_count(objects[i]), objects[i].started_at),
+    )
+
+
+def synthetic_alert_api_id(
+    platform_sequence_id: int,
+    object_index: int,
+    alert_id_base: int = DEFAULT_ALERT_ID_BASE,
+) -> int:
+    return alert_id_base + platform_sequence_id * 1000 + object_index

--- a/annotation_api/scripts/data_transfer/ingestion/platform/object_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/object_split.py
@@ -21,6 +21,11 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Set, Tuple
 
+from app.schemas.annotation_validation import (
+    BoundingBox,
+    SequenceAnnotationData,
+    SequenceBBox,
+)
 from .object_clustering import TrackedObject, cluster_objects, object_cone_azimuth
 from .shared import group_records_by_sequence
 
@@ -213,3 +218,28 @@ def split_all_records(
         for group in groups:
             out.extend(group.records)
     return out, stats
+
+
+def build_single_track_annotation(detection_results: List[dict]) -> SequenceAnnotationData:
+    """One `sequences_bbox` track from a posted object's detection results.
+
+    Every detection here belongs to the same object (the split happened
+    upstream), so the annotation is exactly one conservative is_smoke track —
+    the server's empty-bbox auto-generation would re-cluster by IoU and can
+    fragment a drifting object into several tracks, so we bypass it.
+
+    Returns sequences_bbox=[] when nothing valid was posted (the server
+    auto-generation then runs as a harmless no-op on empty predictions).
+    """
+    ordered = sorted(detection_results, key=lambda r: _parse_dt(r["recorded_at"]))
+    bboxes = [
+        BoundingBox(detection_id=r["annotation_detection_id"], xyxyn=[float(c) for c in xy[:4]])
+        for r in ordered
+        for xy in r.get("xyxyns", [])
+        if xy[0] < xy[2] and xy[1] < xy[3]  # BoundingBox rejects zero-area boxes
+    ]
+    if not bboxes:
+        return SequenceAnnotationData(sequences_bbox=[])
+    return SequenceAnnotationData(
+        sequences_bbox=[SequenceBBox(is_smoke=True, false_positive_types=[], bboxes=bboxes)]
+    )

--- a/annotation_api/scripts/data_transfer/ingestion/platform/object_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/object_split.py
@@ -17,10 +17,12 @@ the 409-skip. Siblings get
 `alert_id_base + platform_sequence_id * 1000 + object_index`.
 """
 
+from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Set, Tuple
+from typing import Dict, List, Set, Tuple
 
-from .object_clustering import TrackedObject
+from .object_clustering import TrackedObject, cluster_objects, object_cone_azimuth
+from .shared import group_records_by_sequence
 
 DEFAULT_ALERT_ID_BASE = 1_000_000_000
 
@@ -92,3 +94,122 @@ def synthetic_alert_api_id(
     alert_id_base: int = DEFAULT_ALERT_ID_BASE,
 ) -> int:
     return alert_id_base + platform_sequence_id * 1000 + object_index
+
+
+@dataclass
+class ObjectGroup:
+    """One detected object, as rewritten platform records ready for posting."""
+
+    object_index: int  # 0 = primary
+    alert_api_id: int
+    is_primary: bool
+    is_fallback: bool
+    records: List[dict]
+
+
+def split_sequence_records(
+    sequence_records: List[dict],
+    *,
+    alert_id_base: int = DEFAULT_ALERT_ID_BASE,
+) -> List[ObjectGroup]:
+    """Split one platform sequence's records into per-object groups.
+
+    Falls back to a single unmodified group when clustering yields no
+    qualifying object (sequence shorter than the spawn threshold, or boxless)
+    so nothing is silently dropped.
+    """
+    platform_sid = sequence_records[0]["sequence_id"]
+    frames, primary_keys = build_frames(sequence_records)
+    objects = cluster_objects(frames)
+    records_by_key = {_frame_key(r): r for r in sequence_records}
+
+    if not objects:
+        return [
+            ObjectGroup(
+                object_index=0,
+                alert_api_id=platform_sid,
+                is_primary=True,
+                is_fallback=True,
+                records=[dict(r) for r in sequence_records],
+            )
+        ]
+
+    primary = select_primary_index(objects, primary_keys)
+    ordered = [objects[primary]] + sorted(
+        (o for i, o in enumerate(objects) if i != primary), key=lambda o: o.started_at
+    )
+
+    # frame_key -> [(object_position, box), ...] so each detection can carry
+    # the OTHER objects' boxes on the same frame as others_bboxes.
+    boxes_by_frame: Dict[str, List[Tuple[int, List[float]]]] = {}
+    for pos, obj in enumerate(ordered):
+        for member in obj.members:
+            boxes_by_frame.setdefault(member.image_filename, []).append((pos, member.box))
+
+    groups: List[ObjectGroup] = []
+    for pos, obj in enumerate(ordered):
+        own_by_frame: Dict[str, List[List[float]]] = {}
+        for member in obj.members:
+            own_by_frame.setdefault(member.image_filename, []).append(member.box)
+
+        alert_id = (
+            platform_sid if pos == 0 else synthetic_alert_api_id(platform_sid, pos, alert_id_base)
+        )
+        member_keys = sorted(own_by_frame, key=lambda k: _parse_dt(records_by_key[k]["detection_created_at"]))
+        recorded = [records_by_key[k]["detection_created_at"] for k in member_keys]
+
+        base_record = records_by_key[member_keys[0]]
+        camera_azimuth = base_record.get("camera_azimuth")
+        cone = (
+            object_cone_azimuth(obj, camera_azimuth, base_record.get("camera_angle_of_view"))
+            if camera_azimuth is not None
+            else None
+        )
+
+        member_records: List[dict] = []
+        for key in member_keys:
+            record = dict(records_by_key[key])
+            record["sequence_id"] = alert_id
+            record["detection_bboxes"] = own_by_frame[key]
+            record["detection_others_bboxes"] = [
+                box for other_pos, box in boxes_by_frame.get(key, []) if other_pos != pos
+            ]
+            record["sequence_started_at"] = recorded[0]
+            record["sequence_last_seen_at"] = recorded[-1]
+            if cone is not None:
+                record["camera_azimuth"] = cone
+            member_records.append(record)
+
+        groups.append(
+            ObjectGroup(
+                object_index=pos,
+                alert_api_id=alert_id,
+                is_primary=(pos == 0),
+                is_fallback=False,
+                records=member_records,
+            )
+        )
+    return groups
+
+
+def split_all_records(
+    records: List[dict],
+    *,
+    alert_id_base: int = DEFAULT_ALERT_ID_BASE,
+) -> Tuple[List[dict], dict]:
+    """Split every platform sequence's records into per-object records.
+
+    Returns the flat rewritten record list (feed it to the existing posting
+    pipeline — each object group has its own sequence_id) plus summary stats.
+    """
+    stats = {"platform_sequences": 0, "objects": 0, "sibling_objects": 0, "fallback_sequences": 0}
+    out: List[dict] = []
+    for _sid, seq_records in group_records_by_sequence(records).items():
+        groups = split_sequence_records(seq_records, alert_id_base=alert_id_base)
+        stats["platform_sequences"] += 1
+        stats["objects"] += len(groups)
+        stats["sibling_objects"] += sum(1 for g in groups if not g.is_primary)
+        stats["fallback_sequences"] += sum(1 for g in groups if g.is_fallback)
+        for group in groups:
+            out.extend(group.records)
+    return out, stats

--- a/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/platform/shared.py
@@ -350,6 +350,9 @@ def _process_single_detection(
         "detection_id": record["detection_id"],
         "success": False,
         "error": None,
+        "annotation_detection_id": None,
+        "xyxyns": [],
+        "recorded_at": record["detection_created_at"],
     }
 
     # Transform detection data
@@ -382,6 +385,11 @@ def _process_single_detection(
 
             logging.debug(f"Created detection with ID: {annotation_detection['id']}")
             result["success"] = True
+            result["annotation_detection_id"] = annotation_detection["id"]
+            result["xyxyns"] = [
+                pred["xyxyn"]
+                for pred in detection_data["algo_predictions"]["predictions"]
+            ]
             return result
 
         except ValidationError as e:
@@ -474,12 +482,14 @@ def post_sequence_to_annotation_api(
                 "successful_detections": 0,
                 "failed_detections": len(sequence_records),
                 "total_detections": len(sequence_records),
+                "detection_results": [],
             }
         raise
 
     # Create detections for this sequence using parallel processing
     successful_detections = 0
     failed_detections = 0
+    detection_results: List[dict] = []
 
     if len(sequence_records) == 1:
         # Single detection - process directly to avoid thread overhead
@@ -492,6 +502,7 @@ def post_sequence_to_annotation_api(
         )
         if result["success"]:
             successful_detections = 1
+            detection_results.append(result)
         else:
             failed_detections = 1
     else:
@@ -519,6 +530,7 @@ def post_sequence_to_annotation_api(
                     result = future.result()
                     if result["success"]:
                         successful_detections += 1
+                        detection_results.append(result)
                     else:
                         failed_detections += 1
                 except Exception as e:
@@ -534,6 +546,7 @@ def post_sequence_to_annotation_api(
         "successful_detections": successful_detections,
         "failed_detections": failed_detections,
         "total_detections": len(sequence_records),
+        "detection_results": detection_results,
     }
 
 
@@ -570,6 +583,7 @@ def post_records_to_annotation_api(
             "failed_detections": 0,
             "total_detections": 0,
             "successful_sequence_ids": [],
+            "sequence_results": [],
         }
 
     # Resolve credentials and get a single auth token up-front to avoid repeated logins
@@ -589,6 +603,7 @@ def post_records_to_annotation_api(
     total_successful_detections = 0
     total_failed_detections = 0
     successful_sequence_ids = []
+    sequence_results = []
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         # Submit all sequence posting tasks
@@ -622,6 +637,7 @@ def post_records_to_annotation_api(
                     platform_sequence_id, sequence_records = future_to_sequence[future]
                     try:
                         result = future.result()
+                        sequence_results.append(result)
 
                         if result.get("skipped"):
                             skipped_sequences += 1
@@ -683,4 +699,5 @@ def post_records_to_annotation_api(
         "failed_detections": total_failed_detections,
         "total_detections": len(records),
         "successful_sequence_ids": successful_sequence_ids,
+        "sequence_results": sequence_results,
     }

--- a/annotation_api/src/tests/scripts/factories.py
+++ b/annotation_api/src/tests/scripts/factories.py
@@ -1,0 +1,29 @@
+"""Record factories for platform-ingestion script tests."""
+
+
+def make_record(det_id, created_at, bboxes, others=None, sid=47105, **overrides):
+    """A platform record as produced by utils.to_record (boxes already parsed)."""
+    record = {
+        "organization_id": 1,
+        "organization_name": "org",
+        "camera_id": 7,
+        "camera_name": "cam-01",
+        "camera_lat": 44.0,
+        "camera_lon": 5.0,
+        "camera_is_trustable": True,
+        "camera_angle_of_view": 87.0,
+        "sequence_id": sid,
+        "sequence_is_wildfire": "wildfire_smoke",
+        "sequence_started_at": "2026-07-01T10:00:00",
+        "sequence_last_seen_at": "2026-07-01T10:30:00",
+        "camera_azimuth": 100.0,
+        "detection_id": det_id,
+        "detection_created_at": created_at,
+        "detection_azimuth": None,
+        "detection_url": f"https://img.example/{det_id}.jpg",
+        "detection_bboxes": bboxes,
+        "detection_others_bboxes": others or [],
+        "detection_bucket_key": f"key/{det_id}.jpg",
+    }
+    record.update(overrides)
+    return record

--- a/annotation_api/src/tests/scripts/test_annotate_split_sequence.py
+++ b/annotation_api/src/tests/scripts/test_annotate_split_sequence.py
@@ -1,0 +1,90 @@
+import scripts.data_transfer.ingestion.platform.annotation_management as am
+
+
+def seq_result(failed=0, detection_results=None):
+    return {
+        "success": True,
+        "sequence_id": 42,
+        "platform_sequence_id": 47105,
+        "successful_detections": 3 - failed,
+        "failed_detections": failed,
+        "total_detections": 3,
+        "detection_results": detection_results
+        if detection_results is not None
+        else [
+            {
+                "annotation_detection_id": 11,
+                "xyxyns": [[0.1, 0.1, 0.2, 0.2]],
+                "recorded_at": "2026-07-01T10:00:00",
+            },
+            {
+                "annotation_detection_id": 12,
+                "xyxyns": [[0.1, 0.1, 0.2, 0.2]],
+                "recorded_at": "2026-07-01T10:01:00",
+            },
+            {
+                "annotation_detection_id": 13,
+                "xyxyns": [[0.1, 0.1, 0.2, 0.2]],
+                "recorded_at": "2026-07-01T10:02:00",
+            },
+        ],
+    }
+
+
+class TestAnnotateSplitSequence:
+    def test_happy_path_creates_one_track_annotation(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(am, "check_existing_annotation", lambda url, sid: None)
+
+        def fake_create(
+            url, sid, annotation_data, dry_run, existing_id, stage, config=None
+        ):
+            captured.update(
+                sid=sid,
+                data=annotation_data,
+                dry_run=dry_run,
+                existing=existing_id,
+                stage=stage,
+            )
+            return True
+
+        monkeypatch.setattr(am, "create_annotation_from_data", fake_create)
+        result = am.annotate_split_sequence(
+            seq_result(), "http://annotation.test", dry_run=False
+        )
+        assert result["annotation_created"] is True
+        assert result["errors"] == []
+        assert captured["sid"] == 42
+        assert len(captured["data"].sequences_bbox) == 1
+        assert [b.detection_id for b in captured["data"].sequences_bbox[0].bboxes] == [
+            11,
+            12,
+            13,
+        ]
+
+    def test_partial_import_rolls_back_sequence(self, monkeypatch):
+        deleted = []
+        monkeypatch.setattr(
+            am.shared, "get_annotation_credentials", lambda url: ("u", "p")
+        )
+        monkeypatch.setattr(am, "get_auth_token", lambda url, username, password: "tok")
+        monkeypatch.setattr(
+            am, "delete_sequence", lambda url, token, sid: deleted.append(sid)
+        )
+        result = am.annotate_split_sequence(
+            seq_result(failed=1), "http://annotation.test", dry_run=False
+        )
+        assert deleted == [42]
+        assert result["annotation_created"] is False
+        assert result["errors"] and "rolled back" in result["errors"][0]
+
+    def test_annotation_failure_reports_error(self, monkeypatch):
+        monkeypatch.setattr(am, "check_existing_annotation", lambda url, sid: None)
+        monkeypatch.setattr(
+            am, "create_annotation_from_data", lambda *args, **kwargs: False
+        )
+        result = am.annotate_split_sequence(
+            seq_result(), "http://annotation.test", dry_run=False
+        )
+        assert result["annotation_created"] is False
+        assert result["errors"]

--- a/annotation_api/src/tests/scripts/test_object_clustering.py
+++ b/annotation_api/src/tests/scripts/test_object_clustering.py
@@ -1,0 +1,64 @@
+from datetime import datetime, timedelta
+
+from scripts.data_transfer.ingestion.platform.object_clustering import (
+    cluster_objects,
+)
+
+T0 = datetime(2026, 7, 1, 10, 0, 0)
+
+BOX_A = [0.10, 0.10, 0.20, 0.20, 0.9]  # object A, stable position
+BOX_B = [0.60, 0.60, 0.70, 0.70, 0.8]  # object B, disjoint from A
+
+
+def make_frames(box_lists, minutes_apart=1):
+    """box_lists: one list of boxes per frame, 1 minute apart by default."""
+    return [
+        {
+            "frame_idx": i,
+            "recorded_at": T0 + timedelta(minutes=i * minutes_apart),
+            "image_filename": f"img_{i}.jpg",
+            "boxes": boxes,
+        }
+        for i, boxes in enumerate(box_lists)
+    ]
+
+
+class TestClusterObjects:
+    def test_overlapping_boxes_across_frames_form_one_object(self):
+        objects = cluster_objects(make_frames([[BOX_A], [BOX_A], [BOX_A], [BOX_A]]))
+        assert len(objects) == 1
+        assert len(objects[0].members) == 4
+
+    def test_two_disjoint_box_groups_form_two_objects(self):
+        frames = make_frames([[BOX_A, BOX_B], [BOX_A, BOX_B], [BOX_A, BOX_B]])
+        objects = cluster_objects(frames)
+        assert len(objects) == 2
+        assert all(len(o.members) == 3 for o in objects)
+
+    def test_below_spawn_threshold_yields_no_objects(self):
+        # min_dets=3: two overlapping detections never spawn an object
+        assert cluster_objects(make_frames([[BOX_A], [BOX_A]])) == []
+
+    def test_straggler_boxes_below_threshold_are_dropped(self):
+        # A spawns (3 dets); B appears only twice -> dropped
+        frames = make_frames([[BOX_A, BOX_B], [BOX_A, BOX_B], [BOX_A]])
+        objects = cluster_objects(frames)
+        assert len(objects) == 1
+        assert all(m.box[:4] == BOX_A[:4] for m in objects[0].members)
+
+    def test_late_box_joins_open_object_within_relaxation_window(self):
+        frames = make_frames([[BOX_A], [BOX_A], [BOX_A]])
+        frames.append(
+            {
+                "frame_idx": 3,
+                "recorded_at": T0 + timedelta(minutes=30),  # > 5min spawn window, < 2h relaxation
+                "image_filename": "img_3.jpg",
+                "boxes": [BOX_A],
+            }
+        )
+        objects = cluster_objects(frames)
+        assert len(objects) == 1
+        assert len(objects[0].members) == 4
+
+    def test_empty_frames_yield_no_objects(self):
+        assert cluster_objects(make_frames([[], [], []])) == []

--- a/annotation_api/src/tests/scripts/test_object_split.py
+++ b/annotation_api/src/tests/scripts/test_object_split.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+
+from scripts.data_transfer.ingestion.platform.object_clustering import cluster_objects
+from scripts.data_transfer.ingestion.platform.object_split import (
+    DEFAULT_ALERT_ID_BASE,
+    build_frames,
+    select_primary_index,
+    synthetic_alert_api_id,
+)
+
+# No __init__.py convention in src/tests/ — pytest inserts the test dir on
+# sys.path, so sibling helpers are imported as top-level modules.
+from factories import make_record
+
+BOX_A = [0.10, 0.10, 0.20, 0.20, 0.9]  # in the platform's own `bbox` field
+BOX_B = [0.60, 0.60, 0.70, 0.70, 0.8]  # sibling, in `others_bboxes`
+
+
+def two_object_records():
+    """Mirrors platform seq 47105 from #166: A tracked, B in others_bboxes."""
+    return [
+        make_record(1, "2026-07-01T10:00:00", [BOX_A], others=[BOX_B]),
+        make_record(2, "2026-07-01T10:01:00", [BOX_A], others=[BOX_B]),
+        make_record(3, "2026-07-01T10:02:00", [BOX_A], others=[BOX_B]),
+    ]
+
+
+class TestBuildFrames:
+    def test_frames_merge_own_and_others_boxes(self):
+        frames, primary_keys = build_frames(two_object_records())
+        assert len(frames) == 3
+        assert all(len(f["boxes"]) == 2 for f in frames)
+        assert all(isinstance(f["recorded_at"], datetime) for f in frames)
+        # only the bbox-sourced boxes are tagged primary
+        assert primary_keys == {(str(i), tuple(BOX_A[:4])) for i in (1, 2, 3)}
+
+    def test_frames_are_time_ordered_and_keyed_by_detection_id(self):
+        records = list(reversed(two_object_records()))
+        frames, _ = build_frames(records)
+        assert [f["image_filename"] for f in frames] == ["1", "2", "3"]
+        assert [f["frame_idx"] for f in frames] == [0, 1, 2]
+
+    def test_malformed_boxes_are_skipped(self):
+        records = [make_record(1, "2026-07-01T10:00:00", [[0.1, 0.1]], others=None)]
+        frames, primary_keys = build_frames(records)
+        assert frames[0]["boxes"] == []
+        assert primary_keys == set()
+
+
+class TestSelectPrimaryIndex:
+    def test_object_with_most_bbox_sourced_boxes_wins(self):
+        frames, primary_keys = build_frames(two_object_records())
+        objects = cluster_objects(frames)
+        assert len(objects) == 2
+        primary = select_primary_index(objects, primary_keys)
+        assert objects[primary].members[0].box[:4] == BOX_A[:4]
+
+    def test_tie_broken_by_earliest_start(self):
+        # No box is bbox-sourced -> counts all zero -> earliest object wins
+        frames, _ = build_frames(two_object_records())
+        objects = cluster_objects(frames)
+        primary = select_primary_index(objects, primary_keys=set())
+        starts = [o.started_at for o in objects]
+        assert objects[primary].started_at == min(starts)
+
+
+class TestSyntheticAlertApiId:
+    def test_scheme(self):
+        assert (
+            synthetic_alert_api_id(47105, 1) == DEFAULT_ALERT_ID_BASE + 47105 * 1000 + 1
+        )
+
+    def test_custom_base(self):
+        assert (
+            synthetic_alert_api_id(5, 2, alert_id_base=2_000_000_000) == 2_000_005_002
+        )

--- a/annotation_api/src/tests/scripts/test_object_split.py
+++ b/annotation_api/src/tests/scripts/test_object_split.py
@@ -11,6 +11,10 @@ from scripts.data_transfer.ingestion.platform.object_split import (
 # No __init__.py convention in src/tests/ — pytest inserts the test dir on
 # sys.path, so sibling helpers are imported as top-level modules.
 from factories import make_record
+from scripts.data_transfer.ingestion.platform.object_split import (
+    split_all_records,
+    split_sequence_records,
+)
 
 BOX_A = [0.10, 0.10, 0.20, 0.20, 0.9]  # in the platform's own `bbox` field
 BOX_B = [0.60, 0.60, 0.70, 0.70, 0.8]  # sibling, in `others_bboxes`
@@ -74,3 +78,92 @@ class TestSyntheticAlertApiId:
         assert (
             synthetic_alert_api_id(5, 2, alert_id_base=2_000_000_000) == 2_000_005_002
         )
+
+
+class TestSplitSequenceRecords:
+    def test_two_objects_yield_two_groups_primary_first(self):
+        groups = split_sequence_records(two_object_records())
+        assert len(groups) == 2
+        primary, sibling = groups
+        assert primary.is_primary and primary.object_index == 0
+        assert primary.alert_api_id == 47105  # keeps the platform id
+        assert not sibling.is_primary and sibling.object_index == 1
+        assert sibling.alert_api_id == DEFAULT_ALERT_ID_BASE + 47105 * 1000 + 1
+        assert not primary.is_fallback and not sibling.is_fallback
+
+    def test_rewritten_records_carry_object_boxes_and_ids(self):
+        primary, sibling = split_sequence_records(two_object_records())
+        for record in primary.records:
+            assert record["sequence_id"] == 47105
+            assert record["detection_bboxes"] == [BOX_A]
+            assert record["detection_others_bboxes"] == [BOX_B]
+        for record in sibling.records:
+            assert record["sequence_id"] == sibling.alert_api_id
+            assert record["detection_bboxes"] == [BOX_B]
+            assert record["detection_others_bboxes"] == [BOX_A]
+
+    def test_rewritten_records_have_per_object_temporal_extent(self):
+        records = two_object_records()
+        # object B misses the last frame
+        records[2]["detection_others_bboxes"] = []
+        records.append(make_record(4, "2026-07-01T10:03:00", [BOX_A], others=[BOX_B]))
+        primary, sibling = split_sequence_records(records)
+        assert primary.records[0]["sequence_started_at"] == "2026-07-01T10:00:00"
+        assert primary.records[0]["sequence_last_seen_at"] == "2026-07-01T10:03:00"
+        assert sibling.records[0]["sequence_started_at"] == "2026-07-01T10:00:00"
+        assert sibling.records[0]["sequence_last_seen_at"] == "2026-07-01T10:03:00"
+        # B has no box on frame 3
+        assert len(sibling.records) == 3
+
+    def test_per_object_cone_azimuth_rewrites_camera_azimuth(self):
+        import pytest
+
+        primary, sibling = split_sequence_records(two_object_records())
+        # resolve_cone(100.0, [BOX_A], 87.0): center 0.15 -> 100 + 87*(0.15-0.5) = 69.55
+        # (resolve_cone rounds to 1 decimal; tolerate float-rounding at the last digit)
+        assert primary.records[0]["camera_azimuth"] == pytest.approx(69.55, abs=0.06)
+        # BOX_B center 0.65 -> 100 + 87*(0.65-0.5) = 113.05
+        assert sibling.records[0]["camera_azimuth"] == pytest.approx(113.05, abs=0.06)
+
+    def test_no_azimuth_rewrite_without_angle_of_view(self):
+        records = [
+            make_record(i, f"2026-07-01T10:0{i}:00", [BOX_A], camera_angle_of_view=None)
+            for i in range(1, 4)
+        ]
+        (group,) = split_sequence_records(records)
+        assert group.records[0]["camera_azimuth"] == 100.0
+
+    def test_too_short_sequence_falls_back_to_single_unmodified_group(self):
+        records = two_object_records()[:2]  # below min_dets=3
+        (group,) = split_sequence_records(records)
+        assert group.is_fallback and group.is_primary
+        assert group.alert_api_id == 47105
+        assert len(group.records) == 2
+        assert group.records[0]["detection_bboxes"] == [BOX_A]
+        assert group.records[0]["detection_others_bboxes"] == [BOX_B]
+
+    def test_boxless_sequence_falls_back(self):
+        records = [make_record(i, f"2026-07-01T10:0{i}:00", []) for i in range(1, 5)]
+        (group,) = split_sequence_records(records)
+        assert group.is_fallback
+        assert len(group.records) == 4
+
+
+class TestSplitAllRecords:
+    def test_flattens_groups_and_reports_stats(self):
+        records = two_object_records() + [
+            make_record(10 + i, f"2026-07-01T11:0{i}:00", [BOX_A], sid=200)
+            for i in range(3)
+        ]
+        out, stats = split_all_records(records)
+        assert stats == {
+            "platform_sequences": 2,
+            "objects": 3,
+            "sibling_objects": 1,
+            "fallback_sequences": 0,
+        }
+        assert {r["sequence_id"] for r in out} == {
+            47105,
+            DEFAULT_ALERT_ID_BASE + 47105 * 1000 + 1,
+            200,
+        }

--- a/annotation_api/src/tests/scripts/test_object_split.py
+++ b/annotation_api/src/tests/scripts/test_object_split.py
@@ -1,20 +1,21 @@
 from datetime import datetime
 
+import pytest
+
 from scripts.data_transfer.ingestion.platform.object_clustering import cluster_objects
 from scripts.data_transfer.ingestion.platform.object_split import (
     DEFAULT_ALERT_ID_BASE,
     build_frames,
+    build_single_track_annotation,
     select_primary_index,
+    split_all_records,
+    split_sequence_records,
     synthetic_alert_api_id,
 )
 
 # No __init__.py convention in src/tests/ — pytest inserts the test dir on
 # sys.path, so sibling helpers are imported as top-level modules.
 from factories import make_record
-from scripts.data_transfer.ingestion.platform.object_split import (
-    split_all_records,
-    split_sequence_records,
-)
 
 BOX_A = [0.10, 0.10, 0.20, 0.20, 0.9]  # in the platform's own `bbox` field
 BOX_B = [0.60, 0.60, 0.70, 0.70, 0.8]  # sibling, in `others_bboxes`
@@ -116,8 +117,6 @@ class TestSplitSequenceRecords:
         assert len(sibling.records) == 3
 
     def test_per_object_cone_azimuth_rewrites_camera_azimuth(self):
-        import pytest
-
         primary, sibling = split_sequence_records(two_object_records())
         # resolve_cone(100.0, [BOX_A], 87.0): center 0.15 -> 100 + 87*(0.15-0.5) = 69.55
         # (resolve_cone rounds to 1 decimal; tolerate float-rounding at the last digit)
@@ -167,3 +166,36 @@ class TestSplitAllRecords:
             DEFAULT_ALERT_ID_BASE + 47105 * 1000 + 1,
             200,
         }
+
+
+class TestBuildSingleTrackAnnotation:
+    def test_one_track_with_time_ordered_bboxes(self):
+        results = [
+            {"annotation_detection_id": 12, "xyxyns": [[0.1, 0.1, 0.2, 0.2]], "recorded_at": "2026-07-01T10:01:00"},
+            {"annotation_detection_id": 11, "xyxyns": [[0.1, 0.1, 0.2, 0.2]], "recorded_at": "2026-07-01T10:00:00"},
+        ]
+        data = build_single_track_annotation(results)
+        assert len(data.sequences_bbox) == 1
+        track = data.sequences_bbox[0]
+        assert track.is_smoke is True
+        assert track.false_positive_types == []
+        assert [b.detection_id for b in track.bboxes] == [11, 12]
+
+    def test_multiple_boxes_on_one_detection_become_multiple_track_entries(self):
+        results = [
+            {
+                "annotation_detection_id": 11,
+                "xyxyns": [[0.1, 0.1, 0.2, 0.2], [0.3, 0.3, 0.4, 0.4]],
+                "recorded_at": "2026-07-01T10:00:00",
+            }
+        ]
+        data = build_single_track_annotation(results)
+        assert len(data.sequences_bbox[0].bboxes) == 2
+
+    def test_zero_area_and_empty_results_yield_empty_sequences_bbox(self):
+        # zero-area boxes would fail BoundingBox validation -> must be filtered
+        results = [
+            {"annotation_detection_id": 11, "xyxyns": [[0.5, 0.5, 0.5, 0.9]], "recorded_at": "2026-07-01T10:00:00"}
+        ]
+        assert build_single_track_annotation(results).sequences_bbox == []
+        assert build_single_track_annotation([]).sequences_bbox == []

--- a/annotation_api/src/tests/scripts/test_shared_posting.py
+++ b/annotation_api/src/tests/scripts/test_shared_posting.py
@@ -1,0 +1,49 @@
+import scripts.data_transfer.ingestion.platform.shared as shared
+
+from factories import make_record
+
+BOX = [0.1, 0.1, 0.2, 0.2, 0.9]
+
+
+def _patch_clients(monkeypatch, created_ids):
+    monkeypatch.setattr(shared, "create_sequence", lambda url, token, data: {"id": 99})
+
+    def fake_create(url, token, detection_data, source_key):
+        created_ids.append(detection_data["alert_api_id"])
+        return {"id": 500 + len(created_ids)}
+
+    monkeypatch.setattr(shared, "create_detection_from_bucket_key", fake_create)
+
+
+class TestDetectionResultsPlumbing:
+    def test_post_sequence_collects_detection_results(self, monkeypatch):
+        created = []
+        _patch_clients(monkeypatch, created)
+        records = [
+            make_record(1, "2026-07-01T10:00:00", [BOX]),
+            make_record(2, "2026-07-01T10:01:00", [BOX]),
+        ]
+        result = shared.post_sequence_to_annotation_api(
+            "http://annotation.test", records, "token", max_detection_workers=1
+        )
+        assert result["successful_detections"] == 2
+        by_time = sorted(result["detection_results"], key=lambda r: r["recorded_at"])
+        assert [r["annotation_detection_id"] for r in by_time] == [501, 502]
+        assert by_time[0]["xyxyns"] == [[0.1, 0.1, 0.2, 0.2]]
+        assert by_time[0]["recorded_at"] == "2026-07-01T10:00:00"
+
+    def test_failed_detection_not_in_detection_results(self, monkeypatch):
+        monkeypatch.setattr(
+            shared, "create_sequence", lambda url, token, data: {"id": 99}
+        )
+
+        def failing_create(url, token, detection_data, source_key):
+            raise shared.ValidationError("bad detection", field_errors=[])
+
+        monkeypatch.setattr(shared, "create_detection_from_bucket_key", failing_create)
+        records = [make_record(1, "2026-07-01T10:00:00", [BOX])]
+        result = shared.post_sequence_to_annotation_api(
+            "http://annotation.test", records, "token", max_detection_workers=1
+        )
+        assert result["failed_detections"] == 1
+        assert result["detection_results"] == []

--- a/docs/specs/2026-07-27-consolidate-platform-import-design.md
+++ b/docs/specs/2026-07-27-consolidate-platform-import-design.md
@@ -1,0 +1,174 @@
+# Consolidate the platform importers into one (#166 + #167)
+
+**Date:** 2026-07-27
+**Issues:** [#166](https://github.com/pyronear/pyro-annotator/issues/166) (object-split from platform boxes), [#167](https://github.com/pyronear/pyro-annotator/issues/167) (consolidate the 3 import scripts)
+
+## Problem
+
+Three overlapping importers live under `annotation_api/scripts/data_transfer/ingestion/platform/`:
+
+| Script | Make target | Object-split? | Extra deps |
+|---|---|---|---|
+| `import.py` | `import-platform` | no | none |
+| `import_filtered.py` | `import-platform-filtered` | no | pyro-dataset + pyro-engine (registry dedup + predictor filter) |
+| `import_predictor_split.py` | `import-platform-predictor-split` | yes | pyro-dataset + pyro-engine (re-fetch + re-predict + cluster) |
+
+Three entry points confuse operators, and two of them shell out to sister-repo venvs
+(onnx/torch) just to import data. Both heavy importers are **already broken**: they
+invoke `scripts/platform_train_loop/fetch_all_platform_sequences.py` and
+`predict_and_filter_sequences.py` in pyro-dataset, neither of which exists in the
+current pyro-dataset checkout — their `_validate_paths` exits immediately.
+
+Meanwhile the plain import maps one platform sequence to one annotation sequence:
+sibling smoke objects appear only as read-only `others_bboxes` hints and can never be
+annotated (#166). The platform's own detection payloads (`bbox` + `others_bboxes`)
+carry every object's boxes, so object-splitting needs no re-prediction — only the
+clustering rule that already exists in `object_clustering.py`.
+
+Box *quality* is no longer the importer's concern: the auto-annotate worker (#162)
+re-runs the detector locally and stores `auto_predictions` on each detection.
+
+## Decisions made
+
+| Topic | Decision |
+|---|---|
+| Scope | #166 and #167 together, one branch, two stacked PRs |
+| Precision filter (`import_filtered.py`) | **Dropped entirely.** The pyro-dataset scripts it depends on no longer exist; dedup remains via the annotation API's 409-on-duplicate-`alert_api_id` skip; quality judgment belongs to the worker + human annotators |
+| Object-split | **Always on**, no flag. Clustering knobs (`min_dets=3`, `min_interval=300s`, `relaxation=7200s`) stay internal constants in `object_clustering.py` |
+| Clone mode (annotation→annotation sync) | **Removed from `import.py`**; a follow-up ticket covers rebuilding it as a standalone `sync.py` (deleted code referenced via git history). Sync is unavailable in the interim — accepted |
+| `--risk-score` | Dropped; hard-coded to `extreme` (fetch everything; the flag existed only to re-enable the platform's FWI volume filter) |
+| `--force-url` | Renamed to `--image-transfer {bucket-copy,url}`, default `bucket-copy` |
+| `--detections-limit` | Renamed to `--frames-limit` (caps *images per sequence*; CLI-surface rename only — code and APIs keep "detection") |
+| `--max-sequences` | Default changes 10 → **0 (no cap)** |
+| Group assignment | Stays a separate explicit step (`make assign-groups`); the importer never calls it |
+| "platform" naming | The upstream API is the **alert API**; "platform" properly means the firefighter frontend. Rename only surfaces this work touches (flags, Make target, help text, rewritten docs). Directory `ingestion/platform/`, `PLATFORM_*` env vars, and other scripts keep the old name; a follow-up ticket covers the deep rename |
+
+## End-state interface
+
+One importer: `scripts/data_transfer/ingestion/platform/import.py` (name kept; the
+`import` keyword only prevents in-code imports, and the sole consumer that needed
+that — `import_filtered.py` — is deleted). Make target: **`import-alert-api`**
+(replaces `import-platform`).
+
+```
+--date-from / --date-end      inclusive range; end defaults to today
+--alert-api-url               alert API URL (choices: alertapi | apicenia), default alertapi
+--annotation-api-url          default http://localhost:5050
+--max-sequences               default 0 = no cap
+--frames-limit                max images per sequence, default 30
+--sequence-list               comma-separated platform ids, or path to a text file
+--image-transfer              bucket-copy | url, default bucket-copy
+--dry-run
+--max-workers                 default 4
+--loglevel                    debug|info|warning|error, default info
+```
+
+Hard-coded behavior (no flags): `risk_score=extreme` on the alert API fetch,
+chronological (`asc`) detection order, clustering constants.
+
+Removed flags: `--source-annotation-url`, `--clone-processing-stage`,
+`--clone-count-only` (clone mode removed), `--confidence-threshold`,
+`--iou-threshold`, `--min-cluster-size` (server auto-generation no longer used by
+this path), `--risk-score`, `--detections-order-by`.
+
+## Import data flow
+
+Fetch is unchanged: `sequence_fetching.fetch_all_sequences_within` loads cameras +
+organizations, pages sequences per date, fetches detections per sequence, dedupes by
+`bucket_key` to one record per image; each record carries the tracked object's `bbox`
+and the sibling objects' `others_bboxes`.
+
+Then, per platform sequence:
+
+1. **Build frames.** For each image: `boxes = own bbox ∪ others_bboxes` — every box
+   visible on that frame. Each box keeps a source tag (`bbox` vs `others_bboxes`);
+   clustering ignores it, primary-object selection (below) uses it.
+2. **Cluster** with `object_clustering.cluster_objects` (module unchanged) → N
+   tracked objects. The module replays pyro-api's detection→sequence association
+   offline and is source-agnostic.
+3. **Post one annotation sequence per object.**
+   - **Primary selection:** the primary object is the cluster containing the most
+     boxes sourced from the platform's own `bbox` field (the platform's tracked
+     object); ties broken by earliest first detection. If no cluster contains any
+     `bbox`-sourced box, the earliest cluster is primary.
+   - **IDs:** the primary object keeps the raw platform `alert_api_id`, so past
+     plain imports dedup naturally via the existing 409-skip. Siblings get
+     `1_000_000_000 + platform_id * 1000 + object_index` — the scheme already proven
+     by `import_predictor_split.py`, equally 409-deduped on re-runs.
+   - Per-object `camera_azimuth` via `object_cone_azimuth`; per-object
+     `recorded_at` / `last_seen_at` from the object's member frames.
+   - Detections are posted only for the object's member frames:
+     `algo_predictions` = the object's box(es) on that frame, `others_bboxes` = the
+     *other* objects' boxes on that frame. Images transfer per `--image-transfer`:
+     server-side bucket-key copy (default, production) or `/from-url` (local dev
+     where the annotation API cannot reach the platform S3 bucket). Existing
+     502/503/504 retry-with-backoff logic in `shared.py` is reused.
+   - **Annotation is written client-side**: one `sequences_bbox` track per object,
+     stage `READY_TO_ANNOTATE`. Server-side IoU auto-generation is bypassed.
+4. **Fallback.** If clustering yields zero qualifying objects (sequence too short
+   for `min_dets`, or boxless), import as a single annotation sequence with all its
+   boxes in one track — nothing silently dropped, shape matches today's plain
+   import. Logged as a fallback. When at least one object qualifies, frames whose
+   boxes belong to no qualifying object are not posted (predictor-split behavior).
+5. **Failure isolation.** Per-sequence: a failed sequence is reported and the run
+   continues. A partially posted object (some detections failed) is rolled back by
+   deleting the created sequence. Exit code 1 if any sequence failed critically.
+
+## Deletions
+
+- `import_filtered.py`, `import_predictor_split.py`, `predictor_runner.py`
+- Clone-mode code inside `import.py` (`fetch_records_from_annotation_api`,
+  `create_placeholder_sequence_annotation` call path, `update_source_annotations_stage`,
+  clone CLI flags)
+- Make targets `import-platform-filtered`, `import-platform-predictor-split`;
+  `import-platform` is replaced by `import-alert-api`
+- All pyro-dataset / pyro-engine coupling in the ingestion path
+
+`object_clustering.py` stays — it becomes the importer's dependency.
+
+## Documentation updates
+
+- `README.md`: rewrite the admin-workflow import section; delete the predictor-split
+  section (and its mention at the pull-time merge note)
+- `annotation_api/CLAUDE.md`: new interface; also fixes the stale
+  `--skip-platform-fetch` flag it still documents
+- Root `CLAUDE.md`: platform-import section
+- `annotation_api/docs/data-ingestion-guide.md` and
+  `annotation_api/docs/sequence-annotation-guide.md`: updated invocations and
+  parameter reference (both currently document removed/stale flags)
+
+## Delivery
+
+- **PR1 (#166):** object-split in `import.py` + unit tests. Minimal CLI churn; the
+  server-auto-gen flags go dead here but are removed in PR2.
+- **PR2 (#167, stacked on PR1):** clone-mode removal, CLI trim + renames, Make
+  target changes, deletion of the two heavy importers + `predictor_runner.py`, docs.
+- **Follow-up tickets to file:**
+  1. Rebuild annotation→annotation sync as a standalone `sync.py` + Make target
+     (reference implementation: the clone code deleted in PR2, via git history).
+  2. Deep "platform → alert-api" rename (directory, `PLATFORM_*` env vars with
+     fallback, remaining scripts and docs).
+
+## Testing
+
+There is currently **zero** test coverage for any importer or for
+`object_clustering.py`.
+
+- **PR1 unit tests** (plain `pytest`, no Docker): frame-building from platform
+  records, cluster→object mapping, the `alert_api_id` scheme, per-object
+  `others_bboxes` assembly, the zero-cluster fallback, and first-ever tests for
+  `object_clustering.cluster_objects`.
+- **End-to-end (manual):** import a date containing a known multi-object sequence
+  (e.g. platform seq 47105 from #166) into the local stack with
+  `--image-transfer url`; verify sibling sequences appear, are annotatable, and
+  carry correct `others_bboxes`.
+- **PR2:** mostly deletion/extraction — verified by `make lint`, CI, and a local
+  smoke import.
+
+## Out of scope
+
+- Implementing `sync.py` (ticket)
+- The deep alert-api rename (ticket)
+- Any change to the auto-annotate worker, server-side annotation generation
+  service, or the frontend
+- Improvements to clone/sync behavior beyond what existed


### PR DESCRIPTION
Closes #166.

Extends the plain platform import to cluster each alert sequence's `bbox` + `others_bboxes` across frames (via the existing `object_clustering` port of pyro-api's association rule) and import one annotation sequence per smoke object — no pyro-engine / pyro-dataset involved.

- Primary object keeps the platform `alert_api_id` (past imports dedup via the 409-skip); siblings get `1_000_000_000 + sid*1000 + index`.
- Annotations are written client-side as one `sequences_bbox` track per object (server IoU auto-generation is bypassed for this path); partially-imported objects are rolled back.
- Sequences below the spawn threshold fall back to today's single-sequence import — nothing is silently dropped.
- New unit tests for `object_clustering`, `object_split`, the posting plumbing, and the annotation step.

Design spec: `docs/specs/2026-07-27-consolidate-platform-import-design.md`. Stacked follow-up: the consolidation PR (#167).
