### PR TITLE
feat(api)!: remove POST /sequence_groups/assign

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
@@ -30,7 +30,6 @@ from app.schemas.sequence_group import (
     SequenceGroupStats,
     SequenceGroupUpdate,
 )
-from app.services.group_assignment import AssignGroupsResult, assign_ungrouped_sequences
 
 router = APIRouter()
 
@@ -302,22 +301,3 @@ async def reinclude_sequence_in_grouping(
     seq.is_group_excluded = False
     session.add(seq)
     await session.commit()
-
-
-# -------------------- assign-groups --------------------
-
-
-@router.post(
-    "/assign",
-    response_model=AssignGroupsResult,
-    summary="Compute group membership for unassigned sequences (idempotent).",
-)
-async def assign_groups(
-    session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_current_user),
-) -> AssignGroupsResult:
-    """Manual trigger for the assignment sweep (see
-    ``app.services.group_assignment``). The same logic runs automatically
-    every few minutes in the worker; this endpoint exists for on-demand runs.
-    """
-    return await assign_ungrouped_sequences(session, user_id=current_user.id)

--- a/annotation_api/src/app/services/group_assignment.py
+++ b/annotation_api/src/app/services/group_assignment.py
@@ -5,9 +5,9 @@
 
 """Sequence-group assignment sweep.
 
-Shared by the manual endpoint (POST /sequence_groups/assign) and the periodic
-worker task (``assign_sequence_groups`` in ``app.worker``): both call
-``assign_ungrouped_sequences``.
+Called by the periodic worker task (``assign_sequence_groups`` in
+``app.worker``), the sole trigger since the manual endpoint was removed
+(#181): it calls ``assign_ungrouped_sequences``.
 """
 
 import logging
@@ -48,8 +48,8 @@ logger = logging.getLogger(__name__)
 # accidental tiny overlaps; 0.5 was too strict in practice.
 GROUP_IOU_THRESHOLD = 0.3
 
-# Fixed key for the Postgres advisory lock that serializes assignment runs
-# (manual endpoint vs periodic worker sweep). Arbitrary but must never change.
+# Fixed key for the Postgres advisory lock that serializes overlapping
+# assignment sweeps. Arbitrary but must never change.
 ASSIGN_ADVISORY_LOCK_KEY = 743210517
 
 

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -1,7 +1,7 @@
 """Tests for the sequence-groups + bulk-annotate + propagation flow.
 
 Covers:
-- POST /sequence_groups/assign creates a new group from an unassigned sequence
+- assign_ungrouped_sequences creates a new group from an unassigned sequence
 - POST /annotations/sequences/bulk applies labels, writes them onto the
   group, and rejects conflicting labels unless force=True
 - Request validation rejects payloads with neither or both labels
@@ -24,7 +24,8 @@ from httpx import AsyncClient
 from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.models import Sequence
+from app.models import Sequence, User
+from app.services.group_assignment import assign_ungrouped_sequences
 
 
 async def _set_seq_metadata(
@@ -223,16 +224,15 @@ async def test_assign_groups_creates_group_for_unmatched_sequence(
     authenticated_client: AsyncClient,
     sequence_session: AsyncSession,
     detection_session: AsyncSession,
+    test_user: User,
 ):
     """Sequence 1 has detections with bbox in the [0.12-0.5, 0.13-0.55] region;
     no group exists yet → assign should create one and link it."""
     await _set_seq_metadata(sequence_session, 1, camera_id=42, azimuth=90)
     await _create_placeholder_annotation(authenticated_client, 1)
 
-    response = await authenticated_client.post("/sequence_groups/assign")
-    assert response.status_code == 200
-    summary = response.json()
-    assert summary["new_groups"] >= 1
+    result = await assign_ungrouped_sequences(sequence_session, user_id=test_user.id)
+    assert result.new_groups >= 1
 
     # The created group should now own sequence 1.
     seq_response = await authenticated_client.get("/sequences/1")
@@ -246,22 +246,21 @@ async def test_assign_skips_sequences_still_importing(
     authenticated_client: AsyncClient,
     sequence_session: AsyncSession,
     detection_session: AsyncSession,
+    test_user: User,
 ):
     """A sequence with no SequenceAnnotation row is mid-import (imports
     create the annotation only after all detections are posted) — assign
     must leave it alone until the annotation appears."""
     await _set_seq_metadata(sequence_session, 1, camera_id=42, azimuth=90)
 
-    resp = await authenticated_client.post("/sequence_groups/assign")
-    assert resp.status_code == 200
-    assert resp.json()["processed"] == 0
+    result = await assign_ungrouped_sequences(sequence_session, user_id=test_user.id)
+    assert result.processed == 0
     seq_payload = (await authenticated_client.get("/sequences/1")).json()
     assert seq_payload["sequence_group_id"] is None
 
     await _create_placeholder_annotation(authenticated_client, 1)
-    resp = await authenticated_client.post("/sequence_groups/assign")
-    assert resp.status_code == 200
-    assert resp.json()["new_groups"] >= 1
+    result = await assign_ungrouped_sequences(sequence_session, user_id=test_user.id)
+    assert result.new_groups >= 1
     seq_payload = (await authenticated_client.get("/sequences/1")).json()
     assert seq_payload["sequence_group_id"] is not None
 
@@ -271,14 +270,14 @@ async def test_bulk_annotate_writes_label_on_group_and_seqs(
     authenticated_client: AsyncClient,
     sequence_session: AsyncSession,
     detection_session: AsyncSession,
+    test_user: User,
 ):
     """After assigning a group from seq 1, bulk-annotating that seq should
     apply the label, mark the SequenceAnnotation as SEQ_ANNOTATION_DONE, and
     write the label onto the group itself."""
     await _set_seq_metadata(sequence_session, 1, camera_id=42, azimuth=90)
     await _create_placeholder_annotation(authenticated_client, 1)
-    assign_resp = await authenticated_client.post("/sequence_groups/assign")
-    assert assign_resp.status_code == 200
+    await assign_ungrouped_sequences(sequence_session, user_id=test_user.id)
 
     # Discover the group_id from the sequence.
     seq_payload = (await authenticated_client.get("/sequences/1")).json()
@@ -312,12 +311,13 @@ async def test_bulk_annotate_rejects_conflicting_label_without_force(
     authenticated_client: AsyncClient,
     sequence_session: AsyncSession,
     detection_session: AsyncSession,
+    test_user: User,
 ):
     """A group already labeled `wildfire` must reject a request to relabel
     it as `antenna` unless the caller passes force=True."""
     await _set_seq_metadata(sequence_session, 1, camera_id=42, azimuth=90)
     await _create_placeholder_annotation(authenticated_client, 1)
-    await authenticated_client.post("/sequence_groups/assign")
+    await assign_ungrouped_sequences(sequence_session, user_id=test_user.id)
 
     seq_payload = (await authenticated_client.get("/sequences/1")).json()
     group_id = seq_payload["sequence_group_id"]

--- a/docs/specs/2026-07-27-remove-assign-endpoint-design.md
+++ b/docs/specs/2026-07-27-remove-assign-endpoint-design.md
@@ -1,0 +1,60 @@
+# Remove `POST /sequence_groups/assign`
+
+**Date**: 2026-07-27
+**Issue**: [#181](https://github.com/pyronear/pyro-annotator/issues/181)
+**Status**: Approved
+
+## Context
+
+Since #173, group assignment runs automatically every 5 minutes via the
+`assign_sequence_groups` procrastinate task, which calls
+`app/services/group_assignment.py` directly. The `POST /sequence_groups/assign`
+endpoint delegates to the same service and remains only as a manual escape
+hatch. Issue #181 proposed deprecating it first and removing it after worker
+observability (#180) confirmed the sweep runs reliably; the decision here is to
+skip the bake period and remove it now, accepting that until #180 lands, a
+misbehaving worker means waiting for a fix rather than triggering manually.
+
+The frontend never calls the endpoint and the API client library
+(`app/clients/annotation_api.py`) has no wrapper for it, so this is
+backend-only.
+
+## Changes
+
+All in `annotation_api/`:
+
+1. **`src/app/api/api_v1/endpoints/sequence_groups.py`** — delete the
+   `assign_groups` route and the now-unused import of
+   `AssignGroupsResult, assign_ungrouped_sequences`.
+2. **`src/app/services/group_assignment.py`** — update the module docstring
+   (sole caller is now the worker task, not "shared by the manual endpoint and
+   the worker") and the advisory-lock comment (it now serializes overlapping
+   worker runs). Logic untouched.
+3. **`src/tests/endpoints/test_sequence_groups.py`** — replace the four
+   `POST /sequence_groups/assign` calls with direct
+   `assign_ungrouped_sequences(session, user_id=test_user.id)` calls, using the
+   existing `test_user` fixture (same pattern as
+   `tests/services/test_group_assignment.py`). Two of the four test assign
+   behavior itself (group creation, mid-import gate); two use it as setup for
+   bulk-annotate tests. All stay in place — the flow tests keep asserting
+   through the API's GET endpoints. Assertions adapt from
+   `resp.json()["new_groups"]` to `result.new_groups`, etc. Update the module
+   docstring's mention of the endpoint.
+
+## Not touched
+
+- The service logic and its return type `AssignGroupsResult`.
+- The worker task in `src/app/worker.py`.
+- Historical spec docs in `docs/specs/` (dated design records).
+- The SQL-seeding helpers in the test file.
+
+## Attribution note
+
+The endpoint attributed assignment runs to the calling user. After removal,
+all assignment attribution comes from the worker user (#178, already merged).
+
+## Verification
+
+- `make test` — endpoint, service, and worker tests pass with the migrated
+  tests providing the same behavioral coverage.
+- `make lint` — clean.


### PR DESCRIPTION
## Summary

Removes the manual `POST /sequence_groups/assign` endpoint. Since #173, the periodic `assign_sequence_groups` worker task runs the assignment sweep every 5 minutes; it is now the single trigger.

- Delete the `assign_groups` route from `sequence_groups.py` (the service `assign_ungrouped_sequences` and its return type `AssignGroupsResult` are unchanged)
- Migrate the four endpoint tests that exercised the assign flow over HTTP to call the service directly (same pattern as the existing service tests)
- Update the service module docstring and advisory-lock comment to reflect the single trigger path
- Design spec: `docs/specs/2026-07-27-remove-assign-endpoint-design.md`

Skips the deprecation bake period proposed in #181: until #180 (worker observability) lands, a misbehaving worker means waiting for a fix rather than triggering manually — accepted trade-off.

Closes #181

## Test plan

- `make test` — full suite green (438 passed), including the migrated `tests/endpoints/test_sequence_groups.py` and the service/worker tests
- `ruff format --check` / `ruff check` clean on touched files (pre-commit ruff 0.12.7 passed on all commits)