### PR TITLE
feat(frontend): rename routes to the task taxonomy (/classify, /localize)

### DIFF
--- a/docs/specs/2026-07-28-route-taxonomy-rename-design.md
+++ b/docs/specs/2026-07-28-route-taxonomy-rename-design.md
@@ -1,0 +1,141 @@
+# Route Taxonomy Rename — Design
+
+**Issue**: [#210](https://github.com/pyronear/pyro-annotator/issues/210)
+**Date**: 2026-07-28
+**Status**: Approved
+
+## Problem
+
+The dashboard (#208) teaches the pipeline as two passes — **Classify** and
+**Localize** — and the sidebar (#211) now uses the same vocabulary. The routes
+still name database entities (`/sequences/*`, `/detections/*`,
+`/sequence-groups`). Since the unit of both passes is a sequence,
+`/detections/annotate` for Pass 02 is doubly misleading. URLs should speak the
+taxonomy the app teaches.
+
+Prerequisites #207 (stage retirement, PR #220) and the Smoke Localization
+entry point (#212) are merged, so this rename maps the final page set.
+
+## Decisions
+
+1. **Bare pass roots**: the annotate queues live at `/classify` and
+   `/localize` — the queue is the pass's home page.
+2. **`/done`, not `/review`**: finished-work pages use the word the sidebar
+   shows (`Classify → Done`, `Localize → Done`).
+3. **Path-based provenance**: the `?from=` query mechanism is deleted.
+   Provenance (which queue a detail page was entered from) is encoded in the
+   path (`/classify/:id` vs `/classify/done/:id`).
+4. **Storage keys renamed, no migration**: annotators lose saved filters once
+   and re-pick them on next visit.
+
+## Route Table
+
+| Old | New | Component |
+| --- | --- | --- |
+| `/sequences/annotate` | `/classify` | `SequencesPage` |
+| `/sequences/review` | `/classify/done` | `SequencesPageWrapper` |
+| `/sequences/:id/annotate` | `/classify/:id` | `AnnotationInterface` |
+| `/sequences/:id/annotate?from=review` | `/classify/done/:id` | `AnnotationInterface` (done mode) |
+| `/sequence-groups` | `/classify/groups` | `SequenceGroupsListPage` |
+| `/sequence-groups/:id/annotate` | `/classify/groups/:id` | `SequenceGroupAnnotatePage` |
+| `/detections/annotate` | `/localize` | `DetectionAnnotatePage` |
+| `/detections/review` | `/localize/done` | `DetectionReviewPage` |
+| `/detections/:seqId/annotate/:detId?` (`from=localize` or absent) | `/localize/:seqId/:detId?` | `DetectionSequenceAnnotatePage` |
+| `/detections/:seqId/annotate/:detId?` (`from=detections-review`) | `/localize/done/:seqId/:detId?` | `DetectionSequenceAnnotatePage` (done mode) |
+
+Unchanged: `/`, `/login`, `/users`, `/guide`.
+
+No matching conflicts: React Router v6 ranks static segments (`done`,
+`groups`) above dynamic ones (`:id`).
+
+### Mode as a prop
+
+Detail components are mounted twice, with the mode set on the route element:
+
+```tsx
+<Route path="/classify/:id" element={<AnnotationInterface />} />
+<Route path="/classify/done/:id" element={<AnnotationInterface mode="done" />} />
+```
+
+Components read the prop — they do not re-parse `location.pathname`.
+
+### Localize detail flows
+
+Today the localize detail page has three `from=` flows: `localize`
+(lane-submit on save; the only in-app entry from the Smoke queue),
+`detections-review` (done mode), and absent (legacy generic auto-advance,
+reachable only by hand-typed URLs). After the rename:
+
+- `/localize/:seqId/:detId?` **is** the lane-submit flow.
+- `/localize/done/:seqId/:detId?` is the done flow.
+- The legacy generic flow is removed.
+
+## Redirects
+
+Every old route redirects (`replace`) to its new location via a small
+`LegacyRedirect` route element that interpolates path params and translates
+the old `from=` query per the route table above. Redirects stay indefinitely.
+
+Old `from=` values other than the ones tabled (or absent) fall back to the
+non-done target.
+
+## Nav Highlighting (`AppLayout`)
+
+`isPathActive` collapses to prefix matching on the current pathname — all
+`?from=` special-casing and `location.search` reads are deleted:
+
+- `/classify/groups*` → Groups
+- `/classify/done*` → Done (Classify)
+- other `/classify*` → Sequences
+- `/localize/done*` → Done (Localize)
+- other `/localize*` → Smoke
+
+## In-App Link Updates
+
+All link/`navigate` call sites move to the new paths and drop `from=`:
+
+- `SequencesPage` — row links; the `?from=review` suffix logic becomes a
+  base-path choice (`/classify/:id` vs `/classify/done/:id`).
+- `AnnotationInterface` — back URL becomes a ternary on the mode prop.
+- `DetectionAnnotatePage` — entry navigation to `/localize/:seqId`.
+- `DetectionReviewPage` — entry navigation to `/localize/done/:seqId`.
+- `DetectionSequenceAnnotatePage` — advance/back navigation; source-page and
+  filter-key selection derive from the mode prop.
+- `SequenceGroupsListPage` / `SequenceGroupAnnotatePage` — group links.
+- `DashboardPage` CTAs — `/classify/groups`, `/classify`, `/localize`.
+- `HomePage`, `utils/pipeline.ts`, `useAnnotationCounts` — any residual path
+  strings.
+
+## Storage Keys
+
+| Old | New |
+| --- | --- |
+| `filters-sequences-annotate` | `filters-classify` |
+| `filters-sequences-review` | `filters-classify-done` |
+| `filters-detections-annotate` | `filters-localize` |
+| `filters-detections-review` / `filters-detections-review-v2` | `filters-localize-done` |
+| `sequences-review-stage` | `classify-done-stage` |
+
+No value migration. `tabbed-filters-active-tab` is taxonomy-neutral and
+unchanged.
+
+## Testing
+
+- Update existing route/nav assertions (`AppLayout.test.tsx`, page tests
+  using old paths).
+- New redirect tests: each old URL — including `from=` variants — lands on
+  the mapped new URL.
+- Nav-highlight tests for the five prefix rules above.
+- Full suite, type-check, lint stay green.
+
+## Docs
+
+- `frontend/CLAUDE.md` routes table.
+- Root `CLAUDE.md` if it references old routes.
+
+## Out of Scope
+
+- Backend/API paths (`/api/v1/sequences`, `/api/v1/detections`) — entity
+  names are correct for the API.
+- Component/file renames (`SequencesPage.tsx` etc.) — a later cleanup if
+  wanted; this issue is user-facing URLs and their direct plumbing.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -65,17 +65,29 @@ frontend/src/
 
 ## Routes (declared in `App.tsx`)
 
-| Path                                                  | Component                         |
-| ----------------------------------------------------- | --------------------------------- |
-| `/login`                                              | `LoginPage`                       |
-| `/sequences/annotate`                                 | `SequencesPage`                   |
-| `/sequences/review`                                   | `SequencesPageWrapper`            |
-| `/sequences/:id/annotate`                             | `AnnotationInterface`             |
-| `/detections/annotate`                                | `DetectionAnnotatePage` (alert-grouped Localize queue) |
-| `/detections/review`                                  | `DetectionReviewPage` (verification, smoke lanes only) |
-| `/detections/:sequenceId/annotate/:detectionId?`      | `DetectionSequenceAnnotatePage`   |
-| `/users`                                              | `UserManagementPage`              |
-| `/guide`                                              | `GuidePage`                       |
+Path constants and builders live in `src/utils/routes.ts`. Detail pages encode
+provenance in the path: `/classify/:id` was entered from the queue,
+`/classify/done/:id` from the Done list (same component, `mode="done"`).
+
+| Path                                       | Component                         |
+| ------------------------------------------ | --------------------------------- |
+| `/login`                                   | `LoginPage`                       |
+| `/`                                        | `DashboardPage`                   |
+| `/classify`                                | `SequencesPage` (classify queue)  |
+| `/classify/done`                           | `SequencesPageWrapper`            |
+| `/classify/:id`                            | `AnnotationInterface`             |
+| `/classify/done/:id`                       | `AnnotationInterface` (done mode) |
+| `/classify/groups`                         | `SequenceGroupsListPage`          |
+| `/classify/groups/:id`                     | `SequenceGroupAnnotatePage`       |
+| `/localize`                                | `DetectionAnnotatePage` (alert-grouped Localize queue) |
+| `/localize/done`                           | `DetectionReviewPage` (verification, smoke lanes only) |
+| `/localize/:sequenceId/:detectionId?`      | `DetectionSequenceAnnotatePage`   |
+| `/localize/done/:sequenceId/:detectionId?` | `DetectionSequenceAnnotatePage` (done mode) |
+| `/users`                                   | `UserManagementPage`              |
+| `/guide`                                   | `GuidePage`                       |
+
+Old entity-named routes (`/sequences/*`, `/detections/*`, `/sequence-groups*`)
+redirect permanently — see `src/components/routing/legacyRedirects.tsx`.
 
 ## Development Commands
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import SequenceGroupsListPage from '@/pages/SequenceGroupsListPage';
 import UserManagementPage from '@/pages/UserManagementPage';
 import GuidePage from '@/pages/GuidePage';
 import LoginPage from '@/pages/LoginPage';
+import { legacyRedirectRoutes } from '@/components/routing/legacyRedirects';
 import { useAuthStore } from '@/store/useAuthStore';
 
 // Create a client
@@ -76,23 +77,26 @@ function App() {
             element={
               <AppLayout>
                 <Routes>
-                  <Route path="/sequences/annotate" element={<SequencesPage />} />
+                  <Route path="/classify" element={<SequencesPage />} />
                   <Route
-                    path="/sequences/review"
+                    path="/classify/done"
                     element={<SequencesPageWrapper defaultProcessingStage="annotated" />}
                   />
-                  <Route path="/sequences/:id/annotate" element={<AnnotationInterface />} />
-                  <Route path="/detections/annotate" element={<DetectionAnnotatePage />} />
-                  <Route path="/detections/review" element={<DetectionReviewPage />} />
+                  <Route path="/classify/groups" element={<SequenceGroupsListPage />} />
+                  <Route path="/classify/groups/:id" element={<SequenceGroupAnnotatePage />} />
+                  <Route path="/classify/done/:id" element={<AnnotationInterface mode="done" />} />
+                  <Route path="/classify/:id" element={<AnnotationInterface />} />
+                  <Route path="/localize" element={<DetectionAnnotatePage />} />
+                  <Route path="/localize/done" element={<DetectionReviewPage />} />
                   <Route
-                    path="/detections/:sequenceId/annotate/:detectionId?"
+                    path="/localize/done/:sequenceId/:detectionId?"
+                    element={<DetectionSequenceAnnotatePage mode="done" />}
+                  />
+                  <Route
+                    path="/localize/:sequenceId/:detectionId?"
                     element={<DetectionSequenceAnnotatePage />}
                   />
-                  <Route path="/sequence-groups" element={<SequenceGroupsListPage />} />
-                  <Route
-                    path="/sequence-groups/:id/annotate"
-                    element={<SequenceGroupAnnotatePage />}
-                  />
+                  {legacyRedirectRoutes}
                   <Route path="/users" element={<UserManagementPage />} />
                   <Route path="/guide" element={<GuidePage />} />
                 </Routes>

--- a/frontend/src/components/detection-sequence/DetectionGrid.tsx
+++ b/frontend/src/components/detection-sequence/DetectionGrid.tsx
@@ -6,11 +6,9 @@ interface DetectionGridProps {
   onDetectionClick: (index: number) => void;
   showPredictions: boolean;
   detectionAnnotations: Map<number, DetectionAnnotation>;
-  fromParam: string | null;
-  getIsAnnotated: (
-    annotation: DetectionAnnotation | undefined,
-    fromContext: string | null
-  ) => boolean;
+  /** 'done' when the page was entered from the Localize Done list. */
+  mode?: 'done';
+  getIsAnnotated: (annotation: DetectionAnnotation | undefined, mode?: 'done') => boolean;
 }
 
 export function DetectionGrid({
@@ -18,7 +16,7 @@ export function DetectionGrid({
   onDetectionClick,
   showPredictions,
   detectionAnnotations,
-  fromParam,
+  mode,
   getIsAnnotated,
 }: DetectionGridProps) {
   return (
@@ -30,7 +28,7 @@ export function DetectionGrid({
             key={detection.id}
             detection={detection}
             onClick={() => onDetectionClick(index)}
-            isAnnotated={getIsAnnotated(detectionAnnotations.get(detection.id), fromParam)}
+            isAnnotated={getIsAnnotated(detectionAnnotations.get(detection.id), mode)}
             showPredictions={showPredictions}
             userAnnotation={detectionAnnotations.get(detection.id) || null}
           />

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import { clsx } from 'clsx';
 import { useAnnotationCounts } from '@/hooks/useAnnotationCounts';
 import NotificationBadge from '@/components/ui/NotificationBadge';
 import { useAuthStore } from '@/store/useAuthStore';
+import { ROUTES } from '@/utils/routes';
 import logoImg from '@/assets/logo.png';
 
 interface AppLayoutProps {
@@ -95,60 +96,37 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
       children: [
         {
           name: 'Groups',
-          href: '/sequence-groups',
+          href: ROUTES.CLASSIFY_GROUPS,
           badgeCount: groupCount,
           badgeTitle: `${groupCount} groups need validation`,
         },
-        { name: 'Sequences', href: '/sequences/annotate', badgeCount: sequenceCount },
-        { name: 'Done', href: '/sequences/review' },
+        { name: 'Sequences', href: ROUTES.CLASSIFY, badgeCount: sequenceCount },
+        { name: 'Done', href: ROUTES.CLASSIFY_DONE },
       ],
     },
     {
       name: 'Localize',
       children: [
-        { name: 'Smoke', href: '/detections/annotate', badgeCount: detectionCount },
-        { name: 'Done', href: '/detections/review' },
+        { name: 'Smoke', href: ROUTES.LOCALIZE, badgeCount: detectionCount },
+        { name: 'Done', href: ROUTES.LOCALIZE_DONE },
       ],
     },
   ];
 
-  const isPathActive = (href?: string) => {
-    if (!href || href === '#') return false;
-
-    // Handle detection pages directly
-    if (currentPath.startsWith('/detections/')) {
-      // Handle nested detection routes like /detections/{id}/annotate
-      if (href === '/detections/annotate' && currentPath.match(/^\/detections\/\d+\/annotate$/)) {
-        const searchParams = new URLSearchParams(location.search);
-        const fromParam = searchParams.get('from');
-        // Only highlight Detections > Annotate if not coming from detections-review
-        return fromParam !== 'detections-review';
-      }
-      if (href === '/detections/review' && currentPath.match(/^\/detections\/\d+\/annotate$/)) {
-        const searchParams = new URLSearchParams(location.search);
-        const fromParam = searchParams.get('from');
-        // Highlight Detections > Review when coming from detections-review
-        return fromParam === 'detections-review';
-      }
-      if (href === '/detections/review' && currentPath.match(/^\/detections\/\d+\/review$/)) {
-        return true;
-      }
-      return currentPath === href;
+  const isPathActive = (href: string) => {
+    if (currentPath === href) return true;
+    // Bare pass roots own their detail pages, except the done/groups subtrees.
+    if (href === ROUTES.CLASSIFY) {
+      return (
+        currentPath.startsWith('/classify/') &&
+        !currentPath.startsWith(ROUTES.CLASSIFY_DONE) &&
+        !currentPath.startsWith(ROUTES.CLASSIFY_GROUPS)
+      );
     }
-
-    // Special handling for sequence annotation pages to respect source context
-    if (currentPath.includes('/sequences/') && currentPath.includes('/annotate')) {
-      const searchParams = new URLSearchParams(window.location.search);
-      const fromParam = searchParams.get('from');
-
-      if (fromParam === 'review' && href === '/sequences/review') return true;
-      if (fromParam === 'detections' && href === '/detections/annotate') return true;
-      if (fromParam === 'detections-review' && href === '/detections/review') return true;
-      if (!fromParam && href === '/sequences/annotate') return true;
-      return false;
+    if (href === ROUTES.LOCALIZE) {
+      return currentPath.startsWith('/localize/') && !currentPath.startsWith(ROUTES.LOCALIZE_DONE);
     }
-
-    return currentPath === href || currentPath.startsWith(href + '/');
+    return currentPath.startsWith(href + '/');
   };
 
   return (
@@ -170,18 +148,14 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
                 <div className="mt-1">
                   {item.children.map(subItem => {
                     const isSubActive = isPathActive(subItem.href);
-                    const isDisabled = subItem.href === '#';
                     return (
                       <Link
                         key={subItem.name}
-                        to={isDisabled ? '#' : subItem.href}
-                        onClick={e => isDisabled && e.preventDefault()}
+                        to={subItem.href}
                         className={clsx(
                           isSubActive
                             ? 'border-pine bg-pine-soft text-pine'
-                            : isDisabled
-                              ? 'border-transparent text-gray-400 cursor-not-allowed'
-                              : 'border-transparent text-haze hover:bg-ash hover:text-char',
+                            : 'border-transparent text-haze hover:bg-ash hover:text-char',
                           'group flex items-center justify-between border-l-[3px] pl-4 pr-2 py-2 font-body text-[13px] font-medium transition-colors'
                         )}
                       >

--- a/frontend/src/components/routing/legacyRedirects.tsx
+++ b/frontend/src/components/routing/legacyRedirects.tsx
@@ -1,0 +1,72 @@
+/* eslint-disable react-refresh/only-export-components -- route-element table:
+   redirect helpers never need hot refresh */
+import { ReactElement } from 'react';
+import { Navigate, Route, useParams, useSearchParams } from 'react-router-dom';
+import { ROUTES, classifyDetail, classifyGroup, localizeDetail } from '@/utils/routes';
+
+/**
+ * Redirects from the pre-#210 entity-named routes to the task-taxonomy routes.
+ * Old URLs (bookmarks, external links) keep working indefinitely. The old
+ * `?from=` provenance query translates into the path (`/done` segment).
+ */
+
+function LegacyClassifyDetailRedirect() {
+  const { id } = useParams();
+  const [searchParams] = useSearchParams();
+  return <Navigate to={classifyDetail(id!, searchParams.get('from') === 'review')} replace />;
+}
+
+function LegacyGroupDetailRedirect() {
+  const { id } = useParams();
+  return <Navigate to={classifyGroup(id!)} replace />;
+}
+
+function LegacyLocalizeDetailRedirect() {
+  const { sequenceId, detectionId } = useParams();
+  const [searchParams] = useSearchParams();
+  const done = searchParams.get('from') === 'detections-review';
+  return <Navigate to={localizeDetail(sequenceId!, detectionId, done)} replace />;
+}
+
+export const legacyRedirectRoutes: ReactElement[] = [
+  <Route
+    key="/sequences/annotate"
+    path="/sequences/annotate"
+    element={<Navigate to={ROUTES.CLASSIFY} replace />}
+  />,
+  <Route
+    key="/sequences/review"
+    path="/sequences/review"
+    element={<Navigate to={ROUTES.CLASSIFY_DONE} replace />}
+  />,
+  <Route
+    key="/sequences/:id/annotate"
+    path="/sequences/:id/annotate"
+    element={<LegacyClassifyDetailRedirect />}
+  />,
+  <Route
+    key="/sequence-groups"
+    path="/sequence-groups"
+    element={<Navigate to={ROUTES.CLASSIFY_GROUPS} replace />}
+  />,
+  <Route
+    key="/sequence-groups/:id/annotate"
+    path="/sequence-groups/:id/annotate"
+    element={<LegacyGroupDetailRedirect />}
+  />,
+  <Route
+    key="/detections/annotate"
+    path="/detections/annotate"
+    element={<Navigate to={ROUTES.LOCALIZE} replace />}
+  />,
+  <Route
+    key="/detections/review"
+    path="/detections/review"
+    element={<Navigate to={ROUTES.LOCALIZE_DONE} replace />}
+  />,
+  <Route
+    key="/detections/:sequenceId/annotate/:detectionId?"
+    path="/detections/:sequenceId/annotate/:detectionId?"
+    element={<LegacyLocalizeDetailRedirect />}
+  />,
+];

--- a/frontend/src/components/sequence-annotation/AnnotationHeader.tsx
+++ b/frontend/src/components/sequence-annotation/AnnotationHeader.tsx
@@ -52,7 +52,8 @@ interface AnnotationHeaderProps {
   onUnsureChange: (checked: boolean) => void;
 
   // Display options
-  fromParam?: string | null;
+  /** 'done' when the page was entered from the Classify Done list. */
+  mode?: 'done';
 }
 
 export const AnnotationHeader: React.FC<AnnotationHeaderProps> = ({
@@ -73,7 +74,7 @@ export const AnnotationHeader: React.FC<AnnotationHeaderProps> = ({
   isAnnotationComplete,
   isSaving,
   onUnsureChange,
-  fromParam,
+  mode,
 }) => {
   const isSubmitted = isSequenceAnnotationSubmitted(annotation?.processing_stage);
   const headerBgClass = isUnsure
@@ -144,7 +145,7 @@ export const AnnotationHeader: React.FC<AnnotationHeaderProps> = ({
               )}
 
               {/* Completion Badge for Annotated Sequences */}
-              {isSubmitted && fromParam !== 'review' && (
+              {isSubmitted && mode !== 'done' && (
                 <>
                   <span className="text-gray-400">•</span>
                   <span className="inline-flex items-center text-xs text-green-600 font-medium">

--- a/frontend/src/hooks/useAnnotationCounts.ts
+++ b/frontend/src/hooks/useAnnotationCounts.ts
@@ -38,7 +38,7 @@ export function useAnnotationCounts(): AnnotationCounts {
     queryKey: ['annotation-counts', 'detections'],
     queryFn: async () => {
       // Localize queue total: alerts ready for smoke localization (matches
-      // exactly what /detections/annotate shows).
+      // exactly what /localize shows).
       const response = await apiClient.getLocalizationQueue({ size: 1 });
       return response.total;
     },

--- a/frontend/src/pages/AnnotationInterface.tsx
+++ b/frontend/src/pages/AnnotationInterface.tsx
@@ -32,7 +32,7 @@ import {
 } from '@/components/sequence-annotation';
 import { NotificationSystem } from '@/components/ui/NotificationSystem';
 import { useToastNotifications } from '@/utils/notification/toastUtils';
-import { ROUTES } from '@/utils/routes';
+import { ROUTES, classifyDetail, classifyGroup } from '@/utils/routes';
 
 interface AnnotationInterfaceProps {
   /** 'done' when mounted under /classify/done/:id — entered from the Done list. */
@@ -277,7 +277,7 @@ export default function AnnotationInterface({ mode }: AnnotationInterfaceProps =
             `Moving to sequence ${currentIndex + 2} of ${totalSequences}`,
             'info'
           );
-          navigate(`/sequences/${nextSequence.id}/annotate`);
+          navigate(classifyDetail(nextSequence.id, mode === 'done'));
         } else {
           // No more sequences - workflow complete
           const totalCompleted = annotationWorkflow?.sequences?.length || 1;
@@ -321,14 +321,14 @@ export default function AnnotationInterface({ mode }: AnnotationInterfaceProps =
   const handlePreviousSequence = () => {
     const prevSequence = navigateToPreviousInWorkflow();
     if (prevSequence) {
-      navigate(`/sequences/${prevSequence.id}/annotate`);
+      navigate(classifyDetail(prevSequence.id, mode === 'done'));
     }
   };
 
   const handleNextSequence = () => {
     const nextSequence = navigateToNextInWorkflow();
     if (nextSequence) {
-      navigate(`/sequences/${nextSequence.id}/annotate`);
+      navigate(classifyDetail(nextSequence.id, mode === 'done'));
     }
   };
 
@@ -399,7 +399,7 @@ export default function AnnotationInterface({ mode }: AnnotationInterfaceProps =
               <div className="flex items-center gap-2 shrink-0">
                 {groupConflictWarning.groupId != null && (
                   <Link
-                    to={`/sequence-groups/${groupConflictWarning.groupId}/annotate`}
+                    to={classifyGroup(groupConflictWarning.groupId)}
                     className="text-sm font-medium text-amber-900 underline hover:text-amber-700"
                   >
                     Open group

--- a/frontend/src/pages/AnnotationInterface.tsx
+++ b/frontend/src/pages/AnnotationInterface.tsx
@@ -32,8 +32,14 @@ import {
 } from '@/components/sequence-annotation';
 import { NotificationSystem } from '@/components/ui/NotificationSystem';
 import { useToastNotifications } from '@/utils/notification/toastUtils';
+import { ROUTES } from '@/utils/routes';
 
-export default function AnnotationInterface() {
+interface AnnotationInterfaceProps {
+  /** 'done' when mounted under /classify/done/:id — entered from the Done list. */
+  mode?: 'done';
+}
+
+export default function AnnotationInterface({ mode }: AnnotationInterfaceProps = {}) {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -49,10 +55,8 @@ export default function AnnotationInterface() {
 
   const sequenceId = id ? parseInt(id) : null;
 
-  // Determine back navigation URL based on source context
-  const searchParams = new URLSearchParams(window.location.search);
-  const fromParam = searchParams.get('from');
-  const backUrl = fromParam === 'review' ? '/sequences/review' : '/sequences/annotate';
+  // Back navigation target follows the route provenance (queue vs done list)
+  const backUrl = mode === 'done' ? ROUTES.CLASSIFY_DONE : ROUTES.CLASSIFY;
 
   const [bboxes, setBboxes] = useState<SequenceBbox[]>([]);
   const [, setCurrentAnnotation] = useState<SequenceAnnotation | null>(null);
@@ -378,7 +382,7 @@ export default function AnnotationInterface() {
         isAnnotationComplete={isAnnotationComplete(bboxes, missedSmokeReview)}
         isSaving={saveAnnotation.isPending}
         onUnsureChange={setIsUnsure}
-        fromParam={fromParam}
+        mode={mode}
       />
 
       {/* Content with top padding to account for fixed header */}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -2,6 +2,7 @@ import { usePipelineStats } from '@/hooks/usePipelineStats';
 import PipelineStrip from '@/components/dashboard/PipelineStrip';
 import PhaseCard from '@/components/dashboard/PhaseCard';
 import HowItWorks from '@/components/dashboard/HowItWorks';
+import { ROUTES } from '@/utils/routes';
 
 export default function DashboardPage() {
   const stats = usePipelineStats();
@@ -40,13 +41,13 @@ export default function DashboardPage() {
           done={stats.classifyDone}
           doneNoun="classified"
           ctaLabel="Start classifying"
-          ctaTo="/sequences/annotate"
+          ctaTo={ROUTES.CLASSIFY}
           reviewLabel="Review classified"
-          reviewTo="/sequences/review"
+          reviewTo={ROUTES.CLASSIFY_DONE}
           isLoading={stats.isLoading}
           secondaryLink={{
             label: 'Classify by group',
-            to: '/sequence-groups',
+            to: ROUTES.CLASSIFY_GROUPS,
             count: stats.groupsToLabel,
           }}
         />
@@ -60,9 +61,9 @@ export default function DashboardPage() {
           done={stats.complete}
           doneNoun="localized"
           ctaLabel="Start localizing"
-          ctaTo="/detections/annotate"
+          ctaTo={ROUTES.LOCALIZE}
           reviewLabel="Review localized"
-          reviewTo="/detections/review"
+          reviewTo={ROUTES.LOCALIZE_DONE}
           isLoading={stats.isLoading}
         />
       </div>

--- a/frontend/src/pages/DetectionAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionAnnotatePage.tsx
@@ -6,6 +6,7 @@ import { apiClient } from '@/services/api';
 import { LocalizationQueueItem } from '@/types/api';
 import { pickNextLocalizeLane } from '@/utils/annotation/localizeUtils';
 import { formatRelativeTime } from '@/utils/relativeTime';
+import { localizeDetail } from '@/utils/routes';
 
 function unfinishedSmokeLanes(item: LocalizationQueueItem): number {
   return item.lanes.filter(l => l.has_smoke && l.processing_stage === 'seq_annotation_done').length;
@@ -41,7 +42,7 @@ export default function DetectionAnnotatePage() {
     // -1 never matches a sequence id: picks the alert's first unfinished lane.
     const first = pickNextLocalizeLane(item.lanes, -1);
     if (first !== null) {
-      navigate(`/detections/${first}/annotate?from=localize`);
+      navigate(localizeDetail(first));
     }
   };
 

--- a/frontend/src/pages/DetectionReviewPage.tsx
+++ b/frontend/src/pages/DetectionReviewPage.tsx
@@ -22,6 +22,7 @@ import { useSourceApis } from '@/hooks/useSourceApis';
 import { usePersistedFilters, createDefaultFilterState } from '@/hooks/usePersistedFilters';
 import { calculatePresetDateRange } from '@/components/filters/shared/dateRangeUtils';
 import { hasActiveUserFilters } from '@/utils/filterHelpers';
+import { localizeDetail } from '@/utils/routes';
 
 export default function DetectionReviewPage() {
   const navigate = useNavigate();
@@ -56,7 +57,7 @@ export default function DetectionReviewPage() {
     setSelectedSmokeTypes,
     setSelectedModelAccuracy,
     resetFilters,
-  } = usePersistedFilters('filters-detections-review-v2', defaultState);
+  } = usePersistedFilters('filters-localize-done', defaultState);
 
   // Fetch cameras, organizations, and source APIs for dropdown options
   const { data: cameras = [], isLoading: camerasLoading } = useCameras();
@@ -187,7 +188,7 @@ export default function DetectionReviewPage() {
 
   const handleSequenceClick = (clickedSequence: SequenceWithDetectionProgress) => {
     // Navigate to detection annotation interface for review purposes
-    navigate(`/detections/${clickedSequence.id}/annotate?from=detections-review`);
+    navigate(localizeDetail(clickedSequence.id, undefined, true));
   };
 
   if (isLoading) {

--- a/frontend/src/pages/DetectionSequenceAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionSequenceAnnotatePage.tsx
@@ -44,7 +44,14 @@ const getIsAnnotated = (
   }
 };
 
-export default function DetectionSequenceAnnotatePage() {
+interface DetectionSequenceAnnotatePageProps {
+  /** 'done' when mounted under /localize/done/… — entered from the Done list. */
+  mode?: 'done';
+}
+
+export default function DetectionSequenceAnnotatePage({
+  mode,
+}: DetectionSequenceAnnotatePageProps = {}) {
   const { sequenceId, detectionId } = useParams<{ sequenceId: string; detectionId?: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -74,7 +81,7 @@ export default function DetectionSequenceAnnotatePage() {
   const fromParam = searchParams.get('from');
 
   // Determine source page and appropriate filter storage key
-  const sourcePage = fromParam === 'detections-review' ? 'review' : 'annotate';
+  const sourcePage = mode === 'done' ? 'review' : 'annotate';
   const filterStorageKey =
     sourcePage === 'review' ? 'filters-detections-review' : 'filters-detections-annotate';
 

--- a/frontend/src/pages/DetectionSequenceAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionSequenceAnnotatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
-import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, CheckCircle } from 'lucide-react';
 import { useSequenceDetections } from '@/hooks/useSequenceDetections';
@@ -25,21 +25,19 @@ import { createDefaultFilterState } from '@/hooks/usePersistedFilters';
 import { calculateAnnotationCompleteness, sequenceSmokeType } from '@/utils/annotation';
 import { pickNextLocalizeLane } from '@/utils/annotation/localizeUtils';
 import { ImageModal, DetectionGrid, DetectionHeader } from '@/components/detection-sequence';
+import { ROUTES, localizeDetail } from '@/utils/routes';
 
 // Helper function for context-aware annotation status
-const getIsAnnotated = (
-  annotation: DetectionAnnotation | undefined,
-  fromContext: string | null
-): boolean => {
-  if (fromContext === 'detections-review') {
-    // Review context: optimistically assume completed unless explicitly not
+const getIsAnnotated = (annotation: DetectionAnnotation | undefined, mode?: 'done'): boolean => {
+  if (mode === 'done') {
+    // Done context: optimistically assume completed unless explicitly not
     if (!annotation) return true; // Loading state: assume completed
     return (
       annotation.processing_stage === 'annotated' ||
       annotation.processing_stage === 'bbox_annotation'
     );
   } else {
-    // Annotate context: always allow edits regardless of stage
+    // Queue context: always allow edits regardless of stage
     return false;
   }
 };
@@ -76,14 +74,12 @@ export default function DetectionSequenceAnnotatePage({
   const [persistentDrawMode, setPersistentDrawMode] = useState(false);
   const isAutoAdvanceRef = useRef(false);
 
-  // Detect source page from URL search params
-  const [searchParams] = useSearchParams();
-  const fromParam = searchParams.get('from');
+  // Provenance comes from the mounted route: /localize/… vs /localize/done/…
+  const basePath = mode === 'done' ? ROUTES.LOCALIZE_DONE : ROUTES.LOCALIZE;
 
   // Determine source page and appropriate filter storage key
   const sourcePage = mode === 'done' ? 'review' : 'annotate';
-  const filterStorageKey =
-    sourcePage === 'review' ? 'filters-detections-review' : 'filters-detections-annotate';
+  const filterStorageKey = mode === 'done' ? 'filters-localize-done' : 'filters-localize';
 
   // Load persisted filters from the appropriate source page
   const sourcePageFilters = useMemo(() => {
@@ -325,7 +321,7 @@ export default function DetectionSequenceAnnotatePage({
     }
   }, [existingAnnotations]);
 
-  // Localize flow (from=localize): explicit lane submit — the user-driven
+  // Localize queue flow (non-done mode): explicit lane submit — the user-driven
   // seq_annotation_done -> annotated transition (guarded server-side for
   // completeness), then advance to the alert's next unfinished smoke lane.
   const submitLocalizedLane = useMutation({
@@ -371,9 +367,9 @@ export default function DetectionSequenceAnnotatePage({
       }
       setTimeout(() => {
         if (next !== null) {
-          navigate(`/detections/${next}/annotate?from=localize`);
+          navigate(localizeDetail(next));
         } else {
-          navigate('/detections/annotate');
+          navigate(ROUTES.LOCALIZE);
         }
       }, 1000);
     },
@@ -430,7 +426,7 @@ export default function DetectionSequenceAnnotatePage({
 
       // Localize flow: saving completes the boxes; submit the lane and
       // advance within the alert instead of the generic filter navigation.
-      if (fromParam === 'localize') {
+      if (mode !== 'done') {
         submitLocalizedLane.mutate();
         return;
       }
@@ -446,12 +442,10 @@ export default function DetectionSequenceAnnotatePage({
         ) {
           // Auto-advance to next filtered sequence
           const nextSequence = allSequences.items[currentIndex + 1];
-          const sourceParam = fromParam ? `?from=${fromParam}` : '';
-          navigate(`/detections/${nextSequence.id}/annotate${sourceParam}`);
+          navigate(`${basePath}/${nextSequence.id}`);
         } else {
-          // No next sequence, return to appropriate source page
-          const backPath = sourcePage === 'review' ? '/detections/review' : '/detections/annotate';
-          navigate(backPath);
+          // No next sequence, return to the source list page
+          navigate(basePath);
         }
       }, 1500);
     },
@@ -528,12 +522,11 @@ export default function DetectionSequenceAnnotatePage({
         // Mark as auto-advance (drawing mode already stored in onSubmit above)
         isAutoAdvanceRef.current = true;
 
-        // Move to next detection. Keep the query string: losing ?from=localize
-        // here would silently disable the lane-submit flow at save time.
+        // Move to next detection on the same provenance base path so the
+        // lane-submit flow stays active at save time.
         const nextDetectionId = getDetectionIdByIndex(selectedDetectionIndex + 1);
         if (nextDetectionId && sequenceId) {
-          const sourceParam = fromParam ? `?from=${fromParam}` : '';
-          navigate(`/detections/${sequenceId}/annotate/${nextDetectionId}${sourceParam}`);
+          navigate(`${basePath}/${sequenceId}/${nextDetectionId}`);
         }
       } else if (
         selectedDetectionIndex !== null &&
@@ -543,8 +536,7 @@ export default function DetectionSequenceAnnotatePage({
         // At last detection - close modal after a brief delay to show success message
         setTimeout(() => {
           if (sequenceId) {
-            const sourceParam = fromParam ? `?from=${fromParam}` : '';
-            navigate(`/detections/${sequenceId}/annotate${sourceParam}`);
+            navigate(`${basePath}/${sequenceId}`);
           }
         }, 1000);
       }
@@ -559,8 +551,7 @@ export default function DetectionSequenceAnnotatePage({
   });
 
   const handleBack = () => {
-    const backPath = sourcePage === 'review' ? '/detections/review' : '/detections/annotate';
-    navigate(backPath);
+    navigate(basePath);
   };
 
   const handleSave = useCallback(() => {
@@ -591,8 +582,7 @@ export default function DetectionSequenceAnnotatePage({
     const currentIndex = getCurrentSequenceIndex();
     if (currentIndex > 0 && allSequences?.items) {
       const prevSequence = allSequences.items[currentIndex - 1];
-      const sourceParam = fromParam ? `?from=${fromParam}` : '';
-      navigate(`/detections/${prevSequence.id}/annotate${sourceParam}`);
+      navigate(`${basePath}/${prevSequence.id}`);
     }
   };
 
@@ -600,25 +590,22 @@ export default function DetectionSequenceAnnotatePage({
     const currentIndex = getCurrentSequenceIndex();
     if (currentIndex >= 0 && allSequences?.items && currentIndex < allSequences.items.length - 1) {
       const nextSequence = allSequences.items[currentIndex + 1];
-      const sourceParam = fromParam ? `?from=${fromParam}` : '';
-      navigate(`/detections/${nextSequence.id}/annotate${sourceParam}`);
+      navigate(`${basePath}/${nextSequence.id}`);
     }
   };
 
   const openModal = (index: number) => {
     const detectionId = getDetectionIdByIndex(index);
     if (detectionId && sequenceId) {
-      const sourceParam = fromParam ? `?from=${fromParam}` : '';
-      navigate(`/detections/${sequenceId}/annotate/${detectionId}${sourceParam}`);
+      navigate(`${basePath}/${sequenceId}/${detectionId}`);
     }
   };
 
   const closeModal = useCallback(() => {
     if (sequenceId) {
-      const sourceParam = fromParam ? `?from=${fromParam}` : '';
-      navigate(`/detections/${sequenceId}/annotate${sourceParam}`);
+      navigate(`${basePath}/${sequenceId}`);
     }
-  }, [sequenceId, fromParam, navigate]);
+  }, [sequenceId, basePath, navigate]);
 
   const navigateModal = useCallback(
     (direction: 'prev' | 'next') => {
@@ -631,11 +618,10 @@ export default function DetectionSequenceAnnotatePage({
 
       const newDetectionId = getDetectionIdByIndex(newIndex);
       if (newDetectionId) {
-        const sourceParam = fromParam ? `?from=${fromParam}` : '';
-        navigate(`/detections/${sequenceId}/annotate/${newDetectionId}${sourceParam}`);
+        navigate(`${basePath}/${sequenceId}/${newDetectionId}`);
       }
     },
-    [detections, selectedDetectionIndex, sequenceId, getDetectionIdByIndex, fromParam, navigate]
+    [detections, selectedDetectionIndex, sequenceId, getDetectionIdByIndex, basePath, navigate]
   );
 
   // State restoration based on URL parameters
@@ -649,11 +635,10 @@ export default function DetectionSequenceAnnotatePage({
         setSelectedDetectionIndex(index);
         setShowModal(true);
       } else {
-        // Invalid detection ID - redirect to base URL (keep the flow param)
+        // Invalid detection ID - redirect to the provenance base URL
         console.warn(`Invalid detection ID ${detectionId} for sequence ${sequenceId}`);
         if (sequenceId) {
-          const sourceParam = fromParam ? `?from=${fromParam}` : '';
-          navigate(`/detections/${sequenceId}/annotate${sourceParam}`, { replace: true });
+          navigate(`${basePath}/${sequenceId}`, { replace: true });
         }
       }
     } else if (!detectionId) {
@@ -661,7 +646,7 @@ export default function DetectionSequenceAnnotatePage({
       setShowModal(false);
       setSelectedDetectionIndex(null);
     }
-  }, [detectionId, detections, sequenceId, navigate, getDetectionIndexById]);
+  }, [detectionId, detections, sequenceId, navigate, getDetectionIndexById, basePath]);
 
   // Keyboard event handlers
   useEffect(() => {
@@ -934,7 +919,7 @@ export default function DetectionSequenceAnnotatePage({
         onDetectionClick={openModal}
         showPredictions={showPredictions}
         detectionAnnotations={detectionAnnotations}
-        fromParam={fromParam}
+        mode={mode}
         getIsAnnotated={getIsAnnotated}
       />
 
@@ -958,7 +943,7 @@ export default function DetectionSequenceAnnotatePage({
           isSubmitting={annotateIndividualDetection.isPending}
           isAnnotated={getIsAnnotated(
             detectionAnnotations.get(detections[selectedDetectionIndex].id),
-            fromParam
+            mode
           )}
           existingAnnotation={detectionAnnotations.get(detections[selectedDetectionIndex].id)}
           selectedSmokeType={persistentSmokeType}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Activity, Database, BarChart3 } from 'lucide-react';
+import { ROUTES } from '@/utils/routes';
 
 export default function HomePage() {
   return (
@@ -57,7 +58,7 @@ export default function HomePage() {
             View Dashboard
           </Link>
           <Link
-            to="/sequences/annotate"
+            to={ROUTES.CLASSIFY}
             className="inline-flex items-center px-6 py-3 border border-gray-300 text-base font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors duration-200"
           >
             Start Annotating

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -18,6 +18,7 @@ import { usePersistedTabState } from '@/hooks/usePersistedTabState';
 import { formatRelativeTime } from '@/utils/relativeTime';
 import { useState } from 'react';
 import { AlgoPrediction, SequenceGroup, SequenceGroupMember } from '@/types/api';
+import { ROUTES, classifyDetail, classifyGroup } from '@/utils/routes';
 
 // Minimum card width per size step; the auto-fill grid derives the column
 // count from it, so bigger cards automatically flow into more rows.
@@ -140,7 +141,7 @@ function MemberCard({
       </button>
 
       <Link
-        to={`/sequences/${member.sequence_id}/annotate`}
+        to={classifyDetail(member.sequence_id)}
         className="block hover:bg-blue-50"
         title="Open the per-sequence annotation page"
       >
@@ -307,7 +308,7 @@ export default function SequenceGroupAnnotatePage() {
           primary action (validate) stays reachable while scrolling the
           member grid. The root's pt-20 reserves its space. */}
       <div className="fixed top-0 left-0 md:left-64 right-0 z-30 px-6 pt-3 pb-2.5 bg-white/85 border-b border-gray-200 backdrop-blur-sm shadow-sm">
-        <Link to="/sequence-groups" className="text-sm text-gray-500 hover:text-gray-800">
+        <Link to={ROUTES.CLASSIFY_GROUPS} className="text-sm text-gray-500 hover:text-gray-800">
           ← Sequence groups
         </Link>
         <div className="mt-1 flex items-center justify-between gap-4">
@@ -335,7 +336,7 @@ export default function SequenceGroupAnnotatePage() {
           <div className="flex flex-none items-center gap-2">
             {prevId ? (
               <Link
-                to={`/sequence-groups/${prevId}/annotate`}
+                to={classifyGroup(prevId)}
                 title="Previous group"
                 className="p-1.5 rounded-lg border border-gray-300 bg-white text-gray-600 hover:bg-gray-50"
               >
@@ -351,7 +352,7 @@ export default function SequenceGroupAnnotatePage() {
             )}
             {nextId ? (
               <Link
-                to={`/sequence-groups/${nextId}/annotate`}
+                to={classifyGroup(nextId)}
                 title="Next group"
                 className="p-1.5 rounded-lg border border-gray-300 bg-white text-gray-600 hover:bg-gray-50"
               >

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -13,6 +13,7 @@ import {
 import { apiClient } from '@/services/api';
 import { formatRelativeTime } from '@/utils/relativeTime';
 import { SequenceGroupStats } from '@/types/api';
+import { classifyGroup } from '@/utils/routes';
 
 type Filter = 'all' | 'labeled' | 'unlabeled';
 type OrderBy = 'member_count' | 'camera_name' | 'azimuth' | 'created_at';
@@ -227,13 +228,13 @@ export default function SequenceGroupsListPage() {
                     // Leave modified clicks and text selection to the browser;
                     // the camera-name <Link> handles open-in-new-tab.
                     if (e.ctrlKey || e.metaKey || window.getSelection()?.toString()) return;
-                    navigate(`/sequence-groups/${g.id}/annotate`);
+                    navigate(classifyGroup(g.id));
                   }}
                   className="border-t border-gray-100 hover:bg-blue-50 cursor-pointer"
                 >
                   <td className="px-3 py-2.5">
                     <Link
-                      to={`/sequence-groups/${g.id}/annotate`}
+                      to={classifyGroup(g.id)}
                       onClick={e => e.stopPropagation()}
                       className="font-semibold text-gray-900 hover:text-blue-700"
                     >

--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -24,6 +24,7 @@ import { useSourceApis } from '@/hooks/useSourceApis';
 import { usePersistedFilters, createDefaultFilterState } from '@/hooks/usePersistedFilters';
 import { calculatePresetDateRange } from '@/components/filters/shared/dateRangeUtils';
 import { hasActiveUserFilters } from '@/utils/filterHelpers';
+import { classifyDetail } from '@/utils/routes';
 
 interface SequencesPageProps {
   defaultProcessingStage?: ProcessingStageStatus;
@@ -39,8 +40,8 @@ export default function SequencesPage({
   const navigate = useNavigate();
   const { startAnnotationWorkflow } = useSequenceStore();
 
-  // Storage key separates review vs annotate filters; review filters are shared across stages.
-  const storageKey = isReviewPage ? 'filters-sequences-review' : 'filters-sequences-annotate';
+  // Storage key separates done vs queue filters; done filters are shared across stages.
+  const storageKey = isReviewPage ? 'filters-classify-done' : 'filters-classify';
 
   // Use persisted filters hook
   const {
@@ -174,9 +175,8 @@ export default function SequencesPage({
       startAnnotationWorkflow(sequences.items, clickedSequence.id, apiFilters);
     }
 
-    // Navigate to annotation interface with context about source page
-    const queryParam = isReviewPage ? '?from=review' : '';
-    navigate(`/sequences/${clickedSequence.id}/annotate${queryParam}`);
+    // Navigate to the annotation interface; provenance is in the path
+    navigate(classifyDetail(clickedSequence.id, isReviewPage));
   };
 
   if (isLoading) {

--- a/frontend/src/pages/SequencesPageWrapper.tsx
+++ b/frontend/src/pages/SequencesPageWrapper.tsx
@@ -15,7 +15,7 @@ export default function SequencesPageWrapper({
   const isReview = defaultProcessingStage === 'annotated';
 
   const [storedStage, setStage] = usePersistedTabState<ProcessingStage>(
-    'sequences-review-stage',
+    'classify-done-stage',
     'seq_annotation_done'
   );
   // localStorage may hold a stage that no longer exists (e.g. the retired

--- a/frontend/src/utils/pipeline.ts
+++ b/frontend/src/utils/pipeline.ts
@@ -15,7 +15,7 @@ export interface RawPipelineCounts {
   annotatedStage: number;
   detectionComplete: number;
   // Total of the gated localization queue (alerts ready for smoke
-  // localization) — matches exactly what /detections/annotate shows.
+  // localization) — matches exactly what /localize shows.
   localizeQueueTotal: number;
 }
 

--- a/frontend/src/utils/routes.ts
+++ b/frontend/src/utils/routes.ts
@@ -1,0 +1,30 @@
+/**
+ * Frontend route paths for the task taxonomy (Classify / Localize).
+ * Detail pages encode provenance in the path: /classify/:id was entered from
+ * the queue, /classify/done/:id from the Done list (same component, done mode).
+ */
+export const ROUTES = {
+  CLASSIFY: '/classify',
+  CLASSIFY_DONE: '/classify/done',
+  CLASSIFY_GROUPS: '/classify/groups',
+  LOCALIZE: '/localize',
+  LOCALIZE_DONE: '/localize/done',
+} as const;
+
+export function classifyDetail(id: number | string, done = false): string {
+  return done ? `${ROUTES.CLASSIFY_DONE}/${id}` : `${ROUTES.CLASSIFY}/${id}`;
+}
+
+export function classifyGroup(id: number | string): string {
+  return `${ROUTES.CLASSIFY_GROUPS}/${id}`;
+}
+
+export function localizeDetail(
+  sequenceId: number | string,
+  detectionId?: number | string,
+  done = false
+): string {
+  const base = done ? ROUTES.LOCALIZE_DONE : ROUTES.LOCALIZE;
+  const detSegment = detectionId !== undefined ? `/${detectionId}` : '';
+  return `${base}/${sequenceId}${detSegment}`;
+}

--- a/frontend/tests/components/dashboard/DashboardPage.test.tsx
+++ b/frontend/tests/components/dashboard/DashboardPage.test.tsx
@@ -30,7 +30,7 @@ describe('DashboardPage', () => {
     expect(screen.getByText('How annotation works')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Classify by group/ })).toHaveAttribute(
       'href',
-      '/sequence-groups'
+      '/classify/groups'
     );
   });
 });

--- a/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
+++ b/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
@@ -80,7 +80,7 @@ describe('DetectionAnnotatePage (Localize queue)', () => {
     render(<DetectionAnnotatePage />, { wrapper });
     await waitFor(() => expect(screen.getByText('CAM_01')).toBeTruthy());
     fireEvent.click(screen.getByText('CAM_01'));
-    expect(navigateMock).toHaveBeenCalledWith('/detections/11/annotate?from=localize');
+    expect(navigateMock).toHaveBeenCalledWith('/localize/11');
   });
 
   it('shows an empty state when the queue is empty', async () => {

--- a/frontend/tests/components/dashboard/PhaseCard.test.tsx
+++ b/frontend/tests/components/dashboard/PhaseCard.test.tsx
@@ -13,9 +13,9 @@ const props = {
   done: 453,
   doneNoun: 'classified',
   ctaLabel: 'Start classifying',
-  ctaTo: '/sequences/annotate',
+  ctaTo: '/classify',
   reviewLabel: 'Review classified',
-  reviewTo: '/sequences/review',
+  reviewTo: '/classify/done',
   isLoading: false,
 };
 
@@ -28,11 +28,11 @@ describe('PhaseCard', () => {
     expect(screen.getByText('453 classified so far')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Start classifying' })).toHaveAttribute(
       'href',
-      '/sequences/annotate'
+      '/classify'
     );
     expect(screen.getByRole('link', { name: /Review classified/ })).toHaveAttribute(
       'href',
-      '/sequences/review'
+      '/classify/done'
     );
   });
 
@@ -40,13 +40,13 @@ describe('PhaseCard', () => {
     render(
       <PhaseCard
         {...props}
-        secondaryLink={{ label: 'Classify by group', to: '/sequence-groups', count: 12 }}
+        secondaryLink={{ label: 'Classify by group', to: '/classify/groups', count: 12 }}
       />,
       { wrapper: MemoryRouter }
     );
     expect(screen.getByRole('link', { name: /Classify by group/ })).toHaveAttribute(
       'href',
-      '/sequence-groups'
+      '/classify/groups'
     );
   });
 
@@ -54,7 +54,7 @@ describe('PhaseCard', () => {
     render(
       <PhaseCard
         {...props}
-        secondaryLink={{ label: 'Classify by group', to: '/sequence-groups', count: 0 }}
+        secondaryLink={{ label: 'Classify by group', to: '/classify/groups', count: 0 }}
       />,
       { wrapper: MemoryRouter }
     );

--- a/frontend/tests/components/detection-sequence/DetectionGrid.test.tsx
+++ b/frontend/tests/components/detection-sequence/DetectionGrid.test.tsx
@@ -9,7 +9,7 @@ import { DetectionGrid } from '@/components/detection-sequence/DetectionGrid';
 import type { Detection, DetectionAnnotation } from '@/types/api';
 
 // Mock the icons to avoid test complications
-vi.mock('lucide-react', async (importOriginal) => {
+vi.mock('lucide-react', async importOriginal => {
   const actual = await importOriginal<typeof import('lucide-react')>();
   return {
     ...actual,
@@ -30,8 +30,14 @@ interface MockDetectionCardProps {
 }
 
 vi.mock('@/components/detection-annotation', () => ({
-  DetectionImageCard: ({ detection, onClick, isAnnotated, showPredictions, userAnnotation }: MockDetectionCardProps) => (
-    <div 
+  DetectionImageCard: ({
+    detection,
+    onClick,
+    isAnnotated,
+    showPredictions,
+    userAnnotation,
+  }: MockDetectionCardProps) => (
+    <div
       data-testid={`detection-card-${detection.id}`}
       data-annotated={isAnnotated}
       data-show-predictions={showPredictions}
@@ -75,16 +81,11 @@ describe('DetectionGrid', () => {
   });
 
   const defaultProps = {
-    detections: [
-      createDetection(1, 0.95),
-      createDetection(2, 0.75),
-      createDetection(3, 0.65),
-    ],
+    detections: [createDetection(1, 0.95), createDetection(2, 0.75), createDetection(3, 0.65)],
     onDetectionClick: vi.fn(),
     showPredictions: true,
     detectionAnnotations: new Map(),
-    fromParam: null,
-    getIsAnnotated: vi.fn((annotation) => !!annotation),
+    getIsAnnotated: vi.fn(annotation => !!annotation),
   };
 
   beforeEach(() => {
@@ -94,17 +95,19 @@ describe('DetectionGrid', () => {
   describe('Rendering Tests', () => {
     it('should render grid container with correct classes', () => {
       const { container } = render(<DetectionGrid {...defaultProps} />);
-      
+
       const gridContainer = container.querySelector('.space-y-6.pt-20');
       expect(gridContainer).toBeInTheDocument();
-      
-      const gridLayout = container.querySelector('.grid.grid-cols-2.md\\:grid-cols-3.lg\\:grid-cols-4.gap-6');
+
+      const gridLayout = container.querySelector(
+        '.grid.grid-cols-2.md\\:grid-cols-3.lg\\:grid-cols-4.gap-6'
+      );
       expect(gridLayout).toBeInTheDocument();
     });
 
     it('should render all detections as cards', () => {
       render(<DetectionGrid {...defaultProps} />);
-      
+
       expect(screen.getByTestId('detection-card-1')).toBeInTheDocument();
       expect(screen.getByTestId('detection-card-2')).toBeInTheDocument();
       expect(screen.getByTestId('detection-card-3')).toBeInTheDocument();
@@ -112,7 +115,7 @@ describe('DetectionGrid', () => {
 
     it('should display detection confidence scores', () => {
       render(<DetectionGrid {...defaultProps} />);
-      
+
       expect(screen.getByText(/Detection 1 - 0.95/)).toBeInTheDocument();
       expect(screen.getByText(/Detection 2 - 0.75/)).toBeInTheDocument();
       expect(screen.getByText(/Detection 3 - 0.65/)).toBeInTheDocument();
@@ -120,21 +123,19 @@ describe('DetectionGrid', () => {
 
     it('should apply responsive grid classes', () => {
       const { container } = render(<DetectionGrid {...defaultProps} />);
-      
+
       const gridElement = container.querySelector('.grid');
       expect(gridElement).toHaveClass(
-        'grid-cols-2',    // Mobile: 2 columns
-        'md:grid-cols-3', // Medium: 3 columns  
+        'grid-cols-2', // Mobile: 2 columns
+        'md:grid-cols-3', // Medium: 3 columns
         'lg:grid-cols-4', // Large: 4 columns
-        'gap-6'           // Consistent gap
+        'gap-6' // Consistent gap
       );
     });
 
     it('should render empty grid when no detections provided', () => {
-      const { container } = render(
-        <DetectionGrid {...defaultProps} detections={[]} />
-      );
-      
+      const { container } = render(<DetectionGrid {...defaultProps} detections={[]} />);
+
       const gridContainer = container.querySelector('.grid');
       expect(gridContainer).toBeInTheDocument();
       expect(gridContainer?.children).toHaveLength(0);
@@ -144,7 +145,7 @@ describe('DetectionGrid', () => {
   describe('Props Testing', () => {
     it('should pass showPredictions prop to each detection card', () => {
       render(<DetectionGrid {...defaultProps} showPredictions={false} />);
-      
+
       const cards = screen.getAllByTestId(/detection-card-/);
       cards.forEach(card => {
         expect(card).toHaveAttribute('data-show-predictions', 'false');
@@ -156,40 +157,44 @@ describe('DetectionGrid', () => {
         [1, createDetectionAnnotation(1, true)],
         [2, createDetectionAnnotation(2, false)],
       ]);
-      
+
       render(<DetectionGrid {...defaultProps} detectionAnnotations={annotations} />);
-      
+
       expect(screen.getByTestId('detection-card-1')).toHaveAttribute('data-has-annotation', 'true');
       expect(screen.getByTestId('detection-card-2')).toHaveAttribute('data-has-annotation', 'true');
-      expect(screen.getByTestId('detection-card-3')).toHaveAttribute('data-has-annotation', 'false');
+      expect(screen.getByTestId('detection-card-3')).toHaveAttribute(
+        'data-has-annotation',
+        'false'
+      );
     });
 
     it('should call getIsAnnotated with correct parameters', () => {
       const getIsAnnotated = vi.fn().mockReturnValue(true);
       const annotations = new Map([[1, createDetectionAnnotation(1)]]);
-      
+
       render(
-        <DetectionGrid 
-          {...defaultProps} 
+        <DetectionGrid
+          {...defaultProps}
           getIsAnnotated={getIsAnnotated}
           detectionAnnotations={annotations}
-          fromParam="visual-check"
+          mode="done"
         />
       );
-      
-      expect(getIsAnnotated).toHaveBeenCalledWith(annotations.get(1), "visual-check");
-      expect(getIsAnnotated).toHaveBeenCalledWith(undefined, "visual-check");
+
+      expect(getIsAnnotated).toHaveBeenCalledWith(annotations.get(1), 'done');
+      expect(getIsAnnotated).toHaveBeenCalledWith(undefined, 'done');
       expect(getIsAnnotated).toHaveBeenCalledTimes(3); // Once per detection
     });
 
     it('should pass isAnnotated result to detection cards', () => {
-      const getIsAnnotated = vi.fn()
-        .mockReturnValueOnce(true)   // Detection 1: annotated
-        .mockReturnValueOnce(false)  // Detection 2: not annotated
-        .mockReturnValueOnce(true);  // Detection 3: annotated
-      
+      const getIsAnnotated = vi
+        .fn()
+        .mockReturnValueOnce(true) // Detection 1: annotated
+        .mockReturnValueOnce(false) // Detection 2: not annotated
+        .mockReturnValueOnce(true); // Detection 3: annotated
+
       render(<DetectionGrid {...defaultProps} getIsAnnotated={getIsAnnotated} />);
-      
+
       expect(screen.getByTestId('detection-card-1')).toHaveAttribute('data-annotated', 'true');
       expect(screen.getByTestId('detection-card-2')).toHaveAttribute('data-annotated', 'false');
       expect(screen.getByTestId('detection-card-3')).toHaveAttribute('data-annotated', 'true');
@@ -200,9 +205,9 @@ describe('DetectionGrid', () => {
     it('should call onDetectionClick with correct index when card is clicked', () => {
       const onDetectionClick = vi.fn();
       render(<DetectionGrid {...defaultProps} onDetectionClick={onDetectionClick} />);
-      
+
       fireEvent.click(screen.getByTestId('detection-card-2'));
-      
+
       expect(onDetectionClick).toHaveBeenCalledWith(1); // Index 1 for second detection
       expect(onDetectionClick).toHaveBeenCalledTimes(1);
     });
@@ -210,10 +215,10 @@ describe('DetectionGrid', () => {
     it('should handle multiple card clicks correctly', () => {
       const onDetectionClick = vi.fn();
       render(<DetectionGrid {...defaultProps} onDetectionClick={onDetectionClick} />);
-      
+
       fireEvent.click(screen.getByTestId('detection-card-1'));
       fireEvent.click(screen.getByTestId('detection-card-3'));
-      
+
       expect(onDetectionClick).toHaveBeenNthCalledWith(1, 0); // First detection (index 0)
       expect(onDetectionClick).toHaveBeenNthCalledWith(2, 2); // Third detection (index 2)
       expect(onDetectionClick).toHaveBeenCalledTimes(2);
@@ -222,9 +227,9 @@ describe('DetectionGrid', () => {
     it('should support keyboard navigation on cards', () => {
       const onDetectionClick = vi.fn();
       render(<DetectionGrid {...defaultProps} onDetectionClick={onDetectionClick} />);
-      
+
       const card = screen.getByTestId('detection-card-1');
-      
+
       // Cards should have proper keyboard attributes
       expect(card).toHaveAttribute('role', 'button');
       expect(card).toHaveAttribute('tabIndex', '0');
@@ -234,41 +239,34 @@ describe('DetectionGrid', () => {
   describe('Integration Tests', () => {
     it('should handle mixed annotation states correctly', () => {
       const annotations = new Map([
-        [1, createDetectionAnnotation(1, true)],  // True positive
+        [1, createDetectionAnnotation(1, true)], // True positive
         [2, createDetectionAnnotation(2, false)], // False positive
         // Detection 3 has no annotation
       ]);
-      
-      const getIsAnnotated = vi.fn()
-        .mockImplementation((annotation) => !!annotation);
-      
+
+      const getIsAnnotated = vi.fn().mockImplementation(annotation => !!annotation);
+
       render(
-        <DetectionGrid 
-          {...defaultProps} 
+        <DetectionGrid
+          {...defaultProps}
           detectionAnnotations={annotations}
           getIsAnnotated={getIsAnnotated}
         />
       );
-      
+
       // Verify all detections are rendered with correct annotation state
       expect(screen.getByTestId('detection-card-1')).toHaveAttribute('data-annotated', 'true');
       expect(screen.getByTestId('detection-card-2')).toHaveAttribute('data-annotated', 'true');
       expect(screen.getByTestId('detection-card-3')).toHaveAttribute('data-annotated', 'false');
     });
 
-    it('should handle fromParam context correctly', () => {
+    it('should pass the done mode context to getIsAnnotated', () => {
       const getIsAnnotated = vi.fn().mockReturnValue(false);
-      
-      render(
-        <DetectionGrid 
-          {...defaultProps} 
-          fromParam="sequence-list"
-          getIsAnnotated={getIsAnnotated}
-        />
-      );
-      
-      // Verify fromParam is passed to getIsAnnotated for all detections
-      expect(getIsAnnotated).toHaveBeenCalledWith(undefined, "sequence-list");
+
+      render(<DetectionGrid {...defaultProps} mode="done" getIsAnnotated={getIsAnnotated} />);
+
+      // Verify mode is passed to getIsAnnotated for all detections
+      expect(getIsAnnotated).toHaveBeenCalledWith(undefined, 'done');
       expect(getIsAnnotated).toHaveBeenCalledTimes(3);
     });
 
@@ -278,24 +276,24 @@ describe('DetectionGrid', () => {
         createDetection(3, 0.88),
         createDetection(7, 0.77),
       ];
-      
+
       const onDetectionClick = vi.fn();
-      
+
       render(
-        <DetectionGrid 
-          {...defaultProps} 
+        <DetectionGrid
+          {...defaultProps}
           detections={detectionsInOrder}
           onDetectionClick={onDetectionClick}
         />
       );
-      
+
       // Verify detections are rendered in the provided order
       const cards = screen.getAllByTestId(/detection-card-/);
       expect(cards).toHaveLength(3);
       expect(cards[0]).toHaveAttribute('data-testid', 'detection-card-5');
       expect(cards[1]).toHaveAttribute('data-testid', 'detection-card-3');
       expect(cards[2]).toHaveAttribute('data-testid', 'detection-card-7');
-      
+
       // Verify click indices match array positions, not detection IDs
       fireEvent.click(cards[1]);
       expect(onDetectionClick).toHaveBeenCalledWith(1); // Array index, not detection ID
@@ -308,84 +306,79 @@ describe('DetectionGrid', () => {
         { ...createDetection(1), confidence: undefined },
         { ...createDetection(2), algo_predictions: { smoke_bbox_confidence: 0 } },
       ] as Detection[];
-      
+
       expect(() => {
         render(<DetectionGrid {...defaultProps} detections={detectionsWithMissingData} />);
       }).not.toThrow();
-      
+
       // Should still render the cards
       expect(screen.getByTestId('detection-card-1')).toBeInTheDocument();
       expect(screen.getByTestId('detection-card-2')).toBeInTheDocument();
     });
 
-    it('should handle null/undefined fromParam', () => {
+    it('should handle an absent mode (queue context)', () => {
       const getIsAnnotated = vi.fn().mockReturnValue(true);
-      
-      render(
-        <DetectionGrid 
-          {...defaultProps} 
-          fromParam={null}
-          getIsAnnotated={getIsAnnotated}
-        />
-      );
-      
-      expect(getIsAnnotated).toHaveBeenCalledWith(undefined, null);
+
+      render(<DetectionGrid {...defaultProps} getIsAnnotated={getIsAnnotated} />);
+
+      expect(getIsAnnotated).toHaveBeenCalledWith(undefined, undefined);
     });
 
     it('should handle empty annotation map', () => {
       const getIsAnnotated = vi.fn().mockReturnValue(false);
-      
+
       render(
-        <DetectionGrid 
-          {...defaultProps} 
+        <DetectionGrid
+          {...defaultProps}
           detectionAnnotations={new Map()}
           getIsAnnotated={getIsAnnotated}
         />
       );
-      
+
       // Should call getIsAnnotated with undefined for all detections
-      expect(getIsAnnotated).toHaveBeenCalledWith(undefined, null);
+      expect(getIsAnnotated).toHaveBeenCalledWith(undefined, undefined);
       expect(getIsAnnotated).toHaveBeenCalledTimes(3);
     });
 
     it('should handle very large detection arrays efficiently', () => {
       const manyDetections = Array.from({ length: 100 }, (_, i) => createDetection(i + 1));
-      
-      const { container } = render(
-        <DetectionGrid {...defaultProps} detections={manyDetections} />
-      );
-      
+
+      const { container } = render(<DetectionGrid {...defaultProps} detections={manyDetections} />);
+
       const gridContainer = container.querySelector('.grid');
       expect(gridContainer?.children).toHaveLength(100);
     });
 
     it('should maintain component stability with prop changes', () => {
       const { rerender } = render(<DetectionGrid {...defaultProps} />);
-      
+
       // Change showPredictions
       rerender(<DetectionGrid {...defaultProps} showPredictions={false} />);
-      
+
       // Should still render all cards
       expect(screen.getByTestId('detection-card-1')).toBeInTheDocument();
       expect(screen.getByTestId('detection-card-2')).toBeInTheDocument();
       expect(screen.getByTestId('detection-card-3')).toBeInTheDocument();
-      
+
       // Verify prop was updated
-      expect(screen.getByTestId('detection-card-1')).toHaveAttribute('data-show-predictions', 'false');
+      expect(screen.getByTestId('detection-card-1')).toHaveAttribute(
+        'data-show-predictions',
+        'false'
+      );
     });
   });
 
   describe('Accessibility', () => {
     it('should provide proper semantic structure', () => {
       const { container } = render(<DetectionGrid {...defaultProps} />);
-      
+
       const gridContainer = container.querySelector('[role="grid"], .grid');
       expect(gridContainer).toBeInTheDocument();
     });
 
     it('should ensure all cards are keyboard accessible', () => {
       render(<DetectionGrid {...defaultProps} />);
-      
+
       const cards = screen.getAllByRole('button');
       cards.forEach(card => {
         expect(card).toHaveAttribute('tabIndex', '0');
@@ -394,10 +387,10 @@ describe('DetectionGrid', () => {
 
     it('should maintain focus management', () => {
       render(<DetectionGrid {...defaultProps} />);
-      
+
       const firstCard = screen.getByTestId('detection-card-1');
       firstCard.focus();
-      
+
       expect(document.activeElement).toBe(firstCard);
     });
   });

--- a/frontend/tests/components/layout/AppLayout.test.tsx
+++ b/frontend/tests/components/layout/AppLayout.test.tsx
@@ -213,4 +213,13 @@ describe('AppLayout path-based nav highlighting', () => {
     expect(activeLinks).toHaveLength(1);
     expect(activeLinks[0]).toHaveAttribute('href', activeHref);
   });
+
+  it.each([['/'], ['/users'], ['/guide']])('at %s no nav link is active', path => {
+    const { container } = renderLayoutAt(path);
+
+    const activeLinks = Array.from(container.querySelectorAll('a')).filter(a =>
+      a.className.includes('text-pine')
+    );
+    expect(activeLinks).toHaveLength(0);
+  });
 });

--- a/frontend/tests/components/layout/AppLayout.test.tsx
+++ b/frontend/tests/components/layout/AppLayout.test.tsx
@@ -52,7 +52,7 @@ describe('AppLayout sidebar navigation', () => {
     );
 
   it('styles the active link with the pine accent and a left bar', () => {
-    renderLayoutAt('/sequence-groups');
+    renderLayoutAt('/classify/groups');
 
     const groupsLink = screen.getByRole('link', { name: /groups/i });
     expect(groupsLink).toHaveClass('bg-pine-soft', 'text-pine', 'border-pine', 'border-l-[3px]');
@@ -60,7 +60,7 @@ describe('AppLayout sidebar navigation', () => {
   });
 
   it('styles inactive links with haze text, ash hover, and a transparent left bar', () => {
-    renderLayoutAt('/sequence-groups');
+    renderLayoutAt('/classify/groups');
 
     const smokeLink = screen.getByRole('link', { name: /smoke/i });
     expect(smokeLink).toHaveClass(
@@ -77,14 +77,14 @@ describe('AppLayout sidebar navigation', () => {
   });
 
   it('stacks nav links without vertical gaps between them', () => {
-    renderLayoutAt('/sequence-groups');
+    renderLayoutAt('/classify/groups');
 
     const groupsLink = screen.getByRole('link', { name: /groups/i });
     expect(groupsLink.parentElement).not.toHaveClass('space-y-1');
   });
 
   it('lets nav links span the full sidebar width', () => {
-    const { container } = renderLayoutAt('/sequence-groups');
+    const { container } = renderLayoutAt('/classify/groups');
 
     const nav = container.querySelector('nav');
     expect(nav).not.toHaveClass('px-2');
@@ -94,7 +94,7 @@ describe('AppLayout sidebar navigation', () => {
     renderLayout();
 
     const groupsLink = screen.getByRole('link', { name: /groups/i });
-    expect(groupsLink).toHaveAttribute('href', '/sequence-groups');
+    expect(groupsLink).toHaveAttribute('href', '/classify/groups');
 
     const badge = within(groupsLink).getByText('8');
     expect(badge).toHaveAttribute('title', '8 groups need validation');
@@ -107,7 +107,7 @@ describe('AppLayout sidebar navigation', () => {
     const groupsLink = screen.getByRole('link', { name: /groups/i });
     const sequencesLinks = screen.getAllByRole('link', { name: /sequences/i });
     const classifySequencesLink = sequencesLinks.find(
-      link => link.getAttribute('href') === '/sequences/annotate'
+      link => link.getAttribute('href') === '/classify'
     );
 
     expect(classifySequencesLink).toBeDefined();
@@ -172,12 +172,45 @@ describe('AppLayout detections nav', () => {
       </MemoryRouter>
     );
 
-  it('points the Localize section queue entry (Smoke) at /detections/annotate', () => {
+  it('points the Localize section queue entry (Smoke) at /localize', () => {
     renderLayout();
 
     const smokeLink = screen.getByRole('link', { name: /smoke/i });
-    expect(smokeLink).toHaveAttribute('href', '/detections/annotate');
+    expect(smokeLink).toHaveAttribute('href', '/localize');
     // The old entity-named "Annotate" entry is gone from the detections nav.
     expect(screen.queryByRole('link', { name: /^annotate$/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('AppLayout path-based nav highlighting', () => {
+  const renderLayoutAt = (path: string) =>
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <AppLayout>
+          <div>page content</div>
+        </AppLayout>
+      </MemoryRouter>
+    );
+
+  it.each([
+    ['/classify', '/classify'],
+    ['/classify/42', '/classify'],
+    ['/classify/done', '/classify/done'],
+    ['/classify/done/42', '/classify/done'],
+    ['/classify/groups', '/classify/groups'],
+    ['/classify/groups/7', '/classify/groups'],
+    ['/localize', '/localize'],
+    ['/localize/5', '/localize'],
+    ['/localize/5/9', '/localize'],
+    ['/localize/done', '/localize/done'],
+    ['/localize/done/5', '/localize/done'],
+  ])('at %s the single active link is %s', (path, activeHref) => {
+    const { container } = renderLayoutAt(path);
+
+    const activeLinks = Array.from(container.querySelectorAll('a')).filter(a =>
+      a.className.includes('text-pine')
+    );
+    expect(activeLinks).toHaveLength(1);
+    expect(activeLinks[0]).toHaveAttribute('href', activeHref);
   });
 });

--- a/frontend/tests/components/routing/legacyRedirects.test.tsx
+++ b/frontend/tests/components/routing/legacyRedirects.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { legacyRedirectRoutes } from '@/components/routing/legacyRedirects';
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+const renderAt = (url: string) =>
+  render(
+    <MemoryRouter initialEntries={[url]}>
+      <Routes>
+        {legacyRedirectRoutes}
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('legacy route redirects', () => {
+  it.each([
+    ['/sequences/annotate', '/classify'],
+    ['/sequences/review', '/classify/done'],
+    ['/sequences/42/annotate', '/classify/42'],
+    ['/sequences/42/annotate?from=review', '/classify/done/42'],
+    ['/sequence-groups', '/classify/groups'],
+    ['/sequence-groups/7/annotate', '/classify/groups/7'],
+    ['/detections/annotate', '/localize'],
+    ['/detections/review', '/localize/done'],
+    ['/detections/5/annotate', '/localize/5'],
+    ['/detections/5/annotate?from=localize', '/localize/5'],
+    ['/detections/5/annotate/9?from=localize', '/localize/5/9'],
+    ['/detections/5/annotate?from=detections-review', '/localize/done/5'],
+    ['/detections/5/annotate/9?from=detections-review', '/localize/done/5/9'],
+  ])('redirects %s to %s', (oldUrl, newPath) => {
+    renderAt(oldUrl);
+    expect(screen.getByTestId('location')).toHaveTextContent(newPath);
+  });
+});

--- a/frontend/tests/components/routing/routeMatching.test.ts
+++ b/frontend/tests/components/routing/routeMatching.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Locks in React Router's static-over-dynamic segment ranking for the route
+ * patterns App.tsx mounts (keep the list in sync with App.tsx). Guards the
+ * spec claim that /classify/done, /classify/groups and /localize/done never
+ * fall through to the :id / :sequenceId routes.
+ */
+import { matchRoutes } from 'react-router-dom';
+
+const routes = [
+  { path: '/classify' },
+  { path: '/classify/done' },
+  { path: '/classify/groups' },
+  { path: '/classify/groups/:id' },
+  { path: '/classify/done/:id' },
+  { path: '/classify/:id' },
+  { path: '/localize' },
+  { path: '/localize/done' },
+  { path: '/localize/done/:sequenceId/:detectionId?' },
+  { path: '/localize/:sequenceId/:detectionId?' },
+];
+
+const matchedPath = (url: string): string | undefined => {
+  const matches = matchRoutes(routes, url);
+  return matches?.[matches.length - 1]?.route.path;
+};
+
+describe('taxonomy route matching precedence', () => {
+  it.each([
+    ['/classify', '/classify'],
+    ['/classify/done', '/classify/done'],
+    ['/classify/42', '/classify/:id'],
+    ['/classify/done/42', '/classify/done/:id'],
+    ['/classify/groups', '/classify/groups'],
+    ['/classify/groups/7', '/classify/groups/:id'],
+    ['/localize', '/localize'],
+    ['/localize/done', '/localize/done'],
+    ['/localize/5', '/localize/:sequenceId/:detectionId?'],
+    ['/localize/5/9', '/localize/:sequenceId/:detectionId?'],
+    ['/localize/done/5', '/localize/done/:sequenceId/:detectionId?'],
+    ['/localize/done/5/9', '/localize/done/:sequenceId/:detectionId?'],
+  ])('%s matches %s', (url, expected) => {
+    expect(matchedPath(url)).toBe(expected);
+  });
+});

--- a/frontend/tests/pages/SequencesPageWrapper.test.tsx
+++ b/frontend/tests/pages/SequencesPageWrapper.test.tsx
@@ -15,14 +15,14 @@ describe('SequencesPageWrapper', () => {
   });
 
   it('uses the persisted review stage when it is still valid', () => {
-    localStorage.setItem('sequences-review-stage', 'annotated');
+    localStorage.setItem('classify-done-stage', 'annotated');
     render(<SequencesPageWrapper defaultProcessingStage="annotated" />);
     expect(screen.getByTestId('stage-probe')).toHaveTextContent('annotated');
   });
 
   it('falls back to seq_annotation_done when the persisted stage is retired', () => {
     // e.g. 'in_review' persisted before the stage was removed (#207)
-    localStorage.setItem('sequences-review-stage', 'in_review');
+    localStorage.setItem('classify-done-stage', 'in_review');
     render(<SequencesPageWrapper defaultProcessingStage="annotated" />);
     expect(screen.getByTestId('stage-probe')).toHaveTextContent('seq_annotation_done');
   });

--- a/frontend/tests/utils/routes.test.ts
+++ b/frontend/tests/utils/routes.test.ts
@@ -1,0 +1,27 @@
+import { ROUTES, classifyDetail, classifyGroup, localizeDetail } from '@/utils/routes';
+
+describe('routes', () => {
+  it('exposes the taxonomy path constants', () => {
+    expect(ROUTES.CLASSIFY).toBe('/classify');
+    expect(ROUTES.CLASSIFY_DONE).toBe('/classify/done');
+    expect(ROUTES.CLASSIFY_GROUPS).toBe('/classify/groups');
+    expect(ROUTES.LOCALIZE).toBe('/localize');
+    expect(ROUTES.LOCALIZE_DONE).toBe('/localize/done');
+  });
+
+  it('builds classify detail paths for queue and done provenance', () => {
+    expect(classifyDetail(42)).toBe('/classify/42');
+    expect(classifyDetail(42, true)).toBe('/classify/done/42');
+  });
+
+  it('builds classify group paths', () => {
+    expect(classifyGroup(7)).toBe('/classify/groups/7');
+  });
+
+  it('builds localize detail paths with optional detection id and provenance', () => {
+    expect(localizeDetail(5)).toBe('/localize/5');
+    expect(localizeDetail(5, 9)).toBe('/localize/5/9');
+    expect(localizeDetail(5, undefined, true)).toBe('/localize/done/5');
+    expect(localizeDetail(5, 9, true)).toBe('/localize/done/5/9');
+  });
+});


### PR DESCRIPTION
Closes #210

## Summary

- Routes renamed from entity names to the task taxonomy the dashboard and sidebar teach:
  | Old | New |
  | --- | --- |
  | `/sequences/annotate` | `/classify` |
  | `/sequences/review` | `/classify/done` |
  | `/sequences/:id/annotate` | `/classify/:id` (or `/classify/done/:id` from the Done list) |
  | `/sequence-groups` (+ `:id/annotate`) | `/classify/groups` (+ `/:id`) |
  | `/detections/annotate` | `/localize` |
  | `/detections/review` | `/localize/done` |
  | `/detections/:seqId/annotate/:detId?` | `/localize/:seqId/:detId?` (or `/localize/done/…`) |
- **Provenance moved from `?from=` into the path**: detail components mount twice (plain and `mode="done"`); the `from=` mechanism is deleted end-to-end (back-links, nav highlighting, filter-key selection, lane-submit guard all derive from the mode prop). The legacy no-`from` generic localize flow (unreachable in-app) is removed.
- **Permanent redirects** from every old URL, translating old `from=` queries into the new paths (`src/components/routing/legacyRedirects.tsx`, 13 mapping tests).
- **Sidebar highlighting** collapses to pure pathname prefix rules (all query-string reads deleted); the dead `'#'` disabled-link branch flagged in #211's review dies with it.
- **Storage keys renamed** (no migration): `filters-classify`, `filters-classify-done`, `filters-localize`, `filters-localize-done`, `classify-done-stage`. Incidentally fixes a pre-existing mismatch where the localize done list wrote `filters-detections-review-v2` but the detail page read `filters-detections-review`.
- New `src/utils/routes.ts` centralizes path constants/builders; `frontend/CLAUDE.md` routes table updated.

Design spec: `docs/specs/2026-07-28-route-taxonomy-rename-design.md`

## Test plan

- [x] 13 redirect-mapping tests (incl. `from=` translation), 11 nav-highlight cases, routes builder tests
- [x] Full suite: 713 tests / 41 files green; type-check + format:check clean; lint matches main's baseline (2 pre-existing no-console warnings)
- [x] Dev-server spot check: new and legacy URLs all serve and redirect correctly