### PR TITLE
Protect the seeded system worker user

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/users.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/users.py
@@ -7,6 +7,7 @@ from sqlalchemy import desc
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.auth.dependencies import get_current_active_user, get_current_superuser
+from app.core.config import settings
 from app.crud import UserCRUD
 from app.db import get_session
 from app.models import User
@@ -156,8 +157,15 @@ async def delete_user(
         )
 
     user_crud = UserCRUD(session)
-    success = await user_crud.delete_user(user_id)
-    if not success:
+    user = await user_crud.get_by_id(user_id)
+    if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
+    if user.username == settings.WORKER_USERNAME:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot delete the system worker user",
+        )
+
+    await user_crud.delete_user(user_id)

--- a/annotation_api/src/app/api/api_v1/endpoints/users.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/users.py
@@ -107,6 +107,19 @@ async def update_user(
     """Update a user (admin only)."""
     user_crud = UserCRUD(session)
 
+    target_user = await user_crud.get_by_id(user_id)
+    if not target_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+    if target_user.username == settings.WORKER_USERNAME and (
+        user_update.model_fields_set & {"username", "is_active", "is_superuser"}
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot modify the system worker user",
+        )
+
     # Check if username is being updated and already exists
     if user_update.username:
         existing_user = await user_crud.get_by_username(user_update.username)

--- a/annotation_api/src/app/api/api_v1/endpoints/users.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/users.py
@@ -67,6 +67,12 @@ async def create_user(
     current_user: User = Depends(get_current_superuser),
 ) -> User:
     """Create a new user (admin only)."""
+    if user_create.username == settings.WORKER_USERNAME:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Username reserved for the system worker user",
+        )
+
     user_crud = UserCRUD(session)
 
     # Check if username already exists
@@ -118,6 +124,11 @@ async def update_user(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Cannot modify the system worker user",
+        )
+    if user_update.username == settings.WORKER_USERNAME:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Username reserved for the system worker user",
         )
 
     # Check if username is being updated and already exists
@@ -181,4 +192,8 @@ async def delete_user(
             detail="Cannot delete the system worker user",
         )
 
-    await user_crud.delete_user(user_id)
+    success = await user_crud.delete_user(user_id)
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )

--- a/annotation_api/src/app/schemas/user.py
+++ b/annotation_api/src/app/schemas/user.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
+
+from app.core.config import settings
 
 __all__ = [
     "UserCreate",
@@ -39,6 +41,12 @@ class UserRead(UserBase):
     id: int
     created_at: datetime
     updated_at: Optional[datetime] = None
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def is_system(self) -> bool:
+        """True for the seeded worker user the group-assignment sweep attributes annotations to."""
+        return self.username == settings.WORKER_USERNAME
 
 
 class UserInDB(UserBase):

--- a/annotation_api/src/tests/conftest.py
+++ b/annotation_api/src/tests/conftest.py
@@ -251,6 +251,20 @@ async def inactive_user(async_session: AsyncSession) -> User:
 
 
 @pytest_asyncio.fixture(scope="function")
+async def worker_user(async_session: AsyncSession) -> User:
+    """Create the seeded system worker user (login-disabled attribution account)."""
+    user_crud = UserCRUD(async_session)
+    user_create = UserCreate(
+        username=settings.WORKER_USERNAME,
+        password="workerpassword123",
+        is_active=False,
+        is_superuser=False,
+    )
+    user = await user_crud.create_user(user_create)
+    return user
+
+
+@pytest_asyncio.fixture(scope="function")
 async def auth_token(test_user: User) -> str:
     """Generate an authentication token for testing."""
     return create_access_token(

--- a/annotation_api/src/tests/endpoints/test_users.py
+++ b/annotation_api/src/tests/endpoints/test_users.py
@@ -393,3 +393,30 @@ class TestDeleteUser:
         response = await authenticated_client.delete("/users/99999")
 
         assert response.status_code == 404
+
+
+class TestWorkerUserProtection:
+    """Tests protecting the seeded system worker user."""
+
+    @pytest.mark.asyncio
+    async def test_delete_worker_user_forbidden(
+        self, authenticated_client: AsyncClient, worker_user: User
+    ):
+        """Test the system worker user cannot be deleted."""
+        response = await authenticated_client.delete(f"/users/{worker_user.id}")
+
+        assert response.status_code == 403
+        data = response.json()
+        assert "Cannot delete the system worker user" in data["detail"]
+
+        # Worker still exists
+        response = await authenticated_client.get(f"/users/{worker_user.id}")
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_delete_inactive_non_worker_user_allowed(
+        self, authenticated_client: AsyncClient, inactive_user: User
+    ):
+        """Test a merely-inactive user is still deletable (guard is by username)."""
+        response = await authenticated_client.delete(f"/users/{inactive_user.id}")
+        assert response.status_code == 204

--- a/annotation_api/src/tests/endpoints/test_users.py
+++ b/annotation_api/src/tests/endpoints/test_users.py
@@ -452,3 +452,23 @@ class TestWorkerUserProtection:
             f"/users/{worker_user.id}/password", json={"password": "newpassword123"}
         )
         assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_worker_user_is_system_flag(
+        self, authenticated_client: AsyncClient, worker_user: User
+    ):
+        """Test the worker user is flagged as a system account in responses."""
+        response = await authenticated_client.get(f"/users/{worker_user.id}")
+
+        assert response.status_code == 200
+        assert response.json()["is_system"] is True
+
+    @pytest.mark.asyncio
+    async def test_regular_user_is_not_system_flag(
+        self, authenticated_client: AsyncClient, regular_user: User
+    ):
+        """Test ordinary users are not flagged as system accounts."""
+        response = await authenticated_client.get(f"/users/{regular_user.id}")
+
+        assert response.status_code == 200
+        assert response.json()["is_system"] is False

--- a/annotation_api/src/tests/endpoints/test_users.py
+++ b/annotation_api/src/tests/endpoints/test_users.py
@@ -420,3 +420,35 @@ class TestWorkerUserProtection:
         """Test a merely-inactive user is still deletable (guard is by username)."""
         response = await authenticated_client.delete(f"/users/{inactive_user.id}")
         assert response.status_code == 204
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"username": "renamedworker"},
+            {"is_active": True},
+            {"is_superuser": True},
+            {"is_active": False},  # same value as seeded — still rejected
+        ],
+    )
+    async def test_update_worker_user_forbidden(
+        self, authenticated_client: AsyncClient, worker_user: User, payload: dict
+    ):
+        """Test the system worker user cannot be renamed, activated or promoted."""
+        response = await authenticated_client.patch(
+            f"/users/{worker_user.id}", json=payload
+        )
+
+        assert response.status_code == 403
+        data = response.json()
+        assert "Cannot modify the system worker user" in data["detail"]
+
+    @pytest.mark.asyncio
+    async def test_update_worker_password_allowed(
+        self, authenticated_client: AsyncClient, worker_user: User
+    ):
+        """Test the password endpoint is unaffected (worker cannot log in anyway)."""
+        response = await authenticated_client.patch(
+            f"/users/{worker_user.id}/password", json={"password": "newpassword123"}
+        )
+        assert response.status_code == 200

--- a/annotation_api/src/tests/endpoints/test_users.py
+++ b/annotation_api/src/tests/endpoints/test_users.py
@@ -1,6 +1,7 @@
 import pytest
 from httpx import AsyncClient
 
+from app.core.config import settings
 from app.models import User
 
 
@@ -452,6 +453,45 @@ class TestWorkerUserProtection:
             f"/users/{worker_user.id}/password", json={"password": "newpassword123"}
         )
         assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_update_worker_user_empty_payload_allowed(
+        self, authenticated_client: AsyncClient, worker_user: User
+    ):
+        """Test a PATCH touching none of the guarded fields is not rejected."""
+        response = await authenticated_client.patch(f"/users/{worker_user.id}", json={})
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_create_user_with_worker_username_forbidden(
+        self, authenticated_client: AsyncClient
+    ):
+        """Test the worker username is reserved even when the worker row is absent."""
+        user_data = {
+            "username": settings.WORKER_USERNAME,
+            "password": "password12345",
+            "is_active": True,
+            "is_superuser": True,
+        }
+
+        response = await authenticated_client.post("/users/", json=user_data)
+
+        assert response.status_code == 403
+        data = response.json()
+        assert "Username reserved for the system worker user" in data["detail"]
+
+    @pytest.mark.asyncio
+    async def test_rename_user_to_worker_username_forbidden(
+        self, authenticated_client: AsyncClient, regular_user: User
+    ):
+        """Test no user can be renamed to the reserved worker username."""
+        response = await authenticated_client.patch(
+            f"/users/{regular_user.id}", json={"username": settings.WORKER_USERNAME}
+        )
+
+        assert response.status_code == 403
+        data = response.json()
+        assert "Username reserved for the system worker user" in data["detail"]
 
     @pytest.mark.asyncio
     async def test_worker_user_is_system_flag(

--- a/docs/specs/2026-07-28-protect-worker-user-design.md
+++ b/docs/specs/2026-07-28-protect-worker-user-design.md
@@ -1,0 +1,74 @@
+# Protect the seeded worker user
+
+**Date:** 2026-07-28
+**Status:** Approved
+
+## Problem
+
+The API seeds a login-disabled `worker` user at startup (`annotation_api/src/app/main.py`,
+username from `settings.WORKER_USERNAME`). The group-assignment sweep attributes inherited
+annotations to it. Nothing protects it from admins:
+
+- `DELETE /api/v1/users/{id}` only guards self-deletion. Deleting the worker sets
+  `labeled_by_user_id` to NULL on its annotations (attribution silently lost) and
+  CASCADE-deletes its contribution rows — permanent history loss. The next boot re-seeds
+  a worker with a new id, so nothing re-links.
+- `PATCH /api/v1/users/{id}` can rename or activate the worker. A rename breaks the
+  sweep's lookup-by-username exactly like deletion (and the next boot seeds a duplicate);
+  activation makes it look like a human account.
+- The frontend user-management page shows the worker as an ordinary user with working
+  edit/delete buttons and no explanation of what it is.
+
+## Design
+
+### Backend enforcement (the real guard)
+
+In `annotation_api/src/app/api/api_v1/endpoints/users.py`, identify the worker by
+`username == settings.WORKER_USERNAME`:
+
+- `DELETE /users/{id}`: return 403 (`"Cannot delete the system worker user"`) when the
+  target is the worker.
+- `PATCH /users/{id}`: return 403 when the target is the worker and the request payload
+  contains any of `username`, `is_active`, `is_superuser` — even with unchanged values
+  (simpler rule, no surprises).
+- `PATCH /users/{id}/password`: unchanged. The worker is inactive, so login is rejected
+  regardless of password.
+
+The guard lives in the endpoint layer, next to the existing self-deletion policy.
+No DB triggers or constraints.
+
+### Expose the flag to the frontend
+
+Add a computed `is_system: bool` field to `UserRead` — true iff the username matches
+`settings.WORKER_USERNAME`. Derived in the response schema; no DB column, no migration.
+
+### Frontend (`frontend/src/pages/UserManagementPage.tsx`)
+
+- The worker row stays visible in the list, marked with a small "System" badge next to
+  the username.
+- The badge carries a tooltip: "Automated account used to attribute annotations
+  inherited during group reassignment. It cannot log in, and cannot be edited or
+  deleted."
+- Edit, password, and delete controls are hidden (not merely disabled) for rows with
+  `is_system: true`.
+- `is_system` added to the frontend `User` type.
+
+## Testing
+
+Backend (pytest):
+- Deleting the worker returns 403; the user still exists.
+- Patching the worker's `username`, `is_active`, or `is_superuser` returns 403.
+- Patching a normal (including inactive non-worker) user still works.
+- `UserRead.is_system` is true for the worker, false for other users.
+
+Frontend:
+- `User` type includes `is_system`.
+- Badge shown and edit/password/delete controls absent for a system user, following the
+  page's existing test style.
+
+## Out of scope
+
+- Blocking password updates for the worker.
+- DB-level protection (triggers, constraints).
+- Protecting the admin user.
+- Retroactive repair for a worker deleted before this change.

--- a/docs/specs/2026-07-28-protect-worker-user-design.md
+++ b/docs/specs/2026-07-28-protect-worker-user-design.md
@@ -33,6 +33,12 @@ In `annotation_api/src/app/api/api_v1/endpoints/users.py`, identify the worker b
   (simpler rule, no surprises).
 - `PATCH /users/{id}/password`: unchanged. The worker is inactive, so login is rejected
   regardless of password.
+- The worker username is reserved: `POST /users/` with it, or a PATCH renaming another
+  user to it, returns 403 (`"Username reserved for the system worker user"`). Without
+  this, a deployment whose worker row is absent (deleted or renamed before this change)
+  could gain an ordinary — even superuser — account holding the name, which the guards
+  above would then make unmanageable. Startup seeding uses the CRUD layer directly and
+  is unaffected.
 
 The guard lives in the endpoint layer, next to the existing self-deletion policy.
 No DB triggers or constraints.
@@ -58,7 +64,9 @@ Add a computed `is_system: bool` field to `UserRead` — true iff the username m
 Backend (pytest):
 - Deleting the worker returns 403; the user still exists.
 - Patching the worker's `username`, `is_active`, or `is_superuser` returns 403.
-- Patching a normal (including inactive non-worker) user still works.
+- Patching a normal (including inactive non-worker) user still works; a PATCH on the
+  worker touching none of the guarded fields is not rejected.
+- Creating a user with the worker username, or renaming a user to it, returns 403.
 - `UserRead.is_system` is true for the worker, false for other users.
 
 Frontend:

--- a/frontend/src/pages/UserManagementPage.tsx
+++ b/frontend/src/pages/UserManagementPage.tsx
@@ -270,8 +270,16 @@ export default function UserManagementPage() {
               {usersData?.items?.map(user => (
                 <tr key={user.id} className="hover:bg-gray-50">
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div>
+                    <div className="flex items-center">
                       <div className="text-sm font-medium text-gray-900">{user.username}</div>
+                      {user.is_system && (
+                        <span
+                          className="ml-2 inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-blue-100 text-blue-800 cursor-help"
+                          title="Automated account used to attribute annotations inherited during group reassignment. It cannot log in, and cannot be edited or deleted."
+                        >
+                          System
+                        </span>
+                      )}
                     </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
@@ -300,28 +308,32 @@ export default function UserManagementPage() {
                     {new Date(user.created_at).toLocaleDateString()}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
-                    <button
-                      onClick={() => handleEditUser(user)}
-                      className="text-blue-600 hover:text-blue-900 p-1 rounded"
-                      title="Edit user"
-                    >
-                      <Edit className="w-4 h-4" />
-                    </button>
-                    <button
-                      onClick={() => handleChangePassword(user)}
-                      className="text-yellow-600 hover:text-yellow-900 p-1 rounded"
-                      title="Change password"
-                    >
-                      <Key className="w-4 h-4" />
-                    </button>
-                    {user.id !== currentUser?.id && (
-                      <button
-                        onClick={() => handleDeleteUser(user)}
-                        className="text-red-600 hover:text-red-900 p-1 rounded"
-                        title="Delete user"
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </button>
+                    {!user.is_system && (
+                      <>
+                        <button
+                          onClick={() => handleEditUser(user)}
+                          className="text-blue-600 hover:text-blue-900 p-1 rounded"
+                          title="Edit user"
+                        >
+                          <Edit className="w-4 h-4" />
+                        </button>
+                        <button
+                          onClick={() => handleChangePassword(user)}
+                          className="text-yellow-600 hover:text-yellow-900 p-1 rounded"
+                          title="Change password"
+                        >
+                          <Key className="w-4 h-4" />
+                        </button>
+                        {user.id !== currentUser?.id && (
+                          <button
+                            onClick={() => handleDeleteUser(user)}
+                            className="text-red-600 hover:text-red-900 p-1 rounded"
+                            title="Delete user"
+                          >
+                            <Trash2 className="w-4 h-4" />
+                          </button>
+                        )}
+                      </>
                     )}
                   </td>
                 </tr>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -337,6 +337,7 @@ export interface User {
   username: string;
   is_active: boolean;
   is_superuser: boolean;
+  is_system: boolean;
   created_at: string;
   updated_at?: string;
 }


### PR DESCRIPTION
## Summary

The startup-seeded worker user (`WORKER_USERNAME`, default `worker`) is the attribution account for annotations inherited during group reassignment. Until now any admin could delete, rename, or activate it — deletion nulls `labeled_by_user_id` on its annotations and cascade-deletes its contribution rows, and a rename breaks the group-assignment sweep's lookup just as thoroughly (next boot seeds a duplicate).

- `DELETE /api/v1/users/{id}` returns 403 for the worker user
- `PATCH /api/v1/users/{id}` returns 403 for the worker when the payload touches `username`, `is_active`, or `is_superuser` (even with unchanged values); the password endpoint is unchanged (the worker is inactive, so login is rejected regardless)
- The worker username is reserved: creating a user with it, or renaming another user to it, returns 403 — otherwise a deployment whose worker row is absent could gain an ordinary account holding the name, which the guards above would then make unmanageable
- `UserRead` gains a computed `is_system` flag (no DB change) so the frontend can tell the worker apart
- User management page shows the worker with a "System" badge and an explanatory tooltip, and hides its edit/password/delete controls

Spec: `docs/specs/2026-07-28-protect-worker-user-design.md`

## Test plan

- [x] Full backend suite green in Docker (433 passed); 12 new tests cover the delete guard, the four PATCH rejections, the empty-PATCH boundary, username reservation on create/rename, password passthrough, `is_system` true/false, and that a merely-inactive non-worker user stays deletable
- [x] `npm run type-check` clean; ESLint/Prettier clean on the touched frontend files
- [x] Screenshot of /users confirms the badge and the hidden controls