### PR TITLE
Richer /localize queue table (thumbnail, source, azimuth, absolute time, frames)

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -686,6 +686,7 @@ async def _build_queue_item(
                 processing_stage=annotation.processing_stage.value
                 if annotation
                 else "no_annotation",
+                smoke_types=(annotation.smoke_types or []) if annotation else [],
                 total_detections=stats_by_seq.get(seq.id, (0, 0))[0],
                 annotated_detections=stats_by_seq.get(seq.id, (0, 0))[1],
                 auto_annotated_at=seq.auto_annotated_at,

--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -676,6 +676,7 @@ async def _build_queue_item(
         platform_alert_id=platform_alert_id,
         camera_name=first_seq.camera_name,
         organisation_name=first_seq.organisation_name,
+        azimuth=first_seq.azimuth,
         recorded_at=recorded_at,
         lanes=[
             LocalizationQueueLane(

--- a/annotation_api/src/app/schemas/sequence.py
+++ b/annotation_api/src/app/schemas/sequence.py
@@ -145,5 +145,6 @@ class LocalizationQueueItem(BaseModel):
     platform_alert_id: int
     camera_name: str
     organisation_name: str
+    azimuth: Optional[int]
     recorded_at: datetime
     lanes: List[LocalizationQueueLane]

--- a/annotation_api/src/app/schemas/sequence.py
+++ b/annotation_api/src/app/schemas/sequence.py
@@ -133,6 +133,7 @@ class LocalizationQueueLane(BaseModel):
     alert_api_id: int
     has_smoke: bool
     processing_stage: str
+    smoke_types: List[str]
     total_detections: int
     annotated_detections: int
     auto_annotated_at: Optional[datetime]

--- a/annotation_api/src/tests/endpoints/test_localization_queue.py
+++ b/annotation_api/src/tests/endpoints/test_localization_queue.py
@@ -30,6 +30,7 @@ async def _lane(
     recorded_at=NOW,
     camera_name="cam",
     azimuth=None,
+    smoke_types=None,
 ):
     seq = Sequence(
         source_api=SourceApi.PYRONEAR_FRENCH_API,
@@ -60,6 +61,7 @@ async def _lane(
                 annotation={"sequences_bbox": []},
                 processing_stage=stage,
                 created_at=recorded_at,
+                smoke_types=smoke_types or [],
             )
         )
     for i in range(n_detections):
@@ -99,6 +101,7 @@ async def test_alert_appears_with_lane_stats(
         n_detections=4,
         n_annotated=1,
         camera_name="CAM_A",
+        smoke_types=["wildfire"],
     )
     await _lane(
         async_session,
@@ -122,6 +125,9 @@ async def test_alert_appears_with_lane_stats(
     assert smoke_lane["total_detections"] == 4
     assert smoke_lane["annotated_detections"] == 1
     assert smoke_lane["auto_annotated_at"] is not None
+    assert smoke_lane["smoke_types"] == ["wildfire"]
+    fp_lane = next(lane for lane in item["lanes"] if not lane["has_smoke"])
+    assert fp_lane["smoke_types"] == []
 
 
 @pytest.mark.asyncio

--- a/annotation_api/src/tests/endpoints/test_localization_queue.py
+++ b/annotation_api/src/tests/endpoints/test_localization_queue.py
@@ -29,6 +29,7 @@ async def _lane(
     n_annotated=0,
     recorded_at=NOW,
     camera_name="cam",
+    azimuth=None,
 ):
     seq = Sequence(
         source_api=SourceApi.PYRONEAR_FRENCH_API,
@@ -44,6 +45,7 @@ async def _lane(
         organisation_name="org",
         organisation_id=1,
         auto_annotated_at=NOW if auto_annotated else None,
+        azimuth=azimuth,
     )
     session.add(seq)
     await session.flush()
@@ -113,6 +115,7 @@ async def test_alert_appears_with_lane_stats(
     assert item["platform_alert_id"] == 500
     assert item["source_api"] == "pyronear_french"
     assert item["camera_name"] == "CAM_A"
+    assert item["azimuth"] is None
     assert len(item["lanes"]) == 2
     smoke_lane = next(lane for lane in item["lanes"] if lane["has_smoke"])
     assert smoke_lane["processing_stage"] == "seq_annotation_done"
@@ -210,6 +213,38 @@ async def test_pagination_orders_by_recorded_at_desc(
     data = resp.json()
     assert data["total"] == 3
     assert [item["platform_alert_id"] for item in data["items"]] == [502, 501]
+
+
+@pytest.mark.asyncio
+async def test_azimuth_comes_from_primary_lane(
+    authenticated_client: AsyncClient, async_session
+):
+    # Primary lane (lowest alert_api_id) has azimuth 143; the object-split
+    # sibling carries a different per-object cone azimuth that must NOT win.
+    await _lane(
+        async_session,
+        alert_api_id=600,
+        platform_alert_id=600,
+        stage=Stage.SEQ_ANNOTATION_DONE,
+        has_smoke=True,
+        auto_annotated=True,
+        n_detections=1,
+        azimuth=143,
+    )
+    await _lane(
+        async_session,
+        alert_api_id=1_000_600_001,
+        platform_alert_id=600,
+        stage=Stage.SEQ_ANNOTATION_DONE,
+        has_smoke=True,
+        auto_annotated=True,
+        n_detections=1,
+        azimuth=157,
+    )
+    resp = await authenticated_client.get("/sequences/localization-queue")
+    assert resp.status_code == 200
+    (item,) = resp.json()["items"]
+    assert item["azimuth"] == 143
 
 
 @pytest.mark.asyncio

--- a/docs/specs/2026-07-28-localize-table-columns-design.md
+++ b/docs/specs/2026-07-28-localize-table-columns-design.md
@@ -1,0 +1,63 @@
+# /localize Queue Table — Column Redesign
+
+**Date:** 2026-07-28
+**Status:** Approved
+**Scope:** `frontend/src/pages/DetectionAnnotatePage.tsx`, `frontend/src/types/api.ts`, `annotation_api` localization-queue endpoint
+
+## Goal
+
+Make the Smoke Localization queue (`/localize`) rows more informative for picking
+work: show a visual preview, provenance, camera direction, and workload size —
+and drop the two progress-oriented columns that were not useful there.
+
+## Current state
+
+Columns today: Camera, Organisation, Recorded (relative time, e.g. "3 hours
+ago"), Objects ("2 of 3 objects to localize"), Progress ("5/12 boxes").
+
+## Target columns
+
+| Column       | Content                                                                    | Source                                              |
+| ------------ | -------------------------------------------------------------------------- | --------------------------------------------------- |
+| Preview      | Thumbnail of the alert's first detection image (`DetectionImageThumbnail`, `h-16`) | Primary lane's `sequence_id` (`lanes[0]`)           |
+| Camera       | Camera name, with muted `Azimuth: 143°` text when azimuth is non-null       | `camera_name`, new `azimuth` field                  |
+| Organisation | Unchanged                                                                   | `organisation_name`                                 |
+| Source       | `source_api` as the blue pill used in the classify queue rows               | `source_api` (already in the payload, not shown)    |
+| Recorded     | Absolute date-time via `new Date(...).toLocaleString()` (app convention)    | `recorded_at`                                       |
+| Frames       | Total images to box across the alert's smoke lanes, e.g. "20 frames" — 2 objects × 10 frames = 20 | Sum of `total_detections` over `has_smoke` lanes    |
+
+Dropped: Objects and Progress columns, and the helpers that only served them
+(`unfinishedSmokeLanes`, `annotatedBoxes`). The existing `totalBoxes` helper is
+the Frames computation (rename to match its new meaning).
+
+## Backend change
+
+`GET /api/v1/sequences/localization-queue` gains one field:
+
+- `LocalizationQueueItem.azimuth: Optional[int]` (`schemas/sequence.py`),
+  populated in `_build_queue_item` from the primary lane's sequence
+  (`first_seq.azimuth`, same source as `camera_name`). Object-split siblings can
+  carry per-object cone azimuths; the primary's value represents the camera's
+  viewing direction, which is what the queue row needs.
+
+No query changes; no performance impact.
+
+## Frontend change
+
+- `LocalizationQueueItem` type gains `azimuth: number | null`.
+- Table restructured to the target columns above. Thumbnail requests reuse
+  `DetectionImageThumbnail` (two cached queries per row — same pattern and page
+  size as the classify queue, an accepted cost).
+
+## Testing
+
+- Backend: extend the localization-queue endpoint tests to assert `azimuth` is
+  returned, and `None` when the sequence has no azimuth.
+- Frontend: cover the Frames computation (smoke lanes only) and the rendered
+  columns, following whatever test coverage the page has today.
+
+## Out of scope
+
+- Sorting/filtering of the queue.
+- Per-lane azimuth display or any per-object breakdown.
+- Backend-provided thumbnail URLs (client-side fetch is the established pattern).

--- a/docs/specs/2026-07-28-localize-table-columns-design.md
+++ b/docs/specs/2026-07-28-localize-table-columns-design.md
@@ -23,6 +23,7 @@ ago"), Objects ("2 of 3 objects to localize"), Progress ("5/12 boxes").
 | Camera       | Camera name, with muted `Azimuth: 143°` text when azimuth is non-null       | `camera_name`, new `azimuth` field                  |
 | Organisation | Unchanged                                                                   | `organisation_name`                                 |
 | Source       | `source_api` as the blue pill used in the classify queue rows               | `source_api` (already in the payload, not shown)    |
+| Smoke type   | Union of classify-phase smoke types across the alert's smoke lanes, deduped, as the app's orange emoji pills (`getSmokeTypeEmoji` + `formatSmokeType`) | New per-lane `smoke_types` field                    |
 | Recorded     | Absolute date-time via `new Date(...).toLocaleString()` (app convention)    | `recorded_at`                                       |
 | Frames       | Total images to box across the alert's smoke lanes, e.g. "20 frames" — 2 objects × 10 frames = 20 | Sum of `total_detections` over `has_smoke` lanes    |
 
@@ -32,13 +33,17 @@ the Frames computation (rename to match its new meaning).
 
 ## Backend change
 
-`GET /api/v1/sequences/localization-queue` gains one field:
+`GET /api/v1/sequences/localization-queue` gains two fields:
 
 - `LocalizationQueueItem.azimuth: Optional[int]` (`schemas/sequence.py`),
   populated in `_build_queue_item` from the primary lane's sequence
   (`first_seq.azimuth`, same source as `camera_name`). Object-split siblings can
   carry per-object cone azimuths; the primary's value represents the camera's
   viewing direction, which is what the queue row needs.
+- `LocalizationQueueLane.smoke_types: List[str]`, populated from the lane's
+  `SequenceAnnotation.smoke_types` (`[]` when the lane has no annotation).
+  Per-lane is the faithful shape — each lane is one classified object; the
+  frontend unions across smoke lanes for display.
 
 No query changes; no performance impact.
 
@@ -52,9 +57,11 @@ No query changes; no performance impact.
 ## Testing
 
 - Backend: extend the localization-queue endpoint tests to assert `azimuth` is
-  returned, and `None` when the sequence has no azimuth.
-- Frontend: cover the Frames computation (smoke lanes only) and the rendered
-  columns, following whatever test coverage the page has today.
+  returned (`None` when the sequence has no azimuth), and that each lane's
+  `smoke_types` passes through (`[]` for the no-annotation case).
+- Frontend: cover the Frames computation (smoke lanes only), the rendered
+  columns, and the smoke-type union/dedup across smoke lanes, following
+  whatever test coverage the page has today.
 
 ## Out of scope
 

--- a/frontend/src/pages/DetectionAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionAnnotatePage.tsx
@@ -4,20 +4,14 @@ import { useNavigate } from 'react-router-dom';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { apiClient } from '@/services/api';
 import { LocalizationQueueItem } from '@/types/api';
+import DetectionImageThumbnail from '@/components/DetectionImageThumbnail';
 import { pickNextLocalizeLane } from '@/utils/annotation/localizeUtils';
-import { formatRelativeTime } from '@/utils/relativeTime';
 import { localizeDetail } from '@/utils/routes';
 
-function unfinishedSmokeLanes(item: LocalizationQueueItem): number {
-  return item.lanes.filter(l => l.has_smoke && l.processing_stage === 'seq_annotation_done').length;
-}
-
-function totalBoxes(item: LocalizationQueueItem): number {
+// Images the annotator will draw boxes on: each smoke object replays the
+// alert's frames, so two objects x 10 frames is 20 boxes of work.
+function smokeFrames(item: LocalizationQueueItem): number {
   return item.lanes.filter(l => l.has_smoke).reduce((sum, l) => sum + l.total_detections, 0);
-}
-
-function annotatedBoxes(item: LocalizationQueueItem): number {
-  return item.lanes.filter(l => l.has_smoke).reduce((sum, l) => sum + l.annotated_detections, 0);
 }
 
 export default function DetectionAnnotatePage() {
@@ -94,19 +88,22 @@ export default function DetectionAnnotatePage() {
             <thead className="bg-gray-50">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Preview
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Camera
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Organisation
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Source
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Recorded
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Objects
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Progress
+                  Frames
                 </th>
               </tr>
             </thead>
@@ -117,20 +114,33 @@ export default function DetectionAnnotatePage() {
                   onClick={() => handleAlertClick(item)}
                   className="cursor-pointer hover:bg-gray-50"
                 >
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <DetectionImageThumbnail
+                      sequenceId={item.lanes[0].sequence_id}
+                      className="h-16 w-24"
+                    />
+                  </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                     {item.camera_name}
+                    {item.azimuth !== null && item.azimuth !== undefined && (
+                      <span className="ml-2 text-xs font-normal text-gray-400">
+                        Azimuth: {item.azimuth}°
+                      </span>
+                    )}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                     {item.organisation_name}
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {formatRelativeTime(item.recorded_at)}
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                      {item.source_api}
+                    </span>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {unfinishedSmokeLanes(item)} of {item.lanes.length} objects to localize
+                    {new Date(item.recorded_at).toLocaleString()}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {annotatedBoxes(item)}/{totalBoxes(item)} boxes
+                    {smokeFrames(item)} frames
                   </td>
                 </tr>
               ))}

--- a/frontend/src/pages/DetectionAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionAnnotatePage.tsx
@@ -16,8 +16,9 @@ function smokeFrames(item: LocalizationQueueItem): number {
 }
 
 // Classify-phase smoke types across the alert's smoke objects, deduped.
+// `?? []` guards payloads from a backend that predates the field.
 function smokeTypes(item: LocalizationQueueItem): string[] {
-  return [...new Set(item.lanes.filter(l => l.has_smoke).flatMap(l => l.smoke_types))];
+  return [...new Set(item.lanes.filter(l => l.has_smoke).flatMap(l => l.smoke_types ?? []))];
 }
 
 export default function DetectionAnnotatePage() {

--- a/frontend/src/pages/DetectionAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionAnnotatePage.tsx
@@ -89,29 +89,29 @@ export default function DetectionAnnotatePage() {
           </div>
         </div>
       ) : (
-        <div className="bg-white shadow rounded-lg overflow-hidden">
+        <div className="bg-white shadow rounded-lg overflow-x-auto">
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Preview
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Camera
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Organisation
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Source
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Smoke type
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Recorded
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Frames
                 </th>
               </tr>
@@ -123,13 +123,13 @@ export default function DetectionAnnotatePage() {
                   onClick={() => handleAlertClick(item)}
                   className="cursor-pointer hover:bg-gray-50"
                 >
-                  <td className="px-6 py-4 whitespace-nowrap">
+                  <td className="px-4 py-4 whitespace-nowrap">
                     <DetectionImageThumbnail
                       sequenceId={item.lanes[0].sequence_id}
                       className="h-16 w-24"
                     />
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                  <td className="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                     {item.camera_name}
                     {item.azimuth !== null && item.azimuth !== undefined && (
                       <span className="ml-2 text-xs font-normal text-gray-400">
@@ -137,15 +137,15 @@ export default function DetectionAnnotatePage() {
                       </span>
                     )}
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
                     {item.organisation_name}
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
+                  <td className="px-4 py-4 whitespace-nowrap">
                     <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                       {item.source_api}
                     </span>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
+                  <td className="px-4 py-4 whitespace-nowrap">
                     <div className="flex flex-wrap gap-1">
                       {smokeTypes(item).map(type => (
                         <span
@@ -157,10 +157,10 @@ export default function DetectionAnnotatePage() {
                       ))}
                     </div>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
                     {new Date(item.recorded_at).toLocaleString()}
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
                     {smokeFrames(item)} frames
                   </td>
                 </tr>

--- a/frontend/src/pages/DetectionAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionAnnotatePage.tsx
@@ -6,12 +6,18 @@ import { apiClient } from '@/services/api';
 import { LocalizationQueueItem } from '@/types/api';
 import DetectionImageThumbnail from '@/components/DetectionImageThumbnail';
 import { pickNextLocalizeLane } from '@/utils/annotation/localizeUtils';
+import { formatSmokeType, getSmokeTypeEmoji } from '@/utils/modelAccuracy';
 import { localizeDetail } from '@/utils/routes';
 
 // Images the annotator will draw boxes on: each smoke object replays the
 // alert's frames, so two objects x 10 frames is 20 boxes of work.
 function smokeFrames(item: LocalizationQueueItem): number {
   return item.lanes.filter(l => l.has_smoke).reduce((sum, l) => sum + l.total_detections, 0);
+}
+
+// Classify-phase smoke types across the alert's smoke objects, deduped.
+function smokeTypes(item: LocalizationQueueItem): string[] {
+  return [...new Set(item.lanes.filter(l => l.has_smoke).flatMap(l => l.smoke_types))];
 }
 
 export default function DetectionAnnotatePage() {
@@ -100,6 +106,9 @@ export default function DetectionAnnotatePage() {
                   Source
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Smoke type
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Recorded
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -135,6 +144,18 @@ export default function DetectionAnnotatePage() {
                     <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                       {item.source_api}
                     </span>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <div className="flex flex-wrap gap-1">
+                      {smokeTypes(item).map(type => (
+                        <span
+                          key={type}
+                          className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-orange-100 text-orange-800"
+                        >
+                          {getSmokeTypeEmoji(type)} {formatSmokeType(type)}
+                        </span>
+                      ))}
+                    </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                     {new Date(item.recorded_at).toLocaleString()}

--- a/frontend/src/pages/DetectionSequenceAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionSequenceAnnotatePage.tsx
@@ -357,6 +357,7 @@ export default function DetectionSequenceAnnotatePage({
           alert_api_id: s.alert_api_id,
           has_smoke: true,
           processing_stage: 'seq_annotation_done',
+          smoke_types: [],
           total_detections: 0,
           annotated_detections: 0,
           auto_annotated_at: null,

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -35,6 +35,7 @@ export interface LocalizationQueueLane {
   alert_api_id: number;
   has_smoke: boolean;
   processing_stage: string;
+  smoke_types: string[];
   total_detections: number;
   annotated_detections: number;
   auto_annotated_at: string | null;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -46,6 +46,7 @@ export interface LocalizationQueueItem {
   platform_alert_id: number;
   camera_name: string;
   organisation_name: string;
+  azimuth: number | null;
   recorded_at: string;
   lanes: LocalizationQueueLane[];
 }

--- a/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
+++ b/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
@@ -7,6 +7,8 @@ import React from 'react';
 vi.mock('@/services/api', () => ({
   apiClient: {
     getLocalizationQueue: vi.fn(),
+    getSequenceDetections: vi.fn(),
+    getDetectionImageUrl: vi.fn(),
   },
 }));
 
@@ -33,6 +35,7 @@ const queueItem = {
   platform_alert_id: 170000,
   camera_name: 'CAM_01',
   organisation_name: 'Pyronear',
+  azimuth: 143,
   recorded_at: '2026-07-27T10:00:00Z',
   lanes: [
     {
@@ -66,14 +69,37 @@ describe('DetectionAnnotatePage (Localize queue)', () => {
       size: 50,
       total: 1,
     });
+    vi.mocked(apiClient.getSequenceDetections).mockResolvedValue([]);
   });
 
-  it('renders one row per alert with lane summary and progress', async () => {
+  it('renders one row per alert with source, absolute time, azimuth and frames', async () => {
     render(<DetectionAnnotatePage />, { wrapper });
     await waitFor(() => expect(screen.getByText('CAM_01')).toBeTruthy());
     expect(screen.getByText('Pyronear')).toBeTruthy();
-    expect(screen.getByText(/1 of 2 objects to localize/)).toBeTruthy();
-    expect(screen.getByText(/1\/4 boxes/)).toBeTruthy();
+    // Source pill
+    expect(screen.getByText('pyronear_french')).toBeTruthy();
+    // Absolute date-time, app-wide convention
+    expect(screen.getByText(new Date('2026-07-27T10:00:00Z').toLocaleString())).toBeTruthy();
+    // Camera azimuth
+    expect(screen.getByText(/Azimuth: 143°/)).toBeTruthy();
+    // Frames = detections across smoke lanes only (4 from lane 11; lane 12 is FP)
+    expect(screen.getByText(/4 frames/)).toBeTruthy();
+    // Old columns are gone
+    expect(screen.queryByText(/objects to localize/)).toBeNull();
+    expect(screen.queryByText(/boxes/)).toBeNull();
+  });
+
+  it('omits the azimuth text when the alert has none', async () => {
+    vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue({
+      items: [{ ...queueItem, azimuth: null }],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 1,
+    });
+    render(<DetectionAnnotatePage />, { wrapper });
+    await waitFor(() => expect(screen.getByText('CAM_01')).toBeTruthy());
+    expect(screen.queryByText(/Azimuth:/)).toBeNull();
   });
 
   it('clicking a row opens the first unfinished smoke lane in localize flow', async () => {

--- a/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
+++ b/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
@@ -119,6 +119,21 @@ describe('DetectionAnnotatePage (Localize queue)', () => {
     expect(screen.getByText(/Industrial/)).toBeTruthy();
   });
 
+  it('tolerates lanes without smoke_types (payloads from an older backend)', async () => {
+    const legacyLane = { ...queueItem.lanes[0] } as Record<string, unknown>;
+    delete legacyLane.smoke_types;
+    vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue({
+      items: [{ ...queueItem, lanes: [legacyLane as unknown as (typeof queueItem.lanes)[0]] }],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 1,
+    });
+    render(<DetectionAnnotatePage />, { wrapper });
+    await waitFor(() => expect(screen.getByText('CAM_01')).toBeTruthy());
+    expect(screen.queryByText(/Wildfire/)).toBeNull();
+  });
+
   it('omits the azimuth text when the alert has none', async () => {
     vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue({
       items: [{ ...queueItem, azimuth: null }],

--- a/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
+++ b/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
@@ -43,6 +43,7 @@ const queueItem = {
       alert_api_id: 170000,
       has_smoke: true,
       processing_stage: 'seq_annotation_done',
+      smoke_types: ['wildfire'],
       total_detections: 4,
       annotated_detections: 1,
       auto_annotated_at: '2026-07-27T11:00:00Z',
@@ -52,6 +53,7 @@ const queueItem = {
       alert_api_id: 170000001,
       has_smoke: false,
       processing_stage: 'annotated',
+      smoke_types: [],
       total_detections: 2,
       annotated_detections: 2,
       auto_annotated_at: null,
@@ -84,9 +86,37 @@ describe('DetectionAnnotatePage (Localize queue)', () => {
     expect(screen.getByText(/Azimuth: 143°/)).toBeTruthy();
     // Frames = detections across smoke lanes only (4 from lane 11; lane 12 is FP)
     expect(screen.getByText(/4 frames/)).toBeTruthy();
+    // Smoke type pill from the classify phase (smoke lanes only)
+    expect(screen.getByText(/Wildfire/)).toBeTruthy();
     // Old columns are gone
     expect(screen.queryByText(/objects to localize/)).toBeNull();
     expect(screen.queryByText(/boxes/)).toBeNull();
+  });
+
+  it('unions and dedupes smoke types across smoke lanes', async () => {
+    vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue({
+      items: [
+        {
+          ...queueItem,
+          lanes: [
+            { ...queueItem.lanes[0], smoke_types: ['wildfire'] },
+            {
+              ...queueItem.lanes[1],
+              has_smoke: true,
+              smoke_types: ['wildfire', 'industrial'],
+            },
+          ],
+        },
+      ],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 1,
+    });
+    render(<DetectionAnnotatePage />, { wrapper });
+    await waitFor(() => expect(screen.getByText('CAM_01')).toBeTruthy());
+    expect(screen.getAllByText(/Wildfire/)).toHaveLength(1);
+    expect(screen.getByText(/Industrial/)).toBeTruthy();
   });
 
   it('omits the azimuth text when the alert has none', async () => {


### PR DESCRIPTION
## Summary

Redesigns the Smoke Localization queue (`/localize`) table per `docs/specs/2026-07-28-localize-table-columns-design.md`:

- **New columns**: Preview thumbnail (first detection image of the primary lane), Source API pill, Smoke type (classify-phase smoke types unioned across the alert's smoke objects, deduped), Frames (total images to box across the alert's smoke lanes).
- **Camera** now shows the camera azimuth (muted, hidden when null) — the queue payload gains an `azimuth` field sourced from the primary lane's sequence.
- **Recorded** switches from relative time ("3 hours ago") to the app-wide absolute `toLocaleString()` format.
- **Dropped**: the "X of Y objects to localize" and "A/B boxes" progress columns.

## Backend

`GET /api/v1/sequences/localization-queue` gains two fields:
- `LocalizationQueueItem.azimuth: int | null` — from the primary lane's sequence, like `camera_name`.
- `LocalizationQueueLane.smoke_types: list[str]` — the lane's classify-phase `SequenceAnnotation.smoke_types` (`[]` without an annotation).

No query changes.

## Testing

- Backend: endpoint tests cover azimuth (primary lane wins over sibling cone azimuth; null passthrough) and per-lane smoke_types passthrough; full suite 476 passed in an isolated compose stack.
- Frontend: page tests cover the new columns, null azimuth, and smoke-type union/dedup; full suite 44 files / 744 tests green; type-check, Prettier, and ESLint clean on changed files (the 2 pre-existing `no-console` warnings in `DetectionSequenceAnnotatePage.tsx` are untouched).