### PR TITLE
fix: durable local S3 via MinIO (LocalStack wiped images on every restart)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Each submodule has its own `CLAUDE.md` with detailed context — read those when
 ## Quick Start
 
 ```bash
-# Start all services (PostgreSQL, LocalStack S3, API, Frontend)
+# Start all services (PostgreSQL, MinIO S3, API, Frontend)
 docker compose up -d
 
 # Services:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ docker compose up -d
 # Frontend:  http://localhost:3000
 # API:       http://localhost:5050  (docs at /docs)
 # Database:  localhost:5432
-# S3:        http://localhost:4566
+# S3:        http://localhost:4566  (MinIO console: http://localhost:9001)
 ```
 
 ## Backend (`annotation_api/`)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Once running, access the services at:
 - **Backend API**: http://localhost:5050
 - **API Documentation**: http://localhost:5050/docs
 - **PostgreSQL Database**: localhost:5432
-- **LocalStack S3**: http://localhost:4566
+- **MinIO S3**: http://localhost:4566 (console at http://localhost:9001, login `fake`/`fakefake`)
 
 ## Main Workflow
 
@@ -101,7 +101,7 @@ make import-alert-api DATE_FROM=2025-03-04 DATE_END=2025-03-04 \
 - `DATE_END` defaults to `DATE_FROM` if omitted.
 - `MAX_SEQUENCES` is an optional cap on the number of sequences imported; default is no cap.
 - `REMOTE_API` defaults to `https://annotationapi.pyronear.org`; override to target staging/local.
-- `IMAGE_TRANSFER=url` routes detection images through the `/from-url` endpoint instead of a server-side S3 bucket copy. This is required when the target annotation API can't reach the alert API's S3 bucket — notably local dev with LocalStack, where the default bucket-copy mode fails every detection with `Source object not found`. Leave it unset for the production API (the script picks the right mode per source).
+- `IMAGE_TRANSFER=url` routes detection images through the `/from-url` endpoint instead of a server-side S3 bucket copy. This is required when the target annotation API can't reach the alert API's S3 bucket — notably local dev, where the default bucket-copy mode fails every detection with `Source object not found`. Leave it unset for the production API (the script picks the right mode per source).
 - To use an alert-id filter, call the underlying script directly with `--sequence-list alerts_id_list.txt`.
 - Use `LOGLEVEL=debug` if you need more detail during imports.
 - Each alert sequence is object-split: one annotation sequence per detected smoke object (siblings get synthetic `alert_api_id`s).
@@ -159,7 +159,7 @@ For detailed documentation, parameter reference, and troubleshooting, see [Data 
 ### Troubleshooting
 
 **Services won't start:**
-- Ensure ports 3000, 5050, 5432, and 4566 are available
+- Ensure ports 3000, 5050, 5432, 4566, and 9001 are available
 - Check logs: `docker compose logs [service_name]`
 - Rebuild images: `docker compose build --no-cache`
 

--- a/annotation_api/CLAUDE.md
+++ b/annotation_api/CLAUDE.md
@@ -116,7 +116,7 @@ The API provides enhanced endpoints with pagination, filtering, and ordering:
 
 ### Docker Volume Persistence
 - **PostgreSQL**: Data persists in `postgres_data` named volume
-- **LocalStack S3**: Data persists in `localstack_data` named volume (limited persistence in Community edition with PERSISTENCE=1)
+- **LocalStack S3**: objects live in LocalStack process memory (`PERSISTENCE=1` is Pro-only) and do NOT survive container restart — the dev/test stack is ephemeral by design; the root compose stack uses MinIO for durable S3
 - **Preserving data**: Use `make stop` to stop containers while keeping volumes
 - **Reset volumes**: Use `make clean` (runs `docker compose down -v`) to remove all data
 - **Backup volumes**: Use `docker volume` commands or Docker Desktop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,23 +17,34 @@ services:
       timeout: 20s
       retries: 10
 
-  # LocalStack S3 service
-  localstack:
-    image: localstack/localstack:1.4.0
+  # MinIO S3 service (S3 API kept on 4566 so existing env/scripts/presigned URLs keep working)
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    command: server /data --address ':4566' --console-address ':9001'
     ports:
       - "4566:4566"
+      - "9001:9001"
     environment:
-      - EDGE_PORT=4566
-      - SERVICES=s3
-      - PERSISTENCE=1
+      - MINIO_ROOT_USER=fake
+      - MINIO_ROOT_PASSWORD=fakefake
     volumes:
-      - ./annotation_api/scripts/localstack:/etc/localstack/init/ready.d
-      - localstack_data:/var/lib/localstack
+      - minio_data:/data
     healthcheck:
-      test: ["CMD-SHELL", "awslocal --endpoint-url=http://localhost:4566 s3 ls s3://admin"]
+      test: ["CMD", "curl", "-f", "http://localhost:4566/minio/health/ready"]
       interval: 10s
       timeout: 20s
       retries: 10
+
+  # One-shot bucket bootstrap (replaces the LocalStack ready.d init script).
+  # Idempotent: re-runs on every `up` and exits 0 if the bucket exists.
+  minio-init:
+    image: minio/mc:RELEASE.2025-07-21T05-28-08Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "mc alias set local http://minio:4566 fake fakefake
+      && mc mb --ignore-existing local/annotation-api"
 
   # Annotation API backend
   annotation_api:
@@ -45,8 +56,10 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      localstack:
+      minio:
         condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
     ports:
       - "5050:5050"
     environment:
@@ -54,9 +67,9 @@ services:
       # DB
       - POSTGRES_URL=postgresql+asyncpg://dummy_pg_user:dummy_pg_pwd@postgres/dummy_pg_db
       # S3
-      - S3_ENDPOINT_URL=http://localstack:4566
+      - S3_ENDPOINT_URL=http://minio:4566
       - S3_ACCESS_KEY=fake
-      - S3_SECRET_KEY=fake
+      - S3_SECRET_KEY=fakefake
       - S3_REGION=us-east-1
       - S3_PROXY_URL=http://localhost:4566
       # Authentication
@@ -80,17 +93,19 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      localstack:
+      minio:
         condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
       annotation_api:
         condition: service_healthy
     environment:
       # DB
       - POSTGRES_URL=postgresql+asyncpg://dummy_pg_user:dummy_pg_pwd@postgres/dummy_pg_db
       # S3
-      - S3_ENDPOINT_URL=http://localstack:4566
+      - S3_ENDPOINT_URL=http://minio:4566
       - S3_ACCESS_KEY=fake
-      - S3_SECRET_KEY=fake
+      - S3_SECRET_KEY=fakefake
       - S3_REGION=us-east-1
       # Auto-annotate model (baked into the image)
       - AUTOANNOTATE_MODEL_PATH=/app/models
@@ -124,4 +139,4 @@ services:
 
 volumes:
   postgres_data:
-  localstack_data:
+  minio_data:


### PR DESCRIPTION
## Root cause

The root `docker-compose.yml` sets `PERSISTENCE=1` and mounts a volume for LocalStack, but persistence is a LocalStack **Pro** feature — the Community image keeps all S3 objects in process memory. Any `docker compose restart` (or `down`/`up`) wiped every detection image while Postgres kept its rows, leaving the DB referencing objects that no longer exist. Verified: a 5-day-old container held ~216 MB of objects while its volume's `state/` dir was empty, and a throwaway repro lost a bucket on plain `docker restart`.

## Change

- Replace the `localstack` service with pinned `minio/minio` serving the S3 API on the same port **4566** (`--address ':4566'`), objects on a `minio_data` named volume, console on 9001.
- One-shot `minio-init` (`minio/mc`) creates the `annotation-api` bucket; `annotation_api`/`worker` gate on it via `service_completed_successfully` because the API probes `head_bucket` at import time.
- `S3_SECRET_KEY` becomes `fakefake` (MinIO requires ≥8 chars). Endpoint env now `http://minio:4566`.
- **No backend changes**: boto3 emits SigV2 presigned URLs (Host not signed), so the `S3_PROXY_URL` string-replace in `storage.py` works unchanged against MinIO (verified empirically — a host-rewritten URL returns 200).
- Removing the `ready.d` bind mount also eliminates the config-drift/recreation issue when compose runs from different checkouts.

Test/dev stacks (`annotation_api/docker-compose*.yml`, CI) intentionally stay on LocalStack — ephemeral S3 is fine there.

## Verification (all run locally)

- Fresh stack: all services healthy, `minio-init` exits 0, bucket created.
- Sentinel object survives `docker compose restart` **and** `down`+`up -d` (both wiped LocalStack before).
- Real import (`make import-alert-api REMOTE_API=http://localhost:5050 IMAGE_TRANSFER=url`, 4 sequences): images land in MinIO, and the full API → presigned URL → S3 fetch returns HTTP 200 with image bytes.

Note for local dev: host `aws` CLI gets `SignatureDoesNotMatch` against MinIO (aws-cli v2 signing quirk) — use dockerized `minio/mc` or boto3 instead.