### PR TITLE
feat(frontend): move sequence groups link under Sequences > Groups

### DIFF
--- a/docs/specs/2026-07-28-nav-groups-under-sequences-design.md
+++ b/docs/specs/2026-07-28-nav-groups-under-sequences-design.md
@@ -1,0 +1,40 @@
+# Move Sequence Groups Link Under Sequences — Design
+
+**Date:** 2026-07-28
+**Status:** Approved
+
+## Problem
+
+"Sequence groups" sits as a top-level sidebar item, while the rest of the
+sequence workflow lives under the collapsible **Sequences** section. The link
+belongs with its siblings: `Sequences > Groups`.
+
+(Reported alongside a missing badge pill; that turned out to be a stale
+`annotation_api` Docker image missing the `/sequence_groups/stats` route — an
+environment fix, no code change.)
+
+## Design
+
+All changes in `frontend/src/components/layout/AppLayout.tsx`:
+
+1. Remove the top-level "Sequence groups" navigation item.
+2. Add **Groups** as the *first* child of the Sequences section:
+   `Sequences > Groups, Annotate, Review`, with `href: '/sequence-groups'`
+   and `badgeCount: groupCount` (sub-item badge rendering already exists).
+3. Add optional `badgeTitle` to `NavigationSubItem` and pass it to
+   `NotificationBadge`, preserving the "N groups need validation" tooltip.
+4. Remove the now-unused `Boxes` icon import.
+
+## Behavior notes
+
+- Active-state highlighting is unchanged: `/sequence-groups/...` paths do not
+  collide with the `/sequences/` special-casing in `isPathActive`.
+- The Sequences section defaults to expanded, so the pill is visible on load.
+  A manually collapsed section hides the count; no aggregated section-header
+  badge (YAGNI).
+
+## Verification
+
+- Component test: sidebar renders Groups under Sequences with the badge count.
+- `npm run type-check`, `npm run lint`, `npm test`.
+- Visual check on the dev server (pill shows the unvalidated count).

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -11,7 +11,6 @@ import {
   LogOut,
   User,
   Users,
-  Boxes,
   LucideIcon,
 } from 'lucide-react';
 import { clsx } from 'clsx';
@@ -29,14 +28,13 @@ interface NavigationItem {
   href?: string;
   icon: LucideIcon;
   children?: NavigationSubItem[];
-  badgeCount?: number;
-  badgeTitle?: string;
 }
 
 interface NavigationSubItem {
   name: string;
   href: string;
   badgeCount?: number;
+  badgeTitle?: string;
 }
 
 // Navigation structure is now dynamically generated in SidebarContent to include badge counts
@@ -114,16 +112,15 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
   const navigationWithBadges: NavigationItem[] = [
     { name: 'Dashboard', href: '/', icon: BarChart3 },
     {
-      name: 'Sequence groups',
-      href: '/sequence-groups',
-      icon: Boxes,
-      badgeCount: groupCount,
-      badgeTitle: `${groupCount} groups need validation`,
-    },
-    {
       name: 'Sequences',
       icon: Layers,
       children: [
+        {
+          name: 'Groups',
+          href: '/sequence-groups',
+          badgeCount: groupCount,
+          badgeTitle: `${groupCount} groups need validation`,
+        },
         { name: 'Annotate', href: '/sequences/annotate', badgeCount: sequenceCount },
         { name: 'Review', href: '/sequences/review' },
       ],
@@ -229,9 +226,6 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
                     aria-hidden="true"
                   />
                   <span className="flex-1">{item.name}</span>
-                  {item.badgeCount !== undefined && (
-                    <NotificationBadge count={item.badgeCount} title={item.badgeTitle} />
-                  )}
                 </Link>
               );
             }
@@ -282,7 +276,10 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
                         >
                           <span>{subItem.name}</span>
                           {subItem.badgeCount !== undefined && (
-                            <NotificationBadge count={subItem.badgeCount} />
+                            <NotificationBadge
+                              count={subItem.badgeCount}
+                              title={subItem.badgeTitle}
+                            />
                           )}
                         </Link>
                       );

--- a/frontend/tests/components/layout/AppLayout.test.tsx
+++ b/frontend/tests/components/layout/AppLayout.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * Sidebar navigation structure tests for AppLayout.
+ * Focuses on the Sequences section containing the Groups link with its badge.
+ */
+
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AppLayout from '@/components/layout/AppLayout';
+
+vi.mock('@/hooks/useAnnotationCounts', () => ({
+  useAnnotationCounts: () => ({
+    sequenceCount: 3,
+    detectionCount: 2,
+    groupCount: 8,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('@/store/useAuthStore', () => ({
+  useAuthStore: () => ({
+    user: { username: 'tester' },
+    logout: vi.fn(),
+    isSuperuser: () => false,
+  }),
+}));
+
+describe('AppLayout sidebar navigation', () => {
+  const renderLayout = () =>
+    render(
+      <MemoryRouter>
+        <AppLayout>
+          <div>page content</div>
+        </AppLayout>
+      </MemoryRouter>
+    );
+
+  it('renders Groups as a sub-item of the Sequences section with its badge count', () => {
+    renderLayout();
+
+    const groupsLink = screen.getByRole('link', { name: /groups/i });
+    expect(groupsLink).toHaveAttribute('href', '/sequence-groups');
+
+    const badge = within(groupsLink).getByText('8');
+    expect(badge).toHaveAttribute('title', '8 groups need validation');
+  });
+
+  it('places Groups first among the Sequences sub-items, after the section header', () => {
+    renderLayout();
+
+    const sequencesHeader = screen.getByRole('button', { name: /sequences/i });
+    const groupsLink = screen.getByRole('link', { name: /groups/i });
+    const annotateLinks = screen.getAllByRole('link', { name: /annotate/i });
+    const sequencesAnnotateLink = annotateLinks.find(
+      link => link.getAttribute('href') === '/sequences/annotate'
+    );
+
+    expect(sequencesAnnotateLink).toBeDefined();
+    expect(
+      sequencesHeader.compareDocumentPosition(groupsLink) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      groupsLink.compareDocumentPosition(sequencesAnnotateLink!) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it('does not render a top-level Sequence groups item', () => {
+    renderLayout();
+
+    expect(screen.queryByRole('link', { name: /sequence groups/i })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Moves the top-level **Sequence groups** sidebar item into the **Sequences** section as its first sub-item: `Sequences > Groups, Annotate, Review`.
- Keeps the unvalidated-count pill and its "N groups need validation" tooltip by adding an optional `badgeTitle` to `NavigationSubItem`.
- Removes the now-unused top-level badge fields and `Boxes` icon import.
- Adds sidebar structure tests (`frontend/tests/components/layout/AppLayout.test.tsx`).

Design doc: `docs/specs/2026-07-28-nav-groups-under-sequences-design.md`

Note: the "missing pill" from the original report was a stale `annotation_api` Docker image lacking the `/sequence_groups/stats` route — fixed by rebuilding the container, no code change needed.

## Test plan

- `npm test` — 644 passed (3 new AppLayout tests)
- `npm run type-check`, `npm run format:check` — clean
- `npm run lint` — only 2 pre-existing `no-console` warnings in `DetectionSequenceAnnotatePage.tsx` (untouched)