### PR TITLE
feat: unvalidated sequence group count badge in sidebar

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
@@ -27,6 +27,7 @@ from app.schemas.sequence_group import (
     SequenceGroupMember,
     SequenceGroupRead,
     SequenceGroupReadWithMembers,
+    SequenceGroupStats,
     SequenceGroupUpdate,
 )
 from app.services.group_assignment import AssignGroupsResult, assign_ungrouped_sequences
@@ -101,6 +102,40 @@ async def list_sequence_groups(
     # `unique=False` is required because the row tuple includes the JSONB
     # `representative_bbox`, which is a dict and therefore not hashable.
     return await apaginate(session, query, params, unique=False)
+
+
+@router.get(
+    "/stats",
+    response_model=SequenceGroupStats,
+    summary="Aggregate counts of sequence groups (3+ members only)",
+)
+async def get_sequence_group_stats(
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> SequenceGroupStats:
+    # Same 3+ member population as the list endpoint, so the sidebar badge
+    # always matches what the groups page shows.
+    member_count_subq = (
+        select(Sequence.sequence_group_id.label("group_id"))
+        .where(Sequence.sequence_group_id.is_not(None))
+        .group_by(Sequence.sequence_group_id)
+        .having(func.count(Sequence.id) >= 3)
+        .subquery()
+    )
+    query = (
+        select(
+            func.count(SequenceGroup.id).label("total"),
+            func.count(SequenceGroup.id)
+            .filter(SequenceGroup.is_validated.is_(True))
+            .label("validated"),
+        )
+        .select_from(SequenceGroup)
+        .join(member_count_subq, member_count_subq.c.group_id == SequenceGroup.id)
+    )
+    total, validated = (await session.exec(query)).one()
+    return SequenceGroupStats(
+        total=total, validated=validated, unvalidated=total - validated
+    )
 
 
 @router.get(

--- a/annotation_api/src/app/schemas/sequence_group.py
+++ b/annotation_api/src/app/schemas/sequence_group.py
@@ -92,6 +92,15 @@ class SequenceGroupListItem(BaseModel):
     member_count: int
 
 
+class SequenceGroupStats(BaseModel):
+    """Aggregate counts over groups with 3 or more members — the same
+    population the list endpoint returns, so UI counts match the list."""
+
+    total: int
+    validated: int
+    unvalidated: int
+
+
 class SequenceGroupUpdate(BaseModel):
     """Patch the group's review state. For now, only `is_validated` is
     user-mutable here — labels are written by the per-sequence annotation

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -36,7 +36,7 @@ async def _set_seq_metadata(
 ) -> None:
     await session.exec(
         text(
-            "UPDATE sequences SET camera_id = :cam, azimuth = :az " "WHERE id = :sid"
+            "UPDATE sequences SET camera_id = :cam, azimuth = :az WHERE id = :sid"
         ).bindparams(cam=camera_id, az=azimuth, sid=sequence_id)
     )
     await session.commit()
@@ -383,9 +383,7 @@ async def test_propagation_skipped_when_group_not_validated(
     assert group_resp.json()["smoke_type"] is None
 
     # No fan-out: seq 2 should still have no annotation row.
-    other_anno = await authenticated_client.get(
-        "/annotations/sequences/?sequence_id=2"
-    )
+    other_anno = await authenticated_client.get("/annotations/sequences/?sequence_id=2")
     assert other_anno.json()["total"] == 0
 
 
@@ -398,9 +396,7 @@ async def test_propagation_writes_label_and_fans_out(
     """Validated group, no existing label, no conflict → group gets the
     derived label and the other unlocked member gets an inherited
     annotation in SEQ_ANNOTATION_DONE."""
-    group_id = await _seed_two_member_group(
-        sequence_session, [1, 2], is_validated=True
-    )
+    group_id = await _seed_two_member_group(sequence_session, [1, 2], is_validated=True)
 
     payload = _annotation_payload(stage="seq_annotation_done", smoke_type="wildfire")
     payload["sequence_id"] = 1
@@ -493,9 +489,7 @@ async def test_propagation_fans_out_unsure_flag(
     """Validated group, no existing label → saving seq 1 as unsure marks the
     group unsure and fans the unsure flag out to the other unlocked member in
     SEQ_ANNOTATION_DONE."""
-    group_id = await _seed_two_member_group(
-        sequence_session, [1, 2], is_validated=True
-    )
+    group_id = await _seed_two_member_group(sequence_session, [1, 2], is_validated=True)
 
     payload = _unsure_payload(stage="seq_annotation_done")
     payload["sequence_id"] = 1
@@ -572,3 +566,46 @@ async def test_bulk_annotate_requires_exactly_one_label(
         },
     )
     assert both.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_stats_empty(authenticated_client: AsyncClient):
+    resp = await authenticated_client.get("/sequence_groups/stats")
+    assert resp.status_code == 200
+    assert resp.json() == {"total": 0, "validated": 0, "unvalidated": 0}
+
+
+@pytest.mark.asyncio
+async def test_stats_counts_only_groups_with_three_plus_members(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """total/validated/unvalidated cover the same 3+ member population as
+    the list endpoint; the 2-member group is invisible to all counts."""
+    to_validate = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        alert_api_id_start=100,
+    )
+    await _seed_group_with_members(
+        async_session,
+        n_members=4,
+        created_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        alert_api_id_start=200,
+    )
+    await _seed_group_with_members(
+        async_session,
+        n_members=2,
+        created_at=datetime(2026, 1, 3, tzinfo=timezone.utc),
+        alert_api_id_start=300,
+    )
+
+    resp = await authenticated_client.patch(
+        f"/sequence_groups/{to_validate}", json={"is_validated": True}
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = await authenticated_client.get("/sequence_groups/stats")
+    assert resp.status_code == 200
+    assert resp.json() == {"total": 2, "validated": 1, "unvalidated": 1}

--- a/docs/specs/2026-07-27-sequence-group-count-badge-design.md
+++ b/docs/specs/2026-07-27-sequence-group-count-badge-design.md
@@ -1,0 +1,95 @@
+# Sequence Group Count Badge — Design
+
+**Date:** 2026-07-27
+**Status:** Approved
+
+## Goal
+
+Show a count pill next to the "Sequence groups" entry in the sidebar navigation. The
+count is the number of **unvalidated** sequence groups (groups with 3 or more members
+where `is_validated = false`) and stays in sync as annotators validate or unvalidate
+groups.
+
+## Backend
+
+### New endpoint: `GET /api/v1/sequence_groups/stats`
+
+- Returns aggregate counts over sequence groups that have **3 or more members** — the
+  same `HAVING count(members) >= 3` rule the list endpoint uses, so the badge always
+  matches what the list page shows.
+- Response schema `SequenceGroupStats`:
+
+  ```json
+  {
+    "total": 12,
+    "validated": 5,
+    "unvalidated": 7
+  }
+  ```
+
+- Same JWT auth dependency as the other sequence-group endpoints.
+- The route must be declared **before** `GET /{group_id}` in
+  `annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py`, otherwise FastAPI
+  tries to parse `"stats"` as an integer group id and returns 422.
+
+### Schema
+
+- New `SequenceGroupStats` Pydantic model in
+  `annotation_api/src/app/schemas/sequence_group.py` with `total`, `validated`,
+  `unvalidated` (all `int`).
+
+## Frontend
+
+### API client and types
+
+- `SequenceGroupStats` interface in `frontend/src/types/api.ts`.
+- `apiClient.getSequenceGroupStats()` in `frontend/src/services/api.ts` calling
+  `GET /sequence_groups/stats`.
+
+### Count hook
+
+- Extend `frontend/src/hooks/useAnnotationCounts.ts` with a third query:
+  - Query key: `['annotation-counts', 'sequence-groups']`. Nesting under the
+    `['annotation-counts']` prefix means every existing broad invalidation (e.g. after
+    label propagation in `AnnotationInterface`) refreshes it for free.
+  - Fetches `getSequenceGroupStats()` and exposes `groupCount = stats.unvalidated`.
+  - Same options as the existing queries: `staleTime` 5 min, `gcTime` 10 min,
+    `refetchOnWindowFocus: true`.
+
+### Sidebar badge
+
+- `frontend/src/components/layout/AppLayout.tsx`:
+  - Add `badgeCount?: number` to the `NavigationItem` interface (top-level items
+    currently have no badge slot — only `NavigationSubItem` does).
+  - Render `<NotificationBadge>` in the top-level `item.href` branch, mirroring the
+    existing sub-item badge layout (`justify-between` flex row).
+  - Set `badgeCount` on the "Sequence groups" entry from the hook's `groupCount`.
+- `frontend/src/components/ui/NotificationBadge.tsx`: add an optional `title` prop
+  (default: current hardcoded `"{count} items need annotation"`) so the groups pill can
+  show an accurate tooltip like `"{count} groups need validation"`.
+
+### Keeping the count in sync
+
+- `frontend/src/pages/SequenceGroupAnnotatePage.tsx`:
+  - The validate/unvalidate mutation currently invalidates only
+    `['sequenceGroup', groupId]`. Additionally invalidate `['annotation-counts']`
+    (refreshes the badge) and `['sequenceGroupsList']` (fixes the pre-existing stale
+    list-page gap after validating).
+  - The remove-member mutation gets the same additional invalidations, since dropping a
+    group below 3 members changes the counts.
+
+## Testing
+
+- **Backend** (`annotation_api/src/tests/endpoints/test_sequence_groups.py`):
+  - Stats with no groups → all zeros.
+  - Mixed validated/unvalidated groups → correct split.
+  - Groups with fewer than 3 members are excluded from all counts.
+- **Frontend**: `npm run quality` (ESLint + type-check) and existing Vitest suite stay
+  green. New unit coverage only if a matching test pattern already exists for
+  `useAnnotationCounts` (it currently has none — do not invent a new harness).
+
+## Out of scope
+
+- No `validated` filter on the list endpoint (not needed for the badge).
+- No extra stats fields (labeled/unlabeled breakdowns) until something consumes them.
+- No badge on the list page itself.

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -29,6 +29,8 @@ interface NavigationItem {
   href?: string;
   icon: LucideIcon;
   children?: NavigationSubItem[];
+  badgeCount?: number;
+  badgeTitle?: string;
 }
 
 interface NavigationSubItem {
@@ -105,13 +107,19 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
   });
 
   // Get annotation counts for badges and current user
-  const { sequenceCount, detectionCount } = useAnnotationCounts();
+  const { sequenceCount, detectionCount, groupCount } = useAnnotationCounts();
   const { isSuperuser } = useAuthStore();
 
   // Create dynamic navigation with badge counts
   const navigationWithBadges: NavigationItem[] = [
     { name: 'Dashboard', href: '/', icon: BarChart3 },
-    { name: 'Sequence groups', href: '/sequence-groups', icon: Boxes },
+    {
+      name: 'Sequence groups',
+      href: '/sequence-groups',
+      icon: Boxes,
+      badgeCount: groupCount,
+      badgeTitle: `${groupCount} groups need validation`,
+    },
     {
       name: 'Sequences',
       icon: Layers,
@@ -220,7 +228,10 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
                     )}
                     aria-hidden="true"
                   />
-                  {item.name}
+                  <span className="flex-1">{item.name}</span>
+                  {item.badgeCount !== undefined && (
+                    <NotificationBadge count={item.badgeCount} title={item.badgeTitle} />
+                  )}
                 </Link>
               );
             }

--- a/frontend/src/components/ui/NotificationBadge.tsx
+++ b/frontend/src/components/ui/NotificationBadge.tsx
@@ -1,9 +1,14 @@
 interface NotificationBadgeProps {
   count: number;
   className?: string;
+  title?: string;
 }
 
-export default function NotificationBadge({ count, className = '' }: NotificationBadgeProps) {
+export default function NotificationBadge({
+  count,
+  className = '',
+  title,
+}: NotificationBadgeProps) {
   // Don't render if count is 0 or negative
   if (count <= 0) {
     return null;
@@ -15,7 +20,7 @@ export default function NotificationBadge({ count, className = '' }: Notificatio
   return (
     <span
       className={`inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 bg-red-500 text-white text-xs font-medium rounded-full transition-all duration-200 ${className}`}
-      title={`${count} items need annotation`}
+      title={title ?? `${count} items need annotation`}
     >
       {displayCount}
     </span>

--- a/frontend/src/hooks/useAnnotationCounts.ts
+++ b/frontend/src/hooks/useAnnotationCounts.ts
@@ -4,6 +4,7 @@ import { apiClient } from '@/services/api';
 export interface AnnotationCounts {
   sequenceCount: number;
   detectionCount: number;
+  groupCount: number;
   isLoading: boolean;
   error: Error | null;
 }
@@ -49,10 +50,27 @@ export function useAnnotationCounts(): AnnotationCounts {
     refetchOnWindowFocus: true,
   });
 
+  // Query for sequence groups awaiting validation
+  const {
+    data: groupData,
+    isLoading: groupLoading,
+    error: groupError,
+  } = useQuery({
+    queryKey: ['annotation-counts', 'sequence-groups'],
+    queryFn: async () => {
+      const stats = await apiClient.getSequenceGroupStats();
+      return stats.unvalidated;
+    },
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    gcTime: 10 * 60 * 1000, // 10 minutes
+    refetchOnWindowFocus: true,
+  });
+
   return {
     sequenceCount: sequenceData || 0,
     detectionCount: detectionData || 0,
-    isLoading: sequenceLoading || detectionLoading,
-    error: sequenceError || detectionError,
+    groupCount: groupData || 0,
+    isLoading: sequenceLoading || detectionLoading || groupLoading,
+    error: sequenceError || detectionError || groupError,
   };
 }

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -83,6 +83,8 @@ function MemberCard({
     mutationFn: () => apiClient.removeSequenceFromGroup(groupId, member.sequence_id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['sequenceGroup', groupId] });
+      queryClient.invalidateQueries({ queryKey: ['sequenceGroupsList'] });
+      queryClient.invalidateQueries({ queryKey: ['annotation-counts'] });
     },
   });
 
@@ -240,6 +242,8 @@ export default function SequenceGroupAnnotatePage() {
       apiClient.patchSequenceGroup(groupId, { is_validated: validated }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['sequenceGroup', groupId] });
+      queryClient.invalidateQueries({ queryKey: ['sequenceGroupsList'] });
+      queryClient.invalidateQueries({ queryKey: ['annotation-counts'] });
     },
   });
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -24,6 +24,7 @@ import {
   ApiError,
   SequenceGroup,
   SequenceGroupListItem,
+  SequenceGroupStats,
 } from '@/types/api';
 import { API_ENDPOINTS } from '@/utils/constants';
 
@@ -235,6 +236,13 @@ class ApiClient {
     const response: AxiosResponse<PaginatedResponse<SequenceGroupListItem>> = await this.client.get(
       API_ENDPOINTS.SEQUENCE_GROUPS,
       { params: filters }
+    );
+    return response.data;
+  }
+
+  async getSequenceGroupStats(): Promise<SequenceGroupStats> {
+    const response: AxiosResponse<SequenceGroupStats> = await this.client.get(
+      `${API_ENDPOINTS.SEQUENCE_GROUPS}stats`
     );
     return response.data;
   }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -157,6 +157,12 @@ export interface SequenceGroupListItem {
   member_count: number;
 }
 
+export interface SequenceGroupStats {
+  total: number;
+  validated: number;
+  unvalidated: number;
+}
+
 export interface SequenceGroup {
   id: number;
   camera_id: number;

--- a/frontend/tests/components/ui/NotificationBadge.test.tsx
+++ b/frontend/tests/components/ui/NotificationBadge.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * Tests for NotificationBadge component.
+ */
+
+import { render, screen } from '@testing-library/react';
+import NotificationBadge from '@/components/ui/NotificationBadge';
+
+describe('NotificationBadge', () => {
+  it('renders nothing when count is zero', () => {
+    const { container } = render(<NotificationBadge count={0} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the count', () => {
+    render(<NotificationBadge count={7} />);
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('clamps counts above 999', () => {
+    render(<NotificationBadge count={1500} />);
+    expect(screen.getByText('999+')).toBeInTheDocument();
+  });
+
+  it('uses the default title when none is given', () => {
+    render(<NotificationBadge count={3} />);
+    expect(screen.getByTitle('3 items need annotation')).toBeInTheDocument();
+  });
+
+  it('uses a custom title when provided', () => {
+    render(<NotificationBadge count={3} title="3 groups need validation" />);
+    expect(screen.getByTitle('3 groups need validation')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Adds a count pill next to **Sequence groups** in the sidebar showing the number of unvalidated groups (3+ members), kept in sync as groups are validated.

Design spec: `docs/specs/2026-07-27-sequence-group-count-badge-design.md`

## Changes

**Backend**
- New `GET /api/v1/sequence_groups/stats` endpoint returning `{total, validated, unvalidated}` over the same 3+-member population as the list endpoint (declared before `GET /{group_id}` so `"stats"` isn't parsed as a group id).
- New `SequenceGroupStats` schema.

**Frontend**
- `apiClient.getSequenceGroupStats()` + `SequenceGroupStats` type.
- `useAnnotationCounts` gains a `groupCount` query (key `['annotation-counts', 'sequence-groups']`), so existing broad `['annotation-counts']` invalidations refresh it for free.
- Top-level sidebar nav items now support a badge (`badgeCount`/`badgeTitle` on `NavigationItem`); `NotificationBadge` gains an optional `title` prop for an accurate tooltip.
- The validate/unvalidate and remove-member mutations on the group page now also invalidate `['sequenceGroupsList']` and `['annotation-counts']` — this also fixes the pre-existing stale list page after validating a group.

## Tests

- Backend: 2 new endpoint tests (empty stats; validated/unvalidated split with <3-member exclusion) — full suite 399 passed.
- Frontend: new `NotificationBadge` component tests — full suite 641 passed; type-check/ESLint/Prettier clean on changed files.

Note: `ruff format` (pinned pre-commit version) also fixed 4 small pre-existing formatting hunks in `test_sequence_groups.py`.