### PR TITLE
polish(frontend): restyle sign-in page to dashboard palette

### DIFF
--- a/docs/specs/2026-08-03-login-page-restyle-design.md
+++ b/docs/specs/2026-08-03-login-page-restyle-design.md
@@ -1,0 +1,45 @@
+# Sign-in Page Restyle — Design
+
+**Date**: 2026-08-03
+**Status**: Approved (mockup reviewed via visual companion)
+
+## Goal
+
+Bring `/login` in line with the dashboard's visual system. The page currently
+uses a generic blue Tailwind template (blue gradient background, `blue-600`
+button, gray text, default font) that reads as a different product from the
+dashboard's editorial palette. Also replace the tagline copy.
+
+## Scope
+
+One file: `frontend/src/pages/LoginPage.tsx`. Structure, props, state,
+handlers, and accessibility attributes are unchanged — only class names and
+the tagline text change.
+
+## Visual changes
+
+Token sources: `frontend/tailwind.config.js` (`ash`, `paper`, `line`, `char`,
+`haze`, `ember`, `signal`) and the idioms in
+`frontend/src/components/dashboard/PhaseCard.tsx` / `DashboardPage.tsx`.
+
+| Element | Current | New |
+| --- | --- | --- |
+| Page background | `bg-gradient-to-br from-blue-50 to-blue-100` | flat `bg-ash` |
+| Headline | `text-3xl font-bold text-gray-900` | `font-display text-[27px] font-semibold tracking-tight text-char` (dashboard h1 scale) |
+| Tagline | "Wildfire detection annotation system", `text-gray-600` | "Classify and localize wildfire smoke from Pyronear cameras.", `font-body text-[13.5px] text-haze` |
+| Card | `bg-white rounded-xl shadow-lg border-gray-100` | `rounded-[10px] border border-line bg-paper`, no shadow (flat, border-defined like PhaseCard) |
+| Field labels | `text-gray-700` | `font-body font-medium text-char` |
+| Inputs | `border-gray-300`, blue focus ring | `border-line`, `focus:ring-ember focus:border-ember`, `font-body` |
+| Field icons | `text-gray-400` | `text-haze` |
+| Show/hide toggle | `text-gray-400 hover:text-gray-600` | `text-haze hover:text-char` |
+| Error box | `bg-red-50 border-red-200`, `text-red-500/700` | `bg-signal-soft` (no border), icon + text `text-signal` |
+| Submit button | `bg-blue-600 hover:bg-blue-700`, blue focus ring | `bg-ember font-semibold hover:brightness-95 focus:ring-char focus:ring-offset-2` (dashboard CTA idiom), full width; disabled/spinner behavior unchanged |
+| Footer | "Pyronear" `text-xs text-gray-500` | `font-data text-[10.5px] font-medium uppercase tracking-[0.14em] text-haze` (dashboard mono-label motif) |
+
+Logo image is unchanged.
+
+## Verification
+
+- `npm run quality` (type-check + lint + format) and `npm test` pass.
+- Before/after screenshot of `/login` (unauthenticated — no JWT stub needed)
+  confirms the rendered page matches the approved mockup.

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -22,38 +22,45 @@ export default function LoginPage({ onLogin, isLoading = false, error }: LoginPa
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-blue-100 flex items-center justify-center px-4">
+    <div className="min-h-screen bg-ash flex items-center justify-center px-4">
       <div className="max-w-md w-full space-y-8">
         {/* Header */}
         <div className="text-center">
           <div className="flex justify-center">
             <img src={logoImg} alt="PyroAnnotator Logo" className="w-20 h-20 object-contain" />
           </div>
-          <h2 className="mt-6 text-3xl font-bold text-gray-900">Sign in to PyroAnnotator</h2>
-          <p className="mt-2 text-sm text-gray-600">Wildfire detection annotation system</p>
+          <h2 className="mt-6 font-display text-[27px] font-semibold tracking-tight text-char">
+            Sign in to PyroAnnotator
+          </h2>
+          <p className="mt-2 font-body text-[13.5px] text-haze">
+            Classify and localize wildfire smoke from Pyronear cameras.
+          </p>
         </div>
 
         {/* Login Form */}
-        <div className="bg-white rounded-xl shadow-lg p-8 border border-gray-100">
+        <div className="bg-paper rounded-[10px] border border-line p-8">
           <form className="space-y-6" onSubmit={handleSubmit}>
             {/* Error Message */}
             {error && (
-              <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+              <div className="bg-signal-soft rounded-lg p-4">
                 <div className="flex items-center">
-                  <AlertTriangle className="w-4 h-4 text-red-500 mr-2" />
-                  <span className="text-sm text-red-700">{error}</span>
+                  <AlertTriangle className="w-4 h-4 text-signal mr-2" />
+                  <span className="text-sm text-signal">{error}</span>
                 </div>
               </div>
             )}
 
             {/* Username Field */}
             <div>
-              <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-2">
+              <label
+                htmlFor="username"
+                className="block font-body text-sm font-medium text-char mb-2"
+              >
                 Username
               </label>
               <div className="relative">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <User className="h-5 w-5 text-gray-400" />
+                  <User className="h-5 w-5 text-haze" />
                 </div>
                 <input
                   id="username"
@@ -63,7 +70,7 @@ export default function LoginPage({ onLogin, isLoading = false, error }: LoginPa
                   required
                   value={username}
                   onChange={e => setUsername(e.target.value)}
-                  className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
+                  className="block w-full pl-10 pr-3 py-3 font-body border border-line rounded-lg focus:outline-none focus:ring-2 focus:ring-ember focus:border-ember transition-colors"
                   placeholder="Enter your username"
                   disabled={isLoading}
                 />
@@ -72,12 +79,15 @@ export default function LoginPage({ onLogin, isLoading = false, error }: LoginPa
 
             {/* Password Field */}
             <div>
-              <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
+              <label
+                htmlFor="password"
+                className="block font-body text-sm font-medium text-char mb-2"
+              >
                 Password
               </label>
               <div className="relative">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <Lock className="h-5 w-5 text-gray-400" />
+                  <Lock className="h-5 w-5 text-haze" />
                 </div>
                 <input
                   id="password"
@@ -87,14 +97,14 @@ export default function LoginPage({ onLogin, isLoading = false, error }: LoginPa
                   required
                   value={password}
                   onChange={e => setPassword(e.target.value)}
-                  className="block w-full pl-10 pr-12 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
+                  className="block w-full pl-10 pr-12 py-3 font-body border border-line rounded-lg focus:outline-none focus:ring-2 focus:ring-ember focus:border-ember transition-colors"
                   placeholder="Enter your password"
                   disabled={isLoading}
                 />
                 <div className="absolute inset-y-0 right-0 pr-3 flex items-center">
                   <button
                     type="button"
-                    className="text-gray-400 hover:text-gray-600 focus:outline-none"
+                    className="text-haze hover:text-char focus:outline-none"
                     onClick={() => setShowPassword(!showPassword)}
                     disabled={isLoading}
                   >
@@ -143,7 +153,7 @@ export default function LoginPage({ onLogin, isLoading = false, error }: LoginPa
               <button
                 type="submit"
                 disabled={isLoading || !username.trim() || !password.trim()}
-                className="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="group relative w-full flex justify-center py-3 px-4 border border-transparent font-body text-sm font-semibold rounded-lg text-white bg-ember hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-char disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {isLoading ? (
                   <div className="flex items-center">
@@ -160,7 +170,9 @@ export default function LoginPage({ onLogin, isLoading = false, error }: LoginPa
 
         {/* Footer */}
         <div className="text-center">
-          <p className="text-xs text-gray-500">Pyronear</p>
+          <p className="font-data text-[10.5px] font-medium uppercase tracking-[0.14em] text-haze">
+            Pyronear
+          </p>
         </div>
       </div>
     </div>

--- a/frontend/tests/pages/LoginPage.test.tsx
+++ b/frontend/tests/pages/LoginPage.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LoginPage from '@/pages/LoginPage';
+
+describe('LoginPage', () => {
+  it('renders the headline and task-focused tagline', () => {
+    render(<LoginPage onLogin={vi.fn()} />);
+    expect(screen.getByText('Sign in to PyroAnnotator')).toBeInTheDocument();
+    expect(
+      screen.getByText('Classify and localize wildfire smoke from Pyronear cameras.')
+    ).toBeInTheDocument();
+  });
+
+  it('shows the error message when provided', () => {
+    render(<LoginPage onLogin={vi.fn()} error="Invalid username or password" />);
+    expect(screen.getByText('Invalid username or password')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Restyle `/login` from the generic blue Tailwind template to the dashboard's visual system: flat `ash` background, `paper` card with `line` border (no drop shadow), Archivo headline at the dashboard h1 scale, `ember` submit button with the PhaseCard CTA idiom, `signal`/`signal-soft` error state, and the uppercase mono `Pyronear` footer label.
- Replace the tagline copy: "Wildfire detection annotation system" → "Classify and localize wildfire smoke from Pyronear cameras."
- Add `tests/pages/LoginPage.test.tsx` covering the headline/tagline copy and error rendering.
- Spec: `docs/specs/2026-08-03-login-page-restyle-design.md` (mockup reviewed and approved).

Visual-only change — props, state, handlers, and a11y attributes untouched.

## Test plan

- [x] `npm test` — 765 tests pass
- [x] `npm run type-check`, Prettier clean; ESLint clean on changed files (2 pre-existing `no-console` warnings in `DetectionSequenceAnnotatePage.tsx` untouched)
- [x] Screenshot of `/login` (empty + filled states) verified against the approved mockup