### PR TITLE
feat: polish sequence-group review page (consistency, card sizing, navigation)

### DIFF
--- a/docs/specs/2026-07-28-group-annotate-page-polish-design.md
+++ b/docs/specs/2026-07-28-group-annotate-page-polish-design.md
@@ -1,0 +1,86 @@
+# Sequence Group Review Page — Polish & Consistency
+
+**Date:** 2026-07-28
+**Status:** Approved
+**Scope:** `frontend` only — `src/pages/SequenceGroupAnnotatePage.tsx`. No backend changes: the camera name already arrives with each group member.
+
+## Problem
+
+The group review page (`/sequence-groups/:id/annotate`) predates the list-page
+redesign (PR #206) and no longer matches it:
+
+- The header shows the numeric camera id ("camera 97") and leads with the
+  group number, which the list page no longer surfaces.
+- Title size/weight and page layout differ from the other pages
+  (`max-w-7xl` container vs. the app-wide `space-y-6` + layout padding).
+- The workflow explanation is a dense gray paragraph mixing overlay legend,
+  interaction hints, and propagation semantics.
+- The member grid is fixed at 2 cards per row regardless of screen width.
+
+## Design
+
+Approved via mockup review (visual companion). Polish only — no workflow
+changes, no new labeling capability.
+
+### Header & layout
+
+- Root container becomes `space-y-6`, relying on the app layout's `p-6`
+  (drop `max-w-7xl mx-auto px-4 py-6`) — same as the list page.
+- The "← Back" history button becomes a breadcrumb `<Link>` "← Sequence
+  groups" to `/sequence-groups`.
+- Title: `{cameraName} · {azimuth}°` in `text-2xl font-bold text-gray-900`,
+  where `cameraName = group.members[0]?.camera_name`, falling back to
+  `camera #{group.camera_id}` for a memberless group. The group id appears
+  nowhere on the page (it lives in the URL).
+- Subtitle row of pills matching the list page: blue count pill
+  "N sequence(s)", and a label pill — orange `smoke · {type}`, gray
+  `false positive · {type}` (underscores replaced by spaces), or yellow
+  `to label` when unlabeled.
+- Validate/Unvalidate controls keep their position and behavior, restyled
+  to the list page's idiom (rounded-lg buttons, same greens).
+
+### Explainer
+
+The gray legend box is replaced by the list page's blue info box
+(`Info` icon), with this copy:
+
+> **How to label this group:** open any sequence below and label it. If the
+> group is validated, that label propagates to every unannotated member.
+> Use ✕ on a card to eject a sequence that doesn't belong.
+
+Always visible. The old conditional "group is validated…" sentence is
+covered by this copy and is dropped.
+
+### Legend strip
+
+One slim line between the explainer and the grid (`text-xs`, gray
+background bar): red swatch "detected object", dashed fuchsia swatch
+"group reference region", then "left: full frame · right: zoom".
+
+### Grid density
+
+`grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 min-[1920px]:grid-cols-4
+gap-4` — 1 card per row on small screens, 2 on laptops, 3 on wide
+monitors, 4 on very large (≥1920 px) screens.
+
+### Card meta
+
+The card timestamp switches from `toLocaleString()` to the shared
+`formatRelativeTime` helper (added in PR #206), with the exact timestamp in
+the `title` tooltip — consistent with the list page. Everything else on the
+cards (bbox overlays, zoom crop, remove button with its confirm dialog,
+annotated check/clock icons, link to the per-sequence page) is unchanged.
+
+## Out of scope
+
+- Labeling directly from this page (bulk-annotate UI).
+- Progress indicators / guided-workflow changes.
+- Any backend or API change.
+
+## Verification
+
+- `npm run quality` (tsc, ESLint, Prettier) and `npm test` — clean on
+  touched files (repo-wide runs have known pre-existing failures on main:
+  two `no-console` warnings in `DetectionSequenceAnnotatePage.tsx`).
+- Visual check via a Vite dev server against the running local stack,
+  comparing against the approved mockups.

--- a/docs/specs/2026-07-28-group-annotate-page-polish-design.md
+++ b/docs/specs/2026-07-28-group-annotate-page-polish-design.md
@@ -87,6 +87,19 @@ the `title` tooltip — consistent with the list page. Everything else on the
 cards (bbox overlays, zoom crop, remove button with its confirm dialog,
 annotated check/clock icons, link to the per-sequence page) is unchanged.
 
+### Prev/next navigation
+
+Chevron buttons (`‹` / `›`) sit left of the validate controls in the pinned
+header and walk the **full** group list in its default order (biggest group
+first — the list page's unfiltered queue). Neighbor ids come from
+`getSequenceGroups({ page: 1, size: 100 })` cached under
+`['sequenceGroupsList', 'neighbors']` (prefix-invalidated by the existing
+mutations); a chevron renders disabled at either end or when the current
+group is absent from the fetched window. Auto-advance after validating was
+considered and rejected: validation is not the end of the flow (labeling a
+member afterwards is what propagates), so navigating away automatically
+would interrupt the annotator.
+
 ## Out of scope
 
 - Labeling directly from this page (bulk-annotate UI).

--- a/docs/specs/2026-07-28-group-annotate-page-polish-design.md
+++ b/docs/specs/2026-07-28-group-annotate-page-polish-design.md
@@ -32,17 +32,19 @@ changes, no new labeling capability.
   where `cameraName = group.members[0]?.camera_name`, falling back to
   `camera #{group.camera_id}` for a memberless group. The group id appears
   nowhere on the page (it lives in the URL).
-- Subtitle row of pills matching the list page: blue count pill
-  "N sequence(s)", and a label pill — orange `smoke · {type}`, gray
+- Pills inline with the title (one condensed row): blue count pill
+  "N seq", and a label pill — orange `smoke · {type}`, gray
   `false positive · {type}` (underscores replaced by spaces), or yellow
-  `to label` when unlabeled.
+  `to label` when unlabeled. Long camera names truncate rather than wrap
+  so the header height stays fixed.
 - Validate/Unvalidate controls keep their position and behavior, restyled
   to the list page's idiom (rounded-lg buttons, same greens).
 - The whole header block (breadcrumb, title, pills, validate controls) is
   pinned to the viewport top with the same idiom as the per-sequence
   annotation page's `AnnotationHeader`: `fixed top-0 left-0 md:left-64
-  right-0 z-30` with a gray-50 backdrop-blur and shadow; the page root
-  reserves its height with `pt-24`. (A `sticky top-0` variant inside the
+  right-0 z-30` with AnnotationHeader's exact neutral styling
+  (`bg-white/85 border-b border-gray-200 backdrop-blur-sm shadow-sm`); the
+  page root reserves its height with `pt-20`. (A `sticky top-0` variant inside the
   scrolling `<main>` was tried first and let content peek above the header
   through `<main>`'s padding — fixed positioning avoids that.) The
   explainer and legend scroll away normally.

--- a/docs/specs/2026-07-28-group-annotate-page-polish-design.md
+++ b/docs/specs/2026-07-28-group-annotate-page-polish-design.md
@@ -38,6 +38,13 @@ changes, no new labeling capability.
   `to label` when unlabeled.
 - Validate/Unvalidate controls keep their position and behavior, restyled
   to the list page's idiom (rounded-lg buttons, same greens).
+- The whole header block (breadcrumb, title, pills, validate controls) is
+  sticky (`sticky top-0` inside the app's scrolling `<main>`, gray-50
+  backdrop-blur, negative margins bleeding over `<main>`'s `p-6`) so the
+  primary action stays reachable while scrolling the member grid — the
+  pinned-header idiom of the per-sequence annotation page, without its
+  fixed-position offset bookkeeping. The explainer and legend scroll away
+  normally.
 
 ### Explainer
 

--- a/docs/specs/2026-07-28-group-annotate-page-polish-design.md
+++ b/docs/specs/2026-07-28-group-annotate-page-polish-design.md
@@ -39,12 +39,13 @@ changes, no new labeling capability.
 - Validate/Unvalidate controls keep their position and behavior, restyled
   to the list page's idiom (rounded-lg buttons, same greens).
 - The whole header block (breadcrumb, title, pills, validate controls) is
-  sticky (`sticky top-0` inside the app's scrolling `<main>`, gray-50
-  backdrop-blur, negative margins bleeding over `<main>`'s `p-6`) so the
-  primary action stays reachable while scrolling the member grid — the
-  pinned-header idiom of the per-sequence annotation page, without its
-  fixed-position offset bookkeeping. The explainer and legend scroll away
-  normally.
+  pinned to the viewport top with the same idiom as the per-sequence
+  annotation page's `AnnotationHeader`: `fixed top-0 left-0 md:left-64
+  right-0 z-30` with a gray-50 backdrop-blur and shadow; the page root
+  reserves its height with `pt-24`. (A `sticky top-0` variant inside the
+  scrolling `<main>` was tried first and let content peek above the header
+  through `<main>`'s padding — fixed positioning avoids that.) The
+  explainer and legend scroll away normally.
 
 ### Explainer
 

--- a/docs/specs/2026-07-28-group-annotate-page-polish-design.md
+++ b/docs/specs/2026-07-28-group-annotate-page-polish-design.md
@@ -44,12 +44,16 @@ changes, no new labeling capability.
 The gray legend box is replaced by the list page's blue info box
 (`Info` icon), with this copy:
 
-> **How to label this group:** open any sequence below and label it. If the
-> group is validated, that label propagates to every unannotated member.
-> Use ✕ on a card to eject a sequence that doesn't belong.
+> **How to label this group**
+> - **Label** — open any sequence below and label it.
+> - **Validate** — "Validate group" confirms every sequence shows the same
+>   object; once validated, one label propagates to all unannotated members.
+> - **Eject** — use ✕ on a card to remove a sequence that doesn't belong.
+>   Do this before validating.
 
 Always visible. The old conditional "group is validated…" sentence is
-covered by this copy and is dropped.
+covered by this copy and is dropped. The Validate/Unvalidate buttons also
+carry `title` tooltips restating the propagation semantics.
 
 ### Legend strip
 
@@ -57,11 +61,15 @@ One slim line between the explainer and the grid (`text-xs`, gray
 background bar): red swatch "detected object", dashed fuchsia swatch
 "group reference region", then "left: full frame · right: zoom".
 
-### Grid density
+### Grid density & card-size control
 
-`grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 min-[1920px]:grid-cols-4
-gap-4` — 1 card per row on small screens, 2 on laptops, 3 on wide
-monitors, 4 on very large (≥1920 px) screens.
+The grid uses `repeat(auto-fill, minmax(min(<minWidth>px, 100%), 1fr))`
+so the column count derives from a minimum card width and reflows
+automatically at any viewport size. A "Card size" S/M/L segmented control
+on the right of the legend strip switches the minimum width
+(S = 340 px, M = 460 px default, L = 640 px); the choice persists in
+localStorage via the existing `usePersistedTabState` hook
+(key `groupAnnotateCardSize`).
 
 ### Card meta
 

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -12,9 +12,20 @@ import {
 } from 'lucide-react';
 import { apiClient } from '@/services/api';
 import { useDetectionImage } from '@/hooks/useDetectionImage';
+import { usePersistedTabState } from '@/hooks/usePersistedTabState';
 import { formatRelativeTime } from '@/utils/relativeTime';
 import { useState } from 'react';
 import { AlgoPrediction, SequenceGroup, SequenceGroupMember } from '@/types/api';
+
+// Minimum card width per size step; the auto-fill grid derives the column
+// count from it, so bigger cards automatically flow into more rows.
+type CardSize = 'sm' | 'md' | 'lg';
+const CARD_MIN_WIDTH: Record<CardSize, number> = { sm: 340, md: 460, lg: 640 };
+const CARD_SIZES: { value: CardSize; label: string; title: string }[] = [
+  { value: 'sm', label: 'S', title: 'Small cards' },
+  { value: 'md', label: 'M', title: 'Medium cards' },
+  { value: 'lg', label: 'L', title: 'Large cards' },
+];
 
 // Stages past the auto-import placeholder. Mirrors the backend's
 // _BULK_LOCKED_STAGES set in
@@ -230,6 +241,7 @@ export default function SequenceGroupAnnotatePage() {
   const { id } = useParams<{ id: string }>();
   const groupId = Number(id);
   const queryClient = useQueryClient();
+  const [cardSize, setCardSize] = usePersistedTabState<CardSize>('groupAnnotateCardSize', 'md');
 
   const {
     data: group,
@@ -309,6 +321,7 @@ export default function SequenceGroupAnnotatePage() {
                 <button
                   onClick={() => validateMutation.mutate(false)}
                   disabled={validateMutation.isPending}
+                  title="Re-open the group — labels stop propagating to members"
                   className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg bg-white hover:bg-gray-50 disabled:opacity-50"
                 >
                   <ShieldOff className="w-3 h-3 inline mr-1" /> Unvalidate
@@ -318,6 +331,7 @@ export default function SequenceGroupAnnotatePage() {
               <button
                 onClick={() => validateMutation.mutate(true)}
                 disabled={validateMutation.isPending}
+                title="Confirms every sequence shows the same object and enables label propagation"
                 className="px-3 py-1.5 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:bg-gray-300"
               >
                 <ShieldCheck className="w-4 h-4 inline mr-1" /> Validate group
@@ -329,24 +343,58 @@ export default function SequenceGroupAnnotatePage() {
 
       <div className="flex gap-2.5 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
         <Info className="w-4 h-4 flex-none mt-0.5 text-blue-600" />
-        <p>
-          <span className="font-semibold">How to label this group:</span> open any sequence below
-          and label it. If the group is validated, that label propagates to every unannotated
-          member. Use ✕ on a card to eject a sequence that doesn't belong.
-        </p>
+        <div>
+          <p className="font-semibold">How to label this group</p>
+          <ul className="mt-1 space-y-0.5 list-disc list-inside">
+            <li>
+              <span className="font-medium">Label</span> — open any sequence below and label it.
+            </li>
+            <li>
+              <span className="font-medium">Validate</span> — "Validate group" confirms every
+              sequence shows the same object; once validated, one label propagates to all
+              unannotated members.
+            </li>
+            <li>
+              <span className="font-medium">Eject</span> — use ✕ on a card to remove a sequence that
+              doesn't belong. Do this before validating.
+            </li>
+          </ul>
+        </div>
       </div>
 
       <div>
-        <div className="mb-2 flex flex-wrap items-center gap-x-5 gap-y-1 rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 text-xs text-gray-600">
-          <span className="inline-flex items-center gap-1.5">
-            <span className="inline-block w-4 h-3 border-2 border-red-500" />
-            detected object
-          </span>
-          <span className="inline-flex items-center gap-1.5">
-            <span className="inline-block w-4 h-3 border-2 border-dashed border-fuchsia-500" />
-            group reference region
-          </span>
-          <span>left: full frame · right: zoom</span>
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-x-5 gap-y-1 rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 text-xs text-gray-600">
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-1">
+            <span className="inline-flex items-center gap-1.5">
+              <span className="inline-block w-4 h-3 border-2 border-red-500" />
+              detected object
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <span className="inline-block w-4 h-3 border-2 border-dashed border-fuchsia-500" />
+              group reference region
+            </span>
+            <span>left: full frame · right: zoom</span>
+          </div>
+          <div className="inline-flex items-center gap-1.5">
+            <span>Card size</span>
+            <div className="inline-flex rounded-md bg-gray-200 p-0.5 gap-0.5">
+              {CARD_SIZES.map(s => (
+                <button
+                  key={s.value}
+                  type="button"
+                  title={s.title}
+                  onClick={() => setCardSize(s.value)}
+                  className={`px-2 py-0.5 rounded font-semibold ${
+                    cardSize === s.value
+                      ? 'bg-white text-gray-900 shadow-sm'
+                      : 'text-gray-500 hover:text-gray-900'
+                  }`}
+                >
+                  {s.label}
+                </button>
+              ))}
+            </div>
+          </div>
         </div>
 
         {group.members.length === 0 ? (
@@ -354,7 +402,12 @@ export default function SequenceGroupAnnotatePage() {
             This group has no members.
           </div>
         ) : (
-          <section className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 min-[1920px]:grid-cols-4 gap-4">
+          <section
+            className="grid gap-4"
+            style={{
+              gridTemplateColumns: `repeat(auto-fill, minmax(min(${CARD_MIN_WIDTH[cardSize]}px, 100%), 1fr))`,
+            }}
+          >
             {group.members.map(m => (
               <MemberCard
                 key={m.sequence_id}

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -1,17 +1,18 @@
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   Loader2,
   AlertCircle,
   CheckCircle,
   Clock,
-  Tag,
+  Info,
   ShieldCheck,
   ShieldOff,
   X,
 } from 'lucide-react';
 import { apiClient } from '@/services/api';
 import { useDetectionImage } from '@/hooks/useDetectionImage';
+import { formatRelativeTime } from '@/utils/relativeTime';
 import { useState } from 'react';
 import { AlgoPrediction, SequenceGroup, SequenceGroupMember } from '@/types/api';
 
@@ -209,7 +210,9 @@ function MemberCard({
         <div className="px-2 py-1 text-xs text-gray-700">
           <div className="font-medium">seq #{member.sequence_id}</div>
           <div className="flex items-center justify-between">
-            <span>{new Date(member.recorded_at).toLocaleString()}</span>
+            <span title={new Date(member.recorded_at).toLocaleString()}>
+              {formatRelativeTime(member.recorded_at)}
+            </span>
             {memberIsAnnotated(member) ? (
               <CheckCircle className="w-3 h-3 text-green-500" aria-label="annotated" />
             ) : (
@@ -225,7 +228,6 @@ function MemberCard({
 export default function SequenceGroupAnnotatePage() {
   const { id } = useParams<{ id: string }>();
   const groupId = Number(id);
-  const navigate = useNavigate();
   const queryClient = useQueryClient();
 
   const {
@@ -265,25 +267,34 @@ export default function SequenceGroupAnnotatePage() {
     );
   }
 
+  const cameraName = group.members[0]?.camera_name ?? `camera #${group.camera_id}`;
+
   return (
-    <div className="max-w-7xl mx-auto px-4 py-6">
-      <header className="mb-4">
-        <button onClick={() => navigate(-1)} className="text-sm text-gray-500 hover:text-gray-800">
-          ← Back
-        </button>
+    <div className="space-y-6">
+      <div>
+        <Link to="/sequence-groups" className="text-sm text-gray-500 hover:text-gray-800">
+          ← Sequence groups
+        </Link>
         <div className="mt-1 flex items-center justify-between gap-4 flex-wrap">
           <div>
-            <h1 className="text-2xl font-semibold">Sequence group #{group.id}</h1>
-            <div className="text-sm text-gray-600 mt-1">
-              camera {group.camera_id} · azimuth {group.azimuth}° · {group.members.length} members
-              {group.smoke_type && (
-                <span className="ml-2 inline-flex items-center gap-1 text-orange-700">
-                  <Tag className="w-3 h-3" /> smoke / {group.smoke_type}
+            <h1 className="text-2xl font-bold text-gray-900">
+              {cameraName} · {group.azimuth}°
+            </h1>
+            <div className="mt-1.5 flex items-center gap-2">
+              <span className="inline-block rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-semibold text-blue-700">
+                {group.members.length} sequence{group.members.length === 1 ? '' : 's'}
+              </span>
+              {group.smoke_type ? (
+                <span className="inline-block rounded-full bg-orange-100 px-2.5 py-0.5 text-xs font-semibold text-orange-700">
+                  smoke · {group.smoke_type}
                 </span>
-              )}
-              {group.false_positive_type && (
-                <span className="ml-2 inline-flex items-center gap-1 text-gray-700">
-                  <Tag className="w-3 h-3" /> FP / {group.false_positive_type}
+              ) : group.false_positive_type ? (
+                <span className="inline-block rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-700">
+                  false positive · {group.false_positive_type.replace(/_/g, ' ')}
+                </span>
+              ) : (
+                <span className="inline-block rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-semibold text-yellow-800">
+                  to label
                 </span>
               )}
             </div>
@@ -297,7 +308,7 @@ export default function SequenceGroupAnnotatePage() {
                 <button
                   onClick={() => validateMutation.mutate(false)}
                   disabled={validateMutation.isPending}
-                  className="px-3 py-1 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+                  className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg bg-white hover:bg-gray-50 disabled:opacity-50"
                 >
                   <ShieldOff className="w-3 h-3 inline mr-1" /> Unvalidate
                 </button>
@@ -306,53 +317,54 @@ export default function SequenceGroupAnnotatePage() {
               <button
                 onClick={() => validateMutation.mutate(true)}
                 disabled={validateMutation.isPending}
-                className="px-3 py-1 text-sm bg-green-600 text-white rounded hover:bg-green-700 disabled:bg-gray-300"
+                className="px-3 py-1.5 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:bg-gray-300"
               >
                 <ShieldCheck className="w-4 h-4 inline mr-1" /> Validate group
               </button>
             )}
           </div>
         </div>
-      </header>
+      </div>
 
-      <div className="mb-3 px-3 py-2 rounded bg-gray-50 border border-gray-200 text-xs text-gray-600">
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-1">
-          <span className="inline-flex items-center gap-2">
+      <div className="flex gap-2.5 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+        <Info className="w-4 h-4 flex-none mt-0.5 text-blue-600" />
+        <p>
+          <span className="font-semibold">How to label this group:</span> open any sequence below
+          and label it. If the group is validated, that label propagates to every unannotated
+          member. Use ✕ on a card to eject a sequence that doesn't belong.
+        </p>
+      </div>
+
+      <div>
+        <div className="mb-2 flex flex-wrap items-center gap-x-5 gap-y-1 rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 text-xs text-gray-600">
+          <span className="inline-flex items-center gap-1.5">
             <span className="inline-block w-4 h-3 border-2 border-red-500" />
-            tracked prediction (per-sequence)
+            detected object
           </span>
-          <span className="inline-flex items-center gap-2">
+          <span className="inline-flex items-center gap-1.5">
             <span className="inline-block w-4 h-3 border-2 border-dashed border-fuchsia-500" />
             group reference region
           </span>
-          <span>Each row shows the full frame and a zoomed crop of the detected object.</span>
-          <span>Click a thumbnail to annotate the sequence.</span>
-          <span>The X removes a sequence from this group.</span>
-          {group.is_validated && (
-            <span className="text-green-700">
-              Group is validated — annotating any sequence will propagate the labels to all other
-              unannotated members.
-            </span>
-          )}
+          <span>left: full frame · right: zoom</span>
         </div>
-      </div>
 
-      {group.members.length === 0 ? (
-        <div className="px-4 py-12 text-center text-gray-500 border border-dashed border-gray-300 rounded">
-          This group has no members.
-        </div>
-      ) : (
-        <section className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          {group.members.map(m => (
-            <MemberCard
-              key={m.sequence_id}
-              member={m}
-              groupId={group.id}
-              groupBbox={group.representative_bbox}
-            />
-          ))}
-        </section>
-      )}
+        {group.members.length === 0 ? (
+          <div className="px-4 py-12 text-center text-gray-500 border border-dashed border-gray-300 rounded">
+            This group has no members.
+          </div>
+        ) : (
+          <section className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 min-[1920px]:grid-cols-4 gap-4">
+            {group.members.map(m => (
+              <MemberCard
+                key={m.sequence_id}
+                member={m}
+                groupId={group.id}
+                groupBbox={group.representative_bbox}
+              />
+            ))}
+          </section>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -283,40 +283,38 @@ export default function SequenceGroupAnnotatePage() {
   const cameraName = group.members[0]?.camera_name ?? `camera #${group.camera_id}`;
 
   return (
-    <div className="space-y-6 pt-24">
+    <div className="space-y-6 pt-20">
       {/* Pinned header, same idiom as AnnotationHeader on the per-sequence
           page: fixed to the viewport past the sidebar (md:left-64) so the
           primary action (validate) stays reachable while scrolling the
           member grid. The root's pt-24 reserves its space. */}
       <div className="fixed top-0 left-0 md:left-64 right-0 z-30 px-6 pt-3 pb-2.5 bg-gray-50/95 backdrop-blur-sm shadow-sm">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <Link to="/sequence-groups" className="text-sm text-gray-500 hover:text-gray-800">
-              ← Sequence groups
-            </Link>
-            <h1 className="mt-1 text-2xl font-bold text-gray-900">
+        <Link to="/sequence-groups" className="text-sm text-gray-500 hover:text-gray-800">
+          ← Sequence groups
+        </Link>
+        <div className="mt-1 flex items-center justify-between gap-4">
+          <div className="flex items-center gap-2.5 min-w-0">
+            <h1 className="text-2xl font-bold text-gray-900 truncate">
               {cameraName} · {group.azimuth}°
             </h1>
-            <div className="mt-1.5 flex items-center gap-2">
-              <span className="inline-block rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-semibold text-blue-700">
-                {group.members.length} sequence{group.members.length === 1 ? '' : 's'}
+            <span className="flex-none rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-semibold text-blue-700">
+              {group.members.length} seq
+            </span>
+            {group.smoke_type ? (
+              <span className="flex-none rounded-full bg-orange-100 px-2.5 py-0.5 text-xs font-semibold text-orange-700">
+                smoke · {group.smoke_type}
               </span>
-              {group.smoke_type ? (
-                <span className="inline-block rounded-full bg-orange-100 px-2.5 py-0.5 text-xs font-semibold text-orange-700">
-                  smoke · {group.smoke_type}
-                </span>
-              ) : group.false_positive_type ? (
-                <span className="inline-block rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-700">
-                  false positive · {group.false_positive_type.replace(/_/g, ' ')}
-                </span>
-              ) : (
-                <span className="inline-block rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-semibold text-yellow-800">
-                  to label
-                </span>
-              )}
-            </div>
+            ) : group.false_positive_type ? (
+              <span className="flex-none rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-700">
+                false positive · {group.false_positive_type.replace(/_/g, ' ')}
+              </span>
+            ) : (
+              <span className="flex-none rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-semibold text-yellow-800">
+                to label
+              </span>
+            )}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-none items-center gap-2">
             {group.is_validated ? (
               <>
                 <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-green-100 text-green-700 text-sm">

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -207,18 +207,19 @@ function MemberCard({
             )}
           </div>
         </div>
-        <div className="px-2 py-1 text-xs text-gray-700">
-          <div className="font-medium">seq #{member.sequence_id}</div>
-          <div className="flex items-center justify-between">
-            <span title={new Date(member.recorded_at).toLocaleString()}>
+        <div className="px-2 py-1 text-xs text-gray-700 flex items-center justify-between">
+          <span>
+            <span className="font-medium">seq #{member.sequence_id}</span>
+            <span className="text-gray-500" title={new Date(member.recorded_at).toLocaleString()}>
+              {' · '}
               {formatRelativeTime(member.recorded_at)}
             </span>
-            {memberIsAnnotated(member) ? (
-              <CheckCircle className="w-3 h-3 text-green-500" aria-label="annotated" />
-            ) : (
-              <Clock className="w-3 h-3 text-orange-400" />
-            )}
-          </div>
+          </span>
+          {memberIsAnnotated(member) ? (
+            <CheckCircle className="w-3 h-3 text-green-500" aria-label="annotated" />
+          ) : (
+            <Clock className="w-3 h-3 text-orange-400" />
+          )}
         </div>
       </Link>
     </div>

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -4,6 +4,8 @@ import {
   Loader2,
   AlertCircle,
   CheckCircle,
+  ChevronLeft,
+  ChevronRight,
   Clock,
   Info,
   ShieldCheck,
@@ -253,6 +255,20 @@ export default function SequenceGroupAnnotatePage() {
     enabled: !Number.isNaN(groupId),
   });
 
+  // Neighbor ids for the prev/next chevrons, from the list endpoint's
+  // default order (biggest group first) — the same queue the list page
+  // shows unfiltered. Key shares the 'sequenceGroupsList' prefix so the
+  // existing mutation invalidations refresh it too.
+  const { data: neighborList } = useQuery({
+    queryKey: ['sequenceGroupsList', 'neighbors'],
+    queryFn: () => apiClient.getSequenceGroups({ page: 1, size: 100 }),
+  });
+  const neighborIds = neighborList?.items.map(g => g.id) ?? [];
+  const neighborIdx = neighborIds.indexOf(groupId);
+  const prevId = neighborIdx > 0 ? neighborIds[neighborIdx - 1] : null;
+  const nextId =
+    neighborIdx >= 0 && neighborIdx < neighborIds.length - 1 ? neighborIds[neighborIdx + 1] : null;
+
   const validateMutation = useMutation({
     mutationFn: (validated: boolean) =>
       apiClient.patchSequenceGroup(groupId, { is_validated: validated }),
@@ -315,6 +331,32 @@ export default function SequenceGroupAnnotatePage() {
             )}
           </div>
           <div className="flex flex-none items-center gap-2">
+            {prevId ? (
+              <Link
+                to={`/sequence-groups/${prevId}/annotate`}
+                title="Previous group"
+                className="p-1.5 rounded-lg border border-gray-300 bg-white text-gray-600 hover:bg-gray-50"
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </Link>
+            ) : (
+              <span className="p-1.5 rounded-lg border border-gray-200 bg-white text-gray-300">
+                <ChevronLeft className="w-4 h-4" />
+              </span>
+            )}
+            {nextId ? (
+              <Link
+                to={`/sequence-groups/${nextId}/annotate`}
+                title="Next group"
+                className="p-1.5 rounded-lg border border-gray-300 bg-white text-gray-600 hover:bg-gray-50"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </Link>
+            ) : (
+              <span className="p-1.5 rounded-lg border border-gray-200 bg-white text-gray-300">
+                <ChevronRight className="w-4 h-4" />
+              </span>
+            )}
             {group.is_validated ? (
               <>
                 <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-green-100 text-green-700 text-sm">

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -283,11 +283,12 @@ export default function SequenceGroupAnnotatePage() {
   const cameraName = group.members[0]?.camera_name ?? `camera #${group.camera_id}`;
 
   return (
-    <div className="space-y-6">
-      {/* Sticky so the primary action (validate) stays reachable while
-          scrolling the member grid; negative margins bleed over <main>'s
-          p-6 so cards don't peek around the edges when stuck. */}
-      <div className="sticky top-0 z-30 -mx-6 -mt-6 px-6 pt-6 pb-3 bg-gray-50/95 backdrop-blur-sm shadow-sm">
+    <div className="space-y-6 pt-24">
+      {/* Pinned header, same idiom as AnnotationHeader on the per-sequence
+          page: fixed to the viewport past the sidebar (md:left-64) so the
+          primary action (validate) stays reachable while scrolling the
+          member grid. The root's pt-24 reserves its space. */}
+      <div className="fixed top-0 left-0 md:left-64 right-0 z-30 px-6 pt-3 pb-2.5 bg-gray-50/95 backdrop-blur-sm shadow-sm">
         <Link to="/sequence-groups" className="text-sm text-gray-500 hover:text-gray-800">
           ← Sequence groups
         </Link>

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -288,7 +288,7 @@ export default function SequenceGroupAnnotatePage() {
           page: fixed to the viewport past the sidebar (md:left-64) so the
           primary action (validate) stays reachable while scrolling the
           member grid. The root's pt-24 reserves its space. */}
-      <div className="fixed top-0 left-0 md:left-64 right-0 z-30 px-6 pt-3 pb-2.5 bg-gray-50/95 backdrop-blur-sm shadow-sm">
+      <div className="fixed top-0 left-0 md:left-64 right-0 z-30 px-6 pt-3 pb-2.5 bg-white/85 border-b border-gray-200 backdrop-blur-sm shadow-sm">
         <Link to="/sequence-groups" className="text-sm text-gray-500 hover:text-gray-800">
           ← Sequence groups
         </Link>

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -244,6 +244,9 @@ export default function SequenceGroupAnnotatePage() {
   const groupId = Number(id);
   const queryClient = useQueryClient();
   const [cardSize, setCardSize] = usePersistedTabState<CardSize>('groupAnnotateCardSize', 'md');
+  // localStorage may hold a stale value from a renamed size key; an
+  // undefined width would invalidate the whole gridTemplateColumns rule.
+  const cardMinWidth = CARD_MIN_WIDTH[cardSize] ?? CARD_MIN_WIDTH.md;
 
   const {
     data: group,
@@ -253,6 +256,9 @@ export default function SequenceGroupAnnotatePage() {
     queryKey: ['sequenceGroup', groupId],
     queryFn: () => apiClient.getSequenceGroup(groupId),
     enabled: !Number.isNaN(groupId),
+    // Keep the previous group rendered while the next loads so chevron
+    // navigation doesn't unmount the header mid-click.
+    placeholderData: prev => prev,
   });
 
   // Neighbor ids for the prev/next chevrons, from the list endpoint's
@@ -303,7 +309,7 @@ export default function SequenceGroupAnnotatePage() {
       {/* Pinned header, same idiom as AnnotationHeader on the per-sequence
           page: fixed to the viewport past the sidebar (md:left-64) so the
           primary action (validate) stays reachable while scrolling the
-          member grid. The root's pt-24 reserves its space. */}
+          member grid. The root's pt-20 reserves its space. */}
       <div className="fixed top-0 left-0 md:left-64 right-0 z-30 px-6 pt-3 pb-2.5 bg-white/85 border-b border-gray-200 backdrop-blur-sm shadow-sm">
         <Link to="/sequence-groups" className="text-sm text-gray-500 hover:text-gray-800">
           ← Sequence groups
@@ -340,7 +346,10 @@ export default function SequenceGroupAnnotatePage() {
                 <ChevronLeft className="w-4 h-4" />
               </Link>
             ) : (
-              <span className="p-1.5 rounded-lg border border-gray-200 bg-white text-gray-300">
+              <span
+                aria-disabled="true"
+                className="p-1.5 rounded-lg border border-gray-200 bg-white text-gray-300"
+              >
                 <ChevronLeft className="w-4 h-4" />
               </span>
             )}
@@ -353,7 +362,10 @@ export default function SequenceGroupAnnotatePage() {
                 <ChevronRight className="w-4 h-4" />
               </Link>
             ) : (
-              <span className="p-1.5 rounded-lg border border-gray-200 bg-white text-gray-300">
+              <span
+                aria-disabled="true"
+                className="p-1.5 rounded-lg border border-gray-200 bg-white text-gray-300"
+              >
                 <ChevronRight className="w-4 h-4" />
               </span>
             )}
@@ -427,6 +439,7 @@ export default function SequenceGroupAnnotatePage() {
                   key={s.value}
                   type="button"
                   title={s.title}
+                  aria-pressed={cardSize === s.value}
                   onClick={() => setCardSize(s.value)}
                   className={`px-2 py-0.5 rounded font-semibold ${
                     cardSize === s.value
@@ -449,7 +462,7 @@ export default function SequenceGroupAnnotatePage() {
           <section
             className="grid gap-4"
             style={{
-              gridTemplateColumns: `repeat(auto-fill, minmax(min(${CARD_MIN_WIDTH[cardSize]}px, 100%), 1fr))`,
+              gridTemplateColumns: `repeat(auto-fill, minmax(min(${cardMinWidth}px, 100%), 1fr))`,
             }}
           >
             {group.members.map(m => (

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -284,7 +284,10 @@ export default function SequenceGroupAnnotatePage() {
 
   return (
     <div className="space-y-6">
-      <div>
+      {/* Sticky so the primary action (validate) stays reachable while
+          scrolling the member grid; negative margins bleed over <main>'s
+          p-6 so cards don't peek around the edges when stuck. */}
+      <div className="sticky top-0 z-30 -mx-6 -mt-6 px-6 pt-6 pb-3 bg-gray-50/95 backdrop-blur-sm shadow-sm">
         <Link to="/sequence-groups" className="text-sm text-gray-500 hover:text-gray-800">
           ← Sequence groups
         </Link>

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -289,12 +289,12 @@ export default function SequenceGroupAnnotatePage() {
           primary action (validate) stays reachable while scrolling the
           member grid. The root's pt-24 reserves its space. */}
       <div className="fixed top-0 left-0 md:left-64 right-0 z-30 px-6 pt-3 pb-2.5 bg-gray-50/95 backdrop-blur-sm shadow-sm">
-        <Link to="/sequence-groups" className="text-sm text-gray-500 hover:text-gray-800">
-          ← Sequence groups
-        </Link>
-        <div className="mt-1 flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-start justify-between gap-4">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">
+            <Link to="/sequence-groups" className="text-sm text-gray-500 hover:text-gray-800">
+              ← Sequence groups
+            </Link>
+            <h1 className="mt-1 text-2xl font-bold text-gray-900">
               {cameraName} · {group.azimuth}°
             </h1>
             <div className="mt-1.5 flex items-center gap-2">


### PR DESCRIPTION
## Summary

Brings `/sequence-groups/:id/annotate` in line with the redesigned list page (PR #206) and improves the review workflow. Frontend-only; spec at `docs/specs/2026-07-28-group-annotate-page-polish-design.md`.

- **Header**: camera name + azimuth as the title (no group number anywhere), condensed count/label pills inline with the title, "← Sequence groups" breadcrumb, layout/typography matched to the other pages
- **Pinned header**: fixed to the viewport top past the sidebar (same idiom and colors/borders as the per-sequence AnnotationHeader) so the Validate action stays reachable while scrolling; validate controls at the top right
- **Prev/next chevrons** walk the full group queue in the list's default order (real links, disabled at the ends); auto-advance on validate was considered and rejected since labeling a member after validation is what triggers propagation
- **Explainer**: blue info box with a three-step Label / Validate / Eject list replacing the dense gray legend paragraph; validate/unvalidate buttons carry tooltips restating propagation semantics
- **Legend strip**: one slim line (detected object / group reference region / full-frame vs zoom)
- **Card-size control**: S / M / L segmented switch sets the minimum card width for an `auto-fill/minmax` grid that reflows automatically; persisted in localStorage
- **Cards**: single-line footer `seq #id · relative time` (exact timestamp on hover) using the shared `formatRelativeTime` helper

## Test plan

- `npm test` (651 passed), `tsc --noEmit`, ESLint/Prettier clean on the touched file
- Visually verified against the approved mockups on a dev server wired to the local stack, iterating live with the reviewer