### PR TITLE
feat(classify): branded empty states for /classify and /classify/done

### DIFF
--- a/docs/specs/2026-08-03-classify-empty-states-design.md
+++ b/docs/specs/2026-08-03-classify-empty-states-design.md
@@ -1,0 +1,87 @@
+# Classify Empty States Redesign
+
+**Date:** 2026-08-03
+**Pages:** `/classify` and `/classify/done` — both rendered by
+`SequencesPage` (`/classify/done` via `SequencesPageWrapper`, which passes
+`isReviewPage` and a stage selector).
+**Companion:** `docs/specs/2026-08-03-localize-empty-states-design.md`
+(PR #242) — this applies the same design system to the Classify pages.
+
+## Problem
+
+`SequencesPage` renders three bare empty variants in generic Tailwind grays:
+a 🔍 emoji for filtered no-matches (shared by both routes), a 🎉 emoji
+"All caught up!" for the empty queue, and plain stage-scoped text on the
+review page. None match the branded design system now used on the dashboard
+and the Localize pages, and none offer an action.
+
+## Design
+
+All variants use the pattern established in PR #242: a 56px circular icon
+badge (`aria-hidden`), an `<h2>` headline in `font-display` semibold `char`,
+body copy in `haze`, and one action. Centered in the existing `min-h-96`
+stage, inside a `max-w-md` container. Loading and error states untouched.
+Button classes mirror the dashboard `PhaseCard` CTA
+(`frontend/src/components/dashboard/PhaseCard.tsx:79`).
+
+### 1. `/classify` queue empty, no filters (replaces 🎉)
+
+- **Icon:** `Check` (lucide) in `pine` on a `pine-soft` circle
+- **Headline:** "Classification queue is clear"
+- **Body:** "Nice work — every imported sequence has been classified. New
+  ones appear here as imports come in."
+- **CTA:** "Start localizing" → `ROUTES.LOCALIZE`. Solid `pine` button.
+  (Rationale: the queue refills from alert-API imports, not annotator
+  action, so the CTA keeps the annotator moving down the pipeline.)
+
+### 2. Filtered, no matches — shared by both routes (replaces 🔍)
+
+- **Icon:** `Search` (lucide) in `haze` on a white circle with `line` border
+- **Headline:** "No matching sequences"
+- **Body:** "Nothing here matches your current filters. Loosen or clear
+  them to see more."
+- **Action:** "Clear filters" ghost button (white bg, `line` border, `char`
+  text, `hover:bg-ash`) wired to the page's existing `resetFilters`.
+- One shared block: the component's filtered branch already serves both
+  routes and the copy holds for both.
+
+### 3. `/classify/done`, no filters, stage-aware (replaces plain text)
+
+- **Icon:** `ListChecks` (lucide) in `ember` on an `ember-soft` circle
+- **Headline:** stage-aware —
+  - "All classified" selected (`defaultProcessingStage` is an array, i.e.
+    `ALL_CLASSIFIED_STAGES`): "No classified sequences yet"
+  - specific stage selected: `No sequences in "<label>"` using the existing
+    `getStageFilterLabel(defaultProcessingStage)`
+- **Body:** "Sequences you classify land here for review."
+- **CTA:** "Start classifying" → `ROUTES.CLASSIFY`. Solid `ember` button.
+
+## Implementation notes
+
+- All changes inline in `SequencesPage.tsx`'s existing empty-state ternary
+  (`hasFilters` / `isReviewPage` / queue); the branch structure stays.
+- Icons from `lucide-react` (verified present in the installed version); no
+  new dependencies.
+- CTAs are React Router `<Link>`s; "Clear filters" is a `<button>` calling
+  `resetFilters`.
+- "All classified" detection: `Array.isArray(defaultProcessingStage)` —
+  matches how `getStageFilterLabel` distinguishes the pseudo-stage.
+- Filter detection keeps using the existing `hasActiveUserFilters` call
+  (its known `source_api` blind spot is a separate follow-up).
+
+## Testing
+
+- Extend the existing `SequencesPage` test coverage (or add a focused
+  empty-state test file following
+  `frontend/tests/pages/DetectionReviewPage.empty.test.tsx`) with the four
+  states:
+  1. queue empty, no filters → new headline + "Start localizing" href
+     `/localize`, 🎉 gone
+  2. filtered (queue) → "No matching sequences" + "Clear filters" calls
+     `resetFilters`, 🔍 gone
+  3. done, "All classified", no filters → "No classified sequences yet" +
+     "Start classifying" href `/classify`
+  4. done, specific stage, no filters → `No sequences in "<label>"`
+- Full suite passes; `type-check`, lint, and Prettier clean on touched
+  files. (Repo-wide lint has a pre-existing `console.debug` failure in
+  `DetectionSequenceAnnotatePage.tsx`, out of scope.)

--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -302,6 +302,7 @@ export default function SequencesPage({
                   <ListChecks className="h-6 w-6 text-ember" />
                 </span>
                 <h2 className="mt-4 font-display text-base font-semibold text-char">
+                  {/* An array stage is the "All classified" pseudo-stage (see getStageFilterLabel) */}
                   {Array.isArray(defaultProcessingStage)
                     ? 'No classified sequences yet'
                     : `No sequences in "${getStageFilterLabel(defaultProcessingStage)}"`}

--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import { Check, ListChecks, Search } from 'lucide-react';
 import { apiClient } from '@/services/api';
 import {
   ExtendedSequenceFilters,
@@ -25,7 +26,7 @@ import { useSourceApis } from '@/hooks/useSourceApis';
 import { usePersistedFilters, createDefaultFilterState } from '@/hooks/usePersistedFilters';
 import { calculatePresetDateRange } from '@/components/filters/shared/dateRangeUtils';
 import { hasActiveUserFilters } from '@/utils/filterHelpers';
-import { classifyDetail } from '@/utils/routes';
+import { classifyDetail, ROUTES } from '@/utils/routes';
 
 interface SequencesPageProps {
   defaultProcessingStage?: ProcessingStageFilter;
@@ -268,31 +269,75 @@ export default function SequencesPage({
 
         {/* Empty state message */}
         <div className="flex items-center justify-center min-h-96">
-          <div className="text-center">
+          <div className="text-center max-w-md">
             {hasFilters ? (
-              // Filtered results - no matches
+              // Filtered results - no matches (shared by queue and done)
               <>
-                <div className="text-4xl mb-4">🔍</div>
-                <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                  No matching sequences found
-                </h3>
-                <p className="text-gray-500 mb-4">No sequences match your current filters.</p>
-                <p className="text-gray-400 text-sm">Try adjusting your search criteria above.</p>
+                <span
+                  aria-hidden="true"
+                  className="inline-flex h-14 w-14 items-center justify-center rounded-full border border-line bg-white"
+                >
+                  <Search className="h-6 w-6 text-haze" />
+                </span>
+                <h2 className="mt-4 font-display text-base font-semibold text-char">
+                  No matching sequences
+                </h2>
+                <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
+                  Nothing here matches your current filters. Loosen or clear them to see more.
+                </p>
+                <button
+                  onClick={resetFilters}
+                  className="mt-5 inline-block rounded-lg border border-line bg-white px-7 py-2.5 font-body text-[13.5px] font-semibold text-char hover:bg-ash focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2"
+                >
+                  Clear filters
+                </button>
               </>
             ) : isReviewPage ? (
-              // Review page - simple message scoped to the selected stage
-              <p className="text-gray-500">
-                No sequences in &quot;{getStageFilterLabel(defaultProcessingStage)}&quot; at the
-                moment.
-              </p>
-            ) : (
-              // Annotation page - celebratory message
+              // Review page - nothing classified yet (stage-aware)
               <>
-                <div className="text-6xl mb-4">🎉</div>
-                <h3 className="text-xl font-semibold text-gray-900 mb-2">All caught up!</h3>
-                <p className="text-gray-500">
-                  No sequences available for annotation at the moment.
+                <span
+                  aria-hidden="true"
+                  className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-ember-soft"
+                >
+                  <ListChecks className="h-6 w-6 text-ember" />
+                </span>
+                <h2 className="mt-4 font-display text-base font-semibold text-char">
+                  {Array.isArray(defaultProcessingStage)
+                    ? 'No classified sequences yet'
+                    : `No sequences in "${getStageFilterLabel(defaultProcessingStage)}"`}
+                </h2>
+                <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
+                  Sequences you classify land here for review.
                 </p>
+                <Link
+                  to={ROUTES.CLASSIFY}
+                  className="mt-5 inline-block rounded-lg bg-ember px-7 py-2.5 font-body text-[13.5px] font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2"
+                >
+                  Start classifying
+                </Link>
+              </>
+            ) : (
+              // Annotation queue - all imported sequences classified
+              <>
+                <span
+                  aria-hidden="true"
+                  className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-pine-soft"
+                >
+                  <Check className="h-7 w-7 text-pine" />
+                </span>
+                <h2 className="mt-4 font-display text-base font-semibold text-char">
+                  Classification queue is clear
+                </h2>
+                <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
+                  Nice work — every imported sequence has been classified. New ones appear here as
+                  imports come in.
+                </p>
+                <Link
+                  to={ROUTES.LOCALIZE}
+                  className="mt-5 inline-block rounded-lg bg-pine px-7 py-2.5 font-body text-[13.5px] font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2"
+                >
+                  Start localizing
+                </Link>
               </>
             )}
           </div>

--- a/frontend/tests/pages/SequencesPage.empty.test.tsx
+++ b/frontend/tests/pages/SequencesPage.empty.test.tsx
@@ -103,6 +103,16 @@ describe('SequencesPage empty states', () => {
     expect(cta.getAttribute('href')).toBe('/classify');
   });
 
+  it('review page with active filters shows no-matches, not the stage-aware state', async () => {
+    mockedCameraName = 'CAM_01';
+    render(<SequencesPage defaultProcessingStage={ALL_CLASSIFIED_STAGES} isReviewPage />, {
+      wrapper,
+    });
+    await waitFor(() => expect(screen.getByText('No matching sequences')).toBeTruthy());
+    expect(screen.queryByText('No classified sequences yet')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Clear filters' })).toBeTruthy();
+  });
+
   it('review page on a specific stage scopes the headline to that stage', async () => {
     render(<SequencesPage defaultProcessingStage="seq_annotation_done" isReviewPage />, {
       wrapper,

--- a/frontend/tests/pages/SequencesPage.empty.test.tsx
+++ b/frontend/tests/pages/SequencesPage.empty.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+
+vi.mock('@/services/api', () => ({
+  apiClient: {
+    getSequencesWithAnnotations: vi.fn(),
+  },
+}));
+
+vi.mock('@/hooks/useCameras', () => ({
+  useCameras: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('@/hooks/useOrganizations', () => ({
+  useOrganizations: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('@/hooks/useSourceApis', () => ({
+  useSourceApis: () => ({ data: [], isLoading: false }),
+}));
+
+const resetFiltersMock = vi.fn();
+let mockedCameraName: string | undefined;
+
+vi.mock('@/hooks/usePersistedFilters', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/usePersistedFilters')>();
+  return {
+    ...actual,
+    usePersistedFilters: (
+      _key: string,
+      defaultState: Parameters<typeof actual.usePersistedFilters>[1]
+    ): ReturnType<typeof actual.usePersistedFilters> => ({
+      filters: { ...defaultState.filters, camera_name: mockedCameraName },
+      dateFrom: '',
+      dateTo: '',
+      selectedFalsePositiveTypes: [],
+      selectedSmokeTypes: [],
+      selectedModelAccuracy: 'all',
+      selectedUnsure: 'all',
+      setFilters: vi.fn(),
+      setDateFrom: vi.fn(),
+      setDateTo: vi.fn(),
+      setSelectedFalsePositiveTypes: vi.fn(),
+      setSelectedSmokeTypes: vi.fn(),
+      setSelectedModelAccuracy: vi.fn(),
+      setSelectedUnsure: vi.fn(),
+      resetFilters: resetFiltersMock,
+    }),
+  };
+});
+
+import { apiClient } from '@/services/api';
+import SequencesPage from '@/pages/SequencesPage';
+import { ALL_CLASSIFIED_STAGES, getStageFilterLabel } from '@/utils/processingStage';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const emptyPage = { items: [], page: 1, pages: 0, size: 50, total: 0 };
+
+describe('SequencesPage empty states', () => {
+  beforeEach(() => {
+    resetFiltersMock.mockClear();
+    mockedCameraName = undefined;
+    vi.mocked(apiClient.getSequencesWithAnnotations).mockResolvedValue(emptyPage);
+  });
+
+  it('queue without filters shows queue-is-clear state linking to localize', async () => {
+    render(<SequencesPage />, { wrapper });
+    await waitFor(() => expect(screen.getByText('Classification queue is clear')).toBeTruthy());
+    expect(screen.getByText(/every imported sequence has been classified/)).toBeTruthy();
+    const cta = screen.getByRole('link', { name: 'Start localizing' });
+    expect(cta.getAttribute('href')).toBe('/localize');
+    // Old celebratory state is gone
+    expect(screen.queryByText('🎉')).toBeNull();
+    expect(screen.queryByText('All caught up!')).toBeNull();
+  });
+
+  it('with active filters shows no-matches state and Clear filters resets them', async () => {
+    mockedCameraName = 'CAM_01';
+    render(<SequencesPage />, { wrapper });
+    await waitFor(() => expect(screen.getByText('No matching sequences')).toBeTruthy());
+    expect(screen.getByText(/matches your current filters/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    expect(resetFiltersMock).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('🔍')).toBeNull();
+  });
+
+  it('review page on All classified shows no-classified-yet state linking to classify', async () => {
+    render(<SequencesPage defaultProcessingStage={ALL_CLASSIFIED_STAGES} isReviewPage />, {
+      wrapper,
+    });
+    await waitFor(() => expect(screen.getByText('No classified sequences yet')).toBeTruthy());
+    expect(screen.getByText(/land here for review/)).toBeTruthy();
+    const cta = screen.getByRole('link', { name: 'Start classifying' });
+    expect(cta.getAttribute('href')).toBe('/classify');
+  });
+
+  it('review page on a specific stage scopes the headline to that stage', async () => {
+    render(<SequencesPage defaultProcessingStage="seq_annotation_done" isReviewPage />, {
+      wrapper,
+    });
+    const label = getStageFilterLabel('seq_annotation_done');
+    await waitFor(() => expect(screen.getByText(`No sequences in "${label}"`)).toBeTruthy());
+    expect(screen.getByRole('link', { name: 'Start classifying' })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Applies the empty-state design system from #242 to the Classify pages. All three bare variants in `SequencesPage` (serving both routes) are replaced. Design spec: `docs/specs/2026-08-03-classify-empty-states-design.md`.

- **/classify (queue empty)** — replaces the 🎉 emoji: pine check badge, "Classification queue is clear", and a "Start localizing" CTA to `/localize`. The queue refills from alert-API imports rather than annotator action, so the CTA points the annotator down the pipeline instead.
- **Filtered, no matches (both routes)** — replaces the 🔍 emoji: neutral search badge, "No matching sequences", and a functional "Clear filters" button wired to the existing `resetFilters`.
- **/classify/done (nothing in the selected stage)** — replaces the plain text: ember list-checks badge, stage-aware headline ("No classified sequences yet" for All classified, `No sequences in \"<stage>\"` for a specific stage via the existing `getStageFilterLabel`), and a "Start classifying" CTA to `/classify`.

Same structure as #242: `aria-hidden` icon badges, `<h2>` headlines, PhaseCard CTA styling, no new dependencies.

## Test plan

- New `SequencesPage.empty.test.tsx` covering all four states, including the stage-aware headline and `resetFilters` wiring.
- Full suite: 774 passed (770 baseline + 4 new). `type-check` and Prettier clean; lint clean on touched files (repo-wide lint failure is the pre-existing `console.debug`s in `DetectionSequenceAnnotatePage.tsx`, untouched here).