### PR TITLE
perf: bound localization-queue and sweep aggregations to candidate alerts (#215)

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -24,9 +24,11 @@ from sqlalchemy import (
     select,
     and_,
     cast,
+    tuple_,
     ARRAY,
     String,
 )
+from sqlalchemy.orm import aliased
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.dependencies import get_current_user, get_sequence_crud
@@ -521,6 +523,19 @@ async def list_sequences(
         return paginated_result
 
 
+def _ready_smoke_lane(seq, ann):
+    """Smoke lane (has_smoke, not unsure) still at seq_annotation_done whose
+    auto reference layer exists. Parameterized over (possibly aliased)
+    Sequence/SequenceAnnotation so the queue can use it both in its HAVING
+    aggregate and in the candidate-alert pre-filter."""
+    return and_(
+        ann.processing_stage == SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE,
+        ann.has_smoke.is_(True),
+        ann.is_unsure.is_(False),
+        seq.auto_annotated_at.is_not(None),
+    )
+
+
 # NOTE: declared before GET /{sequence_id} — the int path converter would
 # otherwise turn /localization-queue into a 422.
 @router.get("/localization-queue")
@@ -534,12 +549,18 @@ async def localization_queue(
     (has_smoke, not unsure) at seq_annotation_done whose auto reference layer
     exists (auto_annotated_at set). Lanes leave on submit (stage change), so a
     fully-boxed but unsubmitted lane still counts as ready."""
-    ready_smoke_lane = and_(
-        SequenceAnnotation.processing_stage
-        == SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE,
-        SequenceAnnotation.has_smoke.is_(True),
-        SequenceAnnotation.is_unsure.is_(False),
-        Sequence.auto_annotated_at.is_not(None),
+    ready_smoke_lane = _ready_smoke_lane(Sequence, SequenceAnnotation)
+    # Pre-filter to alerts having at least one ready smoke lane BEFORE the
+    # completeness aggregation, so the grouping scans the active working set
+    # (lanes still at seq_annotation_done) instead of all history. The HAVING
+    # ready-lane check already implies this membership, so results are
+    # identical — this only bounds the cost (#215).
+    cand_seq = aliased(Sequence)
+    cand_ann = aliased(SequenceAnnotation)
+    candidate_alerts = (
+        select(cand_seq.source_api, cand_seq.platform_alert_id)
+        .join(cand_ann, cand_ann.sequence_id == cand_seq.id)
+        .where(_ready_smoke_lane(cand_seq, cand_ann))
     )
     alerts = (
         select(
@@ -548,6 +569,11 @@ async def localization_queue(
             func.min(Sequence.recorded_at).label("recorded_at"),
         )
         .outerjoin(SequenceAnnotation, SequenceAnnotation.sequence_id == Sequence.id)
+        .where(
+            tuple_(Sequence.source_api, Sequence.platform_alert_id).in_(
+                candidate_alerts
+            )
+        )
         .group_by(Sequence.source_api, Sequence.platform_alert_id)
         .having(
             and_(

--- a/annotation_api/src/app/services/auto_annotate_scheduling.py
+++ b/annotation_api/src/app/services/auto_annotate_scheduling.py
@@ -14,7 +14,8 @@ id.
 
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import and_, case, func, or_, select
+from sqlalchemy import and_, case, func, or_, select, tuple_
+from sqlalchemy.orm import aliased
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models import (
@@ -37,14 +38,24 @@ DONE_STAGES = (
 RETRY_STALE_AFTER = timedelta(hours=1)
 
 
-def complete_alerts_subquery():
+def complete_alerts_subquery(candidates=None):
     """(source_api, platform_alert_id) pairs where every sibling has a
     done-stage annotation. The outer join makes annotation-less siblings
-    count as not-done (NULL stage falls into the CASE else)."""
+    count as not-done (NULL stage falls into the CASE else).
+
+    ``candidates`` (a select of (source_api, platform_alert_id)) restricts the
+    grouping before it aggregates, so the scan is proportional to the caller's
+    working set rather than all history (#215). Purely a cost bound — callers
+    must only pass a set that already contains every alert they can act on."""
+    query = select(Sequence.source_api, Sequence.platform_alert_id).outerjoin(
+        SequenceAnnotation, SequenceAnnotation.sequence_id == Sequence.id
+    )
+    if candidates is not None:
+        query = query.where(
+            tuple_(Sequence.source_api, Sequence.platform_alert_id).in_(candidates)
+        )
     return (
-        select(Sequence.source_api, Sequence.platform_alert_id)
-        .outerjoin(SequenceAnnotation, SequenceAnnotation.sequence_id == Sequence.id)
-        .group_by(Sequence.source_api, Sequence.platform_alert_id)
+        query.group_by(Sequence.source_api, Sequence.platform_alert_id)
         .having(
             func.count()
             == func.sum(
@@ -55,9 +66,38 @@ def complete_alerts_subquery():
     )
 
 
+def _pending_ready_lane(seq, ann, now):
+    """Smoke lane still awaiting auto-annotation: at seq_annotation_done and
+    either never enqueued or lost (see RETRY_STALE_AFTER). Parameterized over
+    (possibly aliased) Sequence/SequenceAnnotation."""
+    return and_(
+        ann.processing_stage == SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE,
+        ann.has_smoke.is_(True),
+        ann.is_unsure.is_(False),
+        or_(
+            seq.auto_annotate_enqueued_at.is_(None),
+            # Lost-job reconciliation (see RETRY_STALE_AFTER).
+            and_(
+                seq.auto_annotated_at.is_(None),
+                seq.auto_annotate_enqueued_at < now - RETRY_STALE_AFTER,
+            ),
+        ),
+    )
+
+
 async def schedule_pending_auto_annotate(session: AsyncSession) -> list[int]:
     now = datetime.now(UTC)
-    complete = complete_alerts_subquery()
+    # Only alerts with at least one pending lane can produce work; restricting
+    # the completeness aggregation to them keeps the sweep proportional to the
+    # active working set instead of all history (#215).
+    cand_seq = aliased(Sequence)
+    cand_ann = aliased(SequenceAnnotation)
+    candidates = (
+        select(cand_seq.source_api, cand_seq.platform_alert_id)
+        .join(cand_ann, cand_ann.sequence_id == cand_seq.id)
+        .where(_pending_ready_lane(cand_seq, cand_ann, now))
+    )
+    complete = complete_alerts_subquery(candidates)
     lanes = (
         (
             await session.execute(
@@ -73,21 +113,7 @@ async def schedule_pending_auto_annotate(session: AsyncSession) -> list[int]:
                         complete.c.platform_alert_id == Sequence.platform_alert_id,
                     ),
                 )
-                .where(
-                    SequenceAnnotation.processing_stage
-                    == SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE,
-                    SequenceAnnotation.has_smoke.is_(True),
-                    SequenceAnnotation.is_unsure.is_(False),
-                    or_(
-                        Sequence.auto_annotate_enqueued_at.is_(None),
-                        # Lost-job reconciliation (see RETRY_STALE_AFTER).
-                        and_(
-                            Sequence.auto_annotated_at.is_(None),
-                            Sequence.auto_annotate_enqueued_at
-                            < now - RETRY_STALE_AFTER,
-                        ),
-                    ),
-                )
+                .where(_pending_ready_lane(Sequence, SequenceAnnotation, now))
                 .order_by(Sequence.id)
             )
         )


### PR DESCRIPTION
## Context

Closes #215.

The localization queue (`GET /api/v1/sequences/localization-queue`) and the periodic sweep (`schedule_pending_auto_annotate`) both computed alert readiness with a grouping aggregation over **all** sequences joined to their annotations. #215 asked to measure that at production scale and bound it if slow.

## Measurement setup

Isolated `postgres:15-alpine` with the real alembic schema, seeded to a production-sized snapshot (~3 years):

- 430k alerts / 645k sequences / 642k sequence annotations / 806k detections
- history fully annotated; active working set at the tail: 2,000 in-progress alerts, 3,000 with an annotation-less lane, 500 complete-but-parked (awaiting auto-annotate), **150 queue-ready**

## Baseline (answers the issue's questions)

- `ix_sequence_platform_alert_id` is **not** used: both queue queries seq-scan `sequences` + `sequences_annotations`, hash-join 645k rows, and the HAVING aggregation materializes a HashAggregate over all 430k groups, spilling ~32 MB to disk, then discards 429,850 of 430,000 groups.
- Grouping query: **~477 ms**; endpoint page `size=50`: **~860 ms**; total-only `size=1` (badge/dashboard path): **~800 ms**. The sweep's completeness aggregation: **~432 ms** every 5 min.

## Fix: candidate pre-filter (first option in the issue's list)

Restrict the grouping to candidate alerts before the completeness aggregation runs:

- **Queue**: alerts with ≥1 ready smoke lane (`seq_annotation_done`, `has_smoke`, not unsure, `auto_annotated_at` set). The HAVING ready-lane check already implies this membership, so results are identical — verified by `EXCEPT` on the seeded snapshot (0 rows differ both directions).
- **Sweep**: alerts with ≥1 pending lane (`seq_annotation_done` smoke lane never enqueued or stale). Only those can produce enqueues — identical lane set on the snapshot (500 = 500).

The pre-filter runs on the existing `ix_sequence_annotation_processing_stage` index (650 rows at `seq_annotation_done`) and the scoped aggregation on `ix_sequence_platform_alert_id`, so cost is now proportional to the active working set (self-limiting: lanes leave the stage on submit/auto-annotate) instead of all history.

## Results

| Query | Before | After |
|---|---|---|
| Queue grouping query | 477 ms | 1.1 ms |
| Endpoint page `size=50` | ~860 ms | ~45 ms |
| Endpoint total-only `size=1` (badge/dashboard) | ~800 ms | ~8 ms |
| Sweep completeness aggregation | ~432 ms | ~3.4 ms |

Remaining page cost is the per-alert lanes/stats queries, hard-capped by page size.

## Not needed (per the issue's mitigation ladder)

- **Partial index**: the existing stage index already bounds the pre-filter.
- **Badge/dashboard count caching**: moot at ~8 ms/call.
- **Denormalized readiness flag**: moot.

## Verification

- Full backend suite in an isolated compose stack: **476 passed** (includes the 7 localization-queue tests and 12 sweep scheduling tests).
- `ruff format --check` / `ruff check` clean on changed files; mypy unchanged vs main (same 8 pre-existing script-mapping errors).