### PR TITLE
Codify frontend design guidelines (fire-lookout system)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ runs
 .DS_Store
 **annotation_api/outputs
 .claude/
+
+# Superpowers brainstorming sessions
+.superpowers/

--- a/docs/specs/2026-08-03-frontend-design-guidelines-design.md
+++ b/docs/specs/2026-08-03-frontend-design-guidelines-design.md
@@ -1,0 +1,175 @@
+# Frontend Design Guidelines — Design
+
+**Date:** 2026-08-03
+**Status:** Approved
+
+## Problem
+
+The frontend has a coherent visual language — the "fire-lookout" system used by
+/dashboard, /users, the sign-in page, and /guide — but it is not written down
+anywhere canonical. Design intent lives scattered across 8+ per-feature specs
+(`2026-07-28-dashboard-taxonomy-redesign-design.md` being the closest thing to
+a source of truth). Meanwhile the rest of the app still runs on the legacy
+palette (~680 `gray-*` usages vs ~26 `ember`), three different primary button
+styles coexist, `src/index.css` sets a global base that contradicts the new
+look, and a dead `.btn-primary`/`.card` component layer sits unused on the old
+palette.
+
+## Decision
+
+Codify the fire-lookout system into a canonical guidelines document plus a
+minimal token-layer cleanup. Migration of legacy pages is **not** part of this
+work — the doc's deprecation rule handles it incrementally as files are
+touched.
+
+Deliverables:
+
+1. `frontend/DESIGN.md` — the living guidelines document
+2. `frontend/CLAUDE.md` — one pointer line: read DESIGN.md before UI work
+3. `tailwind.config.js` — named tokens for the ad-hoc sizes
+4. `src/index.css` — flip the global base to the new look, remove dead classes
+5. Converted pages adopt the named tokens (mechanical, zero visual change)
+
+## The design language (content of DESIGN.md)
+
+### Palette
+
+Five neutrals, three accents; each accent has a `-soft` tint.
+
+| Role | Token | Hex | Usage rule |
+|---|---|---|---|
+| App background | `ash` | `#F7F6F3` | Pages sit on ash; cards never do |
+| Surface | `paper` | `#FFFFFF` | Cards, tables, modals |
+| Borders | `line` | `#E4E2DC` | All borders/dividers — hairlines instead of shadows; no `shadow-*` |
+| Ink | `char` | `#20261F` | Primary text, neutral emphasis, button focus rings |
+| Muted | `haze` | `#767B72` | Secondary text, icons, placeholders |
+| Action | `ember` / `ember-soft` | `#D9581E` / `#FBEFE8` | Primary CTAs everywhere + Classify lane identity |
+| Calm accent | `pine` / `pine-soft` | `#166A5D` / `#E9F2F0` | Localize lane identity, active nav, positive states |
+| Alert | `signal` / `signal-soft` | `#B3261E` / `#FBEEED` | Errors, destructive, attention **only** — never decorative |
+
+Rules:
+
+- One accent per element; accent color appears only where action or meaning lives.
+- `-soft` tints are used only as fills behind their own accent's text
+  (`bg-ember-soft text-ember`).
+- Hover on solid buttons is `hover:brightness-95`, never a darker shade.
+- Focus rings: `char` on buttons, `ember` on text inputs.
+- Legacy palettes (`primary-*`, `gray-*`, `blue/green/red/orange-*`) are
+  **deprecated: no new usage**. Migrate opportunistically when touching a file.
+
+### Typography
+
+Three families with strict roles (self-hosted via `@fontsource`, imported in
+`src/main.tsx`):
+
+- `font-display` (Archivo 600): page titles and card headings only
+- `font-body` (IBM Plex Sans 400/500/600): all copy, labels, buttons
+- `font-data` (IBM Plex Mono 500/600): every numeral, count, timestamp, stage
+  code, eyebrow, and table header — counts always mono
+
+Named type scale (new `fontSize` tokens):
+
+| Token | Size | Use |
+|---|---|---|
+| `text-title` | 27px | Page h1, with `font-display font-semibold tracking-tight` |
+| `text-heading` | 18.5px | Card h2, with `font-display font-semibold` |
+| `text-body` | 13.5px | Body copy (buttons use standard `text-sm`, per the recipes below) |
+| `text-detail` | 12.5px | Secondary text, usually `text-haze` |
+| `text-eyebrow` | 10.5px | Mono eyebrows and table headers |
+
+One-off sizes (e.g. the 38px dashboard numeral) stay as arbitrary values.
+
+Other tokens: `tracking-eyebrow` (0.14em), `rounded-card` (10px).
+
+The signature eyebrow recipe:
+`font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze`
+(tone color replaces `text-haze` when the eyebrow belongs to an accent
+section).
+
+### Component recipes
+
+DESIGN.md documents these as copyable class strings, sourced verbatim from the
+converted pages:
+
+- **Card**: `rounded-card border border-line bg-paper` — flat, no shadow
+- **Primary button**: `rounded-lg bg-ember px-4 py-2 font-body text-sm
+  font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2
+  focus:ring-char focus:ring-offset-2` (tone may be `pine` in Localize
+  contexts)
+- **Secondary button**: `rounded-lg border border-line bg-paper px-3 py-2
+  font-body text-sm font-medium text-char hover:bg-ash`
+- **Tertiary link**: `font-body text-detail text-haze hover:text-char` with a
+  trailing `→`
+- **Filter chip**: `rounded-full px-3 py-1 font-body text-xs font-medium`;
+  selected `bg-{tone}-soft text-{tone}`, unselected `bg-ash text-haze
+  hover:text-char`
+- **Badge/pill**: `inline-flex rounded-full px-2 py-1 font-body text-xs
+  font-semibold` + soft-tone pairs
+- **Table**: container `rounded-card border border-line bg-paper
+  overflow-hidden`; `divide-y divide-line`; `thead bg-ash`; `th` uses the
+  eyebrow recipe; row hover `hover:bg-ash`; date/count cells `font-data
+  text-detail text-haze`
+- **Input**: `border border-line rounded-lg font-body focus:outline-none
+  focus:ring-2 focus:ring-ember focus:border-ember`; icon well `text-haze`
+- **Error block**: `bg-signal-soft rounded-lg p-4` + `text-signal`
+- **Spinner**: `animate-spin rounded-full border-b-2 border-ember`
+- **Skeleton**: `animate-pulse rounded bg-ash`
+- **Progress bar**: track `h-1 rounded-sm bg-ash`, fill `bg-{tone}` with
+  inline width
+- **Left-bar accent**: `border-l-2 pl-3.5 border-{tone}` (nav uses
+  `border-l-[3px]`)
+
+DESIGN.md also includes a short "migrating a page" note pointing at
+`docs/specs/2026-08-03-login-page-restyle-design.md` for its before/after
+class-mapping table.
+
+## Code changes
+
+### `tailwind.config.js` (additive)
+
+- `fontSize`: `title: '27px'`, `heading: '18.5px'`, `body: '13.5px'`,
+  `detail: '12.5px'`, `eyebrow: '10.5px'`
+- `letterSpacing`: `eyebrow: '0.14em'`
+- `borderRadius`: `card: '10px'`
+- Legacy `primary` ramp stays (106 usages) with a
+  `// DEPRECATED — do not use in new code` comment
+
+### `src/index.css`
+
+- `html` font-family → `"IBM Plex Sans", system-ui, sans-serif`
+- `body` → `@apply bg-ash text-char antialiased` (was `bg-gray-50
+  text-gray-900`)
+- Delete the dead `.btn-primary` / `.btn-secondary` / `.input-primary` /
+  `.card` component layer (zero consumers, verified by grep)
+- Keep `.chevron-seg*`, `.sequence-player-image`, `.image-preload`,
+  `.animate-pulse-subtle`
+
+The base flip shifts every legacy page's background (`gray-50` → `ash`,
+near-identical) and default font (system-ui → IBM Plex Sans, visible) — this
+is intentional drift toward the new look. Minor layout shifts in annotation
+UIs from font metrics are acceptable.
+
+### Converted pages adopt named tokens
+
+Mechanical rename in `DashboardPage`, `UserManagementPage`, `LoginPage`,
+`GuidePage`, and `src/components/dashboard/*`: `text-[27px]` → `text-title`,
+`text-[18.5px]` → `text-heading`, `text-[13.5px]` → `text-body`,
+`text-[12.5px]` → `text-detail`, `text-[10.5px]` → `text-eyebrow`,
+`tracking-[0.14em]` → `tracking-eyebrow`, `rounded-[10px]` → `rounded-card`.
+Same pixel values, new names — zero visual change. Sizes outside the scale
+(11px, 11.5px, 13px, 38px, `tracking-[0.12em]`) stay arbitrary.
+
+## Verification
+
+- `npm run quality` passes (lint, type-check, tests)
+- Screenshot check via the playwright recipe: /dashboard, /users, and login
+  render unchanged; one legacy page (e.g. /sequences) eyeballed to confirm the
+  base flip is acceptable
+
+## Out of scope
+
+- Migrating legacy pages, modals, or the app chrome (`AppLayout`)
+- Shared React components (Button, Card, Badge primitives)
+- Dark mode
+- `src/utils/processingStage.ts` / `src/utils/modelAccuracy.ts` badge maps
+  (legacy-palette consumers; handled during future migration)

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -2,6 +2,10 @@
 
 React/TypeScript SPA for annotating wildfire detection sequences against the PyroAnnotator API.
 
+**Before any UI work, read [DESIGN.md](./DESIGN.md)** — the design guidelines
+(palette, typography, component recipes). New code uses the fire-lookout
+tokens; the legacy `gray-*` / `primary-*` palettes are deprecated.
+
 ## Stack
 - React 18 + TypeScript, Vite 5
 - Tailwind CSS 3, Headless UI, Lucide icons

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -1,0 +1,160 @@
+# Design Guidelines — the fire-lookout system
+
+The canonical visual language for the PyroAnnotator frontend. Reference
+implementations: `src/pages/DashboardPage.tsx`, `src/pages/UserManagementPage.tsx`,
+`src/pages/LoginPage.tsx`, `src/pages/GuidePage.tsx`.
+
+**The rule for new code:** use only the tokens and recipes below. The legacy
+palettes (`primary-*`, `gray-*`, `blue/green/red/orange-*`) are **deprecated —
+no new usage**. When touching a legacy file, migrate the parts you touch.
+
+## Palette
+
+Five neutrals, three accents. Each accent has a `-soft` tint.
+
+| Role | Token | Hex | Usage rule |
+|---|---|---|---|
+| App background | `ash` | `#F7F6F3` | Pages sit on ash (set globally on `body`); cards never do |
+| Surface | `paper` | `#FFFFFF` | Cards, tables, modals |
+| Borders | `line` | `#E4E2DC` | All borders/dividers — hairlines instead of shadows; no `shadow-*` |
+| Ink | `char` | `#20261F` | Primary text, neutral emphasis, button focus rings |
+| Muted | `haze` | `#767B72` | Secondary text, icons, placeholders |
+| Action | `ember` / `ember-soft` | `#D9581E` / `#FBEFE8` | Primary CTAs everywhere + Classify lane identity |
+| Calm accent | `pine` / `pine-soft` | `#166A5D` / `#E9F2F0` | Localize lane identity, active nav, positive states |
+| Alert | `signal` / `signal-soft` | `#B3261E` / `#FBEEED` | Errors, destructive, attention **only** — never decorative |
+
+Rules:
+
+- One accent per element; accent color appears only where action or meaning lives.
+- `-soft` tints are only fills behind their own accent's text: `bg-ember-soft text-ember`.
+- Hover on solid buttons is `hover:brightness-95`, never a darker shade.
+- Focus rings: `focus:ring-char` on buttons, `focus:ring-ember` on text inputs.
+
+## Typography
+
+Three families with strict roles (self-hosted via `@fontsource`, imported in
+`src/main.tsx`):
+
+- `font-display` — Archivo 600. Page titles and card headings **only**.
+- `font-body` — IBM Plex Sans 400/500/600. All copy, labels, buttons. Also the
+  global default (set on `html`).
+- `font-data` — IBM Plex Mono 500/600. Every numeral, count, timestamp, stage
+  code, eyebrow, and table header. **Counts always mono.**
+
+Named type scale:
+
+| Token | Size | Use |
+|---|---|---|
+| `text-title` | 27px | Page h1: `font-display text-title font-semibold tracking-tight text-char` |
+| `text-heading` | 18.5px | Card h2: `font-display text-heading font-semibold text-char` |
+| `text-body` | 13.5px | Body copy (buttons use standard `text-sm`) |
+| `text-detail` | 12.5px | Secondary text, usually `text-haze` |
+| `text-eyebrow` | 10.5px | Mono eyebrows and table headers |
+
+Other tokens: `tracking-eyebrow` (0.14em), `rounded-card` (10px). One-off
+sizes (e.g. the 38px dashboard numeral, `tracking-[0.12em]` in tight strips)
+stay as arbitrary values.
+
+**The signature eyebrow** — small mono uppercase label above headings and in
+table headers:
+
+```
+font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze
+```
+
+Swap `text-haze` for the section's accent (`text-ember`, `text-pine`) when the
+eyebrow belongs to an accent-toned block.
+
+## Component recipes
+
+Copy these class strings; don't improvise variants.
+
+**Card** — flat, border-defined, no shadow:
+
+```
+rounded-card border border-line bg-paper px-[22px] py-5
+```
+
+**Primary button** (tone is `ember` by default; `pine` in Localize contexts):
+
+```
+inline-flex items-center rounded-lg bg-ember px-4 py-2 font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2
+```
+
+**Secondary button**:
+
+```
+inline-flex items-center rounded-lg border border-line bg-paper px-3 py-2 font-body text-sm font-medium text-char hover:bg-ash
+```
+
+**Tertiary link** (trailing `→` in the label):
+
+```
+font-body text-detail text-haze hover:text-char
+```
+
+**Filter chip** (selected / unselected):
+
+```
+inline-flex items-center rounded-full px-3 py-1 font-body text-xs font-medium transition-colors
+  selected:   bg-pine-soft text-pine   (or ember/signal variants)
+  unselected: bg-ash text-haze hover:text-char
+```
+
+**Badge / pill**:
+
+```
+inline-flex rounded-full px-2 py-1 font-body text-xs font-semibold
+  positive:  bg-pine-soft text-pine
+  attention: bg-signal-soft text-signal
+  action:    bg-ember-soft text-ember
+  neutral:   bg-ash text-haze
+```
+
+**Table**:
+
+```
+container: rounded-card border border-line bg-paper overflow-hidden
+table:     min-w-full divide-y divide-line
+thead:     bg-ash
+th:        px-6 py-3 text-left font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze
+tbody:     bg-paper divide-y divide-line
+row hover: hover:bg-ash
+cells:     px-6 py-4 whitespace-nowrap; primary cell font-body text-sm font-medium text-char;
+           dates/counts font-data text-detail text-haze
+```
+
+**Input** (icon well: `absolute inset-y-0 left-0 pl-3` with `h-5 w-5 text-haze`):
+
+```
+block w-full px-3 py-3 font-body border border-line rounded-lg focus:outline-none focus:ring-2 focus:ring-ember focus:border-ember transition-colors
+```
+
+**Error block**:
+
+```
+bg-signal-soft rounded-lg p-4    +    font-body text-sm text-signal
+```
+
+**Spinner**: `animate-spin rounded-full h-8 w-8 border-b-2 border-ember`
+
+**Skeleton**: `animate-pulse rounded bg-ash`
+
+**Progress bar**: track `h-1 overflow-hidden rounded-sm bg-ash`, fill
+`h-full bg-ember` (or `bg-pine`) with inline `style={{ width: pct }}`.
+
+**Left-bar accent** (section markers; nav uses `border-l-[3px]`):
+
+```
+border-l-2 pl-3.5 border-ember   (or border-pine / border-char)
+```
+
+## Migrating a legacy page
+
+Work class-by-class: `gray-50 → ash`, `white → paper`, `gray-200/300 borders →
+line`, `gray-900 → char`, `gray-500/600 → haze`, `primary-600 buttons → the
+primary button recipe`, `blue/green/red badges → the badge recipe`, drop all
+`shadow-*`. See `docs/specs/2026-08-03-login-page-restyle-design.md` for a
+worked before/after mapping table, and
+`docs/specs/2026-07-28-dashboard-taxonomy-redesign-design.md` for the original
+system rationale.

--- a/frontend/src/components/dashboard/HowItWorks.tsx
+++ b/frontend/src/components/dashboard/HowItWorks.tsx
@@ -23,8 +23,8 @@ const STEPS = [
 
 export default function HowItWorks() {
   return (
-    <div className="rounded-[10px] border border-line bg-paper px-[22px] py-5">
-      <h2 className="mb-3 font-data text-[10.5px] font-medium uppercase tracking-[0.14em] text-haze">
+    <div className="rounded-card border border-line bg-paper px-[22px] py-5">
+      <h2 className="mb-3 font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
         How annotation works
       </h2>
       <p className="mb-3.5 font-body text-[13px] leading-relaxed text-char">
@@ -35,15 +35,15 @@ export default function HowItWorks() {
         {STEPS.map(step => (
           <div key={step.key} className={`flex-1 border-l-2 pl-3.5 ${step.border}`}>
             <div
-              className={`mb-1 font-data text-[10.5px] font-medium uppercase tracking-[0.12em] ${step.text}`}
+              className={`mb-1 font-data text-eyebrow font-medium uppercase tracking-[0.12em] ${step.text}`}
             >
               {step.key}
             </div>
-            <p className="font-body text-[12.5px] leading-relaxed text-haze">{step.body}</p>
+            <p className="font-body text-detail leading-relaxed text-haze">{step.body}</p>
           </div>
         ))}
       </div>
-      <div className="flex items-baseline border-t border-line pt-3 font-body text-[12.5px] italic text-haze">
+      <div className="flex items-baseline border-t border-line pt-3 font-body text-detail italic text-haze">
         Why two passes? Classifying is quick and filters out false positives early, so the slower
         localization work is only spent on confirmed smoke.
         <Link

--- a/frontend/src/components/dashboard/PhaseCard.tsx
+++ b/frontend/src/components/dashboard/PhaseCard.tsx
@@ -44,15 +44,15 @@ export default function PhaseCard({
   const pct = total > 0 ? Math.round((done / total) * 100) : 0;
 
   return (
-    <div className="flex-1 rounded-[10px] border border-line bg-paper px-[22px] py-5">
+    <div className="flex-1 rounded-card border border-line bg-paper px-[22px] py-5">
       <div
-        className={`mb-2.5 flex items-center gap-2 font-data text-[10.5px] font-medium uppercase tracking-[0.14em] ${t.text}`}
+        className={`mb-2.5 flex items-center gap-2 font-data text-eyebrow font-medium uppercase tracking-eyebrow ${t.text}`}
       >
         <span className={`h-2 w-2 rounded-full ${t.dot}`} aria-hidden />
         Pass {pass} — {passLabel}
       </div>
-      <h2 className="font-display text-[18.5px] font-semibold text-char">{title}</h2>
-      <p className="mb-4 font-body text-[12.5px] text-haze">{description}</p>
+      <h2 className="font-display text-heading font-semibold text-char">{title}</h2>
+      <p className="mb-4 font-body text-detail text-haze">{description}</p>
       {isLoading ? (
         <div className="mx-auto h-10 w-24 animate-pulse rounded bg-ash" />
       ) : (
@@ -76,13 +76,13 @@ export default function PhaseCard({
       </p>
       <Link
         to={ctaTo}
-        className={`mx-auto block w-fit rounded-lg ${t.bg} px-7 py-2.5 font-body text-[13.5px] font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2`}
+        className={`mx-auto block w-fit rounded-lg ${t.bg} px-7 py-2.5 font-body text-body font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2`}
       >
         {ctaLabel}
       </Link>
       <div className="mt-4 flex items-center justify-between border-t border-line pt-3">
         {secondaryLink && secondaryLink.count > 0 ? (
-          <Link to={secondaryLink.to} className="font-body text-[12.5px] text-haze hover:text-char">
+          <Link to={secondaryLink.to} className="font-body text-detail text-haze hover:text-char">
             {secondaryLink.label} ·{' '}
             <span className="font-semibold text-char">{secondaryLink.count.toLocaleString()}</span>
           </Link>
@@ -91,7 +91,7 @@ export default function PhaseCard({
         )}
         {/* No count on the review link: the review page opens on its own persisted
             stage tab, so any single number here would disagree with what it shows. */}
-        <Link to={reviewTo} className="font-body text-[12.5px] text-haze hover:text-char">
+        <Link to={reviewTo} className="font-body text-detail text-haze hover:text-char">
           {reviewLabel} →
         </Link>
       </div>

--- a/frontend/src/components/dashboard/PipelineStrip.tsx
+++ b/frontend/src/components/dashboard/PipelineStrip.tsx
@@ -21,7 +21,7 @@ function Segment({ first, toneClass, label, count, detail, isLoading }: SegmentP
       className={`${first ? 'chevron-seg-first' : 'chevron-seg'} flex-1 bg-paper px-5 py-3.5 text-center md:px-8`}
     >
       <div
-        className={`font-data text-[10.5px] font-medium uppercase tracking-[0.12em] ${toneClass} mb-1`}
+        className={`font-data text-eyebrow font-medium uppercase tracking-[0.12em] ${toneClass} mb-1`}
       >
         {label}
       </div>

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -150,7 +150,7 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
           {navigationWithBadges.map(item => {
             return (
               <div key={item.name}>
-                <div className="px-4 font-data text-[10.5px] font-medium uppercase tracking-[0.14em] text-haze">
+                <div className="px-4 font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
                   {item.name}
                 </div>
                 <div className="mt-1">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,31 +4,15 @@
 
 @layer base {
   html {
-    font-family: system-ui, sans-serif;
+    font-family: 'IBM Plex Sans', system-ui, sans-serif;
   }
 
   body {
-    @apply bg-gray-50 text-gray-900 antialiased;
+    @apply bg-ash text-char antialiased;
   }
 }
 
 @layer components {
-  .btn-primary {
-    @apply inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors duration-200;
-  }
-
-  .btn-secondary {
-    @apply inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors duration-200;
-  }
-
-  .input-primary {
-    @apply block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm;
-  }
-
-  .card {
-    @apply bg-white rounded-lg border border-gray-200 shadow-sm;
-  }
-
   /* GPU-accelerated image transitions for sequence player */
   .sequence-player-image {
     transform: translateZ(0);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -9,10 +9,10 @@ export default function DashboardPage() {
 
   return (
     <div className="mx-auto max-w-5xl">
-      <h1 className="font-display text-[27px] font-semibold tracking-tight text-char">
+      <h1 className="font-display text-title font-semibold tracking-tight text-char">
         Annotation pipeline
       </h1>
-      <p className="mt-1 font-body text-[13.5px] text-haze">
+      <p className="mt-1 font-body text-body text-haze">
         Two passes: classify what the cameras saw, then localize the smoke.
       </p>
 

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -3,19 +3,19 @@ import { Link } from 'react-router-dom';
 export default function GuidePage() {
   return (
     <div className="mx-auto max-w-3xl">
-      <Link to="/" className="font-body text-[12.5px] text-haze hover:text-char">
+      <Link to="/" className="font-body text-detail text-haze hover:text-char">
         ← Back to dashboard
       </Link>
-      <h1 className="mt-2 font-display text-[27px] font-semibold tracking-tight text-char">
+      <h1 className="mt-2 font-display text-title font-semibold tracking-tight text-char">
         Field guide
       </h1>
-      <p className="mb-8 mt-1 font-body text-[13.5px] text-haze">
+      <p className="mb-8 mt-1 font-body text-body text-haze">
         How a detection sequence becomes training data, and what to do at each pass.
       </p>
 
       <section className="mb-8">
         <h2 className="mb-2 font-display text-lg font-semibold text-char">The pipeline</h2>
-        <p className="font-body text-[13.5px] leading-relaxed text-char">
+        <p className="font-body text-body leading-relaxed text-char">
           Wildfire cameras send detection sequences to the platform. Every sequence travels the same
           path: it is classified first, then localized, and is complete when both passes are done.
           Classifying is quick and filters out false positives early, so the slower localization
@@ -27,13 +27,13 @@ export default function GuidePage() {
         <h2 className="mb-2 font-display text-lg font-semibold text-ember">
           Pass 01 — Classify sequences
         </h2>
-        <p className="mb-2 font-body text-[13.5px] leading-relaxed text-char">
+        <p className="mb-2 font-body text-body leading-relaxed text-char">
           Watch the sequence and decide what each highlighted track really is: wildfire smoke, other
           smoke (chimneys, agricultural burns), or a false positive (clouds, glare, dust, and
           similar). Flag any smoke the AI missed. This is a fast, whole-sequence judgment — when in
           doubt, mark the track unsure rather than guessing.
         </p>
-        <p className="font-body text-[13.5px] leading-relaxed text-haze">
+        <p className="font-body text-body leading-relaxed text-haze">
           Start from the dashboard’s “Start classifying” queue. Submitting moves the sequence to the
           Localize pass.
         </p>
@@ -43,12 +43,12 @@ export default function GuidePage() {
         <h2 className="mb-2 font-display text-lg font-semibold text-pine">
           Pass 02 — Localize smoke
         </h2>
-        <p className="mb-2 font-body text-[13.5px] leading-relaxed text-char">
+        <p className="mb-2 font-body text-body leading-relaxed text-char">
           For sequences that passed classification, draw a tight bounding box around the smoke in
           each image. Boxes should hug the visible plume — tight boxes make better training labels
           than generous ones.
         </p>
-        <p className="font-body text-[13.5px] leading-relaxed text-haze">
+        <p className="font-body text-body leading-relaxed text-haze">
           Start from the dashboard’s “Start localizing” queue. Finishing the last image completes
           the sequence.
         </p>
@@ -56,7 +56,7 @@ export default function GuidePage() {
 
       <section className="border-l-2 border-char pl-4">
         <h2 className="mb-2 font-display text-lg font-semibold text-char">Complete</h2>
-        <p className="font-body text-[13.5px] leading-relaxed text-char">
+        <p className="font-body text-body leading-relaxed text-char">
           Both passes done: the sequence’s labels are ready for dataset export and model training.
         </p>
       </section>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -29,16 +29,16 @@ export default function LoginPage({ onLogin, isLoading = false, error }: LoginPa
           <div className="flex justify-center">
             <img src={logoImg} alt="PyroAnnotator Logo" className="w-20 h-20 object-contain" />
           </div>
-          <h2 className="mt-6 font-display text-[27px] font-semibold tracking-tight text-char">
+          <h2 className="mt-6 font-display text-title font-semibold tracking-tight text-char">
             Sign in to PyroAnnotator
           </h2>
-          <p className="mt-2 font-body text-[13.5px] text-haze">
+          <p className="mt-2 font-body text-body text-haze">
             Classify and localize wildfire smoke from Pyronear cameras.
           </p>
         </div>
 
         {/* Login Form */}
-        <div className="bg-paper rounded-[10px] border border-line p-8">
+        <div className="bg-paper rounded-card border border-line p-8">
           <form className="space-y-6" onSubmit={handleSubmit}>
             {/* Error Message */}
             {error && (
@@ -170,7 +170,7 @@ export default function LoginPage({ onLogin, isLoading = false, error }: LoginPa
 
         {/* Footer */}
         <div className="text-center">
-          <p className="font-data text-[10.5px] font-medium uppercase tracking-[0.14em] text-haze">
+          <p className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
             Pyronear
           </p>
         </div>

--- a/frontend/src/pages/UserManagementPage.tsx
+++ b/frontend/src/pages/UserManagementPage.tsx
@@ -148,12 +148,10 @@ export default function UserManagementPage() {
       {/* Header */}
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="font-display text-[27px] font-semibold tracking-tight text-char">
+          <h1 className="font-display text-title font-semibold tracking-tight text-char">
             User Management
           </h1>
-          <p className="mt-1 font-body text-[13.5px] text-haze">
-            Manage user accounts and permissions
-          </p>
+          <p className="mt-1 font-body text-body text-haze">Manage user accounts and permissions</p>
         </div>
         <div className="flex items-center gap-3">
           <button
@@ -180,7 +178,7 @@ export default function UserManagementPage() {
 
       {/* Filter Options */}
       {showFilters && (
-        <div className="rounded-[10px] border border-line bg-paper p-4">
+        <div className="rounded-card border border-line bg-paper p-4">
           <div className="flex flex-wrap gap-2">
             <button
               onClick={() => toggleFilter('is_active', true)}
@@ -222,24 +220,24 @@ export default function UserManagementPage() {
       )}
 
       {/* Users List */}
-      <div className="rounded-[10px] border border-line bg-paper overflow-hidden">
+      <div className="rounded-card border border-line bg-paper overflow-hidden">
         <div className="overflow-x-auto">
           <table className="min-w-full divide-y divide-line">
             <thead className="bg-ash">
               <tr>
-                <th className="px-6 py-3 text-left font-data text-[10.5px] font-medium uppercase tracking-[0.14em] text-haze">
+                <th className="px-6 py-3 text-left font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
                   User
                 </th>
-                <th className="px-6 py-3 text-left font-data text-[10.5px] font-medium uppercase tracking-[0.14em] text-haze">
+                <th className="px-6 py-3 text-left font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
                   Status
                 </th>
-                <th className="px-6 py-3 text-left font-data text-[10.5px] font-medium uppercase tracking-[0.14em] text-haze">
+                <th className="px-6 py-3 text-left font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
                   Role
                 </th>
-                <th className="px-6 py-3 text-left font-data text-[10.5px] font-medium uppercase tracking-[0.14em] text-haze">
+                <th className="px-6 py-3 text-left font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
                   Created
                 </th>
-                <th className="px-6 py-3 text-right font-data text-[10.5px] font-medium uppercase tracking-[0.14em] text-haze">
+                <th className="px-6 py-3 text-right font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
                   Actions
                 </th>
               </tr>
@@ -280,7 +278,7 @@ export default function UserManagementPage() {
                       {user.is_superuser ? 'Superuser' : 'User'}
                     </span>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap font-data text-[12.5px] text-haze">
+                  <td className="px-6 py-4 whitespace-nowrap font-data text-detail text-haze">
                     {new Date(user.created_at).toLocaleDateString()}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,6 +7,9 @@ export default {
   theme: {
     extend: {
       colors: {
+        // DEPRECATED — legacy red ramp. Do not use in new code; use the
+        // fire-lookout tokens below instead (see DESIGN.md). Kept only until
+        // legacy pages are migrated.
         primary: {
           50: '#fdf4f3',
           100: '#fce7e6',
@@ -29,6 +32,19 @@ export default {
         display: ['Archivo', 'system-ui', 'sans-serif'],
         body: ['"IBM Plex Sans"', 'system-ui', 'sans-serif'],
         data: ['"IBM Plex Mono"', 'ui-monospace', 'monospace'],
+      },
+      fontSize: {
+        title: '27px',
+        heading: '18.5px',
+        body: '13.5px',
+        detail: '12.5px',
+        eyebrow: '10.5px',
+      },
+      letterSpacing: {
+        eyebrow: '0.14em',
+      },
+      borderRadius: {
+        card: '10px',
       },
     },
   },


### PR DESCRIPTION
## Summary

Codifies the fire-lookout design system — already used by /dashboard, /users, sign-in, and /guide — into a canonical guidelines doc plus a minimal token-layer cleanup. Spec: `docs/specs/2026-08-03-frontend-design-guidelines-design.md`.

- **`frontend/DESIGN.md`** — palette with usage rules, type stack + named scale, copyable component recipes, legacy-palette deprecation rule, page-migration notes. `frontend/CLAUDE.md` now points to it.
- **Named tokens** in `tailwind.config.js`: `text-title/heading/body/detail/eyebrow`, `tracking-eyebrow`, `rounded-card`; legacy `primary` ramp marked deprecated.
- **Global base flip** in `src/index.css`: body `bg-ash text-char`, default font IBM Plex Sans; removed the dead `.btn-primary`/`.btn-secondary`/`.input-primary`/`.card` layer (zero consumers).
- **Token adoption** in the converted pages/components (mechanical rename, zero visual change).

## Visual impact

- /dashboard, /users, sign-in, /guide: pixel-identical (verified by screenshot).
- Legacy pages: background shifts gray-50 → ash (near-identical) and default font becomes IBM Plex Sans — intentional drift toward the target look; layout verified intact on /classify.

## Out of scope

Migrating legacy pages/modals, shared React components, dark mode. The deprecation rule in DESIGN.md handles migration incrementally.

## Test plan

- [x] `npm run type-check`, `npm run format:check`, `npm run build` pass
- [x] `npm test` — 768/768
- [x] Playwright screenshots: converted pages unchanged; /classify eyeballed post base-flip

Note: `npm run lint` (strict, not in CI) has 2 pre-existing `no-console` warnings in `DetectionSequenceAnnotatePage.tsx` that exist on main and are untouched here.