### PR TITLE
fix(frontend): make missed-smoke question explicit

### DIFF
--- a/frontend/src/components/sequence/SequencePlayer.tsx
+++ b/frontend/src/components/sequence/SequencePlayer.tsx
@@ -420,7 +420,7 @@ export default function SequencePlayer({
 
               {/* Center - Missed Smoke Review */}
               <div className="flex items-center space-x-4 bg-black/40 px-4 py-2 rounded-lg border border-white/20">
-                <span className="text-sm font-medium text-white">Missed smoke?</span>
+                <span className="text-sm font-medium text-white">Did the model miss any smoke?</span>
                 <label className="flex items-center cursor-pointer hover:bg-white/10 px-2 py-1 rounded transition-colors">
                   <input
                     type="radio"

--- a/frontend/src/components/sequence/SequencePlayer.tsx
+++ b/frontend/src/components/sequence/SequencePlayer.tsx
@@ -420,7 +420,9 @@ export default function SequencePlayer({
 
               {/* Center - Missed Smoke Review */}
               <div className="flex items-center space-x-4 bg-black/40 px-4 py-2 rounded-lg border border-white/20">
-                <span className="text-sm font-medium text-white">Did the model miss any smoke?</span>
+                <span className="text-sm font-medium text-white">
+                  Did the model miss any smoke?
+                </span>
                 <label className="flex items-center cursor-pointer hover:bg-white/10 px-2 py-1 rounded transition-colors">
                   <input
                     type="radio"


### PR DESCRIPTION
## Summary

Renames the sequence-player overlay label "Missed smoke?" to "Did the model miss any smoke?" so new annotators understand what the Yes/No toggle asks, per the discussion in #106.

This is the only place the terse label appeared; the standalone review panel already uses an explicit question ("Does this sequence contain any missed smoke detections?").

Closes #106

## Test plan

- `npm run type-check` passes
- `npm test` — 641 tests pass
- Lint: only 2 pre-existing `no-console` warnings in an unrelated file (`DetectionSequenceAnnotatePage.tsx`)