### PR TITLE
polish(frontend): clarify sidebar logo link hover affordance

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -137,7 +137,11 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
     <div className="flex flex-col h-0 flex-1 border-r border-gray-200 bg-white">
       <div className="flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
         <div className="flex items-center flex-shrink-0 px-4">
-          <Link to="/" className="flex items-center rounded-md hover:opacity-80 transition-opacity">
+          <Link
+            to="/"
+            className="flex items-center rounded-md -mx-2 px-2 py-1.5 hover:bg-ash transition-colors"
+            title="Go to dashboard"
+          >
             <img src={logoImg} alt="PyroAnnotator Logo" className="w-8 h-8" />
             <h1 className="ml-2 text-xl font-bold text-gray-900">PyroAnnotator</h1>
           </Link>


### PR DESCRIPTION
## Summary

The PyroAnnotator logo in the sidebar links to the dashboard, but its hover state was a faint `opacity-80` fade that didn't read as clickable.

- Replace the opacity fade with the same hover language the nav rows use: a `bg-ash` background tint
- Add padding (`-mx-2 px-2 py-1.5`) so the tint forms a rounded pill around the logo and title without shifting their alignment
- Add `title="Go to dashboard"` tooltip

## Test plan

- `npm test` — 763 tests pass
- `npm run type-check`, ESLint, Prettier — clean
- Eyeballed in the dev server: hovering the logo now shows a clear rounded tint