### PR TITLE
fix: reuse curated annotation on group label inheritance

### DIFF
--- a/annotation_api/src/app/services/group_assignment.py
+++ b/annotation_api/src/app/services/group_assignment.py
@@ -29,6 +29,7 @@ from app.models import (
     SequenceGroup,
     SmokeType,
 )
+from app.schemas.annotation_validation import SequenceAnnotationData
 from app.schemas.sequence_annotations import (
     SequenceAnnotationCreate,
     SequenceAnnotationUpdate,
@@ -144,9 +145,9 @@ async def _run_assignment(session: AsyncSession, user_id: int) -> AssignGroupsRe
     (camera_id, azimuth) key, threshold > 0.3. Label inheritance is
     conditional — when the matched group already has a label, the joining
     sequence gets a SequenceAnnotation in SEQ_ANNOTATION_DONE with that
-    label, attributed to ``user_id``. If a placeholder annotation is already
-    there in stage READY_TO_ANNOTATE (the import script's default), it is
-    upgraded in place; any later stage is left untouched.
+    label, attributed to ``user_id``. The importers' curated
+    READY_TO_ANNOTATE annotation is upgraded in place (its tracks reused
+    verbatim); any later stage is left untouched.
     """
     sa_crud = SequenceAnnotationCRUD(session=session)
 
@@ -236,11 +237,14 @@ async def _run_assignment(session: AsyncSession, user_id: int) -> AssignGroupsRe
         if best_group.smoke_type is None and best_group.false_positive_type is None:
             continue
 
-        # Inherit the group's label. import.py creates an empty
-        # READY_TO_ANNOTATE annotation for every imported sequence, so we
-        # need to UPDATE that placeholder rather than skip on existence.
-        # Skip only if the existing annotation is past the placeholder
-        # stage (the human / review pipeline has touched it).
+        # Inherit the group's label. The importers write a curated
+        # READY_TO_ANNOTATE annotation (one track per split object) for
+        # every imported sequence — stamp the label onto those tracks as-is.
+        # Regenerating from algo_predictions would restructure them (e.g.
+        # re-cluster a below-spawn-threshold fallback sequence into several
+        # tracks), so regeneration is reserved for annotations with no
+        # tracks at all. Skip any stage past READY_TO_ANNOTATE (the human /
+        # review pipeline has touched it).
         existing_anno = (
             await session.execute(
                 select(SequenceAnnotation).where(
@@ -253,9 +257,14 @@ async def _run_assignment(session: AsyncSession, user_id: int) -> AssignGroupsRe
         ):
             continue
 
-        generated = await gen_service.generate_annotation_for_sequence(seq.id)
-        if generated is None:
-            continue
+        if existing_anno is not None and (existing_anno.annotation or {}).get(
+            "sequences_bbox"
+        ):
+            generated = SequenceAnnotationData.model_validate(existing_anno.annotation)
+        else:
+            generated = await gen_service.generate_annotation_for_sequence(seq.id)
+            if generated is None:
+                continue
 
         smoke_enum = SmokeType(best_group.smoke_type) if best_group.smoke_type else None
         fp_enum = (

--- a/annotation_api/src/tests/services/test_group_assignment.py
+++ b/annotation_api/src/tests/services/test_group_assignment.py
@@ -1,15 +1,171 @@
-"""Tests for the group-assignment service's concurrency guard."""
+"""Tests for the group-assignment service: concurrency guard and label
+inheritance."""
+
+from datetime import datetime, timezone
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.db import engine
-from app.models import User
+from app.models import (
+    Detection,
+    Sequence,
+    SequenceAnnotation,
+    SequenceAnnotationProcessingStage,
+    SequenceGroup,
+    User,
+)
 from app.services.group_assignment import (
     ASSIGN_ADVISORY_LOCK_KEY,
     assign_ungrouped_sequences,
 )
+
+# Two boxes with zero overlap: their per-coordinate median is
+# [0.35, 0.35, 0.45, 0.45], which is also the group's representative bbox
+# below (IoU 1.0 → the sequence always joins the group). Because they don't
+# overlap, regenerating from algo_predictions (iou_threshold=0.0) would split
+# them into two tracks — the discriminator for "reuse vs regenerate".
+BOX_A = [0.1, 0.1, 0.2, 0.2]
+BOX_B = [0.6, 0.6, 0.7, 0.7]
+REPR_BBOX = {"xyxyn": [0.35, 0.35, 0.45, 0.45], "confidence": 0.9}
+
+
+async def _seed_labeled_group_and_sequence(
+    session: AsyncSession, *, sequences_bbox: list
+) -> int:
+    """Seed a labeled group plus one ungrouped sequence (two detections, one
+    curated READY_TO_ANNOTATE annotation with `sequences_bbox`). Returns the
+    sequence id."""
+    ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    group = SequenceGroup(
+        camera_id=1,
+        azimuth=0,
+        representative_bbox=REPR_BBOX,
+        smoke_type="wildfire",
+        is_unsure=True,
+        labeled_at=ts,
+    )
+    seq = Sequence(
+        source_api="pyronear_french",
+        alert_api_id=9001,
+        created_at=ts,
+        recorded_at=ts,
+        last_seen_at=ts,
+        camera_name="cam",
+        camera_id=1,
+        azimuth=0,
+        is_wildfire_alertapi="wildfire_smoke",
+        organisation_name="org",
+        lat=0.0,
+        lon=0.0,
+        organisation_id=1,
+    )
+    session.add(group)
+    session.add(seq)
+    await session.flush()
+    for i, box in enumerate((BOX_A, BOX_B)):
+        session.add(
+            Detection(
+                sequence_id=seq.id,
+                alert_api_id=9100 + i,
+                recorded_at=ts,
+                bucket_key=f"test-inherit-{i}.jpg",
+                algo_predictions={
+                    "predictions": [
+                        {"xyxyn": box, "confidence": 0.8, "class_name": "smoke"}
+                    ]
+                },
+            )
+        )
+    session.add(
+        SequenceAnnotation(
+            sequence_id=seq.id,
+            has_smoke=False,
+            has_false_positives=False,
+            has_missed_smoke=False,
+            annotation={"sequences_bbox": sequences_bbox},
+            processing_stage=SequenceAnnotationProcessingStage.READY_TO_ANNOTATE,
+        )
+    )
+    await session.commit()
+    return seq.id
+
+
+async def _get_annotation(
+    session: AsyncSession, sequence_id: int
+) -> SequenceAnnotation:
+    anno = (
+        await session.execute(
+            select(SequenceAnnotation).where(
+                SequenceAnnotation.sequence_id == sequence_id
+            )
+        )
+    ).scalar_one()
+    await session.refresh(anno)
+    return anno
+
+
+@pytest.mark.asyncio
+async def test_inheritance_reuses_curated_tracks(
+    async_session: AsyncSession,
+    test_user: User,
+):
+    """A curated non-empty annotation joining a labeled group keeps its
+    tracks exactly as imported — only the label, is_unsure and stage change.
+    (Regeneration would split the single fallback track into two.)"""
+    curated_bboxes = [
+        {"detection_id": 1, "xyxyn": BOX_A},
+        {"detection_id": 2, "xyxyn": BOX_B},
+    ]
+    seq_id = await _seed_labeled_group_and_sequence(
+        async_session,
+        sequences_bbox=[
+            {
+                "is_smoke": True,
+                "false_positive_types": [],
+                "bboxes": curated_bboxes,
+            }
+        ],
+    )
+
+    result = await assign_ungrouped_sequences(async_session, user_id=test_user.id)
+    assert result.joined_existing == 1
+    assert result.inherited_annotations == 1
+
+    anno = await _get_annotation(async_session, seq_id)
+    tracks = anno.annotation["sequences_bbox"]
+    assert len(tracks) == 1, "curated track structure must be preserved"
+    assert tracks[0]["bboxes"] == curated_bboxes
+    assert tracks[0]["is_smoke"] is True
+    assert tracks[0]["smoke_type"] == "wildfire"
+    assert anno.is_unsure is True
+    assert (
+        anno.processing_stage == SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE
+    )
+
+
+@pytest.mark.asyncio
+async def test_inheritance_regenerates_when_annotation_empty(
+    async_session: AsyncSession,
+    test_user: User,
+):
+    """An empty placeholder annotation still goes through regeneration from
+    algo_predictions when it inherits a group label."""
+    seq_id = await _seed_labeled_group_and_sequence(async_session, sequences_bbox=[])
+
+    result = await assign_ungrouped_sequences(async_session, user_id=test_user.id)
+    assert result.inherited_annotations == 1
+
+    anno = await _get_annotation(async_session, seq_id)
+    tracks = anno.annotation["sequences_bbox"]
+    assert len(tracks) == 2, "non-overlapping boxes regenerate as two tracks"
+    for track in tracks:
+        assert track["is_smoke"] is True
+        assert track["smoke_type"] == "wildfire"
+    assert (
+        anno.processing_stage == SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #186

## Problem

When the group-assignment sweep inherits a label onto a newly imported sequence, it filled the annotation by regenerating tracks from raw `algo_predictions` and overwriting the existing annotation — instead of reusing the curated one-track annotation the object-split importer (#176/#177) already wrote. Concretely:

- A below-spawn-threshold fallback sequence (imported whole as one track holding all sparse boxes) got re-clustered into multiple tracks and auto-finalized as `seq_annotation_done` — sub-threshold noise became labeled objects no human ever saw.
- The load-bearing comment still claimed the importer writes an empty placeholder annotation (false since #177).
- If the sweep's `iou_threshold` were ever raised from 0.0, regeneration would start fragmenting drifting plumes on every inheritance.

## Fix

In the inheritance path, when the existing `ready_to_annotate` annotation already has non-empty `sequences_bbox`, validate it into `SequenceAnnotationData` and stamp the inherited label onto the existing tracks (`apply_label_to_sequences_bbox`), updating stage and `is_unsure` as before. Regeneration from `algo_predictions` is kept only for annotations with no tracks at all (or the concurrent-delete race). Stale comment and docstring updated.

## Tests

- `test_inheritance_reuses_curated_tracks` — curated single track holding two non-overlapping boxes + labeled group → track structure and bboxes preserved exactly, label/`is_unsure`/stage applied. Verified failing before the fix (regeneration split it into two tracks).
- `test_inheritance_regenerates_when_annotation_empty` — empty placeholder annotation still goes through the old regeneration path.
- Full suite: 440 passed.