### PR TITLE
feat(frontend): sidebar nav cleanup — Classify/Localize taxonomy

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,17 +1,6 @@
 import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import {
-  Menu,
-  X,
-  ChevronRight,
-  ChevronDown,
-  Layers,
-  Target,
-  LogOut,
-  User,
-  Users,
-  LucideIcon,
-} from 'lucide-react';
+import { Menu, X, Layers, Target, LogOut, User, Users, LucideIcon } from 'lucide-react';
 import { clsx } from 'clsx';
 import { useAnnotationCounts } from '@/hooks/useAnnotationCounts';
 import NotificationBadge from '@/components/ui/NotificationBadge';
@@ -97,18 +86,13 @@ export default function AppLayout({ children }: AppLayoutProps) {
 }
 
 function SidebarContent({ currentPath }: { currentPath: string }) {
-  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
-    Sequences: true,
-    Detections: true,
-  });
-
   // Get annotation counts for badges
   const { sequenceCount, detectionCount, groupCount } = useAnnotationCounts();
 
   // Create dynamic navigation with badge counts
   const navigationWithBadges: NavigationItem[] = [
     {
-      name: 'Sequences',
+      name: 'Classify',
       icon: Layers,
       children: [
         {
@@ -117,26 +101,19 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
           badgeCount: groupCount,
           badgeTitle: `${groupCount} groups need validation`,
         },
-        { name: 'Annotate', href: '/sequences/annotate', badgeCount: sequenceCount },
-        { name: 'Review', href: '/sequences/review' },
+        { name: 'Sequences', href: '/sequences/annotate', badgeCount: sequenceCount },
+        { name: 'Done', href: '/sequences/review' },
       ],
     },
     {
-      name: 'Detections',
+      name: 'Localize',
       icon: Target,
       children: [
-        { name: 'Annotate', href: '/detections/annotate', badgeCount: detectionCount },
-        { name: 'Review', href: '/detections/review' },
+        { name: 'Smoke', href: '/detections/annotate', badgeCount: detectionCount },
+        { name: 'Done', href: '/detections/review' },
       ],
     },
   ];
-
-  const toggleSection = (sectionName: string) => {
-    setExpandedSections(prev => ({
-      ...prev,
-      [sectionName]: !prev[sectionName],
-    }));
-  };
 
   const isPathActive = (href?: string) => {
     if (!href || href === '#') return false;
@@ -193,64 +170,53 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
         <nav className="mt-8 flex-1 px-2 bg-white space-y-1">
           {navigationWithBadges.map(item => {
             const isActive = isSectionActive(item);
-            const isExpanded = expandedSections[item.name];
 
             return (
               <div key={item.name}>
-                <button
-                  onClick={() => toggleSection(item.name)}
+                <div
                   className={clsx(
-                    isActive
-                      ? 'bg-primary-50 text-primary-700'
-                      : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
-                    'group flex items-center px-2 py-2 text-sm font-medium rounded-l-md w-full'
+                    isActive ? 'text-primary-700' : 'text-gray-600',
+                    'flex items-center px-2 py-2 text-sm font-medium'
                   )}
                 >
                   <item.icon
                     className={clsx(
-                      isActive ? 'text-primary-500' : 'text-gray-400 group-hover:text-gray-500',
+                      isActive ? 'text-primary-500' : 'text-gray-400',
                       'mr-3 flex-shrink-0 h-5 w-5'
                     )}
                     aria-hidden="true"
                   />
                   <span className="flex-1 text-left">{item.name}</span>
-                  {isExpanded ? (
-                    <ChevronDown className="h-4 w-4 text-gray-400" />
-                  ) : (
-                    <ChevronRight className="h-4 w-4 text-gray-400" />
-                  )}
-                </button>
-                {isExpanded && item.children && (
-                  <div className="mt-1 space-y-1">
-                    {item.children.map(subItem => {
-                      const isSubActive = isPathActive(subItem.href);
-                      const isDisabled = subItem.href === '#';
-                      return (
-                        <Link
-                          key={subItem.name}
-                          to={isDisabled ? '#' : subItem.href}
-                          onClick={e => isDisabled && e.preventDefault()}
-                          className={clsx(
-                            isSubActive
-                              ? 'bg-primary-50 border-r-4 border-primary-600 text-primary-700'
-                              : isDisabled
-                                ? 'text-gray-400 cursor-not-allowed'
-                                : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
-                            'group flex items-center justify-between pl-11 pr-2 py-2 text-sm font-medium rounded-l-md'
-                          )}
-                        >
-                          <span>{subItem.name}</span>
-                          {subItem.badgeCount !== undefined && (
-                            <NotificationBadge
-                              count={subItem.badgeCount}
-                              title={subItem.badgeTitle}
-                            />
-                          )}
-                        </Link>
-                      );
-                    })}
-                  </div>
-                )}
+                </div>
+                <div className="mt-1 space-y-1">
+                  {item.children.map(subItem => {
+                    const isSubActive = isPathActive(subItem.href);
+                    const isDisabled = subItem.href === '#';
+                    return (
+                      <Link
+                        key={subItem.name}
+                        to={isDisabled ? '#' : subItem.href}
+                        onClick={e => isDisabled && e.preventDefault()}
+                        className={clsx(
+                          isSubActive
+                            ? 'bg-primary-50 border-r-4 border-primary-600 text-primary-700'
+                            : isDisabled
+                              ? 'text-gray-400 cursor-not-allowed'
+                              : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
+                          'group flex items-center justify-between pl-11 pr-2 py-2 text-sm font-medium rounded-l-md'
+                        )}
+                      >
+                        <span>{subItem.name}</span>
+                        {subItem.badgeCount !== undefined && (
+                          <NotificationBadge
+                            count={subItem.badgeCount}
+                            title={subItem.badgeTitle}
+                          />
+                        )}
+                      </Link>
+                    );
+                  })}
+                </div>
               </div>
             );
           })}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -3,7 +3,6 @@ import { Link, useLocation } from 'react-router-dom';
 import {
   Menu,
   X,
-  BarChart3,
   ChevronRight,
   ChevronDown,
   Layers,
@@ -25,9 +24,8 @@ interface AppLayoutProps {
 
 interface NavigationItem {
   name: string;
-  href?: string;
   icon: LucideIcon;
-  children?: NavigationSubItem[];
+  children: NavigationSubItem[];
 }
 
 interface NavigationSubItem {
@@ -104,13 +102,11 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
     Detections: true,
   });
 
-  // Get annotation counts for badges and current user
+  // Get annotation counts for badges
   const { sequenceCount, detectionCount, groupCount } = useAnnotationCounts();
-  const { isSuperuser } = useAuthStore();
 
   // Create dynamic navigation with badge counts
   const navigationWithBadges: NavigationItem[] = [
-    { name: 'Dashboard', href: '/', icon: BarChart3 },
     {
       name: 'Sequences',
       icon: Layers,
@@ -133,7 +129,6 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
         { name: 'Review', href: '/detections/review' },
       ],
     },
-    ...(isSuperuser() ? [{ name: 'User Management', href: '/users', icon: Users }] : []),
   ];
 
   const toggleSection = (sectionName: string) => {
@@ -183,52 +178,22 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
   };
 
   const isSectionActive = (item: NavigationItem) => {
-    if (item.href) {
-      return isPathActive(item.href);
-    }
-    if (item.children) {
-      return item.children.some(child => isPathActive(child.href));
-    }
-    return false;
+    return item.children.some(child => isPathActive(child.href));
   };
 
   return (
     <div className="flex flex-col h-0 flex-1 border-r border-gray-200 bg-white">
       <div className="flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
         <div className="flex items-center flex-shrink-0 px-4">
-          <div className="flex items-center">
+          <Link to="/" className="flex items-center rounded-md hover:opacity-80 transition-opacity">
             <img src={logoImg} alt="PyroAnnotator Logo" className="w-8 h-8" />
             <h1 className="ml-2 text-xl font-bold text-gray-900">PyroAnnotator</h1>
-          </div>
+          </Link>
         </div>
         <nav className="mt-8 flex-1 px-2 bg-white space-y-1">
           {navigationWithBadges.map(item => {
             const isActive = isSectionActive(item);
             const isExpanded = expandedSections[item.name];
-
-            if (item.href) {
-              return (
-                <Link
-                  key={item.name}
-                  to={item.href}
-                  className={clsx(
-                    isActive
-                      ? 'bg-primary-50 border-r-4 border-primary-600 text-primary-700'
-                      : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
-                    'group flex items-center px-2 py-2 text-sm font-medium rounded-l-md'
-                  )}
-                >
-                  <item.icon
-                    className={clsx(
-                      isActive ? 'text-primary-500' : 'text-gray-400 group-hover:text-gray-500',
-                      'mr-3 flex-shrink-0 h-5 w-5'
-                    )}
-                    aria-hidden="true"
-                  />
-                  <span className="flex-1">{item.name}</span>
-                </Link>
-              );
-            }
 
             return (
               <div key={item.name}>
@@ -299,7 +264,7 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
 }
 
 function UserSection() {
-  const { user, logout } = useAuthStore();
+  const { user, logout, isSuperuser } = useAuthStore();
   const [showDropdown, setShowDropdown] = useState(false);
 
   const handleLogout = () => {
@@ -326,6 +291,16 @@ function UserSection() {
 
       {showDropdown && (
         <div className="absolute bottom-full left-0 mb-1 w-full bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5">
+          {isSuperuser() && (
+            <Link
+              to="/users"
+              onClick={() => setShowDropdown(false)}
+              className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-md"
+            >
+              <Users className="h-4 w-4 mr-2" />
+              User Management
+            </Link>
+          )}
           <button
             onClick={handleLogout}
             className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-md"

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Menu, X, Layers, Target, LogOut, User, Users, LucideIcon } from 'lucide-react';
+import { Menu, X, LogOut, User, Users } from 'lucide-react';
 import { clsx } from 'clsx';
 import { useAnnotationCounts } from '@/hooks/useAnnotationCounts';
 import NotificationBadge from '@/components/ui/NotificationBadge';
@@ -13,7 +13,6 @@ interface AppLayoutProps {
 
 interface NavigationItem {
   name: string;
-  icon: LucideIcon;
   children: NavigationSubItem[];
 }
 
@@ -93,7 +92,6 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
   const navigationWithBadges: NavigationItem[] = [
     {
       name: 'Classify',
-      icon: Layers,
       children: [
         {
           name: 'Groups',
@@ -107,7 +105,6 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
     },
     {
       name: 'Localize',
-      icon: Target,
       children: [
         { name: 'Smoke', href: '/detections/annotate', badgeCount: detectionCount },
         { name: 'Done', href: '/detections/review' },
@@ -154,10 +151,6 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
     return currentPath === href || currentPath.startsWith(href + '/');
   };
 
-  const isSectionActive = (item: NavigationItem) => {
-    return item.children.some(child => isPathActive(child.href));
-  };
-
   return (
     <div className="flex flex-col h-0 flex-1 border-r border-gray-200 bg-white">
       <div className="flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
@@ -167,26 +160,12 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
             <h1 className="ml-2 text-xl font-bold text-gray-900">PyroAnnotator</h1>
           </Link>
         </div>
-        <nav className="mt-8 flex-1 px-2 bg-white space-y-1">
+        <nav className="mt-8 flex-1 px-2 bg-white space-y-6">
           {navigationWithBadges.map(item => {
-            const isActive = isSectionActive(item);
-
             return (
               <div key={item.name}>
-                <div
-                  className={clsx(
-                    isActive ? 'text-primary-700' : 'text-gray-600',
-                    'flex items-center px-2 py-2 text-sm font-medium'
-                  )}
-                >
-                  <item.icon
-                    className={clsx(
-                      isActive ? 'text-primary-500' : 'text-gray-400',
-                      'mr-3 flex-shrink-0 h-5 w-5'
-                    )}
-                    aria-hidden="true"
-                  />
-                  <span className="flex-1 text-left">{item.name}</span>
+                <div className="px-2 font-data text-[10.5px] font-medium uppercase tracking-[0.14em] text-haze">
+                  {item.name}
                 </div>
                 <div className="mt-1 space-y-1">
                   {item.children.map(subItem => {
@@ -203,7 +182,7 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
                             : isDisabled
                               ? 'text-gray-400 cursor-not-allowed'
                               : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
-                          'group flex items-center justify-between pl-11 pr-2 py-2 text-sm font-medium rounded-l-md'
+                          'group flex items-center justify-between pl-4 pr-2 py-2 text-sm font-medium rounded-l-md'
                         )}
                       >
                         <span>{subItem.name}</span>

--- a/frontend/tests/components/layout/AppLayout.test.tsx
+++ b/frontend/tests/components/layout/AppLayout.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Sidebar navigation structure tests for AppLayout.
- * Focuses on the Sequences section containing the Groups link with its badge.
+ * Focuses on the Classify section containing the Groups link with its badge.
  */
 
 import React from 'react';
@@ -36,7 +36,7 @@ describe('AppLayout sidebar navigation', () => {
       </MemoryRouter>
     );
 
-  it('renders Groups as a sub-item of the Sequences section with its badge count', () => {
+  it('renders Groups as a sub-item of the Classify section with its badge count', () => {
     renderLayout();
 
     const groupsLink = screen.getByRole('link', { name: /groups/i });
@@ -46,22 +46,22 @@ describe('AppLayout sidebar navigation', () => {
     expect(badge).toHaveAttribute('title', '8 groups need validation');
   });
 
-  it('places Groups first among the Sequences sub-items, after the section header', () => {
+  it('places Groups first among the Classify sub-items, after the section header', () => {
     renderLayout();
 
-    const sequencesHeader = screen.getByRole('button', { name: /sequences/i });
+    const classifyHeader = screen.getByText('Classify');
     const groupsLink = screen.getByRole('link', { name: /groups/i });
-    const annotateLinks = screen.getAllByRole('link', { name: /annotate/i });
-    const sequencesAnnotateLink = annotateLinks.find(
+    const sequencesLinks = screen.getAllByRole('link', { name: /sequences/i });
+    const classifySequencesLink = sequencesLinks.find(
       link => link.getAttribute('href') === '/sequences/annotate'
     );
 
-    expect(sequencesAnnotateLink).toBeDefined();
+    expect(classifySequencesLink).toBeDefined();
     expect(
-      sequencesHeader.compareDocumentPosition(groupsLink) & Node.DOCUMENT_POSITION_FOLLOWING
+      classifyHeader.compareDocumentPosition(groupsLink) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
-      groupsLink.compareDocumentPosition(sequencesAnnotateLink!) & Node.DOCUMENT_POSITION_FOLLOWING
+      groupsLink.compareDocumentPosition(classifySequencesLink!) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
   });
 

--- a/frontend/tests/components/layout/AppLayout.test.tsx
+++ b/frontend/tests/components/layout/AppLayout.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import AppLayout from '@/components/layout/AppLayout';
 
@@ -18,13 +18,19 @@ vi.mock('@/hooks/useAnnotationCounts', () => ({
   }),
 }));
 
+let isSuperuserValue = false;
+
 vi.mock('@/store/useAuthStore', () => ({
   useAuthStore: () => ({
     user: { username: 'tester' },
     logout: vi.fn(),
-    isSuperuser: () => false,
+    isSuperuser: () => isSuperuserValue,
   }),
 }));
+
+beforeEach(() => {
+  isSuperuserValue = false;
+});
 
 describe('AppLayout sidebar navigation', () => {
   const renderLayout = () =>
@@ -69,5 +75,23 @@ describe('AppLayout sidebar navigation', () => {
     renderLayout();
 
     expect(screen.queryByRole('link', { name: /sequence groups/i })).not.toBeInTheDocument();
+  });
+
+  it('shows User Management in the user dropdown for superusers', () => {
+    isSuperuserValue = true;
+    renderLayout();
+
+    fireEvent.click(screen.getByRole('button', { name: /tester/i }));
+
+    const userManagementLink = screen.getByRole('link', { name: /user management/i });
+    expect(userManagementLink).toHaveAttribute('href', '/users');
+  });
+
+  it('does not show User Management anywhere for regular users', () => {
+    renderLayout();
+
+    fireEvent.click(screen.getByRole('button', { name: /tester/i }));
+
+    expect(screen.queryByRole('link', { name: /user management/i })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Clicking the PyroAnnotator logo now navigates to the dashboard (`/`); the Dashboard entry is removed from the left navigation
- The superuser-only **User Management** link moves from the nav into the user dropdown at the bottom of the sidebar (above Sign out)
- Nav sections renamed to match the dashboard's pass taxonomy:
  - **Classify** (was Sequences): Groups / Sequences / Done
  - **Localize** (was Detections): Smoke / Done
- Sections are no longer collapsible — headers are static dashboard-style eyebrow labels (mono, uppercase, haze) with sub-items always visible

## Test plan

- [x] `npm run type-check`, ESLint + Prettier clean on changed files
- [x] Full Vitest suite passes (665 tests, 38 files) — `AppLayout.test.tsx` updated for the new naming
- [x] Manually verified in dev server: logo navigation, section rendering, user dropdown (superuser + regular)