### PR TITLE
Dedicated worker user for automatic group assignment

### DIFF
--- a/annotation_api/CLAUDE.md
+++ b/annotation_api/CLAUDE.md
@@ -129,6 +129,7 @@ Key environment variables (see `src/app/core/config.py`):
 ### Authentication
 - `AUTH_USERNAME` - Login username (default: `admin`)
 - `AUTH_PASSWORD` - Login password (default: `admin`)
+- `WORKER_USERNAME` - Identity (not a secret) of the login-disabled user the group-assignment sweep attributes annotations to (default: `worker`); if overridden, must match on API and worker
 - `JWT_SECRET` - JWT token signing secret (default: `your-secret-key-change-in-production`)
 - `ACCESS_TOKEN_EXPIRE_HOURS` - Token expiration in hours (default: `24`)
 

--- a/annotation_api/src/app/core/config.py
+++ b/annotation_api/src/app/core/config.py
@@ -23,6 +23,10 @@ class Settings(BaseSettings):
     # Authentication
     AUTH_USERNAME: str = os.environ.get("AUTH_USERNAME", "admin")
     AUTH_PASSWORD: str = os.environ.get("AUTH_PASSWORD", "admin")
+    # Identity (not a secret) of the login-disabled user that the worker
+    # attributes automatic group-assignment annotations to. Must match on
+    # API and worker if overridden.
+    WORKER_USERNAME: str = os.environ.get("WORKER_USERNAME", "worker")
     JWT_SECRET: str = os.environ.get(
         "JWT_SECRET", "your-secret-key-change-in-production"
     )

--- a/annotation_api/src/app/main.py
+++ b/annotation_api/src/app/main.py
@@ -51,6 +51,10 @@ async def seed_default_users(session) -> None:
             logger.info("Admin user created successfully")
         except Exception as e:
             logger.error(f"Failed to create admin user: {e}")
+            # A failed commit (e.g. losing a concurrent-boot race on the
+            # username unique constraint) leaves the session unusable until
+            # rolled back; the worker-user seeding below reuses it.
+            await session.rollback()
     else:
         logger.info("Admin user already exists")
 
@@ -71,6 +75,15 @@ async def seed_default_users(session) -> None:
             logger.info("Worker user created successfully")
         except Exception as e:
             logger.error(f"Failed to create worker user: {e}")
+            await session.rollback()
+    elif worker_user.is_active:
+        # get-or-create adopted a pre-existing account: attribution will go
+        # to what looks like a human user. Almost certainly a naming
+        # collision — pick a different WORKER_USERNAME.
+        logger.warning(
+            f"User {settings.WORKER_USERNAME!r} already exists and is active; "
+            "the group-assignment sweep will attribute annotations to it."
+        )
     else:
         logger.info("Worker user already exists")
 

--- a/annotation_api/src/app/main.py
+++ b/annotation_api/src/app/main.py
@@ -4,6 +4,7 @@
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
 import logging
+import secrets
 import time
 import traceback
 from contextlib import asynccontextmanager
@@ -30,6 +31,50 @@ from app.worker import app as procrastinate_app
 logger = logging.getLogger("uvicorn.error")
 
 
+async def seed_default_users(session) -> None:
+    """Idempotent startup seeding: the human admin (AUTH_USERNAME) and the
+    login-disabled worker user (WORKER_USERNAME) that the group-assignment
+    sweep attributes inherited annotations to."""
+    user_crud = UserCRUD(session)
+
+    admin_user = await user_crud.get_by_username(settings.AUTH_USERNAME)
+    if not admin_user:
+        logger.info(f"Creating admin user: {settings.AUTH_USERNAME}")
+        try:
+            admin_create = UserCreate(
+                username=settings.AUTH_USERNAME,
+                password=settings.AUTH_PASSWORD,
+                is_active=True,
+                is_superuser=True,
+            )
+            await user_crud.create_user(admin_create)
+            logger.info("Admin user created successfully")
+        except Exception as e:
+            logger.error(f"Failed to create admin user: {e}")
+    else:
+        logger.info("Admin user already exists")
+
+    worker_user = await user_crud.get_by_username(settings.WORKER_USERNAME)
+    if not worker_user:
+        logger.info(f"Creating worker user: {settings.WORKER_USERNAME}")
+        try:
+            worker_create = UserCreate(
+                username=settings.WORKER_USERNAME,
+                # Random and immediately discarded: this user exists purely
+                # for attribution and must never be able to log in (also
+                # seeded inactive, which login rejects independently).
+                password=secrets.token_urlsafe(32),
+                is_active=False,
+                is_superuser=False,
+            )
+            await user_crud.create_user(worker_create)
+            logger.info("Worker user created successfully")
+        except Exception as e:
+            logger.error(f"Failed to create worker user: {e}")
+    else:
+        logger.info("Worker user already exists")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan manager for startup and shutdown events.
@@ -37,29 +82,8 @@ async def lifespan(app: FastAPI):
     Database schema is managed by Alembic (see ``src/migrations``); migrations
     are applied by the container entrypoint before uvicorn starts.
     """
-    # Create admin user from environment variables if not exists
     async for session in get_session():
-        user_crud = UserCRUD(session)
-
-        # Check if admin user exists
-        admin_user = await user_crud.get_by_username(settings.AUTH_USERNAME)
-
-        if not admin_user:
-            logger.info(f"Creating admin user: {settings.AUTH_USERNAME}")
-            try:
-                admin_create = UserCreate(
-                    username=settings.AUTH_USERNAME,
-                    password=settings.AUTH_PASSWORD,
-                    is_active=True,
-                    is_superuser=True,
-                )
-                await user_crud.create_user(admin_create)
-                logger.info("Admin user created successfully")
-            except Exception as e:
-                logger.error(f"Failed to create admin user: {e}")
-        else:
-            logger.info("Admin user already exists")
-
+        await seed_default_users(session)
         break  # Exit after first session
 
     # Open the procrastinate connector so endpoints can defer auto-annotate jobs.

--- a/annotation_api/src/app/main.py
+++ b/annotation_api/src/app/main.py
@@ -19,6 +19,7 @@ from fastapi.responses import JSONResponse
 from fastapi_pagination import add_pagination
 from pydantic import ValidationError
 from sqlalchemy import exc
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.api_v1.router import api_router
 from app.core.config import settings
@@ -31,7 +32,7 @@ from app.worker import app as procrastinate_app
 logger = logging.getLogger("uvicorn.error")
 
 
-async def seed_default_users(session) -> None:
+async def seed_default_users(session: AsyncSession) -> None:
     """Idempotent startup seeding: the human admin (AUTH_USERNAME) and the
     login-disabled worker user (WORKER_USERNAME) that the group-assignment
     sweep attributes inherited annotations to."""

--- a/annotation_api/src/app/worker.py
+++ b/annotation_api/src/app/worker.py
@@ -130,22 +130,22 @@ async def auto_annotate_sequence(sequence_id: int) -> None:
 async def assign_sequence_groups(timestamp: int) -> None:
     """Periodic sweep: assign every ungrouped, fully-imported sequence to a
     sequence group (see ``app.services.group_assignment``). Inherited
-    annotations are attributed to the admin user, which the API seeds at
-    startup from AUTH_USERNAME.
+    annotations are attributed to the login-disabled worker user, which the
+    API seeds at startup from WORKER_USERNAME.
 
     expire_on_commit=False matches the API's get_session config: label
     inheritance commits mid-sweep, and expired Sequence instances would
     trigger a sync lazy refresh on the next attribute access, which async
     SQLAlchemy forbids (MissingGreenlet)."""
     async with AsyncSession(engine, expire_on_commit=False) as session:
-        admin = await UserCRUD(session).get_by_username(settings.AUTH_USERNAME)
-        if admin is None:
+        worker_user = await UserCRUD(session).get_by_username(settings.WORKER_USERNAME)
+        if worker_user is None:
             logger.warning(
-                "assign_sequence_groups: admin user %r not found; skipping run",
-                settings.AUTH_USERNAME,
+                "assign_sequence_groups: worker user %r not found; skipping run",
+                settings.WORKER_USERNAME,
             )
             return
-        result = await assign_ungrouped_sequences(session, user_id=admin.id)
+        result = await assign_ungrouped_sequences(session, user_id=worker_user.id)
     if result.already_running:
         logger.info("assign_sequence_groups: another run in progress; skipped")
         return

--- a/annotation_api/src/tests/test_user_seeding.py
+++ b/annotation_api/src/tests/test_user_seeding.py
@@ -1,5 +1,7 @@
 """Tests for startup user seeding (admin + login-disabled worker user)."""
 
+import logging
+
 import pytest
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -21,11 +23,20 @@ async def test_seed_creates_login_disabled_worker_user(
 
 
 @pytest.mark.asyncio
-async def test_seed_is_idempotent(async_session: AsyncSession):
+async def test_seed_is_idempotent(
+    async_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+):
     await seed_default_users(async_session)
     crud = UserCRUD(async_session)
     first = await crud.get_by_username(settings.WORKER_USERNAME)
-    await seed_default_users(async_session)
+
+    # The second run must short-circuit on the existing rows — not attempt a
+    # duplicate create that merely gets swallowed by the unique constraint.
+    with caplog.at_level(logging.ERROR, logger="uvicorn.error"):
+        await seed_default_users(async_session)
+    assert "Failed to create" not in caplog.text
+
     second = await crud.get_by_username(settings.WORKER_USERNAME)
     assert first is not None and second is not None
     assert first.id == second.id

--- a/annotation_api/src/tests/test_user_seeding.py
+++ b/annotation_api/src/tests/test_user_seeding.py
@@ -1,0 +1,46 @@
+"""Tests for startup user seeding (admin + login-disabled worker user)."""
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.config import settings
+from app.crud import UserCRUD
+from app.main import seed_default_users
+
+
+@pytest.mark.asyncio
+async def test_seed_creates_login_disabled_worker_user(
+    async_session: AsyncSession,
+):
+    await seed_default_users(async_session)
+    worker = await UserCRUD(async_session).get_by_username(settings.WORKER_USERNAME)
+    assert worker is not None
+    assert worker.is_active is False
+    assert worker.is_superuser is False
+
+
+@pytest.mark.asyncio
+async def test_seed_is_idempotent(async_session: AsyncSession):
+    await seed_default_users(async_session)
+    crud = UserCRUD(async_session)
+    first = await crud.get_by_username(settings.WORKER_USERNAME)
+    await seed_default_users(async_session)
+    second = await crud.get_by_username(settings.WORKER_USERNAME)
+    assert first is not None and second is not None
+    assert first.id == second.id
+
+
+@pytest.mark.asyncio
+async def test_worker_user_cannot_login(
+    async_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    await seed_default_users(async_session)
+    resp = await async_client.post(
+        "/auth/login",
+        json={"username": settings.WORKER_USERNAME, "password": "anything"},
+    )
+    # Wrong password -> 401 before the is_active check even runs; the
+    # password is random-and-discarded so no password can ever be right.
+    assert resp.status_code == 401

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,9 +94,6 @@ services:
       - S3_REGION=us-east-1
       # Auto-annotate model (baked into the image)
       - AUTOANNOTATE_MODEL_PATH=/app/models
-      # Must match the API's AUTH_USERNAME: the group-assignment sweep
-      # attributes inherited annotations to this (API-seeded) user.
-      - AUTH_USERNAME=admin
     restart: unless-stopped
     command: "procrastinate --app=app.worker.app worker"
     healthcheck:

--- a/docs/specs/2026-07-27-worker-user-design.md
+++ b/docs/specs/2026-07-27-worker-user-design.md
@@ -69,6 +69,13 @@ In `main.py`, immediately after the admin-user seeding block:
   - `is_active=False`
   - `is_superuser=False`
 - Failures are logged and non-fatal, matching the admin seeding's behavior.
+  After a failed create the session is rolled back so a lost
+  concurrent-boot race on the username unique constraint cannot poison the
+  session for the seeding steps that follow.
+- If the configured username already belongs to a pre-existing *active*
+  account, seeding adopts it but logs a warning — that is almost certainly
+  a naming collision with a human user, and sweep attribution would land on
+  it.
 
 ### 3. Worker task
 

--- a/docs/specs/2026-07-27-worker-user-design.md
+++ b/docs/specs/2026-07-27-worker-user-design.md
@@ -1,0 +1,100 @@
+# Dedicated Worker User for Automatic Group Assignment
+
+**Date**: 2026-07-27
+**Status**: Approved
+**Issue**: #178
+
+## Problem
+
+The periodic `assign_sequence_groups` worker task attributes inherited
+annotations to the admin user seeded from `AUTH_USERNAME` (`app/worker.py`,
+with the value pinned in the worker service's compose environment). Two
+drawbacks:
+
+- Inherited annotations are indistinguishable from the human admin's work in
+  contribution counts and contributor UI.
+- The worker reuses an auth setting (`AUTH_USERNAME`) for something that has
+  nothing to do with authentication, and the compose pin exists only to keep
+  the two services accidentally aligned.
+
+## Decision
+
+Seed a dedicated, login-disabled `worker` user in the API's startup lifespan
+(next to the existing admin seeding) and attribute the sweep's inherited
+annotations to it.
+
+Decisions made during design:
+
+- **Seeding location: API startup lifespan.** Same idempotent get-or-create
+  pattern as the admin user. Boot order is already guaranteed in compose:
+  the worker service has `depends_on: annotation_api: condition:
+  service_healthy`, and the API's healthcheck only passes after the lifespan
+  completes. The sweep's existing "user not found → warn and skip this run"
+  fallback covers deployments without that ordering.
+- **No login.** The worker user exists purely for attribution. It is seeded
+  with `is_active=False` and a random, immediately-discarded password
+  (`secrets.token_urlsafe(32)` run through the normal bcrypt hashing —
+  `hashed_password` is a required column). Login is doubly impossible:
+  unknowable password and inactive account. No password env var exists; a
+  credential that doesn't exist can't leak or need rotation. If the need
+  ever arises, an admin can set a password and activate the user via the
+  existing user management.
+- **No HTTP involved.** The worker never calls the API — it invokes the
+  shared service (`assign_ungrouped_sequences`) directly with a DB session
+  and only needs the worker user's row id for the `labeled_by_user_id` /
+  contribution foreign keys. (The manual `POST /sequence_groups/assign`
+  endpoint keeps attributing to the calling user's JWT identity; its
+  deprecation is tracked separately in #181.)
+
+## Design
+
+### 1. Config
+
+- New setting `WORKER_USERNAME` in `app/core/config.py`, default `"worker"`,
+  read from the environment like the other auth settings.
+- It is an identity, not a secret. It only needs overriding if a deployment
+  wants a different username, and must then match on API and worker.
+- The `AUTH_USERNAME` pin on the worker service in `docker-compose.yml`
+  (added in #173) is removed — the worker no longer reads `AUTH_USERNAME`.
+
+### 2. Seeding (API lifespan)
+
+In `main.py`, immediately after the admin-user seeding block:
+
+- `UserCRUD.get_by_username(settings.WORKER_USERNAME)`; if present, done.
+- Otherwise create via the existing `create_user` path with:
+  - `username=settings.WORKER_USERNAME`
+  - `password=secrets.token_urlsafe(32)` (local variable, discarded after
+    hashing; never logged or stored)
+  - `is_active=False`
+  - `is_superuser=False`
+- Failures are logged and non-fatal, matching the admin seeding's behavior.
+
+### 3. Worker task
+
+In `app/worker.py`, the sweep resolves `settings.WORKER_USERNAME` instead of
+`settings.AUTH_USERNAME` and passes that user's id to
+`assign_ungrouped_sequences`. The not-found fallback (warn + skip the run,
+retry next tick) stays unchanged.
+
+### 4. Effect on attribution
+
+Inherited annotations (and their contribution records) are attributed to
+"worker", cleanly separated from human work in contribution counts and any
+contributor UI. Historical annotations already attributed to the admin are
+not migrated.
+
+### 5. Testing
+
+- Lifespan seeding: after app startup, the worker user exists with
+  `is_active=False` and `is_superuser=False`; seeding is idempotent (second
+  startup does not create a duplicate); login as the worker user fails.
+- Worker task: attribution of inherited annotations goes to the worker
+  user's id (the existing service tests pass `user_id` explicitly and are
+  unaffected).
+
+## Out of scope
+
+- Migrating historical admin-attributed annotations.
+- Any UI changes.
+- Endpoint deprecation/removal (#181) and Sentry observability (#180).


### PR DESCRIPTION
Closes #178.

## Summary

The periodic group-assignment sweep now attributes inherited annotations to a dedicated, login-disabled `worker` user instead of the admin account, so automatic work is cleanly separated from human work in contribution counts and contributor UI.

Design doc: `docs/specs/2026-07-27-worker-user-design.md`

## Changes

- **`WORKER_USERNAME` setting** (default `worker`) — an identity, not a secret; only needs overriding if a deployment wants a different name (must then match on API and worker).
- **Seeding** — the lifespan's admin seeding is extracted into `seed_default_users()`, which also get-or-creates the worker user with a random, immediately-discarded password and `is_active=False`. Login is doubly impossible (unknowable password + inactive rejected at both the login endpoint and the JWT dependency). No password env var exists by design.
- **Worker task** — resolves `WORKER_USERNAME` instead of `AUTH_USERNAME`; warn-and-skip fallback unchanged. The `AUTH_USERNAME` pin on the worker's compose service (from #173) is removed.
- **Race hardening** (review round 1): the seeding session is rolled back after a failed create, so losing a concurrent-boot race on `uq_user_username` no longer crashes startup; a warning fires if `WORKER_USERNAME` adopts a pre-existing active account.
- **Attribution actually materialized** (found by live E2E): the annotation CRUD only auto-records contributions at the `ANNOTATED` stage, so machine-written `SEQ_ANNOTATION_DONE` annotations (sweep inheritance, validated-group fan-out, bulk annotate) silently discarded `user_id` — the worker user would have been an identity nothing referenced (equally true for the admin under #173). The three machine-writing paths now record contributions explicitly: **sweep inheritance → worker**, **fan-out → the saving human** (the label is their judgment), **bulk → the calling human**.

## Upgrade path

Existing DBs seed the worker user on the next API boot. Compose ordering (`depends_on: service_healthy`) means the worker only starts after seeding; on other deployments the sweep warn-and-skips until the user exists, then proceeds. Historical machine-written annotations are not backfilled with contributions.

## Verification

- Full backend suite: **401 passed** (new: seeding trio, inheritance/fan-out/bulk attribution assertions).
- **Live end-to-end** on an isolated stack with real platform data: API boot seeds `worker` (inactive, non-superuser); the sweep resolves it, groups fresh imports, and on re-assignment to a labeled group writes the inherited annotation with a contribution row attributing it to `worker` — verified by DB query. Zero worker errors across all ticks.
- Two adversarial review rounds; all findings addressed (round-1 rollback fix, round-2 doc polish) or explicitly accepted.
