### PR TITLE
fix(frontend): make Done-page copy review-focused

### DIFF
--- a/frontend/src/pages/DetectionReviewPage.tsx
+++ b/frontend/src/pages/DetectionReviewPage.tsx
@@ -232,7 +232,9 @@ export default function DetectionReviewPage() {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-bold text-gray-900">Detections</h1>
-            <p className="text-gray-600">Review and verify annotated wildfire detections</p>
+            <p className="text-gray-600">
+              Browse localized smoke detections and review past annotations
+            </p>
           </div>
         </div>
 
@@ -296,8 +298,10 @@ export default function DetectionReviewPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Detection Review</h1>
-          <p className="text-gray-600">Review and verify annotated wildfire detections</p>
+          <h1 className="text-2xl font-bold text-gray-900">Detections</h1>
+          <p className="text-gray-600">
+            Browse localized smoke detections and review past annotations
+          </p>
         </div>
       </div>
 

--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -225,7 +225,11 @@ export default function SequencesPage({
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-bold text-gray-900">Sequences</h1>
-            <p className="text-gray-600">Manage and annotate wildfire detection sequences</p>
+            <p className="text-gray-600">
+              {isReviewPage
+                ? 'Browse classified sequences and review past decisions'
+                : 'Manage and annotate wildfire detection sequences'}
+            </p>
           </div>
           {stageSelector}
         </div>
@@ -302,7 +306,11 @@ export default function SequencesPage({
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Sequences</h1>
-          <p className="text-gray-600">Manage and annotate wildfire detection sequences</p>
+          <p className="text-gray-600">
+            {isReviewPage
+              ? 'Browse classified sequences and review past decisions'
+              : 'Manage and annotate wildfire detection sequences'}
+          </p>
         </div>
         {stageSelector}
       </div>

--- a/frontend/src/utils/processingStage.ts
+++ b/frontend/src/utils/processingStage.ts
@@ -161,7 +161,7 @@ export function filterSequencesByProcessingStage(
  * // Returns: 'No annotation'
  *
  * const label3 = getProcessingStageLabel('annotated');
- * // Returns: 'Annotated'
+ * // Returns: 'Fully annotated'
  * ```
  */
 export function getProcessingStageLabel(status: ProcessingStageStatus | ProcessingStage): string {
@@ -169,8 +169,8 @@ export function getProcessingStageLabel(status: ProcessingStageStatus | Processi
     no_annotation: 'No annotation',
     imported: 'Imported',
     ready_to_annotate: 'Ready to annotate',
-    seq_annotation_done: 'Seq annotation done',
-    annotated: 'Annotated',
+    seq_annotation_done: 'Awaiting localization',
+    annotated: 'Fully annotated',
   };
 
   return labels[status as ProcessingStageStatus] || labels['no_annotation'];

--- a/frontend/tests/utils/processingStage.test.ts
+++ b/frontend/tests/utils/processingStage.test.ts
@@ -33,6 +33,6 @@ describe('getStageFilterLabel', () => {
   });
 
   it('falls back to the single-stage label', () => {
-    expect(getStageFilterLabel('seq_annotation_done')).toBe('Seq annotation done');
+    expect(getStageFilterLabel('seq_annotation_done')).toBe('Awaiting localization');
   });
 });


### PR DESCRIPTION
## Summary

The **Classify > Done** and **Localize > Done** pages described themselves as annotation work even though they show finished work available for review.

- **Classify > Done** (`/sequences/review`): subtitle was "Manage and annotate wildfire detection sequences" (shared with the annotate queue). The review view now says **"Browse classified sequences and review past decisions"**; the annotate queue keeps its existing subtitle.
- **Localize > Done** (`/detections/review`): subtitle "Review and verify annotated wildfire detections" becomes **"Browse localized smoke detections and review past annotations"**. Also unifies the heading to **"Detections"** — it previously flipped between "Detection Review" (results) and "Detections" (empty state).
- **Stage labels** (`getProcessingStageLabel`): the jargony `seq_annotation_done` label "Seq annotation done" becomes **"Awaiting localization"**, and "Annotated" becomes **"Fully annotated"** so the Stage dropdown on Classify > Done reads as a clear pair. This also updates the table-row stage badges and the empty-state message that interpolate the same label.

## Testing

- `npm run type-check` / `npm run format:check` pass
- `npm test`: 41 files, 699 tests pass (updated the one assertion on the old stage label)
- ESLint: 3 pre-existing warnings in `DetectionSequenceAnnotatePage.tsx` (untouched by this PR; CI uses `lint:ci`)