### PR TITLE
fix: migrate alert_api_id to BigInteger

### DIFF
--- a/annotation_api/src/app/models.py
+++ b/annotation_api/src/app/models.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import List, Optional
 
 from sqlalchemy import (
+    BigInteger,
     CheckConstraint,
     Column,
     DateTime,
@@ -201,7 +202,9 @@ class Sequence(SQLModel, table=True):
         default=None, primary_key=True, sa_column_kwargs={"autoincrement": True}
     )
     source_api: SourceApi
-    alert_api_id: int
+    # BigInteger: synthetic sibling ids (1_000_000_000 + platform_sid * 1000 +
+    # object_index) overflow int32 once platform sids pass ~1.15M.
+    alert_api_id: int = Field(sa_type=BigInteger)
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True)),
@@ -360,7 +363,7 @@ class Detection(SQLModel, table=True):
         sa_column=Column(DateTime(timezone=True)),
     )
     recorded_at: datetime = Field(sa_column=Column(DateTime(timezone=True)))
-    alert_api_id: int
+    alert_api_id: int = Field(sa_type=BigInteger)
     sequence_id: Optional[int] = Field(
         default=None, sa_column=Column(ForeignKey("sequences.id", ondelete="CASCADE"))
     )

--- a/annotation_api/src/migrations/versions/2026_07_27_1000-b8c9d0e1f2a3_alert_api_id_bigint.py
+++ b/annotation_api/src/migrations/versions/2026_07_27_1000-b8c9d0e1f2a3_alert_api_id_bigint.py
@@ -1,0 +1,56 @@
+"""alert_api_id Integer -> BigInteger
+
+Synthetic sibling ids from the object-split import
+(1_000_000_000 + platform_sequence_id * 1000 + object_index) overflow int32
+once platform sequence ids exceed ~1.15M.
+
+Revision ID: b8c9d0e1f2a3
+Revises: a7b8c9d0e1f2
+Create Date: 2026-07-27 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b8c9d0e1f2a3"
+down_revision: Union[str, None] = "a7b8c9d0e1f2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "sequences",
+        "alert_api_id",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "detections",
+        "alert_api_id",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "detections",
+        "alert_api_id",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "sequences",
+        "alert_api_id",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+        existing_nullable=False,
+    )

--- a/annotation_api/src/tests/endpoints/test_detections.py
+++ b/annotation_api/src/tests/endpoints/test_detections.py
@@ -492,3 +492,25 @@ async def test_create_detection_different_alert_api_id_allows_duplicate_processi
     assert detection1["alert_api_id"] != detection2["alert_api_id"]
     # Even if they might have same id, the unique constraint (alert_api_id, id) allows this
     # since alert_api_id is different
+
+
+@pytest.mark.asyncio
+async def test_create_detection_with_alert_api_id_above_int32(
+    authenticated_client: AsyncClient, sequence_session: AsyncSession, mock_img: bytes
+):
+    """detections.alert_api_id must be BigInteger, consistent with sequences
+    (platform ids can exceed int32)."""
+    payload = {
+        "sequence_id": "1",
+        "alert_api_id": str(2**31),
+        "recorded_at": (now - timedelta(days=2)).isoformat(),
+        "algo_predictions": json.dumps({"predictions": []}),
+    }
+
+    response = await authenticated_client.post(
+        "/detections/",
+        data=payload,
+        files={"file": ("image.jpg", mock_img, "image/jpeg")},
+    )
+    assert response.status_code == 201
+    assert response.json()["alert_api_id"] == 2**31

--- a/annotation_api/src/tests/endpoints/test_sequence.py
+++ b/annotation_api/src/tests/endpoints/test_sequence.py
@@ -1745,7 +1745,7 @@ async def test_list_sequences_filter_by_null_is_wildfire_alertapi(
     """Test filtering sequences by null is_wildfire_alertapi using the special 'null' filter."""
     # Create a sequence with null is_wildfire_alertapi (no value provided)
     payload_null = {
-        "source_api": "pyronear_french", 
+        "source_api": "pyronear_french",
         "alert_api_id": "999",
         "camera_name": "null_test_cam",
         "camera_id": "999",
@@ -1762,7 +1762,7 @@ async def test_list_sequences_filter_by_null_is_wildfire_alertapi(
     # Create a sequence with is_wildfire_alertapi set to wildfire_smoke
     payload_wildfire = {
         "source_api": "pyronear_french",
-        "alert_api_id": "998", 
+        "alert_api_id": "998",
         "camera_name": "wildfire_test_cam",
         "camera_id": "998",
         "organisation_name": "test_org",
@@ -1770,7 +1770,7 @@ async def test_list_sequences_filter_by_null_is_wildfire_alertapi(
         "is_wildfire_alertapi": "wildfire_smoke",
         "azimuth": "90",
         "lat": "0.0",
-        "lon": "0.0", 
+        "lon": "0.0",
         "recorded_at": now.isoformat(),
         "last_seen_at": now.isoformat(),
     }
@@ -1780,33 +1780,39 @@ async def test_list_sequences_filter_by_null_is_wildfire_alertapi(
     assert response_null.status_code == 201
     null_sequence_id = response_null.json()["id"]
 
-    response_wildfire = await authenticated_client.post("/sequences/", data=payload_wildfire)
+    response_wildfire = await authenticated_client.post(
+        "/sequences/", data=payload_wildfire
+    )
     assert response_wildfire.status_code == 201
     wildfire_sequence_id = response_wildfire.json()["id"]
 
     # Test filtering for null values using the special "null" filter
     response = await authenticated_client.get("/sequences/?is_wildfire_alertapi=null")
     assert response.status_code == 200
-    
+
     data = response.json()
     sequence_ids = [seq["id"] for seq in data["items"]]
-    
+
     # Should include the null sequence but not the wildfire sequence
     assert null_sequence_id in sequence_ids
     assert wildfire_sequence_id not in sequence_ids
 
     # Verify that the null sequence actually has null is_wildfire_alertapi
-    null_sequence = next((seq for seq in data["items"] if seq["id"] == null_sequence_id), None)
+    null_sequence = next(
+        (seq for seq in data["items"] if seq["id"] == null_sequence_id), None
+    )
     assert null_sequence is not None
     assert null_sequence["is_wildfire_alertapi"] is None
 
     # Test filtering for wildfire_smoke to make sure it excludes null values
-    response_wildfire_filter = await authenticated_client.get("/sequences/?is_wildfire_alertapi=wildfire_smoke")
+    response_wildfire_filter = await authenticated_client.get(
+        "/sequences/?is_wildfire_alertapi=wildfire_smoke"
+    )
     assert response_wildfire_filter.status_code == 200
-    
+
     wildfire_data = response_wildfire_filter.json()
     wildfire_sequence_ids = [seq["id"] for seq in wildfire_data["items"]]
-    
+
     # Should include the wildfire sequence but not the null sequence
     assert wildfire_sequence_id in wildfire_sequence_ids
     assert null_sequence_id not in wildfire_sequence_ids
@@ -1885,3 +1891,30 @@ async def test_list_sequences_filter_by_is_unsure_alone(
     assert unsure_id in sequence_ids
     assert sure_id not in sequence_ids
     assert unannotated_id not in sequence_ids
+
+
+@pytest.mark.asyncio
+async def test_create_sequence_with_alert_api_id_above_int32(
+    authenticated_client: AsyncClient,
+):
+    """Synthetic sibling ids (1_000_000_000 + platform_sid * 1000 + object_index)
+    overflow int32 once platform sids pass ~1.15M — the column must be BigInteger."""
+    payload = {
+        "source_api": "pyronear_french",
+        # 2_147_484_000 > 2**31 - 1
+        "alert_api_id": str(1_000_000_000 + 1_147_484 * 1000),
+        "camera_name": "test_cam_bigint",
+        "camera_id": "1",
+        "organisation_name": "test_org",
+        "organisation_id": "1",
+        "azimuth": "90",
+        "lat": "0.0",
+        "lon": "0.0",
+        "created_at": (now - timedelta(days=1)).isoformat(),
+        "recorded_at": (now - timedelta(days=1)).isoformat(),
+        "last_seen_at": now.isoformat(),
+    }
+
+    response = await authenticated_client.post("/sequences/", data=payload)
+    assert response.status_code == 201
+    assert response.json()["alert_api_id"] == 2_147_484_000


### PR DESCRIPTION
Closes #182.

The synthetic sibling id scheme from the object-split import (`1_000_000_000 + platform_sequence_id * 1000 + object_index`) overflows int32 once platform sequence ids exceed ~1.15M. This widens `sequences.alert_api_id` and `detections.alert_api_id` to `BigInteger` before that day arrives.

## Changes

- `models.py`: both `alert_api_id` columns now use `Field(sa_type=BigInteger)`
- New alembic migration `b8c9d0e1f2a3` altering both columns (reversible)
- Regression tests: create a sequence with `alert_api_id = 2_147_484_000` (the synthetic sibling id at platform sid 1,147,484) and a detection with `2**31` — both failed with `value out of int32 range` before the fix
- One format-only commit (`f28b1af`): pre-commit's ruff-format reformatted pre-existing drift in `test_sequence.py`; kept separate from the fix commit

## Verification

- Full suite: 440 passed, 0 failed (suite runs `alembic upgrade head`, exercising the migration)
- `upgrade → downgrade → upgrade` round-trip verified against a fresh Postgres
- ruff + mypy clean on touched files