### PR TITLE
style(frontend): center dashboard pipeline stats, card footer links

### DIFF
--- a/frontend/src/components/dashboard/PhaseCard.tsx
+++ b/frontend/src/components/dashboard/PhaseCard.tsx
@@ -54,9 +54,9 @@ export default function PhaseCard({
       <h2 className="font-display text-[18.5px] font-semibold text-char">{title}</h2>
       <p className="mb-4 font-body text-[12.5px] text-haze">{description}</p>
       {isLoading ? (
-        <div className="h-10 w-24 animate-pulse rounded bg-ash" />
+        <div className="mx-auto h-10 w-24 animate-pulse rounded bg-ash" />
       ) : (
-        <div className={`font-data text-[38px] font-semibold leading-none ${t.text}`}>
+        <div className={`text-center font-data text-[38px] font-semibold leading-none ${t.text}`}>
           {todo.toLocaleString()}
           <span className="ml-1.5 font-body text-xs font-normal text-haze">to do</span>
         </div>
@@ -76,27 +76,25 @@ export default function PhaseCard({
       </p>
       <Link
         to={ctaTo}
-        className={`block w-full rounded-lg ${t.bg} py-2.5 text-center font-body text-[13.5px] font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2`}
+        className={`mx-auto block w-fit rounded-lg ${t.bg} px-7 py-2.5 text-center font-body text-[13.5px] font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2`}
       >
         {ctaLabel}
       </Link>
-      {secondaryLink && secondaryLink.count > 0 && (
-        <Link
-          to={secondaryLink.to}
-          className="mt-2.5 block text-center font-body text-[12.5px] text-haze hover:text-char"
-        >
-          {secondaryLink.label} ·{' '}
-          <span className="font-semibold text-char">{secondaryLink.count.toLocaleString()}</span> →
+      <div className="mt-4 flex items-center justify-between border-t border-line pt-3">
+        {secondaryLink && secondaryLink.count > 0 ? (
+          <Link to={secondaryLink.to} className="font-body text-[12.5px] text-haze hover:text-char">
+            {secondaryLink.label} ·{' '}
+            <span className="font-semibold text-char">{secondaryLink.count.toLocaleString()}</span>
+          </Link>
+        ) : (
+          <span />
+        )}
+        {/* No count on the review link: the review page opens on its own persisted
+            stage tab, so any single number here would disagree with what it shows. */}
+        <Link to={reviewTo} className="font-body text-[12.5px] text-haze hover:text-char">
+          {reviewLabel} →
         </Link>
-      )}
-      {/* No count on the review link: the review page opens on its own persisted
-          stage tab, so any single number here would disagree with what it shows. */}
-      <Link
-        to={reviewTo}
-        className="mt-2.5 block text-center font-body text-[12.5px] text-haze hover:text-char"
-      >
-        {reviewLabel} →
-      </Link>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/dashboard/PhaseCard.tsx
+++ b/frontend/src/components/dashboard/PhaseCard.tsx
@@ -76,7 +76,7 @@ export default function PhaseCard({
       </p>
       <Link
         to={ctaTo}
-        className={`mx-auto block w-fit rounded-lg ${t.bg} px-7 py-2.5 text-center font-body text-[13.5px] font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2`}
+        className={`mx-auto block w-fit rounded-lg ${t.bg} px-7 py-2.5 font-body text-[13.5px] font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2`}
       >
         {ctaLabel}
       </Link>

--- a/frontend/src/components/dashboard/PipelineStrip.tsx
+++ b/frontend/src/components/dashboard/PipelineStrip.tsx
@@ -18,7 +18,7 @@ interface SegmentProps {
 function Segment({ first, toneClass, label, count, detail, isLoading }: SegmentProps) {
   return (
     <div
-      className={`${first ? 'chevron-seg-first md:pl-6' : 'chevron-seg md:pl-8'} flex-1 bg-paper px-5 py-3.5 text-center md:pr-8`}
+      className={`${first ? 'chevron-seg-first' : 'chevron-seg'} flex-1 bg-paper px-5 py-3.5 text-center md:px-8`}
     >
       <div
         className={`font-data text-[10.5px] font-medium uppercase tracking-[0.12em] ${toneClass} mb-1`}

--- a/frontend/src/components/dashboard/PipelineStrip.tsx
+++ b/frontend/src/components/dashboard/PipelineStrip.tsx
@@ -18,7 +18,7 @@ interface SegmentProps {
 function Segment({ first, toneClass, label, count, detail, isLoading }: SegmentProps) {
   return (
     <div
-      className={`${first ? 'chevron-seg-first md:pl-6' : 'chevron-seg md:pl-8'} flex-1 bg-paper px-5 py-3.5 md:pr-8`}
+      className={`${first ? 'chevron-seg-first md:pl-6' : 'chevron-seg md:pl-8'} flex-1 bg-paper px-5 py-3.5 text-center md:pr-8`}
     >
       <div
         className={`font-data text-[10.5px] font-medium uppercase tracking-[0.12em] ${toneClass} mb-1`}
@@ -26,7 +26,7 @@ function Segment({ first, toneClass, label, count, detail, isLoading }: SegmentP
         {label}
       </div>
       {isLoading ? (
-        <div className="h-7 w-14 animate-pulse rounded bg-ash" />
+        <div className="mx-auto h-7 w-14 animate-pulse rounded bg-ash" />
       ) : (
         <div className={`font-data text-2xl font-semibold leading-tight ${toneClass}`}>
           {count.toLocaleString()}


### PR DESCRIPTION
## Summary

Dashboard styling tweaks:

- **PipelineStrip**: chevron segments (label / count / detail) are now text-centered, with symmetric horizontal padding so text centers on the plate; loading skeletons centered to match.
- **PhaseCard**: the big "N to do" figure is centered; the CTA buttons ("Start classifying" / "Start localizing") shrink from full-width blocks to fit-content pills.
- **PhaseCard footer**: the two stacked ghost links are reorganized into a single footer row separated by a hairline top border — secondary entry point ("Classify by group · N") bottom-left, review link bottom-right. The Localize card gets the same footer with just its review link, so both cards share the same structure.

Note: the secondary link intentionally drops its trailing "→" — the arrow now uniquely marks the review direction, and a right-pointing arrow on the left-pinned item read oddly.

## Test plan

- `npm run type-check`, ESLint (`--max-warnings 0`), and Prettier all pass on the touched files.
- Eyeballed at `/dashboard` against the live API: segments centered, buttons sized to content, footers aligned across both cards.
- Reviewed by a code-review pass: no critical/important findings; the two actionable minors (asymmetric chevron padding, orphaned `text-center`) are fixed in the second commit.