### PR TITLE
chore: slim down annotation_api Makefile to essential commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cp .env.example .env
 # then edit .env and set MAIN_ANNOTATION_LOGIN / MAIN_ANNOTATION_PASSWORD
 ```
 
-All make targets accept variable overrides inline, e.g. `make export-dataset LIMIT=500`. Common variables: `REMOTE_API`, `LOCAL_API`, `MAX_SEQUENCES`, `LOGLEVEL`. See `make help` for the full list.
+All make targets accept variable overrides inline, e.g. `make export-dataset LIMIT=500`. Common variables: `REMOTE_API`, `MAX_SEQUENCES`, `LOGLEVEL`. See `make help` for the full list.
 
 ### 1. Annotations
 
@@ -62,18 +62,6 @@ Annotations stay on the API you annotated against; the file-based local→remote
 
 #### B. Other commands
 
-**Reset stages on the remote API** (e.g., move `in_review` back to `seq_annotation_done` to retry a workflow):
-
-```bash
-make update-stage-remote FROM_STAGE=in_review TO_STAGE=seq_annotation_done MAX_SEQUENCES=0
-```
-
-**Update stages on your local API** (e.g., move `seq_annotation_done` to `needs_manual`):
-
-```bash
-make update-stage-local FROM_STAGE=seq_annotation_done TO_STAGE=needs_manual MAX_SEQUENCES=0
-```
-
 **Export images + YOLO labels from the remote API** (use smaller pages and a longer timeout for large datasets):
 
 ```bash
@@ -81,22 +69,6 @@ make export-dataset OUTPUT_DIR=outputs/datasets LIMIT=1000 TIMEOUT=120
 ```
 - Filter by category: `make export-dataset CATEGORY=fp` (also `wildfire`, `other_smoke`). Omit to export all.
 - Object-split sequences are merged on export: sequences from the same camera less than 2h apart (`--merge-gap-hours`) share one view-group folder, frames are exported once with the union of all objects' boxes, and mixed groups land in the highest-priority category (`wildfire` > `other_smoke` > `fp`).
-
-**Import a single sequence from an exported YOLO folder** (images + labels) into an API:
-
-```bash
-make import-yolo-sequence \
-  SEQUENCE_DIR=outputs/datasets/dataset_exported_20260114_211415/antenna/pyronear-sdis-77-croix-augas-01-285-2025-08-02T16-38-42 \
-  ALERT_API_ID=123456 \
-  API_BASE=http://localhost:5050 \
-  SEQUENCE_STAGE=ready_to_annotate
-```
-
-- The script reads `recorded_at` from image filenames and sets sequence `recorded_at`/`last_seen_at`.
-- It tries to infer org/camera IDs from existing sequences by slug; if it cannot, call the underlying script with `--organisation-id/--camera-id/--camera-name/--lat/--lon`.
-- If `ALERT_API_ID` is omitted, it generates one from the folder name (use a stable ID to avoid duplicates).
-- Default stage is `ready_to_annotate`. Use `SEQUENCE_STAGE=annotated` if you want detection annotations created immediately.
-- Smoke classes create detection annotations (only when stage is `annotated`); false positive classes are stored at sequence level.
 
 ## Admin Workflow — Populate the main API from the alert API
 

--- a/annotation_api/Makefile
+++ b/annotation_api/Makefile
@@ -29,7 +29,6 @@ help:
 
 # ---------- Data workflow defaults (override via env or 'make VAR=value target') ----------
 REMOTE_API       ?= https://annotationapi.pyronear.org
-MAX_SEQUENCES    ?= 10
 LOGLEVEL         ?= info
 MAX_WORKERS      ?= 4
 OUTPUT_DIR       ?= outputs/datasets

--- a/annotation_api/Makefile
+++ b/annotation_api/Makefile
@@ -22,10 +22,6 @@ help:
 	@echo ""
 	@echo "Other data commands:"
 	@echo "  export-dataset       - Export images + YOLO labels from remote API"
-	@echo "  import-yolo-sequence - Import one YOLO folder into an API (needs SEQUENCE_DIR=...)"
-	@echo "  import-local-yolo    - Batch-import local YOLO sequences + sequences.csv (needs ROOT_DIR=...)"
-	@echo "  update-stage-remote  - Move annotations between stages on the remote API"
-	@echo "  update-stage-local   - Move annotations between stages on the local API"
 	@echo "  import-alert-api     - (Admin) Import from alert API into annotation API"
 	@echo ""
 	@echo "Override variables inline, e.g.:"
@@ -33,12 +29,9 @@ help:
 
 # ---------- Data workflow defaults (override via env or 'make VAR=value target') ----------
 REMOTE_API       ?= https://annotationapi.pyronear.org
-LOCAL_API        ?= http://localhost:5050
 MAX_SEQUENCES    ?= 10
 LOGLEVEL         ?= info
 MAX_WORKERS      ?= 4
-FROM_STAGE       ?= in_review
-TO_STAGE         ?= seq_annotation_done
 OUTPUT_DIR       ?= outputs/datasets
 LIMIT            ?= 1000
 TIMEOUT          ?= 120
@@ -121,72 +114,6 @@ export-dataset:
 		--loglevel $(LOGLEVEL) \
 		$(if $(CATEGORY),--category $(CATEGORY),)
 
-# Import one YOLO sequence folder (images + labels) into an API.
-# Usage: make import-yolo-sequence SEQUENCE_DIR=path/to/seq ALERT_API_ID=123456 \
-#        [API_BASE=http://localhost:5050] [SEQUENCE_STAGE=ready_to_annotate]
-API_BASE       ?= $(LOCAL_API)
-SEQUENCE_STAGE ?= ready_to_annotate
-SOURCE_API     ?= pyronear_french
-import-yolo-sequence:
-	@if [ -z "$(SEQUENCE_DIR)" ]; then \
-		echo "ERROR: set SEQUENCE_DIR=path/to/sequence"; exit 1; \
-	fi
-	uv run python -m scripts.data_transfer.ingestion.alert_api.import_yolo_sequence \
-		--sequence-dir $(SEQUENCE_DIR) \
-		--api-base $(API_BASE) \
-		$(if $(ALERT_API_ID),--alert-api-id $(ALERT_API_ID),) \
-		--source-api $(SOURCE_API) \
-		--sequence-stage $(SEQUENCE_STAGE) \
-		--loglevel $(LOGLEVEL)
-
-# Batch-import a directory of local YOLO sequence folders paired with a sequences.csv.
-# Usage: make import-local-yolo ROOT_DIR=/path/to/sdis-77-new_model \
-#        [SEQUENCES_SUBDIR=sdis-77] [LABELS_DIR=labels_predictions] \
-#        [API_BASE=http://localhost:5050] [MAX_WORKERS=4] [LIMIT_FOLDERS=0] [SKIP_FOLDERS=0]
-SEQUENCES_SUBDIR ?= sdis-77
-LABELS_DIR       ?= labels_predictions
-LIMIT_FOLDERS    ?= 0
-SKIP_FOLDERS     ?= 0
-import-local-yolo:
-	@if [ -z "$(ROOT_DIR)" ]; then \
-		echo "ERROR: set ROOT_DIR=path/to/dataset/root"; exit 1; \
-	fi
-	uv run python -m scripts.data_transfer.ingestion.alert_api.batch_import_local_yolo \
-		--root-dir $(ROOT_DIR) \
-		--sequences-subdir $(SEQUENCES_SUBDIR) \
-		--labels-dir-name $(LABELS_DIR) \
-		--api-base $(API_BASE) \
-		--source-api $(SOURCE_API) \
-		--sequence-stage $(SEQUENCE_STAGE) \
-		--max-workers $(MAX_WORKERS) \
-		--limit $(LIMIT_FOLDERS) \
-		--skip $(SKIP_FOLDERS) \
-		--loglevel $(LOGLEVEL)
-
-# Move annotations between stages on the remote API.
-# Usage: make update-stage-remote [FROM_STAGE=in_review] [TO_STAGE=seq_annotation_done] [MAX_SEQUENCES=0]
-update-stage-remote:
-	uv run python -m scripts.data_transfer.ingestion.alert_api.update_annotation_stage \
-		--api-url $(REMOTE_API) \
-		--from-stage $(FROM_STAGE) \
-		--to-stage $(TO_STAGE) \
-		--max-sequences $(MAX_SEQUENCES) \
-		--loglevel $(LOGLEVEL)
-
-# Move annotations between stages on the local API (uses admin/admin12345 by default).
-# Usage: make update-stage-local [FROM_STAGE=seq_annotation_done] [TO_STAGE=needs_manual]
-LOCAL_USERNAME ?= admin
-LOCAL_PASSWORD ?= admin12345
-update-stage-local:
-	uv run python -m scripts.data_transfer.ingestion.alert_api.update_annotation_stage \
-		--api-url $(LOCAL_API) \
-		--username $(LOCAL_USERNAME) \
-		--password $(LOCAL_PASSWORD) \
-		--from-stage $(FROM_STAGE) \
-		--to-stage $(TO_STAGE) \
-		--max-sequences $(MAX_SEQUENCES) \
-		--loglevel $(LOGLEVEL)
-
 # --- Admin: alert-api ingestion ---
 
 # Import sequences + detections from the alert API (a.k.a. "platform") into the
@@ -209,6 +136,4 @@ import-alert-api:
 
 .PHONY: help lint fix docker-build start stop clean test test-specific \
 	migrate migrate-up \
-	export-dataset import-yolo-sequence import-local-yolo \
-	update-stage-remote update-stage-local \
-	import-alert-api
+	export-dataset import-alert-api


### PR DESCRIPTION
Closes #190

## What

Slims `annotation_api/Makefile` down to the essential commands. The underlying scripts remain runnable via `uv run python -m scripts.data_transfer...` — this only changes which commands the Makefile advertises.

### Removed

- `import-yolo-sequence`, `import-local-yolo` — one-off importers from past migrations (sdis-77 defaults baked in)
- `update-stage-remote`, `update-stage-local` — admin escape hatches for moving annotation stages
- Variable defaults orphaned by the above: `FROM_STAGE`, `TO_STAGE`, `SEQUENCES_SUBDIR`, `LABELS_DIR`, `LIMIT_FOLDERS`, `SKIP_FOLDERS`, `LOCAL_USERNAME`, `LOCAL_PASSWORD`, `API_BASE`, `SEQUENCE_STAGE`, `SOURCE_API` — plus `LOCAL_API` (not in the issue list, but its only consumers were `update-stage-local` and the `API_BASE` default)

### Notes vs. the issue

- `push-annotations` and the TP/FP FiftyOne targets were already removed from main by the pipeline retirement (#179), so they need no changes here.
- `MAX_SEQUENCES` stays: `import-alert-api` still references it.

### Also

- Updated `help` and `.PHONY` accordingly
- Root `README.md`: dropped the `update-stage-*` / `import-yolo-sequence` doc blocks (kept `export-dataset`) and removed `LOCAL_API` from the common-variables line

## Verification

- `make help` lists exactly the keep set
- `make -n export-dataset`, `make -n import-alert-api DATE_FROM=...`, `make -n lint` all parse cleanly
- Grep over `Makefile` + `README.md` shows no stale references to removed targets/variables