### PR TITLE
feat: redesign sequence-groups list page (camera names, sorting, counts, clickable rows)

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
@@ -4,12 +4,13 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 from datetime import UTC, datetime
+from enum import Enum
 from typing import Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
 from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.sqlalchemy import apaginate
-from sqlalchemy import desc, func, select
+from sqlalchemy import asc, desc, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.dependencies import get_current_user, get_sequence_group_crud
@@ -34,6 +35,22 @@ from app.schemas.sequence_group import (
 router = APIRouter()
 
 
+class SequenceGroupOrderByField(str, Enum):
+    """Valid fields for ordering sequence groups."""
+
+    member_count = "member_count"
+    camera_name = "camera_name"
+    azimuth = "azimuth"
+    created_at = "created_at"
+
+
+class OrderDirection(str, Enum):
+    """Valid directions for ordering."""
+
+    asc = "asc"
+    desc = "desc"
+
+
 @router.get(
     "/",
     response_model=Page[SequenceGroupListItem],
@@ -46,6 +63,12 @@ async def list_sequence_groups(
             "Filter by label presence: true = only labeled groups, "
             "false = only unlabeled, omit for both."
         ),
+    ),
+    order_by: SequenceGroupOrderByField = Query(
+        SequenceGroupOrderByField.member_count, description="Order by field"
+    ),
+    order_direction: OrderDirection = Query(
+        OrderDirection.desc, description="Order direction"
     ),
     params: Params = Depends(),
     session: AsyncSession = Depends(get_session),
@@ -65,6 +88,14 @@ async def list_sequence_groups(
         .having(func.count(Sequence.id) >= 3)
         .subquery()
     )
+    order_columns = {
+        SequenceGroupOrderByField.member_count: member_count_subq.c.member_count,
+        SequenceGroupOrderByField.camera_name: member_count_subq.c.camera_name,
+        SequenceGroupOrderByField.azimuth: SequenceGroup.azimuth,
+        SequenceGroupOrderByField.created_at: SequenceGroup.created_at,
+    }
+    primary = order_columns[order_by]
+    primary = desc(primary) if order_direction == OrderDirection.desc else asc(primary)
     query = (
         select(
             SequenceGroup.id,
@@ -82,10 +113,10 @@ async def list_sequence_groups(
         )
         # Inner-join so small groups (no row in the subquery) drop out.
         .join(member_count_subq, member_count_subq.c.group_id == SequenceGroup.id)
-        # Biggest groups first, then newest within each size. `id` is a final
-        # deterministic tie-breaker so paginated offsets stay stable.
+        # Caller-chosen primary sort; created_at/id remain as deterministic
+        # tie-breakers so paginated offsets stay stable.
         .order_by(
-            desc(member_count_subq.c.member_count),
+            primary,
             desc(SequenceGroup.created_at),
             desc(SequenceGroup.id),
         )

--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
@@ -57,6 +57,8 @@ async def list_sequence_groups(
         select(
             Sequence.sequence_group_id.label("group_id"),
             func.count(Sequence.id).label("member_count"),
+            # All members share one camera; min() just picks that value.
+            func.min(Sequence.camera_name).label("camera_name"),
         )
         .where(Sequence.sequence_group_id.is_not(None))
         .group_by(Sequence.sequence_group_id)
@@ -76,6 +78,7 @@ async def list_sequence_groups(
             SequenceGroup.labeled_at,
             SequenceGroup.created_at,
             member_count_subq.c.member_count,
+            member_count_subq.c.camera_name,
         )
         # Inner-join so small groups (no row in the subquery) drop out.
         .join(member_count_subq, member_count_subq.c.group_id == SequenceGroup.id)

--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
@@ -161,13 +161,23 @@ async def get_sequence_group_stats(
             func.count(SequenceGroup.id)
             .filter(SequenceGroup.is_validated.is_(True))
             .label("validated"),
+            func.count(SequenceGroup.id)
+            .filter(
+                (SequenceGroup.smoke_type.is_not(None))
+                | (SequenceGroup.false_positive_type.is_not(None))
+            )
+            .label("labeled"),
         )
         .select_from(SequenceGroup)
         .join(member_count_subq, member_count_subq.c.group_id == SequenceGroup.id)
     )
-    total, validated = (await session.exec(query)).one()
+    total, validated, labeled = (await session.exec(query)).one()
     return SequenceGroupStats(
-        total=total, validated=validated, unvalidated=total - validated
+        total=total,
+        validated=validated,
+        unvalidated=total - validated,
+        labeled=labeled,
+        unlabeled=total - labeled,
     )
 
 

--- a/annotation_api/src/app/schemas/sequence_group.py
+++ b/annotation_api/src/app/schemas/sequence_group.py
@@ -95,11 +95,15 @@ class SequenceGroupListItem(BaseModel):
 
 class SequenceGroupStats(BaseModel):
     """Aggregate counts over groups with 3 or more members — the same
-    population the list endpoint returns, so UI counts match the list."""
+    population the list endpoint returns, so UI counts match the list.
+    A group is "labeled" when smoke_type or false_positive_type is set —
+    the same predicate as the list endpoint's `labeled` filter."""
 
     total: int
     validated: int
     unvalidated: int
+    labeled: int
+    unlabeled: int
 
 
 class SequenceGroupUpdate(BaseModel):

--- a/annotation_api/src/app/schemas/sequence_group.py
+++ b/annotation_api/src/app/schemas/sequence_group.py
@@ -81,6 +81,7 @@ class SequenceGroupListItem(BaseModel):
 
     id: int
     camera_id: int
+    camera_name: str
     azimuth: int
     representative_bbox: RepresentativeBbox
     smoke_type: Optional[SmokeType]

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -94,6 +94,7 @@ async def _seed_group_with_members(
     created_at: datetime,
     alert_api_id_start: int,
     camera_name: str = "cam",
+    azimuth: int = 0,
 ) -> int:
     """Insert a SequenceGroup with `n_members` member sequences (each with a
     distinct alert_api_id) and return its id."""
@@ -105,12 +106,13 @@ async def _seed_group_with_members(
                     (camera_id, azimuth, representative_bbox, is_validated,
                      created_at)
                 VALUES
-                    (1, 0, CAST(:bbox AS jsonb), false, :created_at)
+                    (1, :azimuth, CAST(:bbox AS jsonb), false, :created_at)
                 RETURNING id
                 """
             ).bindparams(
                 bbox='{"xyxyn":[0.1,0.1,0.4,0.4],"confidence":0.9}',
                 created_at=created_at,
+                azimuth=azimuth,
             )
         )
     ).scalar_one()
@@ -222,6 +224,47 @@ async def test_list_groups_includes_camera_name(
     assert resp.status_code == 200
     row = next(i for i in resp.json()["items"] if i["id"] == gid)
     assert row["camera_name"] == "Serre de Barre"
+
+
+@pytest.mark.asyncio
+async def test_list_groups_orderable_by_camera_azimuth_created(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """order_by/order_direction reorder the list; default stays member_count desc."""
+    alpha = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 1, 3, tzinfo=timezone.utc),
+        alert_api_id_start=500,
+        camera_name="Alpha",
+        azimuth=270,
+    )
+    zulu = await _seed_group_with_members(
+        async_session,
+        n_members=4,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        alert_api_id_start=600,
+        camera_name="Zulu",
+        azimuth=90,
+    )
+
+    async def ids(params: str) -> list[int]:
+        resp = await authenticated_client.get(f"/sequence_groups/{params}")
+        assert resp.status_code == 200
+        return [i["id"] for i in resp.json()["items"]]
+
+    # Default: biggest group first.
+    assert await ids("") == [zulu, alpha]
+    # Camera name ascending: Alpha before Zulu.
+    assert await ids("?order_by=camera_name&order_direction=asc") == [alpha, zulu]
+    # Azimuth ascending: 90 before 270.
+    assert await ids("?order_by=azimuth&order_direction=asc") == [zulu, alpha]
+    # Created ascending: Jan 1 before Jan 3.
+    assert await ids("?order_by=created_at&order_direction=asc") == [zulu, alpha]
+    # Invalid field is rejected.
+    resp = await authenticated_client.get("/sequence_groups/?order_by=bogus")
+    assert resp.status_code == 422
 
 
 def _annotation_payload(*, stage: str, smoke_type: str) -> dict:

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -93,6 +93,7 @@ async def _seed_group_with_members(
     n_members: int,
     created_at: datetime,
     alert_api_id_start: int,
+    camera_name: str = "cam",
 ) -> int:
     """Insert a SequenceGroup with `n_members` member sequences (each with a
     distinct alert_api_id) and return its id."""
@@ -121,7 +122,7 @@ async def _seed_group_with_members(
                 created_at=created_at,
                 recorded_at=created_at,
                 last_seen_at=created_at,
-                camera_name="cam",
+                camera_name=camera_name,
                 camera_id=1,
                 is_wildfire_alertapi="wildfire_smoke",
                 organisation_name="org",
@@ -201,6 +202,26 @@ async def test_list_groups_hides_small_groups_and_sorts_by_size(
     counts = {item["id"]: item["member_count"] for item in items}
     assert counts[big] == 4
     assert counts[medium] == 3
+
+
+@pytest.mark.asyncio
+async def test_list_groups_includes_camera_name(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """List items carry the camera name of their member sequences."""
+    gid = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        alert_api_id_start=400,
+        camera_name="Serre de Barre",
+    )
+
+    resp = await authenticated_client.get("/sequence_groups/")
+    assert resp.status_code == 200
+    row = next(i for i in resp.json()["items"] if i["id"] == gid)
+    assert row["camera_name"] == "Serre de Barre"
 
 
 def _annotation_payload(*, stage: str, smoke_type: str) -> dict:

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -95,6 +95,7 @@ async def _seed_group_with_members(
     alert_api_id_start: int,
     camera_name: str = "cam",
     azimuth: int = 0,
+    smoke_type: str | None = None,
 ) -> int:
     """Insert a SequenceGroup with `n_members` member sequences (each with a
     distinct alert_api_id) and return its id."""
@@ -104,15 +105,20 @@ async def _seed_group_with_members(
                 """
                 INSERT INTO sequence_groups
                     (camera_id, azimuth, representative_bbox, is_validated,
-                     created_at)
+                     created_at, smoke_type, labeled_at)
                 VALUES
-                    (1, :azimuth, CAST(:bbox AS jsonb), false, :created_at)
+                    (1, :azimuth, CAST(:bbox AS jsonb), false, :created_at,
+                     :smoke_type, :labeled_at)
                 RETURNING id
                 """
             ).bindparams(
                 bbox='{"xyxyn":[0.1,0.1,0.4,0.4],"confidence":0.9}',
                 created_at=created_at,
                 azimuth=azimuth,
+                smoke_type=smoke_type,
+                # ck_sequence_group_labeled_at_consistency: a labeled group
+                # must carry a labeled_at timestamp.
+                labeled_at=created_at if smoke_type else None,
             )
         )
     ).scalar_one()
@@ -265,6 +271,41 @@ async def test_list_groups_orderable_by_camera_azimuth_created(
     # Invalid field is rejected.
     resp = await authenticated_client.get("/sequence_groups/?order_by=bogus")
     assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_stats_include_labeled_and_unlabeled_counts(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """Stats expose labeled/unlabeled totals over the 3+-member population."""
+    await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        alert_api_id_start=700,
+        smoke_type="wildfire",
+    )
+    await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        alert_api_id_start=800,
+    )
+    # 2-member group: excluded from every stat.
+    await _seed_group_with_members(
+        async_session,
+        n_members=2,
+        created_at=datetime(2026, 1, 3, tzinfo=timezone.utc),
+        alert_api_id_start=900,
+    )
+
+    resp = await authenticated_client.get("/sequence_groups/stats")
+    assert resp.status_code == 200
+    stats = resp.json()
+    assert stats["total"] == 2
+    assert stats["labeled"] == 1
+    assert stats["unlabeled"] == 1
 
 
 def _annotation_payload(*, stage: str, smoke_type: str) -> dict:
@@ -708,7 +749,13 @@ async def test_bulk_annotate_requires_exactly_one_label(
 async def test_stats_empty(authenticated_client: AsyncClient):
     resp = await authenticated_client.get("/sequence_groups/stats")
     assert resp.status_code == 200
-    assert resp.json() == {"total": 0, "validated": 0, "unvalidated": 0}
+    assert resp.json() == {
+        "total": 0,
+        "validated": 0,
+        "unvalidated": 0,
+        "labeled": 0,
+        "unlabeled": 0,
+    }
 
 
 @pytest.mark.asyncio
@@ -744,4 +791,10 @@ async def test_stats_counts_only_groups_with_three_plus_members(
 
     resp = await authenticated_client.get("/sequence_groups/stats")
     assert resp.status_code == 200
-    assert resp.json() == {"total": 2, "validated": 1, "unvalidated": 1}
+    assert resp.json() == {
+        "total": 2,
+        "validated": 1,
+        "unvalidated": 1,
+        "labeled": 0,
+        "unlabeled": 2,
+    }

--- a/docs/specs/2026-07-28-sequence-groups-list-ui-design.md
+++ b/docs/specs/2026-07-28-sequence-groups-list-ui-design.md
@@ -1,0 +1,117 @@
+# Sequence Groups List — UI/UX Redesign
+
+**Date:** 2026-07-28
+**Status:** Approved
+**Scope:** `frontend` (SequenceGroupsListPage) + `annotation_api` (sequence-groups list & stats endpoints)
+
+## Problem
+
+The sequence-groups list page (`/sequence-groups`) is functional but rough:
+
+- The Camera column shows the numeric `camera_id` instead of the camera name.
+- Nothing on the page explains what a sequence group *is* or why an annotator
+  should care.
+- Only the "Group #" cell is clickable; the natural gesture — click the row to
+  review the group — does nothing.
+- Columns cannot be sorted.
+- The all/unlabeled/labeled filter buttons are plain and give no sense of how
+  much work is left.
+
+## Design
+
+Approved via mockup review (visual companion). A polished, text-only table —
+no thumbnails in the list; the per-group review page already shows imagery.
+
+### Backend changes (`annotation_api`)
+
+1. **`camera_name` in list items.** The list endpoint's member-count subquery
+   additionally selects `min(Sequence.camera_name)` per group (all members of a
+   group share one camera, so `min` is just "pick the one value").
+   `SequenceGroupListItem` gains a required `camera_name: str` field. No
+   migration — camera names are already denormalized on `Sequence`.
+
+2. **Server-side sorting.** New query params on `GET /api/v1/sequence-groups/`,
+   following the existing pattern in `sequences.py`:
+   - `order_by`: `member_count` (default) | `camera_name` | `azimuth` |
+     `created_at`
+   - `order_direction`: `desc` (default) | `asc`
+
+   Whatever the primary sort, `created_at DESC, id DESC` remain as trailing
+   tie-breakers so paginated offsets stay deterministic.
+
+3. **Filter counts.** `GET /api/v1/sequence-groups/stats` gains `labeled` and
+   `unlabeled` fields computed over the same 3-plus-member population as the
+   existing `total` / `validated` / `unvalidated` fields (a group is "labeled"
+   when `smoke_type` or `false_positive_type` is set — same predicate as the
+   list endpoint's `labeled` filter).
+
+4. **Tests.** Extend the sequence-groups endpoint tests: `camera_name` present
+   and correct; each `order_by`/`order_direction` combination orders rows;
+   stats include correct `labeled`/`unlabeled` counts.
+
+### Frontend changes (`frontend`)
+
+`SequenceGroupsListPage.tsx` is rebuilt to match the approved mockup:
+
+1. **Header + explainer.** Title "Sequence groups", subtitle "Label many
+   related sequences at once.", then an info box (blue, info icon):
+
+   > **What is a sequence group?** After each import, sequences from the same
+   > camera looking in the same direction at the same spot are grouped
+   > automatically — usually one recurring smoke plume or false-positive source
+   > (an antenna, a cloud bank…). Open a group, label one of its sequences, and
+   > once the group is validated the label propagates to every member. Only
+   > groups with 3+ sequences are shown.
+
+   Always visible (short enough not to need dismissal).
+
+2. **Segmented filter with counts.** A segmented control replacing the three
+   buttons, in workflow order with live counts from the stats endpoint:
+   **To label [n] · Labeled [n] · All [n]**. Default stays "To label" (maps to
+   `labeled=false`). Counts come from the extended stats endpoint via a
+   React Query hook; while stats load, badges are simply omitted.
+
+3. **Sortable columns.** Clickable headers for Camera, Azimuth, Sequences,
+   Created with an arrow indicator on the active sort. Clicking toggles
+   asc/desc (first click uses each column's natural direction: text asc,
+   numbers/dates desc) and resets to page 1. Sort state drives the new
+   `order_by`/`order_direction` params. Default: Sequences (member_count)
+   descending.
+
+4. **Table presentation.**
+   - Camera: bold camera name, muted `#id` suffix.
+   - Azimuth: `245°`.
+   - Sequences: member count in a blue pill.
+   - Label: orange pill `smoke · <type>`, gray pill `false positive · <type>`,
+     yellow pill `to label` when unlabeled.
+   - Reviewed: green `✓ validated` or muted `—`.
+   - Created: relative time ("2 h ago", "yesterday", falling back to a short
+     date), exact timestamp in `title` tooltip. Implemented as a small local
+     helper — `date-fns` is not a dependency and one function does not justify
+     adding it.
+   - Trailing chevron `›` column signalling clickability.
+
+5. **Row interaction.** The whole row navigates to
+   `/sequence-groups/{id}/annotate` (hover highlight + `cursor-pointer`). The
+   camera-name cell keeps a real `<Link>` to the same URL so middle-click,
+   copy-link, and keyboard navigation still work; its click handler stops
+   propagation to avoid double navigation.
+
+6. **Supporting changes.** `SequenceGroupListItem` type gains `camera_name`;
+   `SequenceGroupStats` gains `labeled`/`unlabeled`; `apiClient.getSequenceGroups`
+   passes `order_by`/`order_direction`. Loading, error, empty-state, and
+   pagination behaviour is unchanged in substance, restyled to match the
+   mockup; empty-state copy updated to the "to label" wording.
+
+## Out of scope
+
+- Thumbnails/imagery in the list rows (option B/C from the mockup review).
+- Sorting by label or reviewed state.
+- Any change to the group review (annotate) page.
+
+## Verification
+
+- Backend: `make lint`; endpoint tests for camera_name, ordering, stats (run
+  via the isolated-compose test setup).
+- Frontend: `npm run quality` (ESLint, type-check, tests).
+- Visual check of the page against the approved mockup in the local dev stack.

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -84,6 +84,7 @@ function MemberCard({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['sequenceGroup', groupId] });
       queryClient.invalidateQueries({ queryKey: ['sequenceGroupsList'] });
+      queryClient.invalidateQueries({ queryKey: ['sequenceGroupStats'] });
       queryClient.invalidateQueries({ queryKey: ['annotation-counts'] });
     },
   });
@@ -243,6 +244,7 @@ export default function SequenceGroupAnnotatePage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['sequenceGroup', groupId] });
       queryClient.invalidateQueries({ queryKey: ['sequenceGroupsList'] });
+      queryClient.invalidateQueries({ queryKey: ['sequenceGroupStats'] });
       queryClient.invalidateQueries({ queryKey: ['annotation-counts'] });
     },
   });

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -49,12 +49,17 @@ function SortableHeader({
   const Arrow = orderDirection === 'asc' ? ArrowUp : ArrowDown;
   return (
     <th
-      onClick={() => onSort(column)}
-      className="px-3 py-2.5 text-left cursor-pointer select-none whitespace-nowrap hover:text-gray-900"
+      className="px-3 py-2.5 text-left whitespace-nowrap"
       aria-sort={active ? (orderDirection === 'asc' ? 'ascending' : 'descending') : undefined}
     >
-      {label}
-      {active && <Arrow className="inline w-3 h-3 ml-1 text-blue-600" />}
+      <button
+        type="button"
+        onClick={() => onSort(column)}
+        className="uppercase tracking-wide select-none hover:text-gray-900"
+      >
+        {label}
+        {active && <Arrow className="inline w-3 h-3 ml-1 text-blue-600" />}
+      </button>
     </th>
   );
 }
@@ -222,7 +227,12 @@ export default function SequenceGroupsListPage() {
               items.map(g => (
                 <tr
                   key={g.id}
-                  onClick={() => navigate(`/sequence-groups/${g.id}/annotate`)}
+                  onClick={e => {
+                    // Leave modified clicks and text selection to the browser;
+                    // the camera-name <Link> handles open-in-new-tab.
+                    if (e.ctrlKey || e.metaKey || window.getSelection()?.toString()) return;
+                    navigate(`/sequence-groups/${g.id}/annotate`);
+                  }}
                   className="border-t border-gray-100 hover:bg-blue-50 cursor-pointer"
                 >
                   <td className="px-3 py-2.5">

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -120,13 +120,13 @@ export default function SequenceGroupsListPage() {
   const totalPages = data?.pages ?? 1;
 
   return (
-    <div className="max-w-6xl mx-auto px-4 py-6">
-      <header className="mb-4">
-        <h1 className="text-2xl font-semibold text-gray-900">Sequence groups</h1>
-        <p className="text-sm text-gray-600 mt-1">Label many related sequences at once.</p>
-      </header>
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Sequence groups</h1>
+        <p className="text-gray-600">Label many related sequences at once.</p>
+      </div>
 
-      <div className="mb-4 flex gap-2.5 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+      <div className="flex gap-2.5 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
         <Info className="w-4 h-4 flex-none mt-0.5 text-blue-600" />
         <p>
           <span className="font-semibold">What is a sequence group?</span> After each import,
@@ -137,7 +137,7 @@ export default function SequenceGroupsListPage() {
         </p>
       </div>
 
-      <div className="mb-3">
+      <div>
         <div className="inline-flex rounded-lg bg-gray-200 p-0.5 gap-0.5 text-sm">
           {FILTERS.map(f => {
             const active = filter === f.value;
@@ -287,7 +287,7 @@ export default function SequenceGroupsListPage() {
       </div>
 
       {totalPages > 1 && (
-        <div className="mt-4 flex items-center justify-between text-sm">
+        <div className="flex items-center justify-between text-sm">
           <button
             onClick={() => setPage(p => Math.max(1, p - 1))}
             disabled={page === 1}

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -243,7 +243,6 @@ export default function SequenceGroupsListPage() {
                     >
                       {g.camera_name}
                     </Link>
-                    <span className="ml-1.5 text-xs text-gray-400">#{g.id}</span>
                   </td>
                   <td className="px-3 py-2.5">{g.azimuth}°</td>
                   <td className="px-3 py-2.5">

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -118,7 +118,6 @@ export default function SequenceGroupsListPage() {
 
   const items = data?.items ?? [];
   const totalPages = data?.pages ?? 1;
-  const total = data?.total ?? 0;
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-6">
@@ -138,7 +137,7 @@ export default function SequenceGroupsListPage() {
         </p>
       </div>
 
-      <div className="mb-3 flex items-center justify-between">
+      <div className="mb-3">
         <div className="inline-flex rounded-lg bg-gray-200 p-0.5 gap-0.5 text-sm">
           {FILTERS.map(f => {
             const active = filter === f.value;
@@ -170,9 +169,6 @@ export default function SequenceGroupsListPage() {
             );
           })}
         </div>
-        <span className="text-sm text-gray-500">
-          {total} group{total === 1 ? '' : 's'}
-        </span>
       </div>
 
       <div className="overflow-x-auto border border-gray-200 rounded-lg bg-white shadow-sm">

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -1,26 +1,99 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Loader2, AlertCircle, Tag, ShieldCheck } from 'lucide-react';
+import {
+  Loader2,
+  AlertCircle,
+  Info,
+  ShieldCheck,
+  ChevronRight,
+  ArrowUp,
+  ArrowDown,
+} from 'lucide-react';
 import { apiClient } from '@/services/api';
+import { formatRelativeTime } from '@/utils/relativeTime';
+import { SequenceGroupStats } from '@/types/api';
 
 type Filter = 'all' | 'labeled' | 'unlabeled';
+type OrderBy = 'member_count' | 'camera_name' | 'azimuth' | 'created_at';
+type OrderDirection = 'asc' | 'desc';
+
+// First click on a column uses its natural direction: text asc, numbers/dates desc.
+const DEFAULT_DIRECTION: Record<OrderBy, OrderDirection> = {
+  member_count: 'desc',
+  camera_name: 'asc',
+  azimuth: 'asc',
+  created_at: 'desc',
+};
+
+const FILTERS: { value: Filter; label: string; countOf: keyof SequenceGroupStats }[] = [
+  { value: 'unlabeled', label: 'To label', countOf: 'unlabeled' },
+  { value: 'labeled', label: 'Labeled', countOf: 'labeled' },
+  { value: 'all', label: 'All', countOf: 'total' },
+];
+
+function SortableHeader({
+  column,
+  label,
+  orderBy,
+  orderDirection,
+  onSort,
+}: {
+  column: OrderBy;
+  label: string;
+  orderBy: OrderBy;
+  orderDirection: OrderDirection;
+  onSort: (column: OrderBy) => void;
+}) {
+  const active = orderBy === column;
+  const Arrow = orderDirection === 'asc' ? ArrowUp : ArrowDown;
+  return (
+    <th
+      onClick={() => onSort(column)}
+      className="px-3 py-2.5 text-left cursor-pointer select-none whitespace-nowrap hover:text-gray-900"
+      aria-sort={active ? (orderDirection === 'asc' ? 'ascending' : 'descending') : undefined}
+    >
+      {label}
+      {active && <Arrow className="inline w-3 h-3 ml-1 text-blue-600" />}
+    </th>
+  );
+}
 
 export default function SequenceGroupsListPage() {
+  const navigate = useNavigate();
   const [filter, setFilter] = useState<Filter>('unlabeled');
   const [page, setPage] = useState(1);
+  const [orderBy, setOrderBy] = useState<OrderBy>('member_count');
+  const [orderDirection, setOrderDirection] = useState<OrderDirection>('desc');
   const size = 50;
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ['sequenceGroupsList', filter, page, size],
+    queryKey: ['sequenceGroupsList', filter, page, size, orderBy, orderDirection],
     queryFn: () =>
       apiClient.getSequenceGroups({
         labeled: filter === 'all' ? undefined : filter === 'labeled',
         page,
         size,
+        order_by: orderBy,
+        order_direction: orderDirection,
       }),
     placeholderData: prev => prev,
   });
+
+  const { data: stats } = useQuery({
+    queryKey: ['sequenceGroupStats'],
+    queryFn: () => apiClient.getSequenceGroupStats(),
+  });
+
+  const handleSort = (column: OrderBy) => {
+    if (orderBy === column) {
+      setOrderDirection(d => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setOrderBy(column);
+      setOrderDirection(DEFAULT_DIRECTION[column]);
+    }
+    setPage(1);
+  };
 
   if (isLoading && !data) {
     return (
@@ -45,44 +118,93 @@ export default function SequenceGroupsListPage() {
   return (
     <div className="max-w-6xl mx-auto px-4 py-6">
       <header className="mb-4">
-        <h1 className="text-2xl font-semibold">Sequence groups</h1>
-        <p className="text-sm text-gray-600 mt-1">
-          {total} group{total === 1 ? '' : 's'} with 3 or more members. Click a row to review
-          membership; annotate one member from the per-sequence page and the labels propagate to the
-          rest if the group has been validated.
-        </p>
+        <h1 className="text-2xl font-semibold text-gray-900">Sequence groups</h1>
+        <p className="text-sm text-gray-600 mt-1">Label many related sequences at once.</p>
       </header>
 
-      <div className="mb-3 flex gap-2 text-sm">
-        {(['all', 'unlabeled', 'labeled'] as Filter[]).map(f => (
-          <button
-            key={f}
-            onClick={() => {
-              setFilter(f);
-              setPage(1);
-            }}
-            className={`px-3 py-1 rounded ${
-              filter === f
-                ? 'bg-blue-600 text-white'
-                : 'bg-white border border-gray-300 text-gray-700 hover:bg-gray-50'
-            }`}
-          >
-            {f}
-          </button>
-        ))}
+      <div className="mb-4 flex gap-2.5 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+        <Info className="w-4 h-4 flex-none mt-0.5 text-blue-600" />
+        <p>
+          <span className="font-semibold">What is a sequence group?</span> After each import,
+          sequences from the same camera looking in the same direction at the same spot are grouped
+          automatically — usually one recurring smoke plume or false-positive source (an antenna, a
+          cloud bank…). Open a group, label one of its sequences, and once the group is validated
+          the label propagates to every member. Only groups with 3+ sequences are shown.
+        </p>
       </div>
 
-      <div className="overflow-x-auto border border-gray-200 rounded-lg bg-white">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="inline-flex rounded-lg bg-gray-200 p-0.5 gap-0.5 text-sm">
+          {FILTERS.map(f => {
+            const active = filter === f.value;
+            const count = stats?.[f.countOf];
+            return (
+              <button
+                key={f.value}
+                onClick={() => {
+                  setFilter(f.value);
+                  setPage(1);
+                }}
+                className={`px-3.5 py-1.5 rounded-md font-medium ${
+                  active
+                    ? 'bg-white text-gray-900 shadow-sm font-semibold'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                {f.label}
+                {count !== undefined && (
+                  <span
+                    className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${
+                      active ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500'
+                    }`}
+                  >
+                    {count}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+        <span className="text-sm text-gray-500">
+          {total} group{total === 1 ? '' : 's'}
+        </span>
+      </div>
+
+      <div className="overflow-x-auto border border-gray-200 rounded-lg bg-white shadow-sm">
         <table className="w-full text-sm">
-          <thead className="bg-gray-50 text-gray-600 text-xs uppercase">
+          <thead className="bg-gray-50 text-gray-600 text-xs uppercase tracking-wide">
             <tr>
-              <th className="px-3 py-2 text-left">Group #</th>
-              <th className="px-3 py-2 text-left">Camera</th>
-              <th className="px-3 py-2 text-left">Azimuth</th>
-              <th className="px-3 py-2 text-left">Members</th>
-              <th className="px-3 py-2 text-left">Label</th>
-              <th className="px-3 py-2 text-left">Validated</th>
-              <th className="px-3 py-2 text-left">Created</th>
+              <SortableHeader
+                column="camera_name"
+                label="Camera"
+                orderBy={orderBy}
+                orderDirection={orderDirection}
+                onSort={handleSort}
+              />
+              <SortableHeader
+                column="azimuth"
+                label="Azimuth"
+                orderBy={orderBy}
+                orderDirection={orderDirection}
+                onSort={handleSort}
+              />
+              <SortableHeader
+                column="member_count"
+                label="Sequences"
+                orderBy={orderBy}
+                orderDirection={orderDirection}
+                onSort={handleSort}
+              />
+              <th className="px-3 py-2.5 text-left">Label</th>
+              <th className="px-3 py-2.5 text-left">Reviewed</th>
+              <SortableHeader
+                column="created_at"
+                label="Created"
+                orderBy={orderBy}
+                orderDirection={orderDirection}
+                onSort={handleSort}
+              />
+              <th className="px-3 py-2.5" />
             </tr>
           </thead>
           <tbody>
@@ -90,51 +212,67 @@ export default function SequenceGroupsListPage() {
               <tr>
                 <td colSpan={7} className="px-3 py-8 text-center text-gray-500">
                   {filter === 'unlabeled'
-                    ? 'No unlabeled multi-sequence groups yet. Groups are ' +
-                      'assigned automatically a few minutes after an import; ' +
-                      'groups with fewer than 3 sequences are intentionally ' +
-                      'hidden here.'
+                    ? 'Nothing to label right now. Groups are assigned ' +
+                      'automatically a few minutes after an import; groups with ' +
+                      'fewer than 3 sequences are intentionally hidden here.'
                     : 'No groups match this filter.'}
                 </td>
               </tr>
             ) : (
               items.map(g => (
-                <tr key={g.id} className="border-t border-gray-100 hover:bg-blue-50">
-                  <td className="px-3 py-2">
+                <tr
+                  key={g.id}
+                  onClick={() => navigate(`/sequence-groups/${g.id}/annotate`)}
+                  className="border-t border-gray-100 hover:bg-blue-50 cursor-pointer"
+                >
+                  <td className="px-3 py-2.5">
                     <Link
                       to={`/sequence-groups/${g.id}/annotate`}
-                      className="text-blue-600 hover:underline"
+                      onClick={e => e.stopPropagation()}
+                      className="font-semibold text-gray-900 hover:text-blue-700"
                     >
-                      #{g.id}
+                      {g.camera_name}
                     </Link>
+                    <span className="ml-1.5 text-xs text-gray-400">#{g.id}</span>
                   </td>
-                  <td className="px-3 py-2">{g.camera_id}</td>
-                  <td className="px-3 py-2">{g.azimuth}°</td>
-                  <td className="px-3 py-2 font-medium">{g.member_count}</td>
-                  <td className="px-3 py-2">
+                  <td className="px-3 py-2.5">{g.azimuth}°</td>
+                  <td className="px-3 py-2.5">
+                    <span className="inline-block rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-semibold text-blue-700">
+                      {g.member_count}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2.5">
                     {g.smoke_type ? (
-                      <span className="inline-flex items-center gap-1 text-orange-700">
-                        <Tag className="w-3 h-3" /> smoke / {g.smoke_type}
+                      <span className="inline-block rounded-full bg-orange-100 px-2.5 py-0.5 text-xs font-semibold text-orange-700">
+                        smoke · {g.smoke_type}
                       </span>
                     ) : g.false_positive_type ? (
-                      <span className="inline-flex items-center gap-1 text-gray-700">
-                        <Tag className="w-3 h-3" /> FP / {g.false_positive_type}
+                      <span className="inline-block rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-700">
+                        false positive · {g.false_positive_type.replace(/_/g, ' ')}
                       </span>
                     ) : (
-                      <span className="text-gray-400">unlabeled</span>
+                      <span className="inline-block rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-semibold text-yellow-800">
+                        to label
+                      </span>
                     )}
                   </td>
-                  <td className="px-3 py-2">
+                  <td className="px-3 py-2.5">
                     {g.is_validated ? (
-                      <span className="inline-flex items-center gap-1 text-green-700">
-                        <ShieldCheck className="w-3 h-3" /> validated
+                      <span className="inline-flex items-center gap-1 text-green-700 text-xs font-semibold">
+                        <ShieldCheck className="w-3.5 h-3.5" /> validated
                       </span>
                     ) : (
-                      <span className="text-gray-400">no</span>
+                      <span className="text-gray-400">—</span>
                     )}
                   </td>
-                  <td className="px-3 py-2 text-gray-500">
-                    {new Date(g.created_at).toLocaleString()}
+                  <td
+                    className="px-3 py-2.5 text-gray-500"
+                    title={new Date(g.created_at).toLocaleString()}
+                  >
+                    {formatRelativeTime(g.created_at)}
+                  </td>
+                  <td className="px-3 py-2.5 text-right">
+                    <ChevronRight className="inline w-4 h-4 text-gray-400" />
                   </td>
                 </tr>
               ))
@@ -148,17 +286,17 @@ export default function SequenceGroupsListPage() {
           <button
             onClick={() => setPage(p => Math.max(1, p - 1))}
             disabled={page === 1}
-            className="px-3 py-1 border rounded disabled:opacity-40"
+            className="px-3 py-1.5 border border-gray-300 rounded-lg bg-white disabled:opacity-40 hover:bg-gray-50"
           >
             Previous
           </button>
-          <span>
+          <span className="text-gray-600">
             Page {page} / {totalPages}
           </span>
           <button
             onClick={() => setPage(p => Math.min(totalPages, p + 1))}
             disabled={page >= totalPages}
-            className="px-3 py-1 border rounded disabled:opacity-40"
+            className="px-3 py-1.5 border border-gray-300 rounded-lg bg-white disabled:opacity-40 hover:bg-gray-50"
           >
             Next
           </button>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -231,7 +231,13 @@ class ApiClient {
   }
 
   async getSequenceGroups(
-    filters: { labeled?: boolean; page?: number; size?: number } = {}
+    filters: {
+      labeled?: boolean;
+      page?: number;
+      size?: number;
+      order_by?: 'member_count' | 'camera_name' | 'azimuth' | 'created_at';
+      order_direction?: 'asc' | 'desc';
+    } = {}
   ): Promise<PaginatedResponse<SequenceGroupListItem>> {
     const response: AxiosResponse<PaginatedResponse<SequenceGroupListItem>> = await this.client.get(
       API_ENDPOINTS.SEQUENCE_GROUPS,

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -146,6 +146,7 @@ export interface SequenceGroupMember {
 export interface SequenceGroupListItem {
   id: number;
   camera_id: number;
+  camera_name: string;
   azimuth: number;
   representative_bbox: SequenceGroupRepresentativeBbox;
   smoke_type: SmokeType | null;
@@ -161,6 +162,8 @@ export interface SequenceGroupStats {
   total: number;
   validated: number;
   unvalidated: number;
+  labeled: number;
+  unlabeled: number;
 }
 
 export interface SequenceGroup {

--- a/frontend/src/utils/relativeTime.ts
+++ b/frontend/src/utils/relativeTime.ts
@@ -1,0 +1,23 @@
+const MINUTE_MS = 60_000;
+const HOUR_MS = 3_600_000;
+const DAY_MS = 86_400_000;
+
+/**
+ * Compact relative age for list rows: "just now", "45 min ago", "2 h ago",
+ * "yesterday", "3 days ago", then a short date ("Jul 1", "Dec 31, 2025").
+ * `now` is injectable for tests.
+ */
+export function formatRelativeTime(iso: string, now: Date = new Date()): string {
+  const then = new Date(iso);
+  const diffMs = now.getTime() - then.getTime();
+  if (diffMs < MINUTE_MS) return 'just now';
+  if (diffMs < HOUR_MS) return `${Math.floor(diffMs / MINUTE_MS)} min ago`;
+  if (diffMs < DAY_MS) return `${Math.floor(diffMs / HOUR_MS)} h ago`;
+  if (diffMs < 2 * DAY_MS) return 'yesterday';
+  if (diffMs < 7 * DAY_MS) return `${Math.floor(diffMs / DAY_MS)} days ago`;
+  return then.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    ...(then.getFullYear() !== now.getFullYear() ? { year: 'numeric' } : {}),
+  });
+}

--- a/frontend/tests/utils/relativeTime.test.ts
+++ b/frontend/tests/utils/relativeTime.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { formatRelativeTime } from '@/utils/relativeTime';
+
+describe('formatRelativeTime', () => {
+  const now = new Date('2026-07-28T12:00:00Z');
+
+  it('renders sub-minute ages as "just now"', () => {
+    expect(formatRelativeTime('2026-07-28T11:59:30Z', now)).toBe('just now');
+  });
+
+  it('renders minutes', () => {
+    expect(formatRelativeTime('2026-07-28T11:15:00Z', now)).toBe('45 min ago');
+  });
+
+  it('renders hours', () => {
+    expect(formatRelativeTime('2026-07-28T09:30:00Z', now)).toBe('2 h ago');
+  });
+
+  it('renders yesterday', () => {
+    expect(formatRelativeTime('2026-07-27T10:00:00Z', now)).toBe('yesterday');
+  });
+
+  it('renders days within a week', () => {
+    expect(formatRelativeTime('2026-07-25T12:00:00Z', now)).toBe('3 days ago');
+  });
+
+  it('falls back to a short date beyond a week', () => {
+    expect(formatRelativeTime('2026-07-01T12:00:00Z', now)).toBe('Jul 1');
+  });
+
+  it('includes the year for other years', () => {
+    expect(formatRelativeTime('2025-12-31T12:00:00Z', now)).toBe('Dec 31, 2025');
+  });
+});


### PR DESCRIPTION
## Summary

Redesigns the `/sequence-groups` list page per the approved spec (`docs/specs/2026-07-28-sequence-groups-list-ui-design.md`):

- **Camera names instead of ids** — the list endpoint now returns `camera_name`, picked up from member sequences in the existing member-count subquery (no migration)
- **Explainer copy** — an info box explains what a sequence group is, how label propagation works, and why only 3+-member groups appear
- **Sortable columns** — server-side `order_by` (`member_count` | `camera_name` | `azimuth` | `created_at`) + `order_direction` params, same pattern as the sequences endpoint; deterministic `created_at DESC, id DESC` tie-breakers keep pagination stable
- **Segmented filter with live counts** — "To label / Labeled / All" backed by new `labeled`/`unlabeled` fields on `/sequence_groups/stats`
- **Clickable rows** — whole row opens the group review page; camera name stays a real link for middle-click/keyboard
- **Presentation** — status pills, relative dates (small local helper, no new dependency) with exact timestamp on hover

## Backend changes

- `SequenceGroupListItem` gains required `camera_name`
- `GET /api/v1/sequence_groups/` gains `order_by`/`order_direction` (default unchanged: biggest groups first); invalid fields are rejected with 422
- `SequenceGroupStats` gains `labeled`/`unlabeled` (same 3+-member population as `total`)

## Test plan

- Backend: 3 new endpoint tests (camera_name presence, all order_by/order_direction combinations, labeled/unlabeled stats); full suite 424 passed in an isolated compose stack; live smoke test of the new params
- Frontend: new Vitest suite for `formatRelativeTime` (7 cases); full suite 648 passed; tsc/ESLint/Prettier clean on all touched files