### PR TITLE
feat(localize): branded empty states for /localize and /localize/done

### DIFF
--- a/docs/specs/2026-08-03-localize-empty-states-design.md
+++ b/docs/specs/2026-08-03-localize-empty-states-design.md
@@ -1,0 +1,78 @@
+# Localize Empty States Redesign
+
+**Date:** 2026-08-03
+**Pages:** `/localize` (`DetectionAnnotatePage`), `/localize/done` (`DetectionReviewPage`)
+
+## Problem
+
+Both localize pages render bare-text empty states in generic Tailwind grays,
+disconnected from the branded design system (Archivo display font, char/haze
+text, ember/pine accents) used on the dashboard. The `/localize/done` filtered
+state uses a 🔍 emoji. Copy leaks engineering vocabulary ("the auto reference
+layer is computed") and offers no next action.
+
+## Design
+
+All three empty states share one visual pattern, consistent with the dashboard:
+a 56px circular icon badge, an Archivo (`font-display`) semibold headline in
+`char`, body copy in `haze`, and one action button. Layout stays centered in
+the existing `min-h-96` stage. Loading and error states are untouched.
+
+### 1. `/localize` — queue empty
+
+An empty queue means the annotator is done: frame it as success.
+
+- **Icon:** `Check` (lucide) in `pine` on a `pine-soft` circle
+- **Headline:** "Localization queue is clear"
+- **Body:** "Nice work — nothing to box right now. Classifying more alerts is
+  what fills this queue."
+- **CTA:** "Start classifying" → `ROUTES.CLASSIFY`. Solid `pine` button styled
+  like the dashboard `PhaseCard` CTA (white text, rounded-lg,
+  hover:brightness-95, focus ring).
+
+### 2. `/localize/done` — no filters, nothing localized yet
+
+A review list with nothing reviewed is a "work to do" state, not a success —
+ember accent.
+
+- **Icon:** `BoxSelect` (lucide, dashed rectangle) in `ember` on an
+  `ember-soft` circle
+- **Headline:** "No localized alerts yet"
+- **Body:** "Finished localizations show up here for review. Head to the queue
+  to box your first alert."
+- **CTA:** "Start localizing" → `ROUTES.LOCALIZE`. Solid `ember` button, same
+  button treatment as above.
+
+### 3. `/localize/done` — filters active, no matches
+
+Neutral, replaces the emoji; the action actually clears filters instead of
+telling the user to adjust them.
+
+- **Icon:** `Search` (lucide) in `haze` on a white circle with `line` border
+- **Headline:** "No matching alerts"
+- **Body:** "Nothing localized matches your current filters. Loosen or clear
+  them to see more."
+- **Action:** "Clear filters" ghost button (white bg, `line` border, `char`
+  text) wired to the page's existing `resetFilters`.
+
+## Implementation notes
+
+- Icons come from `lucide-react` (already a dependency); no new packages.
+- CTAs are React Router `<Link>`s; "Clear filters" is a `<button>` calling
+  `resetFilters`.
+- The three states are small enough to inline in their pages, matching how the
+  current empty states are written. No shared component unless a third page
+  needs the pattern later.
+- Filter detection on `/localize/done` keeps using the existing
+  `hasActiveUserFilters` logic; only the rendered markup changes.
+
+## Testing
+
+- Update `tests/components/dashboard/DetectionAnnotatePage.test.tsx` (asserts
+  the old "No alerts ready for localization" text) to the new headline, and
+  assert the CTA links to `/classify`.
+- Add coverage for the `/localize/done` states if a rendering test exists for
+  that page; `DetectionReviewPage.defaults.test.ts` is logic-only, so a new
+  test is optional — at minimum verify "Clear filters" calls `resetFilters`
+  if a page-level test harness is practical.
+- `npm run quality` passes.

--- a/docs/specs/2026-08-03-localize-empty-states-design.md
+++ b/docs/specs/2026-08-03-localize-empty-states-design.md
@@ -75,4 +75,6 @@ telling the user to adjust them.
   that page; `DetectionReviewPage.defaults.test.ts` is logic-only, so a new
   test is optional — at minimum verify "Clear filters" calls `resetFilters`
   if a page-level test harness is practical.
-- `npm run quality` passes.
+- `npm run quality` passes for the touched files. (Repo-wide lint currently
+  fails on two pre-existing `console.debug` warnings in
+  `DetectionSequenceAnnotatePage.tsx`, present on `main` and out of scope.)

--- a/frontend/src/pages/DetectionAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionAnnotatePage.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Check, ChevronLeft, ChevronRight } from 'lucide-react';
 import { apiClient } from '@/services/api';
 import { LocalizationQueueItem } from '@/types/api';
 import DetectionImageThumbnail from '@/components/DetectionImageThumbnail';
 import { laneNeedsLocalization, pickNextLocalizeLane } from '@/utils/annotation/localizeUtils';
 import { formatSmokeType, getSmokeTypeEmoji } from '@/utils/modelAccuracy';
-import { localizeDetail } from '@/utils/routes';
+import { localizeDetail, ROUTES } from '@/utils/routes';
 
 // Images the annotator will draw boxes on: each smoke object replays the
 // alert's frames, so two objects x 10 frames is 20 boxes of work.
@@ -81,12 +81,23 @@ export default function DetectionAnnotatePage() {
 
       {items.length === 0 ? (
         <div className="flex items-center justify-center min-h-96">
-          <div className="text-center">
-            <p className="text-gray-900 font-medium">No alerts ready for localization</p>
-            <p className="mt-1 text-sm text-gray-500">
-              Alerts appear here once every object is classified and the auto reference layer is
-              computed
+          <div className="text-center max-w-md">
+            <span className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-pine-soft">
+              <Check className="h-7 w-7 text-pine" />
+            </span>
+            <p className="mt-4 font-display text-base font-semibold text-char">
+              Localization queue is clear
             </p>
+            <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
+              Nice work — nothing to box right now. Classifying more alerts is what fills this
+              queue.
+            </p>
+            <Link
+              to={ROUTES.CLASSIFY}
+              className="mt-5 inline-block rounded-lg bg-pine px-7 py-2.5 font-body text-[13.5px] font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2"
+            >
+              Start classifying
+            </Link>
           </div>
         </div>
       ) : (

--- a/frontend/src/pages/DetectionAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionAnnotatePage.tsx
@@ -82,12 +82,15 @@ export default function DetectionAnnotatePage() {
       {items.length === 0 ? (
         <div className="flex items-center justify-center min-h-96">
           <div className="text-center max-w-md">
-            <span className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-pine-soft">
+            <span
+              aria-hidden="true"
+              className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-pine-soft"
+            >
               <Check className="h-7 w-7 text-pine" />
             </span>
-            <p className="mt-4 font-display text-base font-semibold text-char">
+            <h2 className="mt-4 font-display text-base font-semibold text-char">
               Localization queue is clear
-            </p>
+            </h2>
             <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
               Nice work — nothing to box right now. Classifying more alerts is what fills this
               queue.

--- a/frontend/src/pages/DetectionReviewPage.tsx
+++ b/frontend/src/pages/DetectionReviewPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import { BoxSelect, Search } from 'lucide-react';
 import { apiClient } from '@/services/api';
 import {
   ExtendedSequenceFilters,
@@ -22,7 +23,7 @@ import { useSourceApis } from '@/hooks/useSourceApis';
 import { usePersistedFilters, createDefaultFilterState } from '@/hooks/usePersistedFilters';
 import { calculatePresetDateRange } from '@/components/filters/shared/dateRangeUtils';
 import { hasActiveUserFilters } from '@/utils/filterHelpers';
-import { localizeDetail } from '@/utils/routes';
+import { localizeDetail, ROUTES } from '@/utils/routes';
 
 // Default filter contract for /localize/done — imported by its defaults test.
 // eslint-disable-next-line react-refresh/only-export-components
@@ -271,24 +272,46 @@ export default function DetectionReviewPage() {
 
         {/* Empty state message */}
         <div className="flex items-center justify-center min-h-96">
-          <div className="text-center">
+          <div className="text-center max-w-md">
             {hasFilters ? (
               // Filtered results - no matches
               <>
-                <div className="text-4xl mb-4">🔍</div>
-                <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                  No matching sequences found
-                </h3>
-                <p className="text-gray-500 mb-4">
-                  No sequences with completed detection annotations match your current filters.
+                <span className="inline-flex h-14 w-14 items-center justify-center rounded-full border border-line bg-white">
+                  <Search className="h-6 w-6 text-haze" />
+                </span>
+                <p className="mt-4 font-display text-base font-semibold text-char">
+                  No matching alerts
                 </p>
-                <p className="text-gray-400 text-sm">Try adjusting your search criteria above.</p>
+                <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
+                  Nothing localized matches your current filters. Loosen or clear them to see more.
+                </p>
+                <button
+                  onClick={resetFilters}
+                  className="mt-5 inline-block rounded-lg border border-line bg-white px-7 py-2.5 font-body text-[13.5px] font-semibold text-char hover:bg-ash focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2"
+                >
+                  Clear filters
+                </button>
               </>
             ) : (
-              // No filters - no sequences available
-              <p className="text-gray-500">
-                No sequences with completed detection annotations to review at the moment.
-              </p>
+              // No filters - nothing localized yet
+              <>
+                <span className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-ember-soft">
+                  <BoxSelect className="h-6 w-6 text-ember" />
+                </span>
+                <p className="mt-4 font-display text-base font-semibold text-char">
+                  No localized alerts yet
+                </p>
+                <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
+                  Finished localizations show up here for review. Head to the queue to box your
+                  first alert.
+                </p>
+                <Link
+                  to={ROUTES.LOCALIZE}
+                  className="mt-5 inline-block rounded-lg bg-ember px-7 py-2.5 font-body text-[13.5px] font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2"
+                >
+                  Start localizing
+                </Link>
+              </>
             )}
           </div>
         </div>

--- a/frontend/src/pages/DetectionReviewPage.tsx
+++ b/frontend/src/pages/DetectionReviewPage.tsx
@@ -276,12 +276,15 @@ export default function DetectionReviewPage() {
             {hasFilters ? (
               // Filtered results - no matches
               <>
-                <span className="inline-flex h-14 w-14 items-center justify-center rounded-full border border-line bg-white">
+                <span
+                  aria-hidden="true"
+                  className="inline-flex h-14 w-14 items-center justify-center rounded-full border border-line bg-white"
+                >
                   <Search className="h-6 w-6 text-haze" />
                 </span>
-                <p className="mt-4 font-display text-base font-semibold text-char">
+                <h2 className="mt-4 font-display text-base font-semibold text-char">
                   No matching alerts
-                </p>
+                </h2>
                 <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
                   Nothing localized matches your current filters. Loosen or clear them to see more.
                 </p>
@@ -295,12 +298,15 @@ export default function DetectionReviewPage() {
             ) : (
               // No filters - nothing localized yet
               <>
-                <span className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-ember-soft">
+                <span
+                  aria-hidden="true"
+                  className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-ember-soft"
+                >
                   <BoxSelect className="h-6 w-6 text-ember" />
                 </span>
-                <p className="mt-4 font-display text-base font-semibold text-char">
+                <h2 className="mt-4 font-display text-base font-semibold text-char">
                   No localized alerts yet
-                </p>
+                </h2>
                 <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
                   Finished localizations show up here for review. Head to the queue to box your
                   first alert.

--- a/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
+++ b/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
@@ -154,7 +154,7 @@ describe('DetectionAnnotatePage (Localize queue)', () => {
     expect(navigateMock).toHaveBeenCalledWith('/localize/11');
   });
 
-  it('shows an empty state when the queue is empty', async () => {
+  it('shows an all-caught-up empty state linking to the classify queue', async () => {
     vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue({
       items: [],
       page: 1,
@@ -163,6 +163,11 @@ describe('DetectionAnnotatePage (Localize queue)', () => {
       total: 0,
     });
     render(<DetectionAnnotatePage />, { wrapper });
-    await waitFor(() => expect(screen.getByText(/No alerts ready for localization/)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText('Localization queue is clear')).toBeTruthy());
+    expect(screen.getByText(/Classifying more alerts is what fills this queue/)).toBeTruthy();
+    const cta = screen.getByRole('link', { name: 'Start classifying' });
+    expect(cta.getAttribute('href')).toBe('/classify');
+    // Old copy is gone
+    expect(screen.queryByText(/No alerts ready for localization/)).toBeNull();
   });
 });

--- a/frontend/tests/pages/DetectionReviewPage.empty.test.tsx
+++ b/frontend/tests/pages/DetectionReviewPage.empty.test.tsx
@@ -28,7 +28,10 @@ vi.mock('@/hooks/usePersistedFilters', async importOriginal => {
   const actual = await importOriginal<typeof import('@/hooks/usePersistedFilters')>();
   return {
     ...actual,
-    usePersistedFilters: (key: string, defaultState: { filters: object }) => ({
+    usePersistedFilters: (
+      _key: string,
+      defaultState: Parameters<typeof actual.usePersistedFilters>[1]
+    ): ReturnType<typeof actual.usePersistedFilters> => ({
       filters: { ...defaultState.filters },
       dateFrom: '',
       dateTo: '',

--- a/frontend/tests/pages/DetectionReviewPage.empty.test.tsx
+++ b/frontend/tests/pages/DetectionReviewPage.empty.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+
+vi.mock('@/services/api', () => ({
+  apiClient: {
+    getSequences: vi.fn(),
+    getSequenceAnnotations: vi.fn(),
+  },
+}));
+
+vi.mock('@/hooks/useCameras', () => ({
+  useCameras: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('@/hooks/useOrganizations', () => ({
+  useOrganizations: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('@/hooks/useSourceApis', () => ({
+  useSourceApis: () => ({ data: [], isLoading: false }),
+}));
+
+const resetFiltersMock = vi.fn();
+let mockedSmokeTypes: string[] = [];
+
+vi.mock('@/hooks/usePersistedFilters', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/usePersistedFilters')>();
+  return {
+    ...actual,
+    usePersistedFilters: (key: string, defaultState: { filters: object }) => ({
+      filters: { ...defaultState.filters },
+      dateFrom: '',
+      dateTo: '',
+      selectedFalsePositiveTypes: [],
+      selectedSmokeTypes: mockedSmokeTypes,
+      selectedModelAccuracy: 'all',
+      setFilters: vi.fn(),
+      setDateFrom: vi.fn(),
+      setDateTo: vi.fn(),
+      setSelectedFalsePositiveTypes: vi.fn(),
+      setSelectedSmokeTypes: vi.fn(),
+      setSelectedModelAccuracy: vi.fn(),
+      resetFilters: resetFiltersMock,
+    }),
+  };
+});
+
+import { apiClient } from '@/services/api';
+import DetectionReviewPage from '@/pages/DetectionReviewPage';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const emptyPage = { items: [], page: 1, pages: 0, size: 50, total: 0 };
+
+describe('DetectionReviewPage empty states', () => {
+  beforeEach(() => {
+    resetFiltersMock.mockClear();
+    mockedSmokeTypes = [];
+    vi.mocked(apiClient.getSequences).mockResolvedValue(emptyPage);
+    vi.mocked(apiClient.getSequenceAnnotations).mockResolvedValue(emptyPage);
+  });
+
+  it('without filters, shows nothing-localized-yet state linking to the localize queue', async () => {
+    render(<DetectionReviewPage />, { wrapper });
+    await waitFor(() => expect(screen.getByText('No localized alerts yet')).toBeTruthy());
+    expect(screen.getByText(/Finished localizations show up here for review/)).toBeTruthy();
+    const cta = screen.getByRole('link', { name: 'Start localizing' });
+    expect(cta.getAttribute('href')).toBe('/localize');
+  });
+
+  it('with active filters, shows no-matches state and Clear filters resets them', async () => {
+    mockedSmokeTypes = ['wildfire'];
+    render(<DetectionReviewPage />, { wrapper });
+    await waitFor(() => expect(screen.getByText('No matching alerts')).toBeTruthy());
+    expect(screen.getByText(/matches your current filters/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    expect(resetFiltersMock).toHaveBeenCalledTimes(1);
+    // Old emoji state is gone
+    expect(screen.queryByText('🔍')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the three bare-text empty states on the Localize pages with branded empty states (icon badge + headline + body + action), consistent with the dashboard design system. Design spec: `docs/specs/2026-08-03-localize-empty-states-design.md`.

- **/localize (queue empty)** — an empty queue means the annotator is caught up, so it reads as success: pine check badge, "Localization queue is clear", and a "Start classifying" CTA to `/classify` (the step that feeds this queue).
- **/localize/done (nothing localized yet)** — a review list with nothing reviewed is a work-to-do state: ember dashed-box badge, "No localized alerts yet", "Start localizing" CTA to `/localize`.
- **/localize/done (filters exclude everything)** — replaces the 🔍 emoji with a neutral search badge and a functional "Clear filters" button wired to the page's existing `resetFilters`.

Copy drops the engineering vocabulary ("the auto reference layer is computed") and CTA labels match the dashboard ("Start classifying" / "Start localizing"). No new dependencies — icons from `lucide-react`, colors/typography from existing Tailwind tokens.

## Test plan

- Updated the `/localize` empty-state test: new headline, CTA href, old copy absent.
- New `DetectionReviewPage.empty.test.tsx`: both `/localize/done` states, including "Clear filters" calling `resetFilters`.
- Full suite: 770 passed (768 baseline + 2 new). `type-check` and `format:check` clean; lint clean on all touched files (the repo-wide lint failure is pre-existing `console.debug`s in `DetectionSequenceAnnotatePage.tsx`, untouched here).