### PR TITLE
feat(frontend): open user menu via hamburger button instead of user row

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -221,10 +221,7 @@ function UserSection() {
 
   return (
     <div className="relative">
-      <button
-        onClick={() => setShowDropdown(!showDropdown)}
-        className="flex items-center w-full text-left hover:bg-gray-50 rounded-lg p-2 transition-colors"
-      >
+      <div className="flex items-center p-2">
         <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center">
           <User className="h-4 w-4 text-white" />
         </div>
@@ -232,10 +229,17 @@ function UserSection() {
           <p className="text-sm font-medium text-gray-700">{username}</p>
           <p className="text-xs font-medium text-gray-500">Annotator</p>
         </div>
-      </button>
+        <button
+          onClick={() => setShowDropdown(!showDropdown)}
+          className="p-2 rounded-md text-gray-500 hover:bg-gray-50 hover:text-gray-900 transition-colors"
+        >
+          <span className="sr-only">Open user menu</span>
+          <Menu className="h-5 w-5" aria-hidden="true" />
+        </button>
+      </div>
 
       {showDropdown && (
-        <div className="absolute bottom-full left-0 mb-1 w-full bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5">
+        <div className="absolute bottom-full right-0 mb-1 w-full bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5">
           {isSuperuser() && (
             <Link
               to="/users"

--- a/frontend/tests/components/layout/AppLayout.test.tsx
+++ b/frontend/tests/components/layout/AppLayout.test.tsx
@@ -81,7 +81,7 @@ describe('AppLayout sidebar navigation', () => {
     isSuperuserValue = true;
     renderLayout();
 
-    fireEvent.click(screen.getByRole('button', { name: /tester/i }));
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }));
 
     const userManagementLink = screen.getByRole('link', { name: /user management/i });
     expect(userManagementLink).toHaveAttribute('href', '/users');
@@ -90,8 +90,19 @@ describe('AppLayout sidebar navigation', () => {
   it('does not show User Management anywhere for regular users', () => {
     renderLayout();
 
-    fireEvent.click(screen.getByRole('button', { name: /tester/i }));
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }));
 
     expect(screen.queryByRole('link', { name: /user management/i })).not.toBeInTheDocument();
+  });
+
+  it('opens the user menu only via the hamburger button, not the user row', () => {
+    renderLayout();
+
+    expect(screen.queryByRole('button', { name: /tester/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /sign out/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }));
+
+    expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- The logged-in user row in the sidebar footer is now a static display (avatar + username + role)
- A hamburger button on the right of the row toggles the user dropdown (User Management for superusers, Sign out)
- Dropdown anchors to the right edge, still opening upward above the row

## Test plan
- Updated the two dropdown tests to open the menu via the hamburger button
- Added a test asserting the user row itself no longer opens the menu
- Full frontend suite: 668 tests passing; lint/format/type-check clean on changed files