### PR TITLE
Attribute auto-created detection annotations to the saving user

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -272,8 +272,11 @@ async def auto_create_detection_annotations(
             await session.flush()
             new_annotation_ids = [a.id for a in new_annotations]
             da_crud = DetectionAnnotationCRUD(session)
+            # commit=False: the caller's commit lands the annotations and
+            # their contributions atomically — a partial commit would leave
+            # ANNOTATED rows unattributed, with nothing to backfill them.
             for annotation_id in new_annotation_ids:
-                await da_crud.record_contribution(annotation_id, user_id)
+                await da_crud.record_contribution(annotation_id, user_id, commit=False)
 
 
 async def validate_detection_ids(

--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -21,7 +21,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.dependencies import get_current_user, get_sequence_annotation_crud
 from app.models import User
-from app.crud import SequenceAnnotationCRUD
+from app.crud import DetectionAnnotationCRUD, SequenceAnnotationCRUD
 from app.db import get_session
 from app.models import (
     Detection,
@@ -186,6 +186,7 @@ async def auto_create_detection_annotations(
     has_missed_smoke: bool,
     has_false_positives: bool,
     session: AsyncSession,
+    user_id: int,
 ) -> None:
     """
     Automatically create detection annotations for all detections in a sequence.
@@ -202,6 +203,7 @@ async def auto_create_detection_annotations(
         has_missed_smoke: Whether sequence annotation indicates missed smoke
         has_false_positives: Whether sequence annotation indicates false positives
         session: Database session
+        user_id: ID of the user whose save triggered the auto-creation
     """
     # Determine the appropriate processing stage based on sequence annotation
     if not has_missed_smoke and has_false_positives and not has_smoke:
@@ -260,6 +262,18 @@ async def auto_create_detection_annotations(
     # Bulk insert all new detection annotations at once
     if new_annotations:
         session.add_all(new_annotations)
+
+        # Rows written directly at ANNOTATED (FP-only sequences) are final
+        # content derived from the saving human's sequence-level judgment, so
+        # attribute them to that user. Placeholder rows (visual_check /
+        # bbox_annotation) carry no judgment yet; their annotator is credited
+        # when they submit via the detection-annotation update path.
+        if processing_stage == DetectionAnnotationProcessingStage.ANNOTATED:
+            await session.flush()
+            new_annotation_ids = [a.id for a in new_annotations]
+            da_crud = DetectionAnnotationCRUD(session)
+            for annotation_id in new_annotation_ids:
+                await da_crud.record_contribution(annotation_id, user_id)
 
 
 async def validate_detection_ids(
@@ -358,6 +372,7 @@ async def create_sequence_annotation(
             has_missed_smoke=create_data.has_missed_smoke,
             has_false_positives=sequence_annotation.has_false_positives,
             session=annotations.session,
+            user_id=current_user.id,
         )
         # Commit the detection annotations
         await annotations.session.commit()
@@ -654,6 +669,7 @@ async def update_sequence_annotation(
             has_missed_smoke=updated_annotation.has_missed_smoke,
             has_false_positives=updated_annotation.has_false_positives,
             session=annotations.session,
+            user_id=current_user.id,
         )
         # Commit the detection annotations
         await annotations.session.commit()

--- a/annotation_api/src/app/crud/crud_detection_annotation.py
+++ b/annotation_api/src/app/crud/crud_detection_annotation.py
@@ -88,8 +88,13 @@ class DetectionAnnotationCRUD(
 
         return annotation
 
-    async def _record_contribution(self, annotation_id: int, user_id: int) -> None:
-        """Record a user contribution to the detection annotation."""
+    async def record_contribution(self, annotation_id: int, user_id: int) -> None:
+        """Record a user contribution to the detection annotation.
+
+        The create/update paths only auto-record contributions at the
+        ANNOTATED stage (completed human work). Machine-written annotations
+        (auto-created ANNOTATED rows for FP-only sequences) call this
+        explicitly so the write is attributed."""
         contribution = DetectionAnnotationContribution(
             detection_annotation_id=annotation_id, user_id=user_id
         )

--- a/annotation_api/src/app/crud/crud_detection_annotation.py
+++ b/annotation_api/src/app/crud/crud_detection_annotation.py
@@ -88,18 +88,28 @@ class DetectionAnnotationCRUD(
 
         return annotation
 
-    async def record_contribution(self, annotation_id: int, user_id: int) -> None:
+    async def record_contribution(
+        self, annotation_id: int, user_id: int, commit: bool = True
+    ) -> None:
         """Record a user contribution to the detection annotation.
 
         The create/update paths only auto-record contributions at the
         ANNOTATED stage (completed human work). Machine-written annotations
         (auto-created ANNOTATED rows for FP-only sequences) call this
-        explicitly so the write is attributed."""
+        explicitly so the write is attributed.
+
+        By default this commits the session's whole pending transaction.
+        Pass commit=False to only stage the row, so a caller inserting many
+        annotations can land them and their contributions in one atomic
+        commit — a partial commit would leave ANNOTATED rows unattributed,
+        with no path that ever backfills them.
+        """
         contribution = DetectionAnnotationContribution(
             detection_annotation_id=annotation_id, user_id=user_id
         )
         self.session.add(contribution)
-        await self.session.commit()
+        if commit:
+            await self.session.commit()
 
     async def get_annotation_contributors(self, annotation_id: int) -> List[User]:
         """Get all users who contributed to this detection annotation."""

--- a/annotation_api/src/tests/endpoints/test_sequence_annotations.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_annotations.py
@@ -1759,6 +1759,51 @@ async def test_fp_update_auto_annotated_detection_annotation_attributed_to_savin
 
 
 @pytest.mark.asyncio
+async def test_fp_auto_annotated_attribution_covers_every_detection(
+    authenticated_client: AsyncClient, sequence_session, test_user
+):
+    """With several detections in the sequence, every auto-created ANNOTATED
+    detection annotation gets its own contribution for the saving user."""
+    detection_ids = [
+        await _create_detection(authenticated_client, alert_api_id)
+        for alert_api_id in ("2104", "2105")
+    ]
+
+    false_positive_payload = {
+        "sequence_id": 1,
+        "has_missed_smoke": False,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": False,
+                    "false_positive_types": ["antenna"],
+                    "bboxes": [
+                        {
+                            "detection_id": detection_ids[0],
+                            "xyxyn": [0.1, 0.1, 0.2, 0.2],
+                        }
+                    ],
+                }
+            ]
+        },
+        "processing_stage": models.SequenceAnnotationProcessingStage.ANNOTATED.value,
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+    response = await authenticated_client.post(
+        "/annotations/sequences/", json=false_positive_payload
+    )
+    assert response.status_code == 201
+
+    for detection_id in detection_ids:
+        detection_annotation = await _get_detection_annotation(
+            authenticated_client, detection_id
+        )
+        assert detection_annotation["processing_stage"] == "annotated"
+        contributor_ids = [c["id"] for c in detection_annotation["contributors"]]
+        assert contributor_ids == [test_user.id]
+
+
+@pytest.mark.asyncio
 async def test_placeholder_detection_annotations_have_no_contributors(
     authenticated_client: AsyncClient, sequence_session
 ):

--- a/annotation_api/src/tests/endpoints/test_sequence_annotations.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_annotations.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, UTC
+import io
 import json
 
 import pytest
@@ -1626,6 +1627,172 @@ async def test_false_positive_sequence_auto_annotated_detection_annotations(
     assert detection_annotation["processing_stage"] == "annotated"
     # Should have empty annotation (no bounding boxes needed for false positives)
     assert detection_annotation["annotation"] == {"annotation": []}
+
+
+async def _create_detection(
+    authenticated_client: AsyncClient, alert_api_id: str
+) -> int:
+    """Create a detection on sequence 1 and return its id."""
+    detection_payload = {
+        "sequence_id": "1",
+        "alert_api_id": alert_api_id,
+        "recorded_at": "2024-01-15T10:25:00",
+        "algo_predictions": json.dumps(
+            {
+                "predictions": [
+                    {
+                        "xyxyn": [0.1, 0.1, 0.3, 0.3],
+                        "confidence": 0.87,
+                        "class_name": "smoke",
+                    }
+                ]
+            }
+        ),
+    }
+    img = Image.new("RGB", (100, 100), color="blue")
+    img_bytes = io.BytesIO()
+    img.save(img_bytes, format="JPEG")
+    img_bytes.seek(0)
+    files = {"file": ("test.jpg", img_bytes, "image/jpeg")}
+    response = await authenticated_client.post(
+        "/detections", data=detection_payload, files=files
+    )
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+async def _get_detection_annotation(
+    authenticated_client: AsyncClient, detection_id: int
+) -> dict:
+    """Fetch the auto-created detection annotation for a detection."""
+    response = await authenticated_client.get("/annotations/detections/?sequence_id=1")
+    assert response.status_code == 200
+    for ann in response.json()["items"]:
+        if ann["detection_id"] == detection_id:
+            return ann
+    raise AssertionError("Detection annotation should be auto-created")
+
+
+@pytest.mark.asyncio
+async def test_fp_auto_annotated_detection_annotation_attributed_to_saving_user(
+    authenticated_client: AsyncClient, sequence_session, test_user
+):
+    """Auto-created ANNOTATED detection annotations (FP-only sequence) carry a
+    contribution attributed to the human whose save produced them."""
+    detection_id = await _create_detection(authenticated_client, "2101")
+
+    false_positive_payload = {
+        "sequence_id": 1,
+        "has_missed_smoke": False,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": False,
+                    "false_positive_types": ["antenna"],
+                    "bboxes": [
+                        {"detection_id": detection_id, "xyxyn": [0.1, 0.1, 0.2, 0.2]}
+                    ],
+                }
+            ]
+        },
+        "processing_stage": models.SequenceAnnotationProcessingStage.ANNOTATED.value,
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+    response = await authenticated_client.post(
+        "/annotations/sequences/", json=false_positive_payload
+    )
+    assert response.status_code == 201
+
+    detection_annotation = await _get_detection_annotation(
+        authenticated_client, detection_id
+    )
+    assert detection_annotation["processing_stage"] == "annotated"
+    contributor_ids = [c["id"] for c in detection_annotation["contributors"]]
+    assert contributor_ids == [test_user.id]
+
+
+@pytest.mark.asyncio
+async def test_fp_update_auto_annotated_detection_annotation_attributed_to_saving_user(
+    authenticated_client: AsyncClient, sequence_session, test_user
+):
+    """The PATCH path's auto-created ANNOTATED detection annotations are also
+    attributed to the saving human."""
+    detection_id = await _create_detection(authenticated_client, "2102")
+
+    create_payload = {
+        "sequence_id": 1,
+        "has_missed_smoke": False,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": False,
+                    "false_positive_types": ["antenna"],
+                    "bboxes": [
+                        {"detection_id": detection_id, "xyxyn": [0.1, 0.1, 0.2, 0.2]}
+                    ],
+                }
+            ]
+        },
+        "processing_stage": models.SequenceAnnotationProcessingStage.READY_TO_ANNOTATE.value,
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+    response = await authenticated_client.post(
+        "/annotations/sequences/", json=create_payload
+    )
+    assert response.status_code == 201
+    annotation_id = response.json()["id"]
+
+    response = await authenticated_client.patch(
+        f"/annotations/sequences/{annotation_id}",
+        json={
+            "processing_stage": models.SequenceAnnotationProcessingStage.ANNOTATED.value
+        },
+    )
+    assert response.status_code == 200
+
+    detection_annotation = await _get_detection_annotation(
+        authenticated_client, detection_id
+    )
+    assert detection_annotation["processing_stage"] == "annotated"
+    contributor_ids = [c["id"] for c in detection_annotation["contributors"]]
+    assert contributor_ids == [test_user.id]
+
+
+@pytest.mark.asyncio
+async def test_placeholder_detection_annotations_have_no_contributors(
+    authenticated_client: AsyncClient, sequence_session
+):
+    """Auto-created placeholder detection annotations (VISUAL_CHECK / BBOX_ANNOTATION)
+    carry no one's judgment yet, so they get no contribution row."""
+    detection_id = await _create_detection(authenticated_client, "2103")
+
+    true_positive_payload = {
+        "sequence_id": 1,
+        "has_missed_smoke": False,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": True,
+                    "false_positive_types": [],
+                    "bboxes": [
+                        {"detection_id": detection_id, "xyxyn": [0.1, 0.1, 0.2, 0.2]}
+                    ],
+                }
+            ]
+        },
+        "processing_stage": models.SequenceAnnotationProcessingStage.ANNOTATED.value,
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+    response = await authenticated_client.post(
+        "/annotations/sequences/", json=true_positive_payload
+    )
+    assert response.status_code == 201
+
+    detection_annotation = await _get_detection_annotation(
+        authenticated_client, detection_id
+    )
+    assert detection_annotation["processing_stage"] == "visual_check"
+    assert detection_annotation["contributors"] == []
 
 
 @pytest.mark.asyncio

--- a/docs/specs/2026-07-27-worker-user-design.md
+++ b/docs/specs/2026-07-27-worker-user-design.md
@@ -108,6 +108,28 @@ annotations; human contribution counts include group-accelerated
 throughput (fan-out, bulk). Historical annotations written before this
 change are not backfilled.
 
+The same identity-less pattern existed on the detection side (#195):
+`auto_create_detection_annotations` bulk-inserts `DetectionAnnotation`
+rows when a human saves a sequence annotation at ANNOTATED, with no
+attribution. It now records contributions via
+`DetectionAnnotationCRUD.record_contribution`, with these semantics:
+
+- **Rows written directly at ANNOTATED** (FP-only sequences, where the
+  empty annotation *is* the final content) → attributed to the **saving
+  human**: the detection labels are derived from their sequence-level
+  judgment; the machine only materializes it. Same rationale as the
+  fan-out case above.
+- **Placeholder rows** (VISUAL_CHECK / BBOX_ANNOTATION) → **no
+  contribution**: they are empty scaffolding carrying nobody's judgment
+  yet. The annotator who later completes them is credited by the
+  existing detection-annotation update path.
+- The group-assignment sweep writes no detection annotations, so no
+  worker-user attribution is needed on the detection side. If a
+  detection-annotation path is ever added to the sweep, it must record
+  contributions for the worker user explicitly.
+
+As on the sequence side, historical rows are not backfilled.
+
 ### 5. Testing
 
 - Lifespan seeding: after app startup, the worker user exists with


### PR DESCRIPTION
Closes #195. Same pattern #192 closed on the sequence side, applied to detection annotations.

## Summary

`auto_create_detection_annotations` bulk-inserted `DetectionAnnotation` rows with no user attribution at all — including rows written directly at `ANNOTATED` for FP-only sequences — and `DetectionAnnotationCRUD._record_contribution` was private and dead: an identity-less write path.

- `record_contribution` is now public on the detection CRUD (mirroring `SequenceAnnotationCRUD`), and `auto_create_detection_annotations` takes the acting `user_id` from both endpoints that trigger it (sequence-annotation create and update).
- **Rows written directly at `ANNOTATED`** (FP-only sequences, where the empty annotation *is* the final content) now carry a contribution attributed to the **saving human** — the detection labels are derived from their sequence-level judgment; the machine only materializes it. Same rationale as #192's fan-out case.
- **Placeholder rows** (`VISUAL_CHECK` / `BBOX_ANNOTATION`) intentionally stay unattributed: they are empty scaffolding carrying nobody's judgment yet; the annotator who completes them is credited by the existing detection-annotation update path.
- The group-assignment sweep writes no detection annotations, so no worker-user attribution is needed on this side; the spec notes that any future detection path in the sweep must record contributions for the worker user explicitly.

Semantics documented in `docs/specs/2026-07-27-worker-user-design.md` (section 4), next to the sequence-side decisions from #192. Historical rows are not backfilled.

## Verification

- TDD: the two new attribution tests (create path and PATCH path) failed with empty contributor lists before the fix, pass after; a third test pins the placeholder-rows-stay-unattributed semantics.
- Full backend suite on this tree: **421 passed, 0 failed** (isolated compose stack).
- Adversarial review pass (second commit): `record_contribution` previously committed per call inside the auto-create loop, splitting one logical save into N+1 commits — a mid-loop failure could persist ANNOTATED rows whose contributions were never written, with no backfill path. The loop now stages contributions with `commit=False` and the endpoint's existing trailing commit lands annotations + contributions atomically. A fourth test pins per-detection attribution across a multi-detection sequence.
