### PR TITLE
feat: idempotent alert-api import (no duplicate detections or images on re-run)

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
@@ -348,6 +348,8 @@ def main() -> None:
         "sequences_attempted_import": 0,
         "sequences_import_successful": 0,
         "sequences_import_failed": 0,
+        "sequences_skipped": 0,
+        "detections_skipped": 0,
         "detections_attempted_import": 0,
         "detections_import_successful": 0,
         "detections_import_failed": 0,
@@ -551,6 +553,8 @@ def main() -> None:
                 stats["detections_attempted_import"] = result["total_detections"]
                 stats["detections_import_successful"] = result["successful_detections"]
                 stats["detections_import_failed"] = result["failed_detections"]
+                stats["sequences_skipped"] = result.get("skipped_sequences", 0)
+                stats["detections_skipped"] = result.get("skipped_detections", 0)
                 successfully_imported_sequence_ids = result["successful_sequence_ids"]
 
                 # Prepare step completion stats for display
@@ -558,6 +562,7 @@ def main() -> None:
                     "Records fetched": len(records),
                     "Sequences posted": f"{result['successful_sequences']}/{result['total_sequences']}",
                     "Sequences skipped": result.get("skipped_sequences", 0),
+                    "Detections skipped": result.get("skipped_detections", 0),
                     "Detections posted": f"{result['successful_detections']}/{result['total_detections']}",
                 }
 
@@ -574,7 +579,7 @@ def main() -> None:
 
                 if result["failed_sequences"] > 0 or result["failed_detections"] > 0:
                     error_collector.add_warning(
-                        f"{result['failed_sequences']} sequences and {result['failed_detections']} detections failed to import (likely duplicates). "
+                        f"{result['failed_sequences']} sequences and {result['failed_detections']} detections failed to import. "
                         "Enable --loglevel debug to see per-sequence errors."
                     )
 
@@ -611,7 +616,7 @@ def main() -> None:
             console.print()
             panel = Panel(
                 f"[yellow]No sequences were successfully imported from {organization} alert API data.\n"
-                f"Check import statistics above for details (likely all were duplicates).[/]",
+                f"Check import statistics above for details (all sequences may already be imported — see Skipped).[/]",
                 title=f"⚠️ Processing Complete - {organization} - No Annotations Generated",
                 border_style="yellow",
                 padding=(1, 2),
@@ -747,7 +752,8 @@ def main() -> None:
 • Records fetched: {stats['records_fetched']}
 • Sequences attempted: {stats['sequences_attempted_import']}
 • Successfully imported: {stats['sequences_import_successful']}
-• Failed/duplicates: {stats['sequences_import_failed']}"""
+• Skipped (already imported): {stats['sequences_skipped']} sequences / {stats['detections_skipped']} detections
+• Failed: {stats['sequences_import_failed']}"""
             if stats["sequences_rolled_back"] > 0:
                 import_section += f"\n• Rolled back: {stats['sequences_rolled_back']}"
             summary_parts.append(import_section)
@@ -766,13 +772,6 @@ def main() -> None:
         # Add dry run notice
         if args.dry_run:
             summary_text += "\n\n[yellow]DRY RUN: No actual changes were made[/]"
-
-        # Add context note about duplicates if applicable
-        if (
-            stats.get("sequences_import_failed", 0) > 0
-            and stats["annotations_failed"] == 0
-        ):
-            summary_text += f"\n\n[dim]Note: {stats['sequences_import_failed']} sequences failed import (likely duplicates from re-running same dates)[/]"
 
         panel = Panel(
             summary_text,

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
@@ -556,7 +556,8 @@ def post_sequence_to_annotation_api(
                 "sequence_id": None,
                 "alert_api_sequence_id": first_record["sequence_id"],
                 "successful_detections": 0,
-                "failed_detections": len(sequence_records),
+                "failed_detections": 0,
+                "skipped_detections": len(sequence_records),
                 "total_detections": len(sequence_records),
                 "detection_results": [],
             }
@@ -654,9 +655,11 @@ def post_records_to_annotation_api(
         return {
             "successful_sequences": 0,
             "failed_sequences": 0,
+            "skipped_sequences": 0,
             "total_sequences": 0,
             "successful_detections": 0,
             "failed_detections": 0,
+            "skipped_detections": 0,
             "total_detections": 0,
             "successful_sequence_ids": [],
             "sequence_results": [],
@@ -678,6 +681,7 @@ def post_records_to_annotation_api(
     skipped_sequences = 0
     total_successful_detections = 0
     total_failed_detections = 0
+    total_skipped_detections = 0
     successful_sequence_ids = []
     sequence_results = []
 
@@ -717,7 +721,7 @@ def post_records_to_annotation_api(
 
                         if result.get("skipped"):
                             skipped_sequences += 1
-                            total_failed_detections += result["failed_detections"]
+                            total_skipped_detections += result["skipped_detections"]
                             reason = result.get("skip_reason", "already exists")
                             logging.warning(
                                 f"⚠️ Sequence {alert_api_sequence_id} skipped ({reason})"
@@ -773,6 +777,7 @@ def post_records_to_annotation_api(
         "total_sequences": len(grouped_records),
         "successful_detections": total_successful_detections,
         "failed_detections": total_failed_detections,
+        "skipped_detections": total_skipped_detections,
         "total_detections": len(records),
         "successful_sequence_ids": successful_sequence_ids,
         "sequence_results": sequence_results,

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
@@ -31,6 +31,7 @@ from app.clients.annotation_api import (
     create_sequence,
     create_detection_from_bucket_key,
     create_detection_from_url,
+    list_detections,
     AnnotationAPIError,
     ValidationError,
 )
@@ -341,6 +342,35 @@ def group_records_by_sequence(records: List[dict]) -> Dict[int, List[dict]]:
     return dict(grouped)
 
 
+def _find_existing_detection(
+    annotation_api_url: str,
+    auth_token: str,
+    sequence_id: int,
+    alert_api_id: int,
+) -> Optional[dict]:
+    """Find the detection with this alert_api_id in a sequence, or None.
+
+    The detections list endpoint has no alert_api_id filter, so page through
+    the sequence's detections (a sequence holds at most ~frames-limit rows)
+    and match client-side.
+    """
+    page = 1
+    while True:
+        response = list_detections(
+            annotation_api_url,
+            auth_token,
+            sequence_id=sequence_id,
+            page=page,
+            size=100,
+        )
+        for item in response.get("items", []):
+            if item.get("alert_api_id") == alert_api_id:
+                return item
+        if page >= response.get("pages", 1):
+            return None
+        page += 1
+
+
 def _process_single_detection(
     record: dict,
     annotation_api_url: str,
@@ -427,6 +457,31 @@ def _process_single_detection(
             return result
 
         except AnnotationAPIError as e:
+            if e.status_code == 409:
+                existing = _find_existing_detection(
+                    annotation_api_url,
+                    auth_token,
+                    annotation_sequence_id,
+                    record["detection_id"],
+                )
+                if existing is not None:
+                    logging.info(
+                        f"Detection {record['detection_id']} already exists "
+                        f"as annotation detection {existing['id']} — reusing it"
+                    )
+                    result["success"] = True
+                    result["annotation_detection_id"] = existing["id"]
+                    result["xyxyns"] = [
+                        pred["xyxyn"]
+                        for pred in detection_data["algo_predictions"]["predictions"]
+                    ]
+                    return result
+                result["error"] = (
+                    f"Detection {record['detection_id']} already exists (409) "
+                    "but could not be found in the sequence"
+                )
+                logging.error(result["error"])
+                return result
             if e.status_code in (502, 503, 504) and attempt < max_retries:
                 delay = base_delay * (2**attempt)
                 logging.warning(

--- a/annotation_api/src/app/api/api_v1/endpoints/detections.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/detections.py
@@ -58,7 +58,11 @@ async def _persist_detection(
     the storage op succeeded, the orphaned S3 object is best-effort deleted.
     """
     detections.session.add(detection)
-    await detections.session.flush()
+    try:
+        await detections.session.flush()
+    except Exception:
+        await detections.session.rollback()
+        raise
 
     try:
         bucket_key = await storage_op(detection.id)

--- a/annotation_api/src/app/models.py
+++ b/annotation_api/src/app/models.py
@@ -359,7 +359,9 @@ class SequenceAnnotation(SQLModel, table=True):
 class Detection(SQLModel, table=True):
     __tablename__ = "detections"
     __table_args__ = (
-        UniqueConstraint("alert_api_id", "id", name="uq_detection_alert_id"),
+        UniqueConstraint(
+            "sequence_id", "alert_api_id", name="uq_detection_sequence_alert_api_id"
+        ),
         Index("ix_detection_sequence_id", "sequence_id"),
         Index("ix_detection_created_at", "created_at"),
         Index("ix_detection_recorded_at", "recorded_at"),

--- a/annotation_api/src/migrations/versions/2026_08_03_1000-e1f2a3b4c5d6_detection_unique_per_sequence.py
+++ b/annotation_api/src/migrations/versions/2026_08_03_1000-e1f2a3b4c5d6_detection_unique_per_sequence.py
@@ -1,0 +1,93 @@
+"""detections: replace vacuous (alert_api_id, id) unique with (sequence_id, alert_api_id)
+
+Revision ID: e1f2a3b4c5d6
+Revises: d0e1f2a3b4c5
+Create Date: 2026-08-03
+"""
+
+from typing import Sequence as TypingSequence, Union
+
+from alembic import op
+
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, None] = "d0e1f2a3b4c5"
+branch_labels: Union[str, TypingSequence[str], None] = None
+depends_on: Union[str, TypingSequence[str], None] = None
+
+
+def upgrade() -> None:
+    # The old constraint included the primary key, so duplicates of the same
+    # alert detection within a sequence were never rejected (retries after a
+    # gateway timeout created them). Dedupe before the real constraint lands:
+    # keep the earliest row per (sequence_id, alert_api_id) and preserve any
+    # human annotation by re-pointing it at the survivor.
+    op.execute(
+        """
+        CREATE TEMP TABLE _dup_detections AS
+        SELECT d.id AS dup_id, k.keep_id
+        FROM detections d
+        JOIN (
+            SELECT sequence_id, alert_api_id, MIN(id) AS keep_id
+            FROM detections
+            GROUP BY sequence_id, alert_api_id
+            HAVING COUNT(*) > 1
+        ) k
+          ON d.sequence_id = k.sequence_id AND d.alert_api_id = k.alert_api_id
+        WHERE d.id <> k.keep_id
+        """
+    )
+    # Annotations on doomed rows: drop them when the survivor already has one
+    # (detections_annotations.detection_id is unique) ...
+    op.execute(
+        """
+        DELETE FROM detections_annotations da
+        USING _dup_detections dup, detections_annotations surv
+        WHERE da.detection_id = dup.dup_id AND surv.detection_id = dup.keep_id
+        """
+    )
+    # ... keep only the earliest annotation when several doomed rows of the
+    # same key are annotated ...
+    op.execute(
+        """
+        DELETE FROM detections_annotations da
+        USING _dup_detections dup
+        WHERE da.detection_id = dup.dup_id
+          AND EXISTS (
+            SELECT 1
+            FROM detections_annotations da2
+            JOIN _dup_detections dup2 ON da2.detection_id = dup2.dup_id
+            WHERE dup2.keep_id = dup.keep_id AND da2.id < da.id
+          )
+        """
+    )
+    # ... and re-point the remaining one at the survivor.
+    op.execute(
+        """
+        UPDATE detections_annotations da
+        SET detection_id = dup.keep_id
+        FROM _dup_detections dup
+        WHERE da.detection_id = dup.dup_id
+        """
+    )
+    op.execute(
+        "DELETE FROM detections d USING _dup_detections dup WHERE d.id = dup.dup_id"
+    )
+    op.execute("DROP TABLE _dup_detections")
+
+    op.drop_constraint("uq_detection_alert_id", "detections", type_="unique")
+    op.create_unique_constraint(
+        "uq_detection_sequence_alert_api_id",
+        "detections",
+        ["sequence_id", "alert_api_id"],
+    )
+
+
+def downgrade() -> None:
+    # Deleted duplicate rows are not restorable; only the constraint swap
+    # reverses.
+    op.drop_constraint(
+        "uq_detection_sequence_alert_api_id", "detections", type_="unique"
+    )
+    op.create_unique_constraint(
+        "uq_detection_alert_id", "detections", ["alert_api_id", "id"]
+    )

--- a/annotation_api/src/tests/conftest.py
+++ b/annotation_api/src/tests/conftest.py
@@ -68,7 +68,7 @@ DET_TABLE = [
         "id": 2,
         "created_at": now - timedelta(days=1),
         "sequence_id": 1,
-        "alert_api_id": 1,
+        "alert_api_id": 2,
         "recorded_at": now - timedelta(days=3),
         "bucket_key": "seq1_img2.jpg",
         "algo_predictions": {

--- a/annotation_api/src/tests/endpoints/test_detections.py
+++ b/annotation_api/src/tests/endpoints/test_detections.py
@@ -5,6 +5,8 @@ import pytest
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.services.storage import s3_service
+
 now = datetime.now(UTC)
 
 
@@ -538,6 +540,11 @@ async def test_create_duplicate_detection_returns_409(
     )
     assert first.status_code == 201
 
+    bucket = s3_service.get_bucket(s3_service.resolve_bucket_name())
+    objects_after_first = bucket._s3.list_objects_v2(
+        Bucket=bucket.name, Prefix="detections/sequence_1/"
+    ).get("KeyCount", 0)
+
     second = await authenticated_client.post(
         "/detections/",
         data=payload,
@@ -549,3 +556,9 @@ async def test_create_duplicate_detection_returns_409(
     assert listing.status_code == 200
     matches = [d for d in listing.json()["items"] if d["alert_api_id"] == 4242]
     assert len(matches) == 1
+
+    # The duplicate is rejected at flush time, before any upload happens.
+    objects_after_second = bucket._s3.list_objects_v2(
+        Bucket=bucket.name, Prefix="detections/sequence_1/"
+    ).get("KeyCount", 0)
+    assert objects_after_second == objects_after_first

--- a/annotation_api/src/tests/endpoints/test_detections.py
+++ b/annotation_api/src/tests/endpoints/test_detections.py
@@ -387,10 +387,12 @@ async def test_delete_detection_invalid_id(authenticated_client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_create_detection_unique_constraint_violation(
+async def test_create_detection_same_alert_api_id_other_sequence(
     authenticated_client: AsyncClient, sequence_session: AsyncSession, mock_img: bytes
 ):
-    """Test that creating detections with duplicate (alert_api_id, id) fails due to unique constraint."""
+    """Uniqueness is scoped per sequence: object-split sibling sequences share
+    the same alert detection ids, so the same alert_api_id must be accepted in
+    a different sequence."""
     payload = {
         "sequence_id": "1",
         "alert_api_id": "999",
@@ -408,7 +410,6 @@ async def test_create_detection_unique_constraint_violation(
         ),
     }
 
-    # First detection should be created successfully
     response1 = await authenticated_client.post(
         "/detections/",
         data=payload,
@@ -416,15 +417,9 @@ async def test_create_detection_unique_constraint_violation(
     )
     assert response1.status_code == 201
     detection1 = response1.json()
-    assert "id" in detection1
-    detection1_id = detection1["id"]
 
-    # Now let's manually try to create a detection with the same (alert_api_id, id) combination
-    # This is tricky because id is auto-increment, so we can't directly control it via API
-    # Instead, we'll test that the unique constraint exists by checking we can create another detection
-    # with same alert_api_id but different auto-generated id (which should succeed)
     payload2 = payload.copy()
-    payload2["sequence_id"] = "1"  # Same or different sequence
+    payload2["sequence_id"] = "2"
 
     response2 = await authenticated_client.post(
         "/detections/",
@@ -433,12 +428,9 @@ async def test_create_detection_unique_constraint_violation(
     )
     assert response2.status_code == 201
     detection2 = response2.json()
-    assert "id" in detection2
-    detection2_id = detection2["id"]
 
-    # Verify both detections have same alert_api_id but different ids
     assert detection1["alert_api_id"] == detection2["alert_api_id"]
-    assert detection1_id != detection2_id
+    assert detection1["id"] != detection2["id"]
 
 
 @pytest.mark.asyncio
@@ -514,3 +506,46 @@ async def test_create_detection_with_alert_api_id_above_int32(
     )
     assert response.status_code == 201
     assert response.json()["alert_api_id"] == 2**31
+
+
+@pytest.mark.asyncio
+async def test_create_duplicate_detection_returns_409(
+    authenticated_client: AsyncClient, sequence_session: AsyncSession, mock_img: bytes
+):
+    """Same (sequence_id, alert_api_id) twice: second POST must 409 and not
+    create a second row (idempotent re-import guarantee)."""
+    payload = {
+        "sequence_id": "1",
+        "alert_api_id": "4242",
+        "recorded_at": (now - timedelta(days=2)).isoformat(),
+        "algo_predictions": json.dumps(
+            {
+                "predictions": [
+                    {
+                        "xyxyn": [0.1, 0.1, 0.2, 0.2],
+                        "confidence": 0.95,
+                        "class_name": "smoke",
+                    }
+                ]
+            }
+        ),
+    }
+
+    first = await authenticated_client.post(
+        "/detections/",
+        data=payload,
+        files={"file": ("image.jpg", mock_img, "image/jpeg")},
+    )
+    assert first.status_code == 201
+
+    second = await authenticated_client.post(
+        "/detections/",
+        data=payload,
+        files={"file": ("image.jpg", mock_img, "image/jpeg")},
+    )
+    assert second.status_code == 409
+
+    listing = await authenticated_client.get("/detections/", params={"sequence_id": 1})
+    assert listing.status_code == 200
+    matches = [d for d in listing.json()["items"] if d["alert_api_id"] == 4242]
+    assert len(matches) == 1

--- a/annotation_api/src/tests/migrations/test_detection_dedupe.py
+++ b/annotation_api/src/tests/migrations/test_detection_dedupe.py
@@ -1,0 +1,97 @@
+"""Exercise the dedupe step of migration e1f2a3b4c5d6 against real duplicates.
+
+The ordinary upgrade path in conftest always runs against empty tables, so the
+temp-table/DELETE/UPDATE choreography that guards production data is never
+executed. Here we downgrade one revision, seed the annotated-duplicate cases,
+upgrade back to head, and assert survivors and annotation re-pointing.
+"""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+ALEMBIC_INI = Path(__file__).resolve().parents[2] / "alembic.ini"
+PREV_REVISION = "d0e1f2a3b4c5"
+
+SEED_SQL = """
+INSERT INTO sequences (id, source_api, alert_api_id, platform_alert_id, camera_name,
+                       camera_id, organisation_name, organisation_id, lat, lon,
+                       recorded_at, created_at)
+VALUES (900, 'PYRONEAR_FRENCH_API', 990001, 990001, 'cam', 1, 'org', 1, 0, 0, now(), now());
+
+INSERT INTO detections (id, sequence_id, alert_api_id, recorded_at, created_at, bucket_key)
+VALUES
+    -- group A: survivor unannotated, doomed row annotated -> re-point
+    (9001, 900, 1111, now(), now(), 'a1'),
+    (9002, 900, 1111, now(), now(), 'a2'),
+    -- group B: survivor annotated, doomed row annotated -> doomed annotation dropped
+    (9011, 900, 2222, now(), now(), 'b1'),
+    (9012, 900, 2222, now(), now(), 'b2'),
+    -- group C: survivor unannotated, two annotated doomed rows -> keep earliest annotation
+    (9021, 900, 3333, now(), now(), 'c1'),
+    (9022, 900, 3333, now(), now(), 'c2'),
+    (9023, 900, 3333, now(), now(), 'c3'),
+    -- no duplicate: untouched
+    (9031, 900, 4444, now(), now(), 'd1');
+
+INSERT INTO detections_annotations (id, detection_id, annotation, processing_stage, created_at)
+VALUES
+    (8002, 9002, '{"annotation": []}'::jsonb, 'VISUAL_CHECK', now()),
+    (8011, 9011, '{"annotation": []}'::jsonb, 'VISUAL_CHECK', now()),
+    (8012, 9012, '{"annotation": []}'::jsonb, 'VISUAL_CHECK', now()),
+    (8022, 9022, '{"annotation": []}'::jsonb, 'VISUAL_CHECK', now()),
+    (8023, 9023, '{"annotation": []}'::jsonb, 'VISUAL_CHECK', now());
+"""
+
+
+def _alembic_config() -> Config:
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.set_main_option("script_location", str(ALEMBIC_INI.parent / "migrations"))
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_dedupe_keeps_earliest_detection_and_repoints_annotations(
+    async_session: AsyncSession,
+):
+    # The session must be idle while alembic takes its ACCESS EXCLUSIVE locks,
+    # so commit after every batch of session work.
+    await asyncio.to_thread(command.downgrade, _alembic_config(), PREV_REVISION)
+
+    for statement in SEED_SQL.split(";"):
+        if statement.strip():
+            await async_session.exec(text(statement))
+    await async_session.commit()
+
+    await asyncio.to_thread(command.upgrade, _alembic_config(), "head")
+
+    surviving = await async_session.exec(
+        text("SELECT id FROM detections WHERE sequence_id = 900 ORDER BY id")
+    )
+    assert [row[0] for row in surviving] == [9001, 9011, 9021, 9031]
+
+    annotations = await async_session.exec(
+        text(
+            "SELECT id, detection_id FROM detections_annotations "
+            "WHERE id BETWEEN 8000 AND 8999 ORDER BY id"
+        )
+    )
+    assert [tuple(row) for row in annotations] == [
+        (8002, 9001),  # group A: re-pointed to the survivor
+        (8011, 9011),  # group B: survivor's own annotation kept, doomed's dropped
+        (8022, 9021),  # group C: earliest of the doomed annotations, re-pointed
+    ]
+
+    constraint = await async_session.exec(
+        text(
+            "SELECT 1 FROM pg_constraint "
+            "WHERE conname = 'uq_detection_sequence_alert_api_id'"
+        )
+    )
+    assert constraint.first() is not None
+    await async_session.commit()

--- a/annotation_api/src/tests/scripts/test_shared_posting.py
+++ b/annotation_api/src/tests/scripts/test_shared_posting.py
@@ -107,6 +107,31 @@ class TestDetection409Recovery:
         assert result["failed_detections"] == 1
 
 
+class TestSkippedSequenceStats:
+    def test_skipped_sequence_counts_as_skipped_not_failed(self, monkeypatch):
+        monkeypatch.setattr(
+            shared, "get_auth_token", lambda url, username, password: "token"
+        )
+
+        def conflicting_sequence(url, token, data):
+            raise shared.AnnotationAPIError("duplicate sequence", status_code=409)
+
+        monkeypatch.setattr(shared, "create_sequence", conflicting_sequence)
+
+        records = [
+            make_record(1, "2026-07-01T10:00:00", [BOX]),
+            make_record(2, "2026-07-01T10:01:00", [BOX]),
+        ]
+        result = shared.post_records_to_annotation_api(
+            "http://annotation.test", records, max_workers=1, max_detection_workers=1
+        )
+        assert result["skipped_sequences"] == 1
+        assert result["skipped_detections"] == 2
+        assert result["failed_detections"] == 0
+        assert result["failed_sequences"] == 0
+        assert result["successful_sequences"] == 0
+
+
 class TestTransformSequenceData:
     def test_platform_alert_id_passed_through(self):
         record = make_record(1, "2026-07-01T10:00:00", [BOX])

--- a/annotation_api/src/tests/scripts/test_shared_posting.py
+++ b/annotation_api/src/tests/scripts/test_shared_posting.py
@@ -61,17 +61,24 @@ class TestDetection409Recovery:
         monkeypatch.setattr(
             shared, "create_detection_from_bucket_key", conflicting_create
         )
-        monkeypatch.setattr(
-            shared,
-            "list_detections",
-            lambda url, token, **params: {
-                "items": [
-                    {"id": 777, "alert_api_id": 1, "sequence_id": 99},
-                    {"id": 778, "alert_api_id": 2, "sequence_id": 99},
-                ],
-                "pages": 1,
-            },
-        )
+
+        # Two pages, match on page 2: proves the lookup is scoped to the new
+        # sequence and actually paginates instead of matching page 1 only.
+        list_calls = []
+
+        def fake_list_detections(url, token, **params):
+            list_calls.append(params)
+            if params["page"] == 1:
+                return {
+                    "items": [{"id": 778, "alert_api_id": 2, "sequence_id": 99}],
+                    "pages": 2,
+                }
+            return {
+                "items": [{"id": 777, "alert_api_id": 1, "sequence_id": 99}],
+                "pages": 2,
+            }
+
+        monkeypatch.setattr(shared, "list_detections", fake_list_detections)
 
         records = [make_record(1, "2026-07-01T10:00:00", [BOX])]
         result = shared.post_sequence_to_annotation_api(
@@ -81,6 +88,8 @@ class TestDetection409Recovery:
         assert result["failed_detections"] == 0
         assert result["detection_results"][0]["annotation_detection_id"] == 777
         assert result["detection_results"][0]["xyxyns"] == [[0.1, 0.1, 0.2, 0.2]]
+        assert [call["page"] for call in list_calls] == [1, 2]
+        assert all(call["sequence_id"] == 99 for call in list_calls)
 
     def test_409_with_unfindable_detection_stays_failed(self, monkeypatch):
         monkeypatch.setattr(

--- a/annotation_api/src/tests/scripts/test_shared_posting.py
+++ b/annotation_api/src/tests/scripts/test_shared_posting.py
@@ -49,6 +49,64 @@ class TestDetectionResultsPlumbing:
         assert result["detection_results"] == []
 
 
+class TestDetection409Recovery:
+    def test_409_recovers_existing_detection(self, monkeypatch):
+        monkeypatch.setattr(
+            shared, "create_sequence", lambda url, token, data: {"id": 99}
+        )
+
+        def conflicting_create(url, token, detection_data, source_key):
+            raise shared.AnnotationAPIError("already exists", status_code=409)
+
+        monkeypatch.setattr(
+            shared, "create_detection_from_bucket_key", conflicting_create
+        )
+        monkeypatch.setattr(
+            shared,
+            "list_detections",
+            lambda url, token, **params: {
+                "items": [
+                    {"id": 777, "alert_api_id": 1, "sequence_id": 99},
+                    {"id": 778, "alert_api_id": 2, "sequence_id": 99},
+                ],
+                "pages": 1,
+            },
+        )
+
+        records = [make_record(1, "2026-07-01T10:00:00", [BOX])]
+        result = shared.post_sequence_to_annotation_api(
+            "http://annotation.test", records, "token", max_detection_workers=1
+        )
+        assert result["successful_detections"] == 1
+        assert result["failed_detections"] == 0
+        assert result["detection_results"][0]["annotation_detection_id"] == 777
+        assert result["detection_results"][0]["xyxyns"] == [[0.1, 0.1, 0.2, 0.2]]
+
+    def test_409_with_unfindable_detection_stays_failed(self, monkeypatch):
+        monkeypatch.setattr(
+            shared, "create_sequence", lambda url, token, data: {"id": 99}
+        )
+
+        def conflicting_create(url, token, detection_data, source_key):
+            raise shared.AnnotationAPIError("already exists", status_code=409)
+
+        monkeypatch.setattr(
+            shared, "create_detection_from_bucket_key", conflicting_create
+        )
+        monkeypatch.setattr(
+            shared,
+            "list_detections",
+            lambda url, token, **params: {"items": [], "pages": 1},
+        )
+
+        records = [make_record(1, "2026-07-01T10:00:00", [BOX])]
+        result = shared.post_sequence_to_annotation_api(
+            "http://annotation.test", records, "token", max_detection_workers=1
+        )
+        assert result["successful_detections"] == 0
+        assert result["failed_detections"] == 1
+
+
 class TestTransformSequenceData:
     def test_platform_alert_id_passed_through(self):
         record = make_record(1, "2026-07-01T10:00:00", [BOX])

--- a/docs/specs/2026-08-03-idempotent-alert-api-import-design.md
+++ b/docs/specs/2026-08-03-idempotent-alert-api-import-design.md
@@ -1,0 +1,95 @@
+# Idempotent Alert API Import
+
+**Date:** 2026-08-03
+**Status:** Approved
+**Scope:** `annotation_api` — DB schema, import script, run reporting
+
+## Goal
+
+Re-running the alert API import script over the same date range must not create
+duplicate detection rows in the database or duplicate images in S3, and a pure
+re-run must report success instead of a wall of "failed/duplicates".
+
+## Current behavior
+
+- Sequences are already idempotent: `UNIQUE (alert_api_id, source_api)` makes a
+  re-imported sequence return 409, and the script skips it before posting any
+  detections (so completed sequences never re-upload images).
+- Object-split sibling sequences use deterministic synthetic ids
+  (`base + alert_sid * 1000 + object_index`), so they collide correctly with
+  their previous selves across runs.
+- Detections are **not** protected: `uq_detection_alert_id` is
+  `UNIQUE (alert_api_id, id)`, and `id` is the primary key, so the constraint
+  is vacuous. The real duplicate source is the retry path in
+  `_process_single_detection`: a 502/503/504 received after the server actually
+  committed leads the retry to insert a second row and upload a second image.
+- A re-run over an existing range reports every skipped sequence's detections
+  as "failed", so an idempotent re-run looks like a failure.
+
+## Decisions
+
+- Keep the existing skip-on-409 semantics for sequences (no verify/repair, no
+  full sync). Half-imported sequences left by a crashed run stay as they are.
+- No S3 cleanup work: existing orphaned images are tolerated, and
+  `delete_sequence` keeps its current behavior (no S3 deletion).
+- 409 Conflict stays the server contract for duplicate creates (consistent
+  with sequences and the global `IntegrityError → 409` handler); the endpoint
+  does not switch to 200-with-existing.
+
+## Design
+
+### 1. Migration: real uniqueness for detections
+
+New Alembic revision in `src/migrations/versions/`:
+
+1. **Dedupe existing rows.** For each `(sequence_id, alert_api_id)` group,
+   keep the earliest row (lowest `id`). Before deleting later duplicates,
+   re-point any `detections_annotations` rows referencing a doomed row to the
+   survivor; if the survivor already has an annotation (`detection_id` is
+   unique in that table), delete the duplicate's annotation instead.
+2. **Constraint swap.** Drop `uq_detection_alert_id`; add
+   `UNIQUE (sequence_id, alert_api_id)` (name:
+   `uq_detection_sequence_alert_api_id`). Update the model in
+   `src/app/models.py` to match.
+
+Downgrade reverses the constraint swap only; deleted duplicate rows are not
+restorable.
+
+No endpoint changes are needed: the app-level `IntegrityError` handler already
+maps the violation to 409, and `_persist_detection` flushes the row before the
+S3 upload, so a duplicate insert fails before any image is written.
+
+### 2. Import script: treat detection 409 as "already exists"
+
+In `_process_single_detection` (`scripts/data_transfer/ingestion/alert_api/shared.py`),
+catch `AnnotationAPIError` with `status_code == 409`:
+
+- fetch the existing detection via
+  `list_detections(sequence_id=…, alert_api_id=…)`,
+- fill `annotation_detection_id` and `xyxyns` from the payload as usual,
+- return success.
+
+This converges the retry-after-commit case onto the existing row instead of
+duplicating it.
+
+### 3. Honest re-run reporting
+
+- `post_records_to_annotation_api`: count a skipped sequence's detections in a
+  new `skipped_detections` counter instead of `failed_detections`.
+- `import.py` summary: add "Sequences skipped (already imported)", stop folding
+  skips into "Failed/duplicates", and remove the "likely duplicates" hedging
+  notes. A pure re-run of an already-imported range exits 0 with 0 failures.
+
+## Testing
+
+- Endpoint test: POST the same detection twice into one sequence → second
+  returns 409, exactly one row persists, no second S3 object.
+- Script test (mocked client): `_process_single_detection` recovers from a 409
+  by fetching the existing detection and reporting success.
+- Stats test: skipped sequences produce `skipped_detections` and zero
+  `failed_detections`.
+
+## Success criteria
+
+Run the import twice over the same date range against a local stack: the
+second run exits 0, and detection row count and S3 object count are unchanged.


### PR DESCRIPTION
## Summary

Re-running the alert API import over the same date range must not create duplicate DB rows or S3 images, and a pure re-run should read as a success. Spec: `docs/specs/2026-08-03-idempotent-alert-api-import-design.md`.

- **Real uniqueness for detections** — the old `(alert_api_id, id)` unique constraint included the primary key and never fired; import retries after gateway timeouts silently created duplicate rows + images. New migration dedupes existing rows (keeping the earliest, re-pointing detection annotations at the survivor) and enforces `UNIQUE (sequence_id, alert_api_id)` — scoped per sequence because object-split siblings legitimately share alert detection ids. Duplicate POSTs now 409 via the existing IntegrityError handler, before any S3 upload happens.
- **`_persist_detection` session fix** — a failed pre-upload flush left the session un-rolled-back and unusable for subsequent requests on the same session.
- **Script 409 recovery** — `_process_single_detection` now resolves a 409 by fetching the existing detection and reusing its id (closes the retry-after-commit window).
- **Honest re-run reporting** — skipped sequences/detections get their own counters and summary line instead of being folded into "Failed/duplicates"; a pure re-run exits 0.

## Testing

- New endpoint test: duplicate detection POST → 409, single row persists; same `alert_api_id` in another sequence still allowed.
- New script tests: 409 recovery (found / not-found) and skipped-vs-failed stats.
- Migration dedupe verified manually with seeded duplicates (survivor kept, annotation re-pointed).
- Full suite green in an isolated compose stack: 480 passed, 0 failed.