### PR TITLE
feat(frontend): redesign the localize sticky header (#227)

### DIFF
--- a/docs/specs/2026-07-28-localize-header-redesign-design.md
+++ b/docs/specs/2026-07-28-localize-header-redesign-design.md
@@ -1,0 +1,116 @@
+# Localize Header Redesign — Design
+
+**Date:** 2026-07-28
+**Status:** Approved
+**Issue:** #227
+**Scope:** Frontend only (`frontend/`).
+
+## Problem
+
+The sticky header on `/localize/:sequenceId` (`DetectionHeader.tsx`)
+accumulated controls with the quick-submit work (#223) and is now cramped:
+two rows holding back button, org/camera/time, azimuth, lat/lon, sequence
+x-of-y, nav chevrons, S/M/L, three labeled checkbox toggles, Accept &
+submit, review status, frames progress, accuracy badge, pills, and a
+progress bar. It is also `position: fixed` with a hard-coded content
+offset (`pt-28`), which already caused one overlap bug when the header
+grew. The Cropped-view flipbook carries its own, differently-styled zoom
+controls (large −/+ buttons, wide slider, text Reset button).
+
+## Goals
+
+1. One uncramped header row with only what the user glances at while
+   localizing.
+2. One compact, consistent control language across the header toggles and
+   the flipbook zoom controls.
+3. Retire the fragile fixed-position + hard-coded offset scheme.
+
+## Removals (agreed)
+
+Gone entirely, not hidden: the progress row (Review status, "X of Y
+frames", percent, progress bar), azimuth, lat/lon, and "Sequence x of y".
+Frame progress is already visible in the grid (green borders); the nav
+chevrons stay (with their existing disabled/tooltip states).
+
+## Design
+
+### 1. Single sticky row
+
+`DetectionHeader` renders one flex row, left to right:
+
+- back button
+- **org • camera • time** (truncating on narrow viewports)
+- annotation pills + model-accuracy badge, as compact chips
+- flex spacer
+- prev/next sequence chevrons (loading/error/disabled states unchanged)
+- **ViewToolbar** (below)
+- **Accept & submit** (localize) / legacy **Submit All** (done-mode
+  `allInVisualCheck` gate) — logic unchanged from #223
+
+Positioning: `sticky top-0 z-30` with the current translucent
+background/blur, replacing `fixed top-0 left-0 md:left-64 right-0`. The
+header lives in the page's normal flow, so:
+
+- the sidebar offset (`md:left-64`) is no longer needed;
+- the page's `pt-28` content wrapper is deleted;
+- a wrapped (taller) header on narrow viewports can never cover content —
+  the offset bug class from #227 is retired.
+
+The all-annotated state keeps a subtle green tint plus a small check chip
+(replacing the removed "Completed"/progress affordances).
+
+### 2. `ViewToolbar` component
+
+New `frontend/src/components/detection-sequence/ViewToolbar.tsx`:
+
+- S/M/L segmented pill (moved from `DetectionHeader`, same
+  `CardSize` type and persisted state wiring via props).
+- Three icon toggles sharing one compact button style: eye = Show
+  predictions ("Show predictions (P)"), crop-frame = Crop
+  ("Crop cells (C)"), film = Cropped view ("Cropped view"). Each is
+  `aria-pressed` with a filled pressed state; lucide icons.
+- Crop and Cropped view render only when `isLocalize` (same gating as
+  today). All handlers and keyboard shortcuts pass through unchanged.
+
+Props mirror today's header props: `cardSize`/`onCardSizeChange`,
+`showPredictions`/`onTogglePredictions`, and optional
+`cropMode`/`onToggleCropMode`, `showCroppedView`/`onToggleCroppedView`,
+`isLocalize`.
+
+### 3. Flipbook zoom strip
+
+`CroppedImageSequence`'s zoom controls become one slim row under the
+canvas built from the same compact primitives: small icon buttons for
+−/+, a slim inline slider, the live `Nx` label, and a `RotateCcw` icon
+button for reset (replacing the text "Reset" pill). Behavior (range 1–8,
+default 4, reset-on-prop-change) is unchanged. This component is shared
+with the classify page's cropped view — both pages get the consistent
+styling deliberately.
+
+## Non-goals
+
+- No changes to quick-submit, crop math, cell states, or any grid
+  behavior.
+- No settings popover (rejected in favor of the icon bar).
+- No relocation of the flipbook (stays centered above the grid).
+
+## Testing
+
+- `ViewToolbar` component tests: toggles fire their callbacks, pressed
+  state reflects props, localize gating hides Crop/Cropped view, S/M/L
+  fires `onCardSizeChange`.
+- `DetectionHeader` tests updated: progress/azimuth/lat-lon/sequence-x-of-y
+  assertions removed; submit-button, confirm-state, and navigation tests
+  kept; new assertion that the header is sticky (class-based).
+- Page: remove the `pt-28` expectation context; existing behavior tests
+  unchanged.
+- Live screenshot check (real token against the dev server) to confirm
+  nothing sits under the header and the row fits at common widths.
+
+## Affected files (expected)
+
+- `frontend/src/components/detection-sequence/DetectionHeader.tsx`
+- `frontend/src/components/detection-sequence/ViewToolbar.tsx` (new)
+- `frontend/src/components/annotation/CroppedImageSequence.tsx`
+- `frontend/src/pages/DetectionSequenceAnnotatePage.tsx` (drop `pt-28`)
+- Tests under `frontend/tests/components/detection-sequence/`

--- a/frontend/src/components/annotation/CroppedImageSequence.tsx
+++ b/frontend/src/components/annotation/CroppedImageSequence.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Loader2, AlertCircle } from 'lucide-react';
+import { Loader2, AlertCircle, Minus, Plus, RotateCcw } from 'lucide-react';
 import { BoundingBox } from '@/types/api';
 import { apiClient } from '@/services/api';
 
@@ -245,52 +245,6 @@ export default function CroppedImageSequence({
 
   return (
     <div className={className}>
-      {/* Zoom Controls */}
-      {currentImage?.loaded && currentImage.imageElement && (
-        <div className="mb-4 flex items-center justify-center space-x-4">
-          <button
-            onClick={() => setZoomLevel(prev => Math.max(1, prev - 0.5))}
-            disabled={zoomLevel <= 1}
-            className="px-3 py-1 bg-gray-200 text-gray-700 rounded hover:bg-gray-300 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            −
-          </button>
-
-          <div className="flex items-center space-x-2">
-            <span className="text-sm text-gray-600 w-8">1x</span>
-            <input
-              type="range"
-              min="1"
-              max="8"
-              step="0.5"
-              value={zoomLevel}
-              onChange={e => setZoomLevel(parseFloat(e.target.value))}
-              className="w-24 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-            />
-            <span className="text-sm text-gray-600 w-8">8x</span>
-          </div>
-
-          <button
-            onClick={() => setZoomLevel(prev => Math.min(8, prev + 0.5))}
-            disabled={zoomLevel >= 8}
-            className="px-3 py-1 bg-gray-200 text-gray-700 rounded hover:bg-gray-300 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            +
-          </button>
-
-          <span className="text-sm font-medium text-gray-700 min-w-12">
-            {zoomLevel.toFixed(1)}x
-          </span>
-
-          <button
-            onClick={() => setZoomLevel(4)}
-            className="px-3 py-1 bg-primary-100 text-primary-700 rounded hover:bg-primary-200 text-xs"
-          >
-            Reset
-          </button>
-        </div>
-      )}
-
       {/* Cropped Image Container */}
       <div
         ref={containerRef}
@@ -335,6 +289,49 @@ export default function CroppedImageSequence({
           />
         )}
       </div>
+
+      {/* Zoom controls — compact strip matching the grid's ViewToolbar */}
+      {currentImage?.loaded && currentImage.imageElement && (
+        <div className="mt-2 flex items-center justify-center">
+          <div className="inline-flex items-center rounded-md bg-gray-200 p-0.5 gap-1">
+            <button
+              onClick={() => setZoomLevel(prev => Math.max(1, prev - 0.5))}
+              disabled={zoomLevel <= 1}
+              title="Zoom out"
+              className="px-1.5 py-0.5 rounded text-xs font-semibold text-gray-600 hover:text-gray-900 hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <Minus className="w-3.5 h-3.5" />
+            </button>
+            <input
+              type="range"
+              min="1"
+              max="8"
+              step="0.5"
+              value={zoomLevel}
+              onChange={e => setZoomLevel(parseFloat(e.target.value))}
+              className="w-24 h-1.5 bg-gray-300 rounded-lg appearance-none cursor-pointer"
+            />
+            <button
+              onClick={() => setZoomLevel(prev => Math.min(8, prev + 0.5))}
+              disabled={zoomLevel >= 8}
+              title="Zoom in"
+              className="px-1.5 py-0.5 rounded text-xs font-semibold text-gray-600 hover:text-gray-900 hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <Plus className="w-3.5 h-3.5" />
+            </button>
+            <span className="text-xs font-medium text-gray-700 w-8 text-center">
+              {zoomLevel.toFixed(1)}x
+            </span>
+            <button
+              onClick={() => setZoomLevel(4)}
+              title="Reset zoom"
+              className="px-1.5 py-0.5 rounded text-xs text-gray-600 hover:text-gray-900 hover:bg-white"
+            >
+              <RotateCcw className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/annotation/CroppedImageSequence.tsx
+++ b/frontend/src/components/annotation/CroppedImageSequence.tsx
@@ -259,7 +259,7 @@ export default function CroppedImageSequence({
       >
         {/* Loading State */}
         {showLoadingState && (
-          <div className="absolute inset-0 flex items-center justify-center bg-gray-100 z-30">
+          <div className="absolute inset-0 flex items-center justify-center bg-gray-100 z-10">
             <div className="flex flex-col items-center space-y-3">
               <Loader2 className="animate-spin w-6 h-6 text-primary-600" />
               <span className="text-sm text-gray-600">Loading image...</span>
@@ -269,7 +269,7 @@ export default function CroppedImageSequence({
 
         {/* Error State */}
         {currentImage?.error && (
-          <div className="absolute inset-0 flex items-center justify-center bg-gray-100 z-30">
+          <div className="absolute inset-0 flex items-center justify-center bg-gray-100 z-10">
             <div className="flex flex-col items-center space-y-2">
               <AlertCircle className="w-6 h-6 text-red-400" />
               <span className="text-sm text-gray-600">Failed to load image</span>
@@ -298,6 +298,7 @@ export default function CroppedImageSequence({
               onClick={() => setZoomLevel(prev => Math.max(1, prev - 0.5))}
               disabled={zoomLevel <= 1}
               title="Zoom out"
+              aria-label="Zoom out"
               className="px-1.5 py-0.5 rounded text-xs font-semibold text-gray-600 hover:text-gray-900 hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
             >
               <Minus className="w-3.5 h-3.5" />
@@ -315,6 +316,7 @@ export default function CroppedImageSequence({
               onClick={() => setZoomLevel(prev => Math.min(8, prev + 0.5))}
               disabled={zoomLevel >= 8}
               title="Zoom in"
+              aria-label="Zoom in"
               className="px-1.5 py-0.5 rounded text-xs font-semibold text-gray-600 hover:text-gray-900 hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
             >
               <Plus className="w-3.5 h-3.5" />
@@ -325,6 +327,7 @@ export default function CroppedImageSequence({
             <button
               onClick={() => setZoomLevel(4)}
               title="Reset zoom"
+              aria-label="Reset zoom"
               className="px-1.5 py-0.5 rounded text-xs text-gray-600 hover:text-gray-900 hover:bg-white"
             >
               <RotateCcw className="w-3.5 h-3.5" />

--- a/frontend/src/components/detection-sequence/DetectionHeader.tsx
+++ b/frontend/src/components/detection-sequence/DetectionHeader.tsx
@@ -1,31 +1,23 @@
-import {
-  ArrowLeft,
-  ChevronLeft,
-  ChevronRight,
-  CheckCircle,
-  AlertCircle,
-  Upload,
-} from 'lucide-react';
+/**
+ * Single-row sticky header for the detection sequence grid (#227): back,
+ * sequence identity, status chips, then navigation, the compact view
+ * toolbar, and the primary submit action. Sticky in the page's scroll
+ * flow — content can never be hidden beneath it.
+ */
+
+import { ArrowLeft, ChevronLeft, ChevronRight, CheckCircle, Upload } from 'lucide-react';
 import { Sequence, SequenceAnnotation } from '@/types/api';
 import { analyzeSequenceAccuracy, getModelAccuracyBadgeClasses } from '@/utils/modelAccuracy';
+import { ViewToolbar, CardSize } from './ViewToolbar';
 
-export type CardSize = 'sm' | 'md' | 'lg';
-
-const CARD_SIZES: { value: CardSize; label: string; title: string }[] = [
-  { value: 'sm', label: 'S', title: 'Small cards' },
-  { value: 'md', label: 'M', title: 'Medium cards' },
-  { value: 'lg', label: 'L', title: 'Large cards' },
-];
+export type { CardSize } from './ViewToolbar';
 
 interface DetectionHeaderProps {
   // Sequence data
   sequence?: Sequence;
   sequenceAnnotation?: SequenceAnnotation;
 
-  // Progress data
-  annotatedCount: number;
-  totalCount: number;
-  completionPercentage: number;
+  // Completion state
   isAllAnnotated: boolean;
 
   // Navigation
@@ -34,16 +26,16 @@ interface DetectionHeaderProps {
   canNavigateNext: () => boolean;
   onPreviousSequence: () => void;
   onNextSequence: () => void;
-  getCurrentSequenceIndex: () => number;
 
   // Sequences context
   rawSequencesLoading: boolean;
   rawSequencesError: boolean;
-  allSequences?: { total: number };
 
-  // Controls
+  // View controls
   showPredictions: boolean;
   onTogglePredictions: (show: boolean) => void;
+  cardSize?: CardSize;
+  onCardSizeChange?: (size: CardSize) => void;
 
   // Submit functionality
   allInVisualCheck: boolean;
@@ -65,10 +57,6 @@ interface DetectionHeaderProps {
   showCroppedView?: boolean;
   onToggleCroppedView?: (show: boolean) => void;
 
-  // Card size (S/M/L)
-  cardSize?: CardSize;
-  onCardSizeChange?: (size: CardSize) => void;
-
   // Annotation pills
   getAnnotationPills: () => React.ReactNode[];
 }
@@ -76,21 +64,18 @@ interface DetectionHeaderProps {
 export function DetectionHeader({
   sequence,
   sequenceAnnotation,
-  annotatedCount,
-  totalCount,
-  completionPercentage,
   isAllAnnotated,
   onBack,
   canNavigatePrevious,
   canNavigateNext,
   onPreviousSequence,
   onNextSequence,
-  getCurrentSequenceIndex,
   rawSequencesLoading,
   rawSequencesError,
-  allSequences,
   showPredictions,
   onTogglePredictions,
+  cardSize = 'md',
+  onCardSizeChange,
   allInVisualCheck,
   onSave,
   saveAnnotations,
@@ -103,312 +88,134 @@ export function DetectionHeader({
   onToggleCropMode,
   showCroppedView = false,
   onToggleCroppedView,
-  cardSize = 'md',
-  onCardSizeChange,
   getAnnotationPills,
 }: DetectionHeaderProps) {
+  const accuracy =
+    sequence && sequenceAnnotation
+      ? analyzeSequenceAccuracy({ ...sequence, annotation: sequenceAnnotation })
+      : null;
+
+  const chevronState = rawSequencesLoading
+    ? { disabled: true, title: 'Loading sequences...' }
+    : rawSequencesError
+      ? { disabled: true, title: 'Error loading sequences' }
+      : null;
+
   return (
     <div
-      className={`fixed top-0 left-0 md:left-64 right-0 backdrop-blur-sm shadow-sm z-30 ${
-        isAllAnnotated
-          ? 'bg-green-50/90 border-b border-green-200 border-l-4 border-l-green-500'
-          : 'bg-white/85 border-b border-gray-200'
+      className={`sticky top-0 z-30 -mx-6 -mt-6 mb-4 px-6 py-2 backdrop-blur-sm shadow-sm border-b ${
+        isAllAnnotated ? 'bg-green-50/90 border-green-200' : 'bg-white/85 border-gray-200'
       }`}
     >
-      <div className="px-10 py-3">
-        {/* Top Row: Context + Action Buttons */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-4">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <button
+          onClick={onBack}
+          className="p-1.5 rounded-md hover:bg-gray-100 hover:bg-opacity-75"
+          title="Back to sequences"
+        >
+          <ArrowLeft className="w-4 h-4" />
+        </button>
+
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-sm font-medium text-gray-900 truncate">
+            {sequence?.organisation_name || 'Loading...'}
+          </span>
+          <span className="text-gray-400">•</span>
+          <span className="text-sm text-gray-600 truncate">
+            {sequence?.camera_name || 'Loading...'}
+          </span>
+          <span className="text-gray-400">•</span>
+          <span className="text-sm text-gray-600 whitespace-nowrap">
+            {sequence?.recorded_at ? new Date(sequence.recorded_at).toLocaleString() : 'Loading...'}
+          </span>
+        </div>
+
+        {isAllAnnotated && <CheckCircle className="w-4 h-4 text-green-500 shrink-0" />}
+
+        {accuracy && (
+          <span className={getModelAccuracyBadgeClasses(accuracy, 'sm')}>
+            {accuracy.icon} {accuracy.label}
+          </span>
+        )}
+        <div className="flex items-center gap-1">{getAnnotationPills()}</div>
+
+        <div className="flex-1" />
+
+        <button
+          onClick={onPreviousSequence}
+          disabled={chevronState?.disabled || !canNavigatePrevious()}
+          className="p-1.5 rounded-md hover:bg-gray-100 hover:bg-opacity-75 disabled:opacity-40 disabled:cursor-not-allowed"
+          title={
+            chevronState?.title ??
+            (canNavigatePrevious() ? 'Previous sequence' : 'Already at first sequence')
+          }
+        >
+          <ChevronLeft className={`w-4 h-4 ${rawSequencesLoading ? 'animate-pulse' : ''}`} />
+        </button>
+        <button
+          onClick={onNextSequence}
+          disabled={chevronState?.disabled || !canNavigateNext()}
+          className="p-1.5 rounded-md hover:bg-gray-100 hover:bg-opacity-75 disabled:opacity-40 disabled:cursor-not-allowed"
+          title={
+            chevronState?.title ??
+            (canNavigateNext() ? 'Next sequence' : 'Already at last sequence')
+          }
+        >
+          <ChevronRight className={`w-4 h-4 ${rawSequencesLoading ? 'animate-pulse' : ''}`} />
+        </button>
+
+        <ViewToolbar
+          cardSize={cardSize}
+          onCardSizeChange={onCardSizeChange ?? (() => {})}
+          showPredictions={showPredictions}
+          onTogglePredictions={onTogglePredictions}
+          isLocalize={isLocalize}
+          cropMode={cropMode}
+          onToggleCropMode={onToggleCropMode}
+          showCroppedView={showCroppedView}
+          onToggleCroppedView={onToggleCroppedView}
+        />
+
+        {isLocalize ? (
+          <button
+            onClick={e => {
+              e.stopPropagation();
+              onQuickSubmit?.();
+            }}
+            disabled={quickSubmitPending}
+            className={`inline-flex items-center px-3 py-1.5 border border-transparent rounded-md shadow-sm text-xs font-medium text-white disabled:opacity-50 disabled:cursor-not-allowed ${
+              quickSubmitConfirming
+                ? 'bg-amber-500 hover:bg-amber-600'
+                : 'bg-primary-600 hover:bg-primary-700'
+            }`}
+            title="Accept predicted boxes for all pending frames and submit the sequence (Enter)"
+          >
+            {quickSubmitPending ? (
+              <div className="w-3 h-3 mr-1 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+            ) : (
+              <Upload className="w-3 h-3 mr-1" />
+            )}
+            {quickSubmitConfirming
+              ? `${noBoxCount} frame${noBoxCount === 1 ? '' : 's'} with no box — submit anyway?`
+              : 'Accept & submit'}
+          </button>
+        ) : (
+          allInVisualCheck && (
             <button
-              onClick={onBack}
-              className="p-1.5 rounded-md hover:bg-gray-100 hover:bg-opacity-75"
-              title="Back to sequences"
+              onClick={onSave}
+              disabled={saveAnnotations.isPending}
+              className="inline-flex items-center px-3 py-1.5 border border-transparent rounded-md shadow-sm text-xs font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Submit all detection annotations (Enter) - All flagged as false positive sequences"
             >
-              <ArrowLeft className="w-4 h-4" />
+              {saveAnnotations.isPending ? (
+                <div className="w-3 h-3 mr-1 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+              ) : (
+                <Upload className="w-3 h-3 mr-1" />
+              )}
+              Submit All
             </button>
-            <div className="flex items-center space-x-2">
-              <span className="text-sm font-medium text-gray-900">
-                {sequence?.organisation_name || 'Loading...'}
-              </span>
-              <span className="text-gray-400">•</span>
-              <span className="text-sm text-gray-600">{sequence?.camera_name || 'Loading...'}</span>
-              <span className="text-gray-400">•</span>
-              <span className="text-sm text-gray-600">
-                {sequence?.recorded_at
-                  ? new Date(sequence.recorded_at).toLocaleString()
-                  : 'Loading...'}
-              </span>
-              {sequence?.azimuth !== null && sequence?.azimuth !== undefined && (
-                <>
-                  <span className="text-gray-400">•</span>
-                  <span className="text-xs text-gray-500">{sequence.azimuth}°</span>
-                </>
-              )}
-              {sequence?.lat !== null &&
-                sequence?.lat !== undefined &&
-                sequence?.lon !== null &&
-                sequence?.lon !== undefined && (
-                  <>
-                    <span className="text-gray-400">•</span>
-                    <span className="text-xs text-gray-500">
-                      {sequence.lat.toFixed(3)}, {sequence.lon.toFixed(3)}
-                    </span>
-                  </>
-                )}
-
-              {/* Sequence context */}
-              {rawSequencesLoading ? (
-                <>
-                  <span className="text-gray-400">•</span>
-                  <span className="text-xs text-gray-500 animate-pulse">Loading sequences...</span>
-                </>
-              ) : rawSequencesError ? (
-                <>
-                  <span className="text-gray-400">•</span>
-                  <span className="text-xs text-red-500">Error loading sequences</span>
-                </>
-              ) : allSequences && allSequences.total > 0 ? (
-                <>
-                  <span className="text-gray-400">•</span>
-                  <span className="text-xs text-blue-600 font-medium">
-                    Sequence {getCurrentSequenceIndex() + 1} of {allSequences.total}
-                  </span>
-                </>
-              ) : (
-                <>
-                  <span className="text-gray-400">•</span>
-                  <span className="text-xs text-gray-500">No sequences found</span>
-                </>
-              )}
-
-              {/* Completion Badge */}
-              {isAllAnnotated && (
-                <>
-                  <span className="text-gray-400">•</span>
-                  <span className="inline-flex items-center text-xs text-green-600 font-medium">
-                    <CheckCircle className="w-3 h-3 mr-1" />
-                    Completed
-                  </span>
-                </>
-              )}
-            </div>
-          </div>
-
-          <div className="flex items-center space-x-2">
-            {/* Navigation Buttons */}
-            {rawSequencesLoading ? (
-              <>
-                <button
-                  disabled
-                  className="p-1.5 rounded-md opacity-40 cursor-not-allowed"
-                  title="Loading sequences..."
-                >
-                  <ChevronLeft className="w-4 h-4 animate-pulse" />
-                </button>
-                <button
-                  disabled
-                  className="p-1.5 rounded-md opacity-40 cursor-not-allowed"
-                  title="Loading sequences..."
-                >
-                  <ChevronRight className="w-4 h-4 animate-pulse" />
-                </button>
-              </>
-            ) : rawSequencesError ? (
-              <>
-                <button
-                  disabled
-                  className="p-1.5 rounded-md opacity-40 cursor-not-allowed"
-                  title="Error loading sequences"
-                >
-                  <ChevronLeft className="w-4 h-4" />
-                </button>
-                <button
-                  disabled
-                  className="p-1.5 rounded-md opacity-40 cursor-not-allowed"
-                  title="Error loading sequences"
-                >
-                  <ChevronRight className="w-4 h-4" />
-                </button>
-              </>
-            ) : (
-              <>
-                <button
-                  onClick={onPreviousSequence}
-                  disabled={!canNavigatePrevious()}
-                  className="p-1.5 rounded-md hover:bg-gray-100 hover:bg-opacity-75 disabled:opacity-40 disabled:cursor-not-allowed"
-                  title={canNavigatePrevious() ? 'Previous sequence' : 'Already at first sequence'}
-                >
-                  <ChevronLeft className="w-4 h-4" />
-                </button>
-                <button
-                  onClick={onNextSequence}
-                  disabled={!canNavigateNext()}
-                  className="p-1.5 rounded-md hover:bg-gray-100 hover:bg-opacity-75 disabled:opacity-40 disabled:cursor-not-allowed"
-                  title={canNavigateNext() ? 'Next sequence' : 'Already at last sequence'}
-                >
-                  <ChevronRight className="w-4 h-4" />
-                </button>
-              </>
-            )}
-
-            {/* Card size (S/M/L) */}
-            {onCardSizeChange && (
-              <div className="inline-flex rounded-md bg-gray-200 p-0.5 gap-0.5">
-                {CARD_SIZES.map(s => (
-                  <button
-                    key={s.value}
-                    type="button"
-                    title={s.title}
-                    aria-pressed={cardSize === s.value}
-                    onClick={() => onCardSizeChange(s.value)}
-                    className={`px-2 py-0.5 rounded text-xs font-semibold ${
-                      cardSize === s.value
-                        ? 'bg-white text-gray-900 shadow-sm'
-                        : 'text-gray-500 hover:text-gray-900'
-                    }`}
-                  >
-                    {s.label}
-                  </button>
-                ))}
-              </div>
-            )}
-
-            {/* Predictions Toggle */}
-            <label className="flex items-center space-x-2 px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={showPredictions}
-                onChange={e => onTogglePredictions(e.target.checked)}
-                className="w-3 h-3 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
-              />
-              <span>Show predictions</span>
-            </label>
-
-            {/* Crop Toggle (localize): zoom cells around their boxes */}
-            {isLocalize && (
-              <label
-                className="flex items-center space-x-2 px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50 cursor-pointer"
-                title="Zoom each frame around its boxes (C)"
-              >
-                <input
-                  type="checkbox"
-                  checked={cropMode}
-                  onChange={e => onToggleCropMode?.(e.target.checked)}
-                  className="w-3 h-3 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
-                />
-                <span>Crop</span>
-              </label>
-            )}
-
-            {/* Cropped flipbook toggle (localize) */}
-            {isLocalize && (
-              <label
-                className="flex items-center space-x-2 px-3 py-1.5 border border-gray-300 rounded-md text-xs font-medium text-gray-700 bg-white hover:bg-gray-50 cursor-pointer"
-                title="Show the animated cropped view of the lane's boxes"
-              >
-                <input
-                  type="checkbox"
-                  checked={showCroppedView}
-                  onChange={e => onToggleCroppedView?.(e.target.checked)}
-                  className="w-3 h-3 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
-                />
-                <span>Cropped view</span>
-              </label>
-            )}
-
-            {isLocalize ? (
-              <button
-                onClick={e => {
-                  e.stopPropagation();
-                  onQuickSubmit?.();
-                }}
-                disabled={quickSubmitPending}
-                className={`inline-flex items-center px-3 py-1.5 border border-transparent rounded-md shadow-sm text-xs font-medium text-white disabled:opacity-50 disabled:cursor-not-allowed ${
-                  quickSubmitConfirming
-                    ? 'bg-amber-500 hover:bg-amber-600'
-                    : 'bg-primary-600 hover:bg-primary-700'
-                }`}
-                title="Accept predicted boxes for all pending frames and submit the sequence (Enter)"
-              >
-                {quickSubmitPending ? (
-                  <div className="w-3 h-3 mr-1 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
-                ) : (
-                  <Upload className="w-3 h-3 mr-1" />
-                )}
-                {quickSubmitConfirming
-                  ? `${noBoxCount} frame${noBoxCount === 1 ? '' : 's'} with no box — submit anyway?`
-                  : 'Accept & submit'}
-              </button>
-            ) : (
-              allInVisualCheck && (
-                <button
-                  onClick={onSave}
-                  disabled={saveAnnotations.isPending}
-                  className="inline-flex items-center px-3 py-1.5 border border-transparent rounded-md shadow-sm text-xs font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
-                  title="Submit all detection annotations (Enter) - All flagged as false positive sequences"
-                >
-                  {saveAnnotations.isPending ? (
-                    <div className="w-3 h-3 mr-1 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
-                  ) : (
-                    <Upload className="w-3 h-3 mr-1" />
-                  )}
-                  Submit All
-                </button>
-              )
-            )}
-          </div>
-        </div>
-
-        {/* Bottom Row: Progress + Model Accuracy + Annotation Pills */}
-        <div className="flex items-center justify-between mt-2">
-          <div className="flex items-center space-x-4">
-            <span className="text-xs font-medium text-gray-900">
-              Review:{' '}
-              {isAllAnnotated ? (
-                <span className="text-green-600">Done</span>
-              ) : (
-                <span className="text-orange-600">Pending</span>
-              )}{' '}
-              • {annotatedCount} of {totalCount} frames • {completionPercentage}% complete
-            </span>
-
-            {/* Model Accuracy Context */}
-            {sequence && sequenceAnnotation && (
-              <div className="flex items-center space-x-2">
-                {(() => {
-                  const accuracy = analyzeSequenceAccuracy({
-                    ...sequence,
-                    annotation: sequenceAnnotation,
-                  });
-                  return (
-                    <span className={getModelAccuracyBadgeClasses(accuracy, 'sm')}>
-                      {accuracy.icon} {accuracy.label}
-                    </span>
-                  );
-                })()}
-              </div>
-            )}
-
-            {/* Annotation pills */}
-            <div className="flex items-center space-x-2">{getAnnotationPills()}</div>
-          </div>
-
-          <div className="flex items-center space-x-3">
-            {isAllAnnotated ? (
-              <CheckCircle className="w-4 h-4 text-green-500" />
-            ) : (
-              <AlertCircle className="w-4 h-4 text-orange-500" />
-            )}
-            <div className="w-24 bg-gray-200 rounded-full h-1.5">
-              <div
-                className={`h-1.5 rounded-full transition-all duration-300 ${
-                  isAllAnnotated ? 'bg-green-600' : 'bg-primary-600'
-                }`}
-                style={{ width: `${completionPercentage}%` }}
-              ></div>
-            </div>
-          </div>
-        </div>
+          )
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/detection-sequence/DetectionHeader.tsx
+++ b/frontend/src/components/detection-sequence/DetectionHeader.tsx
@@ -34,8 +34,8 @@ interface DetectionHeaderProps {
   // View controls
   showPredictions: boolean;
   onTogglePredictions: (show: boolean) => void;
-  cardSize?: CardSize;
-  onCardSizeChange?: (size: CardSize) => void;
+  cardSize: CardSize;
+  onCardSizeChange: (size: CardSize) => void;
 
   // Submit functionality
   allInVisualCheck: boolean;
@@ -74,7 +74,7 @@ export function DetectionHeader({
   rawSequencesError,
   showPredictions,
   onTogglePredictions,
-  cardSize = 'md',
+  cardSize,
   onCardSizeChange,
   allInVisualCheck,
   onSave,
@@ -130,14 +130,20 @@ export function DetectionHeader({
           </span>
         </div>
 
-        {isAllAnnotated && <CheckCircle className="w-4 h-4 text-green-500 shrink-0" />}
+        {isAllAnnotated && (
+          <CheckCircle
+            className="w-4 h-4 text-green-500 shrink-0"
+            role="img"
+            aria-label="All frames annotated"
+          />
+        )}
 
+        <div className="flex items-center gap-1">{getAnnotationPills()}</div>
         {accuracy && (
           <span className={getModelAccuracyBadgeClasses(accuracy, 'sm')}>
             {accuracy.icon} {accuracy.label}
           </span>
         )}
-        <div className="flex items-center gap-1">{getAnnotationPills()}</div>
 
         <div className="flex-1" />
 
@@ -166,7 +172,7 @@ export function DetectionHeader({
 
         <ViewToolbar
           cardSize={cardSize}
-          onCardSizeChange={onCardSizeChange ?? (() => {})}
+          onCardSizeChange={onCardSizeChange}
           showPredictions={showPredictions}
           onTogglePredictions={onTogglePredictions}
           isLocalize={isLocalize}

--- a/frontend/src/components/detection-sequence/DetectionHeader.tsx
+++ b/frontend/src/components/detection-sequence/DetectionHeader.tsx
@@ -103,7 +103,7 @@ export function DetectionHeader({
 
   return (
     <div
-      className={`sticky top-0 z-30 -mx-6 -mt-6 mb-4 px-6 py-2 backdrop-blur-sm shadow-sm border-b ${
+      className={`sticky top-0 z-30 px-6 py-2 backdrop-blur-sm shadow-sm border-b ${
         isAllAnnotated ? 'bg-green-50/90 border-green-200' : 'bg-white/85 border-gray-200'
       }`}
     >

--- a/frontend/src/components/detection-sequence/ViewToolbar.tsx
+++ b/frontend/src/components/detection-sequence/ViewToolbar.tsx
@@ -41,6 +41,7 @@ function IconToggle({
     <button
       type="button"
       title={title}
+      aria-label={title}
       aria-pressed={pressed}
       onClick={onClick}
       className={`p-1.5 rounded ${

--- a/frontend/src/components/detection-sequence/ViewToolbar.tsx
+++ b/frontend/src/components/detection-sequence/ViewToolbar.tsx
@@ -1,0 +1,112 @@
+/**
+ * Compact view controls for the detection grid: S/M/L card size plus icon
+ * toggles for predictions, crop mode, and the cropped flipbook. One shared
+ * button style — the header and flipbook speak the same visual language.
+ */
+
+import { Crop, Eye, Film } from 'lucide-react';
+
+export type CardSize = 'sm' | 'md' | 'lg';
+
+const CARD_SIZES: { value: CardSize; label: string; title: string }[] = [
+  { value: 'sm', label: 'S', title: 'Small cards' },
+  { value: 'md', label: 'M', title: 'Medium cards' },
+  { value: 'lg', label: 'L', title: 'Large cards' },
+];
+
+interface ViewToolbarProps {
+  cardSize: CardSize;
+  onCardSizeChange: (size: CardSize) => void;
+  showPredictions: boolean;
+  onTogglePredictions: (show: boolean) => void;
+  isLocalize?: boolean;
+  cropMode?: boolean;
+  onToggleCropMode?: (crop: boolean) => void;
+  showCroppedView?: boolean;
+  onToggleCroppedView?: (show: boolean) => void;
+}
+
+function IconToggle({
+  title,
+  pressed,
+  onClick,
+  children,
+}: {
+  title: string;
+  pressed: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      aria-pressed={pressed}
+      onClick={onClick}
+      className={`p-1.5 rounded ${
+        pressed ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-900'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function ViewToolbar({
+  cardSize,
+  onCardSizeChange,
+  showPredictions,
+  onTogglePredictions,
+  isLocalize = false,
+  cropMode = false,
+  onToggleCropMode,
+  showCroppedView = false,
+  onToggleCroppedView,
+}: ViewToolbarProps) {
+  return (
+    <div className="inline-flex items-center rounded-md bg-gray-200 p-0.5 gap-0.5">
+      {CARD_SIZES.map(s => (
+        <button
+          key={s.value}
+          type="button"
+          title={s.title}
+          aria-pressed={cardSize === s.value}
+          onClick={() => onCardSizeChange(s.value)}
+          className={`px-2 py-0.5 rounded text-xs font-semibold ${
+            cardSize === s.value
+              ? 'bg-white text-gray-900 shadow-sm'
+              : 'text-gray-500 hover:text-gray-900'
+          }`}
+        >
+          {s.label}
+        </button>
+      ))}
+      <div className="w-px self-stretch bg-gray-300 mx-0.5" />
+      <IconToggle
+        title="Show predictions (P)"
+        pressed={showPredictions}
+        onClick={() => onTogglePredictions(!showPredictions)}
+      >
+        <Eye className="w-3.5 h-3.5" />
+      </IconToggle>
+      {isLocalize && (
+        <>
+          <IconToggle
+            title="Crop cells (C)"
+            pressed={cropMode}
+            onClick={() => onToggleCropMode?.(!cropMode)}
+          >
+            <Crop className="w-3.5 h-3.5" />
+          </IconToggle>
+          <IconToggle
+            title="Cropped view"
+            pressed={showCroppedView}
+            onClick={() => onToggleCroppedView?.(!showCroppedView)}
+          >
+            <Film className="w-3.5 h-3.5" />
+          </IconToggle>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/detection-sequence/index.ts
+++ b/frontend/src/components/detection-sequence/index.ts
@@ -5,3 +5,5 @@
 export { ImageModal } from './ImageModal';
 export { DetectionGrid } from './DetectionGrid';
 export { DetectionHeader } from './DetectionHeader';
+export { ViewToolbar } from './ViewToolbar';
+export type { CardSize } from './ViewToolbar';

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -76,9 +76,12 @@ export default function AppLayout({ children }: AppLayoutProps) {
           </button>
         </div>
 
-        {/* Page content */}
-        <main className="flex-1 relative z-0 overflow-y-auto focus:outline-none p-6">
-          {children}
+        {/* Page content. Padding lives on an inner wrapper, not the scroll
+            container itself: scroll-container padding pins sticky children
+            below it (it never scrolls away), which would break sticky
+            page headers. */}
+        <main className="flex-1 relative z-0 overflow-y-auto focus:outline-none">
+          <div className="p-6">{children}</div>
         </main>
       </div>
     </div>

--- a/frontend/src/pages/DetectionSequenceAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionSequenceAnnotatePage.tsx
@@ -1010,7 +1010,10 @@ export default function DetectionSequenceAnnotatePage({
   const isAllAnnotated = annotatedCount === totalCount;
 
   return (
-    <>
+    // Pull the page over <main>'s p-6 so the sticky header's containing
+    // block reaches the scrollport top (sticky cannot escape into padding);
+    // the content re-adds the padding below.
+    <div className="-m-6">
       <DetectionHeader
         sequence={sequence}
         sequenceAnnotation={sequenceAnnotation}
@@ -1043,7 +1046,7 @@ export default function DetectionSequenceAnnotatePage({
         getAnnotationPills={getAnnotationPills}
       />
 
-      <div className="space-y-4">
+      <div className="space-y-4 px-6 pb-6 pt-4">
         {isLocalize && showCroppedView && laneBoxes.length > 0 && sequenceIdNum && (
           <div className="flex justify-center">
             <CroppedImageSequence bboxes={laneBoxes} sequenceId={sequenceIdNum} />
@@ -1113,6 +1116,6 @@ export default function DetectionSequenceAnnotatePage({
           </div>
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/frontend/src/pages/DetectionSequenceAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionSequenceAnnotatePage.tsx
@@ -869,7 +869,7 @@ export default function DetectionSequenceAnnotatePage({
         hasAnnotations: false,
       };
 
-  const { annotatedDetections, totalDetections, completionPercentage } = progressStats;
+  const { annotatedDetections, totalDetections } = progressStats;
   const annotatedCount = annotatedDetections;
   const totalCount = totalDetections;
   const allInVisualCheck = areAllInVisualCheckStage();
@@ -1014,19 +1014,14 @@ export default function DetectionSequenceAnnotatePage({
       <DetectionHeader
         sequence={sequence}
         sequenceAnnotation={sequenceAnnotation}
-        annotatedCount={annotatedCount}
-        totalCount={totalCount}
-        completionPercentage={completionPercentage}
         isAllAnnotated={isAllAnnotated}
         onBack={handleBack}
         canNavigatePrevious={canNavigatePrevious}
         canNavigateNext={canNavigateNext}
         onPreviousSequence={handlePreviousSequence}
         onNextSequence={handleNextSequence}
-        getCurrentSequenceIndex={getCurrentSequenceIndex}
         rawSequencesLoading={rawSequencesLoading}
         rawSequencesError={!!rawSequencesError}
-        allSequences={allSequences || undefined}
         showPredictions={showPredictions}
         onTogglePredictions={setShowPredictions}
         allInVisualCheck={allInVisualCheck}
@@ -1048,7 +1043,7 @@ export default function DetectionSequenceAnnotatePage({
         getAnnotationPills={getAnnotationPills}
       />
 
-      <div className="pt-28 space-y-4">
+      <div className="space-y-4">
         {isLocalize && showCroppedView && laneBoxes.length > 0 && sequenceIdNum && (
           <div className="flex justify-center">
             <CroppedImageSequence bboxes={laneBoxes} sequenceId={sequenceIdNum} />

--- a/frontend/tests/components/detection-sequence/DetectionHeader.test.tsx
+++ b/frontend/tests/components/detection-sequence/DetectionHeader.test.tsx
@@ -1,6 +1,5 @@
 /**
- * Core functionality tests for DetectionHeader component.
- * Focuses on essential user interactions, state management, and accessibility.
+ * Tests for the single-row sticky DetectionHeader (#227 redesign).
  */
 
 import React from 'react';
@@ -9,16 +8,14 @@ import { DetectionHeader } from '@/components/detection-sequence/DetectionHeader
 import type { Sequence, SequenceAnnotation } from '@/types/api';
 
 // Mock the icons to avoid test complications
-vi.mock('lucide-react', async (importOriginal) => {
+vi.mock('lucide-react', async importOriginal => {
   const actual = await importOriginal<typeof import('lucide-react')>();
   return {
     ...actual,
-    // Override specific icons for testing
     ArrowLeft: () => <div data-testid="arrow-left">←</div>,
     ChevronLeft: () => <div data-testid="chevron-left">‹</div>,
     ChevronRight: () => <div data-testid="chevron-right">›</div>,
     CheckCircle: () => <div data-testid="check-circle">✓</div>,
-    AlertCircle: () => <div data-testid="alert-circle">!</div>,
     Upload: () => <div data-testid="upload">↑</div>,
   };
 });
@@ -34,63 +31,60 @@ vi.mock('@/utils/modelAccuracy', () => ({
 }));
 
 describe('DetectionHeader', () => {
-  // Factory function for creating test sequence data
-  const createSequence = (overrides: Partial<Sequence> = {}): Sequence => ({
-    id: 1,
-    source_api: 'test-api',
-    alert_api_id: 123,
-    created_at: '2024-01-01T10:00:00Z',
-    recorded_at: '2024-01-01T10:00:00Z',
-    last_seen_at: '2024-01-01T10:00:00Z',
-    camera_name: 'Camera-01',
-    camera_id: 1,
-    lat: 45.123456,
-    lon: -122.987654,
-    azimuth: 180,
-    is_wildfire_alertapi: 'wildfire_smoke',
-    organisation_name: 'Test Org',
-    organisation_id: 1,
-    ...overrides,
-  });
+  const createSequence = (overrides: Partial<Sequence> = {}): Sequence =>
+    ({
+      id: 1,
+      source_api: 'test-api',
+      alert_api_id: 123,
+      created_at: '2024-01-01T10:00:00Z',
+      recorded_at: '2024-01-01T10:00:00Z',
+      last_seen_at: '2024-01-01T10:00:00Z',
+      camera_name: 'Camera-01',
+      camera_id: 1,
+      lat: 45.123456,
+      lon: -122.987654,
+      azimuth: 180,
+      is_wildfire_alertapi: 'wildfire_smoke',
+      organisation_name: 'Test Org',
+      organisation_id: 1,
+      ...overrides,
+    }) as Sequence;
 
-  // Factory function for creating test sequence annotation
-  const createSequenceAnnotation = (): SequenceAnnotation => ({
-    id: 1,
-    sequence_id: 1,
-    has_smoke: true,
-    has_false_positives: false,
-    false_positive_types: '',
-    smoke_types: ['wildfire'],
-    has_missed_smoke: false,
-    is_unsure: false,
-    annotation: {},
-    processing_stage: 'annotation_complete',
-    created_at: '2024-01-01T10:00:00Z',
-    updated_at: null,
-    contributors: [],
-  });
+  const createSequenceAnnotation = (): SequenceAnnotation =>
+    ({
+      id: 1,
+      sequence_id: 1,
+      has_smoke: true,
+      has_false_positives: false,
+      false_positive_types: '',
+      smoke_types: ['wildfire'],
+      has_missed_smoke: false,
+      is_unsure: false,
+      annotation: {},
+      processing_stage: 'annotation_complete',
+      created_at: '2024-01-01T10:00:00Z',
+      updated_at: null,
+      contributors: [],
+    }) as unknown as SequenceAnnotation;
 
   const defaultProps = {
     sequence: createSequence(),
     sequenceAnnotation: createSequenceAnnotation(),
-    annotatedCount: 5,
-    totalCount: 10,
-    completionPercentage: 50,
     isAllAnnotated: false,
     onBack: vi.fn(),
     canNavigatePrevious: vi.fn(() => true),
     canNavigateNext: vi.fn(() => true),
     onPreviousSequence: vi.fn(),
     onNextSequence: vi.fn(),
-    getCurrentSequenceIndex: vi.fn(() => 0),
     rawSequencesLoading: false,
     rawSequencesError: false,
-    allSequences: { total: 5 },
     showPredictions: true,
     onTogglePredictions: vi.fn(),
     allInVisualCheck: false,
     onSave: vi.fn(),
     saveAnnotations: { isPending: false },
+    cardSize: 'md' as const,
+    onCardSizeChange: vi.fn(),
     getAnnotationPills: vi.fn(() => [<div key="pill">Pill</div>]),
   };
 
@@ -98,347 +92,133 @@ describe('DetectionHeader', () => {
     vi.clearAllMocks();
   });
 
-  describe('Display Tests', () => {
-    it('should render sequence metadata correctly', () => {
+  describe('Layout', () => {
+    it('is sticky, not fixed', () => {
+      const { container } = render(<DetectionHeader {...defaultProps} />);
+      const header = container.firstElementChild as HTMLElement;
+      expect(header.className).toContain('sticky');
+      expect(header.className).not.toContain('fixed');
+    });
+
+    it('renders org, camera, and time — no azimuth, coordinates, or progress', () => {
       render(<DetectionHeader {...defaultProps} />);
-      
       expect(screen.getByText('Test Org')).toBeInTheDocument();
       expect(screen.getByText('Camera-01')).toBeInTheDocument();
-      expect(screen.getByText(/1\/1\/2024/)).toBeInTheDocument(); // Date formatting
-      expect(screen.getByText('180°')).toBeInTheDocument(); // Azimuth
-      expect(screen.getByText(/45\.123, -122\.988/)).toBeInTheDocument(); // Coordinates
+      expect(screen.getByText(/1\/1\/2024/)).toBeInTheDocument();
+      expect(screen.queryByText('180°')).toBeNull();
+      expect(screen.queryByText(/45\.123/)).toBeNull();
+      expect(screen.queryByText(/frames/)).toBeNull();
+      expect(screen.queryByText(/% complete/)).toBeNull();
+      expect(screen.queryByText(/Sequence \d+ of/)).toBeNull();
     });
 
-    it('should display progress information correctly', () => {
+    it('shows a check chip and green tint when all annotated', () => {
+      const { container } = render(<DetectionHeader {...defaultProps} isAllAnnotated />);
+      expect(screen.getByTestId('check-circle')).toBeInTheDocument();
+      expect((container.firstElementChild as HTMLElement).className).toContain('bg-green-50/90');
+    });
+
+    it('renders annotation pills and the accuracy badge', () => {
       render(<DetectionHeader {...defaultProps} />);
-      
-      expect(screen.getByText(/5 of 10 frames/)).toBeInTheDocument();
-      expect(screen.getByText(/50% complete/)).toBeInTheDocument();
-      expect(screen.getByText('Pending')).toBeInTheDocument();
-    });
-
-    it('should show completion status when all annotated', () => {
-      render(
-        <DetectionHeader 
-          {...defaultProps} 
-          isAllAnnotated={true}
-          completionPercentage={100}
-          annotatedCount={10}
-        />
-      );
-      
-      expect(screen.getByText('Done')).toBeInTheDocument();
-      expect(screen.getByText('Completed')).toBeInTheDocument();
-      expect(screen.getAllByTestId('check-circle')).toHaveLength(2);
-    });
-
-    it('should display sequence context information', () => {
-      render(<DetectionHeader {...defaultProps} />);
-      
-      expect(screen.getByText('Sequence 1 of 5')).toBeInTheDocument();
-    });
-
-    it('should show model accuracy when available', () => {
-      render(<DetectionHeader {...defaultProps} />);
-      
+      expect(screen.getByText('Pill')).toBeInTheDocument();
       expect(screen.getByText(/🎯 High Accuracy/)).toBeInTheDocument();
     });
 
-    it('should render annotation pills', () => {
-      render(<DetectionHeader {...defaultProps} />);
-      
-      expect(screen.getByText('Pill')).toBeInTheDocument();
-    });
-
-    it('should handle missing sequence data gracefully', () => {
+    it('handles missing sequence data gracefully', () => {
       render(
-        <DetectionHeader 
-          {...defaultProps} 
-          sequence={undefined}
-          sequenceAnnotation={undefined}
-        />
+        <DetectionHeader {...defaultProps} sequence={undefined} sequenceAnnotation={undefined} />
       );
-      
       expect(screen.getAllByText('Loading...')).toHaveLength(3);
     });
   });
 
-  describe('Navigation Tests', () => {
-    it('should render navigation buttons in normal state', () => {
+  describe('Navigation', () => {
+    it('calls navigation callbacks when chevrons are clicked', () => {
       render(<DetectionHeader {...defaultProps} />);
-      
-      expect(screen.getByTestId('chevron-left')).toBeInTheDocument();
-      expect(screen.getByTestId('chevron-right')).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId('chevron-left').closest('button')!);
+      fireEvent.click(screen.getByTestId('chevron-right').closest('button')!);
+      expect(defaultProps.onPreviousSequence).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onNextSequence).toHaveBeenCalledTimes(1);
     });
 
-    it('should call navigation callbacks when buttons are clicked', () => {
-      const onPreviousSequence = vi.fn();
-      const onNextSequence = vi.fn();
-      
+    it('disables chevrons based on can-navigate functions', () => {
       render(
-        <DetectionHeader 
-          {...defaultProps} 
-          onPreviousSequence={onPreviousSequence}
-          onNextSequence={onNextSequence}
-        />
-      );
-      
-      const prevButton = screen.getByTestId('chevron-left').closest('button')!;
-      const nextButton = screen.getByTestId('chevron-right').closest('button')!;
-      
-      fireEvent.click(prevButton);
-      fireEvent.click(nextButton);
-      
-      expect(onPreviousSequence).toHaveBeenCalledTimes(1);
-      expect(onNextSequence).toHaveBeenCalledTimes(1);
-    });
-
-    it('should disable navigation buttons based on can navigate functions', () => {
-      render(
-        <DetectionHeader 
-          {...defaultProps} 
+        <DetectionHeader
+          {...defaultProps}
           canNavigatePrevious={() => false}
           canNavigateNext={() => false}
         />
       );
-      
-      const prevButton = screen.getByTestId('chevron-left').closest('button')!;
-      const nextButton = screen.getByTestId('chevron-right').closest('button')!;
-      
-      expect(prevButton).toBeDisabled();
-      expect(nextButton).toBeDisabled();
+      expect(screen.getByTestId('chevron-left').closest('button')).toBeDisabled();
+      expect(screen.getByTestId('chevron-right').closest('button')).toBeDisabled();
+      expect(screen.getByTitle('Already at first sequence')).toBeInTheDocument();
+      expect(screen.getByTitle('Already at last sequence')).toBeInTheDocument();
     });
 
-    it('should show loading state for navigation buttons', () => {
-      render(<DetectionHeader {...defaultProps} rawSequencesLoading={true} />);
-      
-      const buttons = screen.getAllByTestId(/chevron-/);
-      buttons.forEach(icon => {
-        const button = icon.closest('button')!;
-        expect(button).toBeDisabled();
-        expect(button).toHaveAttribute('title', 'Loading sequences...');
-      });
-    });
-
-    it('should show error state for navigation buttons', () => {
-      render(<DetectionHeader {...defaultProps} rawSequencesError={true} />);
-      
-      const buttons = screen.getAllByTestId(/chevron-/);
-      buttons.forEach(icon => {
-        const button = icon.closest('button')!;
-        expect(button).toBeDisabled();
-        expect(button).toHaveAttribute('title', 'Error loading sequences');
-      });
-    });
-
-    it('should handle back button click', () => {
-      const onBack = vi.fn();
-      render(<DetectionHeader {...defaultProps} onBack={onBack} />);
-      
-      const backButton = screen.getByTestId('arrow-left').closest('button')!;
-      fireEvent.click(backButton);
-      
-      expect(onBack).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('Controls Tests', () => {
-    it('should render predictions toggle with correct state', () => {
-      render(<DetectionHeader {...defaultProps} showPredictions={true} />);
-      
-      const checkbox = screen.getByLabelText('Show predictions');
-      expect(checkbox).toBeChecked();
-    });
-
-    it('should call toggle function when predictions checkbox is changed', () => {
-      const onTogglePredictions = vi.fn();
-      render(
-        <DetectionHeader 
-          {...defaultProps} 
-          onTogglePredictions={onTogglePredictions}
-          showPredictions={false}
-        />
-      );
-      
-      const checkbox = screen.getByLabelText('Show predictions');
-      fireEvent.click(checkbox);
-      
-      expect(onTogglePredictions).toHaveBeenCalledWith(true);
-    });
-
-    it('should show submit button when allInVisualCheck is true', () => {
-      render(<DetectionHeader {...defaultProps} allInVisualCheck={true} />);
-      
-      expect(screen.getByText('Submit All')).toBeInTheDocument();
-      expect(screen.getByTestId('upload')).toBeInTheDocument();
-    });
-
-    it('should not show submit button when allInVisualCheck is false', () => {
-      render(<DetectionHeader {...defaultProps} allInVisualCheck={false} />);
-      
-      expect(screen.queryByText('Submit All')).not.toBeInTheDocument();
-    });
-
-    it('should handle submit button click', () => {
-      const onSave = vi.fn();
-      render(
-        <DetectionHeader 
-          {...defaultProps} 
-          allInVisualCheck={true}
-          onSave={onSave}
-        />
-      );
-      
-      const submitButton = screen.getByText('Submit All').closest('button')!;
-      fireEvent.click(submitButton);
-      
-      expect(onSave).toHaveBeenCalledTimes(1);
-    });
-
-    it('should show loading state on submit button when saving', () => {
-      render(
-        <DetectionHeader 
-          {...defaultProps} 
-          allInVisualCheck={true}
-          saveAnnotations={{ isPending: true }}
-        />
-      );
-      
-      const submitButton = screen.getByText('Submit All').closest('button')!;
-      expect(submitButton).toBeDisabled();
-      
-      // Should show spinner instead of upload icon
-      expect(screen.queryByTestId('upload')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('State Tests', () => {
-    it('should display loading state for sequences context', () => {
-      render(<DetectionHeader {...defaultProps} rawSequencesLoading={true} />);
-      
-      expect(screen.getByText('Loading sequences...')).toBeInTheDocument();
-    });
-
-    it('should display error state for sequences context', () => {
-      render(<DetectionHeader {...defaultProps} rawSequencesError={true} />);
-      
-      expect(screen.getByText('Error loading sequences')).toBeInTheDocument();
-    });
-
-    it('should handle empty sequences state', () => {
-      render(
-        <DetectionHeader 
-          {...defaultProps} 
-          allSequences={{ total: 0 }}
-        />
-      );
-      
-      expect(screen.getByText('No sequences found')).toBeInTheDocument();
-    });
-
-    it('should apply correct styling for completed state', () => {
-      const { container } = render(
-        <DetectionHeader {...defaultProps} isAllAnnotated={true} />
-      );
-      
-      const header = container.querySelector('.fixed.top-0');
-      expect(header).toHaveClass('bg-green-50/90', 'border-green-200', 'border-l-4', 'border-l-green-500');
-    });
-
-    it('should apply correct styling for incomplete state', () => {
-      const { container } = render(
-        <DetectionHeader {...defaultProps} isAllAnnotated={false} />
-      );
-      
-      const header = container.querySelector('.fixed.top-0');
-      expect(header).toHaveClass('bg-white/85', 'border-gray-200');
-    });
-
-    it('should handle progress bar styling for different states', () => {
+    it('shows loading and error states on chevrons', () => {
       const { rerender } = render(
-        <DetectionHeader {...defaultProps} isAllAnnotated={false} completionPercentage={75} />
+        <DetectionHeader {...defaultProps} rawSequencesLoading={true} />
       );
-      
-      let progressBar = document.querySelector('.bg-primary-600');
-      expect(progressBar).toBeInTheDocument();
-      expect(progressBar).toHaveStyle('width: 75%');
-      
-      // Test completed state
-      rerender(
-        <DetectionHeader {...defaultProps} isAllAnnotated={true} completionPercentage={100} />
-      );
-      
-      progressBar = document.querySelector('.bg-green-600');
-      expect(progressBar).toBeInTheDocument();
-      expect(progressBar).toHaveStyle('width: 100%');
-    });
-  });
-
-  describe('Edge Cases', () => {
-    it('should handle null/undefined coordinates', () => {
-      const sequenceWithoutCoords = createSequence({ 
-        lat: null as unknown as number, 
-        lon: null as unknown as number,
-        azimuth: null 
+      screen.getAllByTestId(/chevron-/).forEach(icon => {
+        expect(icon.closest('button')).toHaveAttribute('title', 'Loading sequences...');
       });
-      
-      render(<DetectionHeader {...defaultProps} sequence={sequenceWithoutCoords} />);
-      
-      // Should not render coordinate information
-      expect(screen.queryByText(/45\.123/)).not.toBeInTheDocument();
-      expect(screen.queryByText('180°')).not.toBeInTheDocument();
+      rerender(<DetectionHeader {...defaultProps} rawSequencesError={true} />);
+      screen.getAllByTestId(/chevron-/).forEach(icon => {
+        expect(icon.closest('button')).toHaveAttribute('title', 'Error loading sequences');
+      });
     });
 
-    it('should handle zero completion percentage', () => {
-      render(
-        <DetectionHeader 
-          {...defaultProps} 
-          completionPercentage={0}
-          annotatedCount={0}
-        />
-      );
-      
-      expect(screen.getByText(/0 of 10 frames/)).toBeInTheDocument();
-      expect(screen.getByText(/0% complete/)).toBeInTheDocument();
-    });
-
-    it('should handle large numbers gracefully', () => {
-      render(
-        <DetectionHeader 
-          {...defaultProps} 
-          annotatedCount={999}
-          totalCount={1000}
-          completionPercentage={99.9}
-          allSequences={{ total: 9999 }}
-          getCurrentSequenceIndex={() => 9998}
-        />
-      );
-      
-      expect(screen.getByText(/999 of 1000 frames/)).toBeInTheDocument();
-      expect(screen.getByText(/99\.9% complete/)).toBeInTheDocument();
-      expect(screen.getByText('Sequence 9999 of 9999')).toBeInTheDocument();
-    });
-
-    it('should handle empty annotation pills array', () => {
-      render(<DetectionHeader {...defaultProps} getAnnotationPills={() => []} />);
-      
-      // Should not crash and should render normally
-      expect(screen.getByText('Test Org')).toBeInTheDocument();
+    it('handles back button click', () => {
+      render(<DetectionHeader {...defaultProps} />);
+      fireEvent.click(screen.getByTitle('Back to sequences'));
+      expect(defaultProps.onBack).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('Localize quick submit', () => {
-    it('shows Accept & submit and fires onQuickSubmit', () => {
+  describe('View controls', () => {
+    it('predictions toggle fires through the toolbar', () => {
+      render(<DetectionHeader {...defaultProps} showPredictions={false} />);
+      fireEvent.click(screen.getByTitle('Show predictions (P)'));
+      expect(defaultProps.onTogglePredictions).toHaveBeenCalledWith(true);
+    });
+
+    it('card size control fires onCardSizeChange', () => {
+      render(<DetectionHeader {...defaultProps} />);
+      fireEvent.click(screen.getByRole('button', { name: 'L' }));
+      expect(defaultProps.onCardSizeChange).toHaveBeenCalledWith('lg');
+    });
+
+    it('crop and cropped-view toggles appear only in localize', () => {
+      const onToggleCropMode = vi.fn();
+      const { rerender } = render(<DetectionHeader {...defaultProps} />);
+      expect(screen.queryByTitle('Crop cells (C)')).toBeNull();
+      expect(screen.queryByTitle('Cropped view')).toBeNull();
+
+      rerender(
+        <DetectionHeader
+          {...defaultProps}
+          isLocalize
+          onQuickSubmit={() => {}}
+          cropMode={false}
+          onToggleCropMode={onToggleCropMode}
+        />
+      );
+      fireEvent.click(screen.getByTitle('Crop cells (C)'));
+      expect(onToggleCropMode).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('Submit', () => {
+    it('localize: Accept & submit fires onQuickSubmit', () => {
       const onQuickSubmit = vi.fn();
       render(
         <DetectionHeader {...defaultProps} isLocalize noBoxCount={0} onQuickSubmit={onQuickSubmit} />
       );
-
       fireEvent.click(screen.getByRole('button', { name: /accept & submit/i }));
       expect(onQuickSubmit).toHaveBeenCalledOnce();
     });
 
-    it('confirm state warns about frames with no box', () => {
+    it('localize confirm state warns about frames with no box', () => {
       render(
         <DetectionHeader
           {...defaultProps}
@@ -448,130 +228,38 @@ describe('DetectionHeader', () => {
           onQuickSubmit={() => {}}
         />
       );
-
       expect(screen.getByText(/2 frames with no box — submit anyway\?/i)).toBeInTheDocument();
     });
 
-    it('disables the button while submitting', () => {
-      render(
-        <DetectionHeader {...defaultProps} isLocalize quickSubmitPending onQuickSubmit={() => {}} />
-      );
-
-      const button = screen.getByText(/accept & submit/i).closest('button')!;
-      expect(button).toBeDisabled();
-    });
-
-    it('shows the crop toggle and fires onToggleCropMode', () => {
-      const onToggleCropMode = vi.fn();
+    it('localize: disables the button while submitting and hides Submit All', () => {
       render(
         <DetectionHeader
           {...defaultProps}
           isLocalize
-          cropMode={false}
-          onToggleCropMode={onToggleCropMode}
+          allInVisualCheck
+          quickSubmitPending
           onQuickSubmit={() => {}}
         />
       );
-
-      fireEvent.click(screen.getByLabelText('Crop'));
-      expect(onToggleCropMode).toHaveBeenCalledWith(true);
+      expect(screen.getByText(/accept & submit/i).closest('button')).toBeDisabled();
+      expect(screen.queryByText('Submit All')).toBeNull();
     });
 
-    it('hides the crop toggle outside localize', () => {
-      render(<DetectionHeader {...defaultProps} />);
-      expect(screen.queryByLabelText('Crop')).toBeNull();
-    });
+    it('non-localize keeps Submit All behavior including pending spinner', () => {
+      const { rerender } = render(<DetectionHeader {...defaultProps} allInVisualCheck />);
+      fireEvent.click(screen.getByText('Submit All').closest('button')!);
+      expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
 
-    it('card size control fires onCardSizeChange', () => {
-      const onCardSizeChange = vi.fn();
-      render(
-        <DetectionHeader {...defaultProps} cardSize="md" onCardSizeChange={onCardSizeChange} />
+      rerender(
+        <DetectionHeader {...defaultProps} allInVisualCheck saveAnnotations={{ isPending: true }} />
       );
-
-      fireEvent.click(screen.getByRole('button', { name: 'L' }));
-      expect(onCardSizeChange).toHaveBeenCalledWith('lg');
+      expect(screen.getByText('Submit All').closest('button')).toBeDisabled();
+      expect(screen.queryByTestId('upload')).toBeNull();
     });
 
-    it('cropped view toggle appears in localize and fires', () => {
-      const onToggleCroppedView = vi.fn();
-      render(
-        <DetectionHeader
-          {...defaultProps}
-          isLocalize
-          onQuickSubmit={() => {}}
-          showCroppedView={false}
-          onToggleCroppedView={onToggleCroppedView}
-        />
-      );
-
-      fireEvent.click(screen.getByLabelText('Cropped view'));
-      expect(onToggleCroppedView).toHaveBeenCalledWith(true);
-    });
-
-    it('hides the legacy Submit All even when allInVisualCheck', () => {
-      render(
-        <DetectionHeader {...defaultProps} isLocalize allInVisualCheck onQuickSubmit={() => {}} />
-      );
-
-      expect(screen.queryByText('Submit All')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Accessibility', () => {
-    it('should have proper button semantics', () => {
+    it('does not show Submit All when allInVisualCheck is false', () => {
       render(<DetectionHeader {...defaultProps} />);
-      
-      const buttons = screen.getAllByRole('button');
-      expect(buttons.length).toBeGreaterThan(0);
-      
-      buttons.forEach(button => {
-        expect(button).toBeInTheDocument();
-      });
-    });
-
-    it('should have descriptive button titles', () => {
-      render(<DetectionHeader {...defaultProps} />);
-      
-      expect(screen.getByTitle('Back to sequences')).toBeInTheDocument();
-      expect(screen.getByTitle('Previous sequence')).toBeInTheDocument();
-      expect(screen.getByTitle('Next sequence')).toBeInTheDocument();
-    });
-
-    it('should update button titles based on navigation state', () => {
-      render(
-        <DetectionHeader 
-          {...defaultProps} 
-          canNavigatePrevious={() => false}
-          canNavigateNext={() => false}
-        />
-      );
-      
-      expect(screen.getByTitle('Already at first sequence')).toBeInTheDocument();
-      expect(screen.getByTitle('Already at last sequence')).toBeInTheDocument();
-    });
-
-    it('should have proper form controls', () => {
-      render(<DetectionHeader {...defaultProps} />);
-      
-      const checkbox = screen.getByLabelText('Show predictions');
-      expect(checkbox).toHaveAttribute('type', 'checkbox');
-    });
-
-    it('should have proper submit button attributes', () => {
-      render(<DetectionHeader {...defaultProps} allInVisualCheck={true} />);
-      
-      const submitButton = screen.getByText('Submit All').closest('button')!;
-      expect(submitButton).toHaveAttribute('title');
-      expect(submitButton.getAttribute('title')).toContain('Submit all detection annotations');
-    });
-
-    it('should maintain focus management', () => {
-      render(<DetectionHeader {...defaultProps} />);
-      
-      const backButton = screen.getByTestId('arrow-left').closest('button')!;
-      backButton.focus();
-      
-      expect(document.activeElement).toBe(backButton);
+      expect(screen.queryByText('Submit All')).toBeNull();
     });
   });
 });

--- a/frontend/tests/components/detection-sequence/ViewToolbar.test.tsx
+++ b/frontend/tests/components/detection-sequence/ViewToolbar.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ViewToolbar } from '@/components/detection-sequence/ViewToolbar';
+
+const baseProps = {
+  cardSize: 'md' as const,
+  onCardSizeChange: vi.fn(),
+  showPredictions: true,
+  onTogglePredictions: vi.fn(),
+};
+
+describe('ViewToolbar', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('S/M/L segmented pill fires onCardSizeChange', () => {
+    render(<ViewToolbar {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: 'L' }));
+    expect(baseProps.onCardSizeChange).toHaveBeenCalledWith('lg');
+  });
+
+  it('marks the active size as pressed', () => {
+    render(<ViewToolbar {...baseProps} />);
+    expect(screen.getByRole('button', { name: 'M' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'S' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('predictions toggle fires with the inverted value and shows pressed state', () => {
+    render(<ViewToolbar {...baseProps} />);
+    const btn = screen.getByTitle('Show predictions (P)');
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(btn);
+    expect(baseProps.onTogglePredictions).toHaveBeenCalledWith(false);
+  });
+
+  it('hides Crop and Cropped view outside localize', () => {
+    render(<ViewToolbar {...baseProps} />);
+    expect(screen.queryByTitle('Crop cells (C)')).toBeNull();
+    expect(screen.queryByTitle('Cropped view')).toBeNull();
+  });
+
+  it('localize: crop toggles fire', () => {
+    const onToggleCropMode = vi.fn();
+    const onToggleCroppedView = vi.fn();
+    render(
+      <ViewToolbar
+        {...baseProps}
+        isLocalize
+        cropMode={false}
+        onToggleCropMode={onToggleCropMode}
+        showCroppedView
+        onToggleCroppedView={onToggleCroppedView}
+      />
+    );
+    fireEvent.click(screen.getByTitle('Crop cells (C)'));
+    expect(onToggleCropMode).toHaveBeenCalledWith(true);
+    fireEvent.click(screen.getByTitle('Cropped view'));
+    expect(onToggleCroppedView).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #227.

Redesigns the crowded sticky header on `/localize/:sequenceId` into a single uncramped row with one consistent compact control language, and retires the fragile fixed-position/hard-coded-offset scheme.

Design spec: `docs/specs/2026-07-28-localize-header-redesign-design.md` (committed in this PR).

### What changed

- **Single sticky row**: back · org • camera • time · accuracy badge + annotation pills · spacer · nav chevrons · compact view toolbar · Accept & submit. Removed outright (agreed in #227): the progress row (status, "X of Y frames", %, bar — the grid's green borders already show progress), azimuth, lat/lon, and "Sequence x of y".
- **`ViewToolbar`** (new component): S/M/L segmented pill plus icon toggles (eye = predictions, crop-frame = Crop, film = Cropped view) with `aria-pressed` state and shortcut-bearing tooltips; Crop/Cropped-view gated to localize mode as before. All handlers and keyboard shortcuts unchanged.
- **Sticky, not fixed**: the header sits in the page flow (`sticky top-0`), so a taller wrapped header can never cover content. This surfaced a real browser gotcha — scroll-container padding never scrolls away, pinning sticky children below it — fixed by moving `p-6` from AppLayout's `<main>` onto an inner wrapper (visually identical on every page) and letting the page pull itself over the padding. The `pt-28` offset patch from #223 is gone.
- **Flipbook zoom strip**: `CroppedImageSequence`'s bulky zoom block is now a slim icon strip (−/slider/+/reset) under the canvas, styled like the toolbar; behavior unchanged (1–8×, default 4). The classify page shares the component and gets the consistent styling too.

### Test plan

- 761 frontend tests passing (`npx vitest run`): new `ViewToolbar` tests, rewritten `DetectionHeader` tests (sticky assertion, removed-element absence, all submit/nav/toggle behaviors), type-check + Prettier clean, `lint:ci` green (2 pre-existing warnings, one fewer than main).
- Screenshot-verified against the live dev stack at 1600px and 1100px: single row (wraps cleanly when narrow), flipbook fully below the header, header pinned flush at the scrollport top with cells passing beneath while scrolled.