### PR TITLE
chore(makefile): expose IMAGE_TRANSFER on import-alert-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,19 @@ Then run:
 
 ```bash
 cd annotation_api
+
+# Import into the remote (production) annotation API
 make import-alert-api DATE_FROM=2025-03-04 DATE_END=2025-03-04
+
+# Import into a local dev stack (see IMAGE_TRANSFER note below)
+make import-alert-api DATE_FROM=2025-03-04 DATE_END=2025-03-04 \
+  REMOTE_API=http://localhost:5050 IMAGE_TRANSFER=url
 ```
 
 - `DATE_END` defaults to `DATE_FROM` if omitted.
 - `MAX_SEQUENCES` is an optional cap on the number of sequences imported; default is no cap.
 - `REMOTE_API` defaults to `https://annotationapi.pyronear.org`; override to target staging/local.
+- `IMAGE_TRANSFER=url` routes detection images through the `/from-url` endpoint instead of a server-side S3 bucket copy. This is required when the target annotation API can't reach the alert API's S3 bucket — notably local dev with LocalStack, where the default bucket-copy mode fails every detection with `Source object not found`. Leave it unset for the production API (the script picks the right mode per source).
 - To use an alert-id filter, call the underlying script directly with `--sequence-list alerts_id_list.txt`.
 - Use `LOGLEVEL=debug` if you need more detail during imports.
 - Each alert sequence is object-split: one annotation sequence per detected smoke object (siblings get synthetic `alert_api_id`s).

--- a/annotation_api/Makefile
+++ b/annotation_api/Makefile
@@ -193,8 +193,12 @@ update-stage-local:
 # target annotation API, object-splitting each alert sequence into one
 # annotation sequence per smoke object (admin-only).
 # Requires ALERT_API_LOGIN/PASSWORD, ALERT_API_ADMIN_LOGIN/PASSWORD, MAIN_ANNOTATION_LOGIN/PASSWORD.
-# Usage: make import-alert-api DATE_FROM=2025-03-04 [DATE_END=2025-03-04] [MAX_SEQUENCES=20]
+# Usage: make import-alert-api DATE_FROM=2025-03-04 [DATE_END=2025-03-04] [MAX_SEQUENCES=20] [IMAGE_TRANSFER=url]
+# Set IMAGE_TRANSFER=url when the target annotation API can't reach the alert
+# API's S3 bucket (e.g. local dev with LocalStack); unset keeps the script's
+# per-source default (bucket-copy for the French alert API, url for CENIA).
 DATE_END ?= $(DATE_FROM)
+IMAGE_TRANSFER ?=
 import-alert-api: MAX_SEQUENCES = 0
 import-alert-api:
 	@if [ -z "$(DATE_FROM)" ]; then \
@@ -205,6 +209,7 @@ import-alert-api:
 		--annotation-api-url $(REMOTE_API) \
 		--max-sequences $(MAX_SEQUENCES) \
 		--max-workers $(MAX_WORKERS) \
+		$(if $(IMAGE_TRANSFER),--image-transfer $(IMAGE_TRANSFER)) \
 		--loglevel $(LOGLEVEL)
 
 .PHONY: help lint fix docker-build start stop clean test test-specific \


### PR DESCRIPTION
Closes #199.

`make import-alert-api` gave no way to pass `--image-transfer`, so importing into a local stack always failed: the default `bucket-copy` mode asks the annotation API to server-side copy images from the alert API's S3 bucket, which LocalStack can't reach — every detection 422s with `Source object not found` and all sequences roll back.

This adds an optional `IMAGE_TRANSFER` variable, forwarded as `--image-transfer` only when set, so the script's per-source default (bucket-copy for the French alert API, url for CENIA) is preserved when unset.

Usage:

```bash
make import-alert-api DATE_FROM=2026-07-15 DATE_END=2026-07-24 REMOTE_API=http://localhost:5050 IMAGE_TRANSFER=url
```

Verified with `make -n`: the flag appears when `IMAGE_TRANSFER=url` is set and is absent when unset.