### PR TITLE
copy(frontend): rename Platform annotation to Alert API annotation

### DIFF
--- a/frontend/src/components/filters/FilterPopover.tsx
+++ b/frontend/src/components/filters/FilterPopover.tsx
@@ -286,7 +286,7 @@ export default function FilterPopover({
                     htmlFor="filter-wildfire"
                     className="block text-sm font-medium text-gray-700 mb-1"
                   >
-                    Wildfire Classification
+                    Alert API annotation
                   </label>
                   <select
                     id="filter-wildfire"

--- a/frontend/src/components/sequences/ClassifyDoneTable.tsx
+++ b/frontend/src/components/sequences/ClassifyDoneTable.tsx
@@ -41,7 +41,7 @@ export function ClassifyDoneTable({ sequences, onSequenceClick }: ClassifyDoneTa
             <th className={HEADER_CLASSES}>Camera</th>
             <th className={HEADER_CLASSES}>Organisation</th>
             <th className={HEADER_CLASSES}>Recorded</th>
-            <th className={HEADER_CLASSES}>Platform annotation</th>
+            <th className={HEADER_CLASSES}>Alert API annotation</th>
             <th className={HEADER_CLASSES}>Source</th>
             <th className={HEADER_CLASSES}>Azimuth</th>
             <th className={HEADER_CLASSES}>Result</th>

--- a/frontend/src/components/sequences/ClassifyQueueTable.tsx
+++ b/frontend/src/components/sequences/ClassifyQueueTable.tsx
@@ -23,7 +23,7 @@ export function ClassifyQueueTable({ sequences, onSequenceClick }: ClassifyQueue
             <th className={HEADER_CLASSES}>Camera</th>
             <th className={HEADER_CLASSES}>Organisation</th>
             <th className={HEADER_CLASSES}>Recorded</th>
-            <th className={HEADER_CLASSES}>Platform annotation</th>
+            <th className={HEADER_CLASSES}>Alert API annotation</th>
             <th className={HEADER_CLASSES}>Source</th>
             <th className={HEADER_CLASSES}>Azimuth</th>
           </tr>

--- a/frontend/src/utils/filterPills.ts
+++ b/frontend/src/utils/filterPills.ts
@@ -81,7 +81,7 @@ export function buildFilterPills(input: FilterPillInput): FilterPill[] {
       filters.is_wildfire_alertapi === null
         ? 'Unclassified'
         : (WILDFIRE_LABELS[filters.is_wildfire_alertapi] ?? String(filters.is_wildfire_alertapi));
-    pills.push({ id: 'wildfire', label: `Wildfire: ${label}` });
+    pills.push({ id: 'wildfire', label: `Alert API: ${label}` });
   }
   if (input.showModelAccuracy && input.selectedModelAccuracy !== 'all') {
     pills.push({

--- a/frontend/tests/components/filters/FilterPopover.test.tsx
+++ b/frontend/tests/components/filters/FilterPopover.test.tsx
@@ -56,7 +56,7 @@ describe('FilterPopover', () => {
     // 2 always-in-More widgets + model accuracy
     fireEvent.click(screen.getByRole('button', { name: /more filters \(3\)/i }));
     expect(screen.getByLabelText('Source API')).toBeInTheDocument();
-    expect(screen.getByLabelText('Wildfire Classification')).toBeInTheDocument();
+    expect(screen.getByLabelText('Alert API annotation')).toBeInTheDocument();
     expect(screen.getByText('Model Accuracy')).toBeInTheDocument();
     // Not enabled for this page:
     expect(screen.queryByLabelText('Certainty')).not.toBeInTheDocument();

--- a/frontend/tests/components/sequences/ClassifyDoneTable.test.tsx
+++ b/frontend/tests/components/sequences/ClassifyDoneTable.test.tsx
@@ -67,7 +67,7 @@ describe('ClassifyDoneTable', () => {
       'Camera',
       'Organisation',
       'Recorded',
-      'Platform annotation',
+      'Alert API annotation',
       'Source',
       'Azimuth',
       'Result',

--- a/frontend/tests/components/sequences/ClassifyQueueTable.test.tsx
+++ b/frontend/tests/components/sequences/ClassifyQueueTable.test.tsx
@@ -46,7 +46,7 @@ describe('ClassifyQueueTable', () => {
   it('renders the column headers', () => {
     render(<ClassifyQueueTable sequences={[createSequence()]} onSequenceClick={onSequenceClick} />);
 
-    for (const header of ['Camera', 'Organisation', 'Recorded', 'Platform annotation', 'Source', 'Azimuth']) {
+    for (const header of ['Camera', 'Organisation', 'Recorded', 'Alert API annotation', 'Source', 'Azimuth']) {
       expect(screen.getByText(header)).toBeInTheDocument();
     }
   });

--- a/frontend/tests/utils/filterPills.test.ts
+++ b/frontend/tests/utils/filterPills.test.ts
@@ -36,12 +36,12 @@ describe('buildFilterPills', () => {
     expect(pills).toEqual([{ id: 'source', label: 'Source: Alert API' }]);
   });
 
-  it('labels wildfire classification values, including null as Unclassified', () => {
+  it('labels alert API annotation values, including null as Unclassified', () => {
     expect(
       buildFilterPills({ ...baseInput, filters: { is_wildfire_alertapi: 'wildfire_smoke' } })
-    ).toEqual([{ id: 'wildfire', label: 'Wildfire: Wildfire Smoke' }]);
+    ).toEqual([{ id: 'wildfire', label: 'Alert API: Wildfire Smoke' }]);
     expect(buildFilterPills({ ...baseInput, filters: { is_wildfire_alertapi: null } })).toEqual([
-      { id: 'wildfire', label: 'Wildfire: Unclassified' },
+      { id: 'wildfire', label: 'Alert API: Unclassified' },
     ]);
   });
 


### PR DESCRIPTION
## Summary

Renames the user-facing copy for the `is_wildfire_alertapi` field, which previously surfaced under two different names:

- **Table headers** in `/classify` and `/classify/done`: "Platform annotation" → "Alert API annotation"
- **Filter popover label**: "Wildfire Classification" → "Alert API annotation", matching the column it filters
- **Active-filter pill prefix**: "Wildfire: …" → "Alert API: …"

Note: `FilterPopover` is shared with `/localize/done`, so the filter label is renamed there too, keeping the naming consistent across pages.

Code-internal identifiers (`PlatformAnnotationPill`, the `'wildfire'` pill id) are intentionally left unchanged — copy-only change.

## Test plan

- [x] Updated test assertions in `ClassifyQueueTable`, `ClassifyDoneTable`, `FilterPopover`, and `filterPills` tests
- [x] `npm test` — 763 tests pass
- [x] `npm run type-check` and `npm run format:check` clean (2 pre-existing lint warnings on main, unrelated)