### PR TITLE
feat(groups): filter routes + branded empty states for /classify/groups

### DIFF
--- a/docs/specs/2026-08-03-groups-empty-states-routes-design.md
+++ b/docs/specs/2026-08-03-groups-empty-states-routes-design.md
@@ -1,0 +1,117 @@
+# Sequence Groups: Filter Routes + Empty States
+
+**Date:** 2026-08-03
+**Page:** `/classify/groups` (`SequenceGroupsListPage`)
+**Companions:** `docs/specs/2026-08-03-localize-empty-states-design.md` (#242),
+`docs/specs/2026-08-03-classify-empty-states-design.md` (#244),
+`frontend/DESIGN.md` (fire-lookout system, #243).
+
+## Problem
+
+The To label / Labeled / All selector is component state (`useState`), so the
+selected tab is not shareable, not bookmarkable, and resets on every visit.
+The empty state is a bare `<td>` inside the table — sortable headers float
+above zero rows — with legacy gray styling and no differentiation between
+"everything is labeled" (success) and "no groups exist".
+
+## Design
+
+### Filter routes
+
+Three routes in `App.tsx`, all rendering `SequenceGroupsListPage` with a
+`filter` prop:
+
+| Path | Filter | Selector label |
+|---|---|---|
+| `/classify/groups` | `unlabeled` | To label (default, canonical bare URL) |
+| `/classify/groups/labeled` | `labeled` | Labeled |
+| `/classify/groups/all` | `all` | All |
+
+- Static segments take precedence over the numeric `/classify/groups/:id`
+  detail route in React Router v6; declare them before it regardless.
+- `routes.ts`: add a `classifyGroups(filter)` builder returning the paths
+  above (bare path for `unlabeled`); keep `ROUTES.CLASSIFY_GROUPS` as-is.
+- The page drops its `filter` state. Selector buttons become `<Link>`s with
+  `aria-current="page"` on the active tab. A `useEffect` on the `filter`
+  prop resets `page` to 1 on tab switch. Sort state intentionally survives
+  tab switches (matches current behavior).
+- Legacy `/sequence-groups*` redirects are unaffected.
+
+### Selector restyle (fire-lookout)
+
+Same segmented shape, migrated tokens per DESIGN.md's touch-it-migrate-it
+rule:
+
+- Container: `inline-flex rounded-lg border border-line bg-ash p-0.5 gap-0.5 text-sm`
+- Tab (active): `bg-paper text-char font-semibold border border-line rounded-md px-3.5 py-1.5`
+  — hairline border, no shadow
+- Tab (inactive): `text-haze hover:text-char font-medium rounded-md px-3.5 py-1.5`
+- Counts: `font-data text-xs` — `text-ember` on the active tab, `text-haze`
+  otherwise (counts always mono; no pill background)
+
+### Empty states
+
+When the active tab has zero rows, the table card and pagination are not
+rendered at all — the centered branded stage replaces them (header and
+selector stay visible). Pattern identical to #242/#244: 56px `aria-hidden`
+icon badge, `<h2>` headline (`mt-4 font-display text-base font-semibold
+text-char`), body (`mt-1.5 font-body text-sm leading-relaxed text-haze`),
+one action; stage is `flex items-center justify-center min-h-96` with a
+`text-center max-w-md` inner container.
+
+1. **To label empty** (all groups labeled — success)
+   - Icon: `Check` in `pine` on `pine-soft`
+   - Headline: "All groups labeled"
+   - Body: "Nice work — every group is labeled. New groups form
+     automatically a few minutes after each import."
+   - CTA: "Start classifying" → `ROUTES.CLASSIFY`, solid `ember` button
+     (primary-CTA tone per DESIGN.md; classify-lane context)
+
+2. **Labeled empty** (nothing labeled yet — work to do)
+   - Icon: `Layers` in `ember` on `ember-soft`
+   - Headline: "No labeled groups yet"
+   - Body: "Groups you label land here."
+   - CTA: "Label groups" → `/classify/groups` (the To label tab), solid
+     `ember` button
+
+3. **All empty** (no groups exist — informational)
+   - Icon: `Layers` in `haze` on `paper` with `line` border
+   - Headline: "No groups yet"
+   - Body: "Groups form automatically after imports — only groups of 3 or
+     more sequences appear here."
+   - No action.
+
+Button recipe (matches #242/#244 CTAs): solid —
+`mt-5 inline-block rounded-lg bg-ember px-7 py-2.5 font-body text-[13.5px]
+font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2
+focus:ring-char focus:ring-offset-2`.
+
+The "what is a sequence group" education stays in the existing Info popover
+next to the page title; empty-state bodies stay short.
+
+## Implementation notes
+
+- `Check` and `Layers` from `lucide-react` (no new dependencies).
+- Loading and error states untouched. Table markup untouched apart from
+  removing the in-`<tbody>` empty branch. The rest of the page's legacy
+  styling (title, table, pills, pagination) is out of scope.
+- The three empty variants key off the `filter` prop, not the fetched data
+  shape: `unlabeled` → state 1, `labeled` → state 2, `all` → state 3.
+
+## Testing
+
+New `frontend/tests/pages/SequenceGroupsListPage.test.tsx` (none exists
+today), mocking `apiClient.getSequenceGroups` / `getSequenceGroupStats`,
+rendering through `MemoryRouter` + `Routes` so route→filter mapping is real:
+
+1. `/classify/groups` renders the To label empty state with "Start
+   classifying" linking to `/classify`; table absent.
+2. `/classify/groups/labeled` renders "No labeled groups yet" with "Label
+   groups" linking to `/classify/groups`.
+3. `/classify/groups/all` renders "No groups yet" with no action button.
+4. Selector links point at the three paths; active tab carries
+   `aria-current="page"`.
+5. With non-empty data, the table renders and the empty stage is absent
+   (guards the happy path).
+
+Full suite passes; `type-check`, ESLint (touched files), Prettier clean.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -83,6 +83,14 @@ function App() {
                     element={<SequencesPageWrapper defaultProcessingStage="annotated" />}
                   />
                   <Route path="/classify/groups" element={<SequenceGroupsListPage />} />
+                  <Route
+                    path="/classify/groups/labeled"
+                    element={<SequenceGroupsListPage filter="labeled" />}
+                  />
+                  <Route
+                    path="/classify/groups/all"
+                    element={<SequenceGroupsListPage filter="all" />}
+                  />
                   <Route path="/classify/groups/:id" element={<SequenceGroupAnnotatePage />} />
                   <Route path="/classify/done/:id" element={<AnnotationInterface mode="done" />} />
                   <Route path="/classify/:id" element={<AnnotationInterface />} />

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -35,34 +35,63 @@ const FILTERS: { value: SequenceGroupsFilter; label: string; countOf: keyof Sequ
     { value: 'all', label: 'All', countOf: 'total' },
   ];
 
+// Same hover-tooltip bubble as components/sequences/ColumnHeader.tsx, kept
+// local because these headers are sortable and use this table's padding.
+function headerTip(tip: string, align: 'left' | 'right' = 'left') {
+  return (
+    <span
+      role="tooltip"
+      className={`pointer-events-none absolute top-full z-10 mt-1 hidden w-max max-w-[16rem] whitespace-normal rounded bg-gray-900 px-2 py-1 text-xs font-normal normal-case tracking-normal text-white shadow group-hover:block ${
+        align === 'right' ? 'right-0' : 'left-0'
+      }`}
+    >
+      {tip}
+    </span>
+  );
+}
+
 function SortableHeader({
   column,
   label,
+  tip,
   orderBy,
   orderDirection,
   onSort,
+  align = 'left',
 }: {
   column: OrderBy;
   label: string;
+  tip: string;
   orderBy: OrderBy;
   orderDirection: OrderDirection;
   onSort: (column: OrderBy) => void;
+  align?: 'left' | 'right';
 }) {
   const active = orderBy === column;
   const Arrow = orderDirection === 'asc' ? ArrowUp : ArrowDown;
   return (
     <th
-      className="px-3 py-2.5 text-left whitespace-nowrap"
+      className="group relative px-3 py-2.5 text-left whitespace-nowrap"
       aria-sort={active ? (orderDirection === 'asc' ? 'ascending' : 'descending') : undefined}
     >
       <button
         type="button"
         onClick={() => onSort(column)}
-        className="uppercase tracking-wide select-none hover:text-gray-900"
+        className="uppercase tracking-wide select-none cursor-help hover:text-gray-900"
       >
         {label}
         {active && <Arrow className="inline w-3 h-3 ml-1 text-blue-600" />}
       </button>
+      {headerTip(tip, align)}
+    </th>
+  );
+}
+
+function PlainHeader({ label, tip }: { label: string; tip: string }) {
+  return (
+    <th className="group relative px-3 py-2.5 text-left">
+      <span className="cursor-help">{label}</span>
+      {headerTip(tip)}
     </th>
   );
 }
@@ -262,6 +291,7 @@ export default function SequenceGroupsListPage({
                   <SortableHeader
                     column="camera_name"
                     label="Camera"
+                    tip="Camera that recorded the group's sequences"
                     orderBy={orderBy}
                     orderDirection={orderDirection}
                     onSort={handleSort}
@@ -269,6 +299,7 @@ export default function SequenceGroupsListPage({
                   <SortableHeader
                     column="azimuth"
                     label="Azimuth"
+                    tip="Camera viewing direction, in degrees"
                     orderBy={orderBy}
                     orderDirection={orderDirection}
                     onSort={handleSort}
@@ -276,18 +307,24 @@ export default function SequenceGroupsListPage({
                   <SortableHeader
                     column="member_count"
                     label="Sequences"
+                    tip="Number of sequences in the group"
                     orderBy={orderBy}
                     orderDirection={orderDirection}
                     onSort={handleSort}
                   />
-                  <th className="px-3 py-2.5 text-left">Label</th>
-                  <th className="px-3 py-2.5 text-left">Reviewed</th>
+                  <PlainHeader
+                    label="Label"
+                    tip="Group label — propagates to every member once the group is validated"
+                  />
+                  <PlainHeader label="Reviewed" tip="Whether a human validated the group's label" />
                   <SortableHeader
                     column="created_at"
                     label="Created"
+                    tip="When the group was created"
                     orderBy={orderBy}
                     orderDirection={orderDirection}
                     onSort={handleSort}
+                    align="right"
                   />
                   <th className="px-3 py-2.5" />
                 </tr>

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -5,7 +5,9 @@ import { Popover } from '@headlessui/react';
 import {
   Loader2,
   AlertCircle,
+  Check,
   Info,
+  Layers,
   ShieldCheck,
   ChevronRight,
   ArrowUp,
@@ -14,7 +16,7 @@ import {
 import { apiClient } from '@/services/api';
 import { formatRelativeTime } from '@/utils/relativeTime';
 import { SequenceGroupStats } from '@/types/api';
-import { classifyGroup, classifyGroups, SequenceGroupsFilter } from '@/utils/routes';
+import { classifyGroup, classifyGroups, ROUTES, SequenceGroupsFilter } from '@/utils/routes';
 type OrderBy = 'member_count' | 'camera_name' | 'azimuth' | 'created_at';
 type OrderDirection = 'asc' | 'desc';
 
@@ -183,141 +185,201 @@ export default function SequenceGroupsListPage({
         </div>
       </div>
 
-      <div className="overflow-x-auto border border-gray-200 rounded-lg bg-white shadow-sm">
-        <table className="w-full text-sm">
-          <thead className="bg-gray-50 text-gray-600 text-xs uppercase tracking-wide">
-            <tr>
-              <SortableHeader
-                column="camera_name"
-                label="Camera"
-                orderBy={orderBy}
-                orderDirection={orderDirection}
-                onSort={handleSort}
-              />
-              <SortableHeader
-                column="azimuth"
-                label="Azimuth"
-                orderBy={orderBy}
-                orderDirection={orderDirection}
-                onSort={handleSort}
-              />
-              <SortableHeader
-                column="member_count"
-                label="Sequences"
-                orderBy={orderBy}
-                orderDirection={orderDirection}
-                onSort={handleSort}
-              />
-              <th className="px-3 py-2.5 text-left">Label</th>
-              <th className="px-3 py-2.5 text-left">Reviewed</th>
-              <SortableHeader
-                column="created_at"
-                label="Created"
-                orderBy={orderBy}
-                orderDirection={orderDirection}
-                onSort={handleSort}
-              />
-              <th className="px-3 py-2.5" />
-            </tr>
-          </thead>
-          <tbody>
-            {items.length === 0 ? (
-              <tr>
-                <td colSpan={7} className="px-3 py-8 text-center text-gray-500">
-                  {filter === 'unlabeled'
-                    ? 'Nothing to label right now. Groups are assigned ' +
-                      'automatically a few minutes after an import; groups with ' +
-                      'fewer than 3 sequences are intentionally hidden here.'
-                    : 'No groups match this filter.'}
-                </td>
-              </tr>
-            ) : (
-              items.map(g => (
-                <tr
-                  key={g.id}
-                  onClick={e => {
-                    // Leave modified clicks and text selection to the browser;
-                    // the camera-name <Link> handles open-in-new-tab.
-                    if (e.ctrlKey || e.metaKey || window.getSelection()?.toString()) return;
-                    navigate(classifyGroup(g.id));
-                  }}
-                  className="border-t border-gray-100 hover:bg-blue-50 cursor-pointer"
+      {items.length === 0 ? (
+        <div className="flex items-center justify-center min-h-96">
+          <div className="text-center max-w-md">
+            {filter === 'unlabeled' ? (
+              // Every group labeled - success
+              <>
+                <span
+                  aria-hidden="true"
+                  className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-pine-soft"
                 >
-                  <td className="px-3 py-2.5">
-                    <Link
-                      to={classifyGroup(g.id)}
-                      onClick={e => e.stopPropagation()}
-                      className="font-semibold text-gray-900 hover:text-blue-700"
-                    >
-                      {g.camera_name}
-                    </Link>
-                  </td>
-                  <td className="px-3 py-2.5">{g.azimuth}°</td>
-                  <td className="px-3 py-2.5">
-                    <span className="inline-block rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-semibold text-blue-700">
-                      {g.member_count}
-                    </span>
-                  </td>
-                  <td className="px-3 py-2.5">
-                    {g.smoke_type ? (
-                      <span className="inline-block rounded-full bg-orange-100 px-2.5 py-0.5 text-xs font-semibold text-orange-700">
-                        smoke · {g.smoke_type}
-                      </span>
-                    ) : g.false_positive_type ? (
-                      <span className="inline-block rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-700">
-                        false positive · {g.false_positive_type.replace(/_/g, ' ')}
-                      </span>
-                    ) : (
-                      <span className="inline-block rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-semibold text-yellow-800">
-                        to label
-                      </span>
-                    )}
-                  </td>
-                  <td className="px-3 py-2.5">
-                    {g.is_validated ? (
-                      <span className="inline-flex items-center gap-1 text-green-700 text-xs font-semibold">
-                        <ShieldCheck className="w-3.5 h-3.5" /> validated
-                      </span>
-                    ) : (
-                      <span className="text-gray-400">—</span>
-                    )}
-                  </td>
-                  <td
-                    className="px-3 py-2.5 text-gray-500"
-                    title={new Date(g.created_at).toLocaleString()}
-                  >
-                    {formatRelativeTime(g.created_at)}
-                  </td>
-                  <td className="px-3 py-2.5 text-right">
-                    <ChevronRight className="inline w-4 h-4 text-gray-400" />
-                  </td>
-                </tr>
-              ))
+                  <Check className="h-7 w-7 text-pine" />
+                </span>
+                <h2 className="mt-4 font-display text-base font-semibold text-char">
+                  All groups labeled
+                </h2>
+                <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
+                  Nice work — every group is labeled. New groups form automatically a few minutes
+                  after each import.
+                </p>
+                <Link
+                  to={ROUTES.CLASSIFY}
+                  className="mt-5 inline-block rounded-lg bg-ember px-7 py-2.5 font-body text-[13.5px] font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2"
+                >
+                  Start classifying
+                </Link>
+              </>
+            ) : filter === 'labeled' ? (
+              // Nothing labeled yet - work to do
+              <>
+                <span
+                  aria-hidden="true"
+                  className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-ember-soft"
+                >
+                  <Layers className="h-6 w-6 text-ember" />
+                </span>
+                <h2 className="mt-4 font-display text-base font-semibold text-char">
+                  No labeled groups yet
+                </h2>
+                <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
+                  Groups you label land here.
+                </p>
+                <Link
+                  to={classifyGroups('unlabeled')}
+                  className="mt-5 inline-block rounded-lg bg-ember px-7 py-2.5 font-body text-[13.5px] font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2"
+                >
+                  Label groups
+                </Link>
+              </>
+            ) : (
+              // No groups at all - informational
+              <>
+                <span
+                  aria-hidden="true"
+                  className="inline-flex h-14 w-14 items-center justify-center rounded-full border border-line bg-paper"
+                >
+                  <Layers className="h-6 w-6 text-haze" />
+                </span>
+                <h2 className="mt-4 font-display text-base font-semibold text-char">
+                  No groups yet
+                </h2>
+                <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
+                  Groups form automatically after imports — only groups of 3 or more sequences
+                  appear here.
+                </p>
+              </>
             )}
-          </tbody>
-        </table>
-      </div>
-
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between text-sm">
-          <button
-            onClick={() => setPage(p => Math.max(1, p - 1))}
-            disabled={page === 1}
-            className="px-3 py-1.5 border border-gray-300 rounded-lg bg-white disabled:opacity-40 hover:bg-gray-50"
-          >
-            Previous
-          </button>
-          <span className="text-gray-600">
-            Page {page} / {totalPages}
-          </span>
-          <button
-            onClick={() => setPage(p => Math.min(totalPages, p + 1))}
-            disabled={page >= totalPages}
-            className="px-3 py-1.5 border border-gray-300 rounded-lg bg-white disabled:opacity-40 hover:bg-gray-50"
-          >
-            Next
-          </button>
+          </div>
         </div>
+      ) : (
+        <>
+          <div className="overflow-x-auto border border-gray-200 rounded-lg bg-white shadow-sm">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-gray-600 text-xs uppercase tracking-wide">
+                <tr>
+                  <SortableHeader
+                    column="camera_name"
+                    label="Camera"
+                    orderBy={orderBy}
+                    orderDirection={orderDirection}
+                    onSort={handleSort}
+                  />
+                  <SortableHeader
+                    column="azimuth"
+                    label="Azimuth"
+                    orderBy={orderBy}
+                    orderDirection={orderDirection}
+                    onSort={handleSort}
+                  />
+                  <SortableHeader
+                    column="member_count"
+                    label="Sequences"
+                    orderBy={orderBy}
+                    orderDirection={orderDirection}
+                    onSort={handleSort}
+                  />
+                  <th className="px-3 py-2.5 text-left">Label</th>
+                  <th className="px-3 py-2.5 text-left">Reviewed</th>
+                  <SortableHeader
+                    column="created_at"
+                    label="Created"
+                    orderBy={orderBy}
+                    orderDirection={orderDirection}
+                    onSort={handleSort}
+                  />
+                  <th className="px-3 py-2.5" />
+                </tr>
+              </thead>
+              <tbody>
+                {items.map(g => (
+                  <tr
+                    key={g.id}
+                    onClick={e => {
+                      // Leave modified clicks and text selection to the browser;
+                      // the camera-name <Link> handles open-in-new-tab.
+                      if (e.ctrlKey || e.metaKey || window.getSelection()?.toString()) return;
+                      navigate(classifyGroup(g.id));
+                    }}
+                    className="border-t border-gray-100 hover:bg-blue-50 cursor-pointer"
+                  >
+                    <td className="px-3 py-2.5">
+                      <Link
+                        to={classifyGroup(g.id)}
+                        onClick={e => e.stopPropagation()}
+                        className="font-semibold text-gray-900 hover:text-blue-700"
+                      >
+                        {g.camera_name}
+                      </Link>
+                    </td>
+                    <td className="px-3 py-2.5">{g.azimuth}°</td>
+                    <td className="px-3 py-2.5">
+                      <span className="inline-block rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-semibold text-blue-700">
+                        {g.member_count}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2.5">
+                      {g.smoke_type ? (
+                        <span className="inline-block rounded-full bg-orange-100 px-2.5 py-0.5 text-xs font-semibold text-orange-700">
+                          smoke · {g.smoke_type}
+                        </span>
+                      ) : g.false_positive_type ? (
+                        <span className="inline-block rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-700">
+                          false positive · {g.false_positive_type.replace(/_/g, ' ')}
+                        </span>
+                      ) : (
+                        <span className="inline-block rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-semibold text-yellow-800">
+                          to label
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2.5">
+                      {g.is_validated ? (
+                        <span className="inline-flex items-center gap-1 text-green-700 text-xs font-semibold">
+                          <ShieldCheck className="w-3.5 h-3.5" /> validated
+                        </span>
+                      ) : (
+                        <span className="text-gray-400">—</span>
+                      )}
+                    </td>
+                    <td
+                      className="px-3 py-2.5 text-gray-500"
+                      title={new Date(g.created_at).toLocaleString()}
+                    >
+                      {formatRelativeTime(g.created_at)}
+                    </td>
+                    <td className="px-3 py-2.5 text-right">
+                      <ChevronRight className="inline w-4 h-4 text-gray-400" />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between text-sm">
+              <button
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+                disabled={page === 1}
+                className="px-3 py-1.5 border border-gray-300 rounded-lg bg-white disabled:opacity-40 hover:bg-gray-50"
+              >
+                Previous
+              </button>
+              <span className="text-gray-600">
+                Page {page} / {totalPages}
+              </span>
+              <button
+                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
+                className="px-3 py-1.5 border border-gray-300 rounded-lg bg-white disabled:opacity-40 hover:bg-gray-50"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { Popover } from '@headlessui/react';
@@ -14,9 +14,7 @@ import {
 import { apiClient } from '@/services/api';
 import { formatRelativeTime } from '@/utils/relativeTime';
 import { SequenceGroupStats } from '@/types/api';
-import { classifyGroup } from '@/utils/routes';
-
-type Filter = 'all' | 'labeled' | 'unlabeled';
+import { classifyGroup, classifyGroups, SequenceGroupsFilter } from '@/utils/routes';
 type OrderBy = 'member_count' | 'camera_name' | 'azimuth' | 'created_at';
 type OrderDirection = 'asc' | 'desc';
 
@@ -28,11 +26,12 @@ const DEFAULT_DIRECTION: Record<OrderBy, OrderDirection> = {
   created_at: 'desc',
 };
 
-const FILTERS: { value: Filter; label: string; countOf: keyof SequenceGroupStats }[] = [
-  { value: 'unlabeled', label: 'To label', countOf: 'unlabeled' },
-  { value: 'labeled', label: 'Labeled', countOf: 'labeled' },
-  { value: 'all', label: 'All', countOf: 'total' },
-];
+const FILTERS: { value: SequenceGroupsFilter; label: string; countOf: keyof SequenceGroupStats }[] =
+  [
+    { value: 'unlabeled', label: 'To label', countOf: 'unlabeled' },
+    { value: 'labeled', label: 'Labeled', countOf: 'labeled' },
+    { value: 'all', label: 'All', countOf: 'total' },
+  ];
 
 function SortableHeader({
   column,
@@ -66,13 +65,21 @@ function SortableHeader({
   );
 }
 
-export default function SequenceGroupsListPage() {
+export default function SequenceGroupsListPage({
+  filter = 'unlabeled',
+}: {
+  filter?: SequenceGroupsFilter;
+} = {}) {
   const navigate = useNavigate();
-  const [filter, setFilter] = useState<Filter>('unlabeled');
   const [page, setPage] = useState(1);
   const [orderBy, setOrderBy] = useState<OrderBy>('member_count');
   const [orderDirection, setOrderDirection] = useState<OrderDirection>('desc');
   const size = 50;
+
+  // Tab switches change the dataset; restart pagination.
+  useEffect(() => {
+    setPage(1);
+  }, [filter]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['sequenceGroupsList', filter, page, size, orderBy, orderDirection],
@@ -147,34 +154,30 @@ export default function SequenceGroupsListPage() {
       </div>
 
       <div>
-        <div className="inline-flex rounded-lg bg-gray-200 p-0.5 gap-0.5 text-sm">
+        <div className="inline-flex rounded-lg border border-line bg-ash p-0.5 gap-0.5 text-sm">
           {FILTERS.map(f => {
             const active = filter === f.value;
             const count = stats?.[f.countOf];
             return (
-              <button
+              <Link
                 key={f.value}
-                onClick={() => {
-                  setFilter(f.value);
-                  setPage(1);
-                }}
-                className={`px-3.5 py-1.5 rounded-md font-medium ${
+                to={classifyGroups(f.value)}
+                aria-current={active ? 'page' : undefined}
+                className={`px-3.5 py-1.5 rounded-md ${
                   active
-                    ? 'bg-white text-gray-900 shadow-sm font-semibold'
-                    : 'text-gray-600 hover:text-gray-900'
+                    ? 'border border-line bg-paper font-semibold text-char'
+                    : 'font-medium text-haze hover:text-char'
                 }`}
               >
                 {f.label}
                 {count !== undefined && (
                   <span
-                    className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${
-                      active ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500'
-                    }`}
+                    className={`ml-1.5 font-data text-xs ${active ? 'text-ember' : 'text-haze'}`}
                   >
                     {count}
                   </span>
                 )}
-              </button>
+              </Link>
             );
           })}
         </div>

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -194,7 +194,7 @@ export default function SequenceGroupsListPage({
                 key={f.value}
                 to={classifyGroups(f.value)}
                 aria-current={active ? 'page' : undefined}
-                className={`px-3.5 py-1.5 rounded-md ${
+                className={`inline-flex items-center px-3.5 py-1.5 rounded-md ${
                   active
                     ? 'border border-line bg-paper font-semibold text-char'
                     : 'border border-transparent font-medium text-haze hover:text-char'

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -184,7 +184,7 @@ export default function SequenceGroupsListPage({
         <p className="text-gray-600">Label many related sequences at once.</p>
       </div>
 
-      <div>
+      <div className="flex justify-center">
         <div className="inline-flex rounded-lg border border-line bg-ash p-0.5 gap-0.5 text-sm">
           {FILTERS.map(f => {
             const active = filter === f.value;

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -194,7 +194,7 @@ export default function SequenceGroupsListPage({
                 key={f.value}
                 to={classifyGroups(f.value)}
                 aria-current={active ? 'page' : undefined}
-                className={`inline-flex items-center px-3.5 py-1.5 rounded-md ${
+                className={`inline-flex items-baseline px-3.5 py-1.5 rounded-md ${
                   active
                     ? 'border border-line bg-paper font-semibold text-char'
                     : 'border border-transparent font-medium text-haze hover:text-char'

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -77,7 +77,7 @@ function SortableHeader({
       <button
         type="button"
         onClick={() => onSort(column)}
-        className="uppercase tracking-wide select-none cursor-help hover:text-gray-900"
+        className="uppercase tracking-wide select-none hover:text-gray-900"
       >
         {label}
         {active && <Arrow className="inline w-3 h-3 ml-1 text-blue-600" />}
@@ -197,7 +197,7 @@ export default function SequenceGroupsListPage({
                 className={`px-3.5 py-1.5 rounded-md ${
                   active
                     ? 'border border-line bg-paper font-semibold text-char'
-                    : 'font-medium text-haze hover:text-char'
+                    : 'border border-transparent font-medium text-haze hover:text-char'
                 }`}
               >
                 {f.label}
@@ -214,7 +214,10 @@ export default function SequenceGroupsListPage({
         </div>
       </div>
 
-      {items.length === 0 ? (
+      {/* Gate on total, not items: a stale page ≥ 2 can refetch empty while
+          groups still exist — that must keep the table + pagination, not
+          show a false "all labeled" success. */}
+      {(data?.total ?? 0) === 0 ? (
         <div className="flex items-center justify-center min-h-96">
           <div className="text-center max-w-md">
             {filter === 'unlabeled' ? (

--- a/frontend/src/utils/routes.ts
+++ b/frontend/src/utils/routes.ts
@@ -19,6 +19,13 @@ export function classifyGroup(id: number | string): string {
   return `${ROUTES.CLASSIFY_GROUPS}/${id}`;
 }
 
+export type SequenceGroupsFilter = 'unlabeled' | 'labeled' | 'all';
+
+// Bare path is the To-label default; other filters are path segments.
+export function classifyGroups(filter: SequenceGroupsFilter): string {
+  return filter === 'unlabeled' ? ROUTES.CLASSIFY_GROUPS : `${ROUTES.CLASSIFY_GROUPS}/${filter}`;
+}
+
 export function localizeDetail(
   sequenceId: number | string,
   detectionId?: number | string,

--- a/frontend/tests/pages/SequenceGroupsListPage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupsListPage.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import React from 'react';
+
+vi.mock('@/services/api', () => ({
+  apiClient: {
+    getSequenceGroups: vi.fn(),
+    getSequenceGroupStats: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/services/api';
+import SequenceGroupsListPage from '@/pages/SequenceGroupsListPage';
+
+// Mirrors the App.tsx route → filter mapping.
+function renderAt(path: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/classify/groups" element={<SequenceGroupsListPage filter="unlabeled" />} />
+          <Route
+            path="/classify/groups/labeled"
+            element={<SequenceGroupsListPage filter="labeled" />}
+          />
+          <Route path="/classify/groups/all" element={<SequenceGroupsListPage filter="all" />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const emptyPage = { items: [], page: 1, pages: 0, size: 50, total: 0 };
+
+const group = {
+  id: 7,
+  camera_name: 'CAM_07',
+  azimuth: 120,
+  member_count: 5,
+  smoke_type: null,
+  false_positive_type: null,
+  is_validated: false,
+  created_at: '2026-08-01T10:00:00Z',
+};
+
+describe('SequenceGroupsListPage', () => {
+  beforeEach(() => {
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue(emptyPage);
+    vi.mocked(apiClient.getSequenceGroupStats).mockResolvedValue({
+      total: 0,
+      labeled: 0,
+      unlabeled: 0,
+    });
+  });
+
+  it('selector tabs are links to the three filter routes with aria-current on the active one', async () => {
+    renderAt('/classify/groups/labeled');
+    await waitFor(() => expect(screen.getByRole('link', { name: /To label/ })).toBeTruthy());
+    expect(screen.getByRole('link', { name: /To label/ }).getAttribute('href')).toBe(
+      '/classify/groups'
+    );
+    const labeled = screen.getByRole('link', { name: /Labeled/ });
+    expect(labeled.getAttribute('href')).toBe('/classify/groups/labeled');
+    expect(labeled.getAttribute('aria-current')).toBe('page');
+    expect(screen.getByRole('link', { name: /All/ }).getAttribute('href')).toBe(
+      '/classify/groups/all'
+    );
+    expect(screen.getByRole('link', { name: /To label/ }).getAttribute('aria-current')).toBeNull();
+  });
+
+  it('renders the groups table when data is present', async () => {
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
+      items: [group],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 1,
+    });
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
+    expect(screen.getByRole('table')).toBeTruthy();
+  });
+});

--- a/frontend/tests/pages/SequenceGroupsListPage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupsListPage.test.tsx
@@ -71,6 +71,35 @@ describe('SequenceGroupsListPage', () => {
     expect(screen.getByRole('link', { name: /To label/ }).getAttribute('aria-current')).toBeNull();
   });
 
+  it('To label empty shows all-groups-labeled state, CTA to classify, and no table', async () => {
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getByText('All groups labeled')).toBeTruthy());
+    expect(screen.getByText(/every group is labeled/)).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Start classifying' }).getAttribute('href')).toBe(
+      '/classify'
+    );
+    expect(screen.queryByRole('table')).toBeNull();
+  });
+
+  it('Labeled empty shows no-labeled-groups state with CTA to the To label tab', async () => {
+    renderAt('/classify/groups/labeled');
+    await waitFor(() => expect(screen.getByText('No labeled groups yet')).toBeTruthy());
+    expect(screen.getByText(/Groups you label land here/)).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Label groups' }).getAttribute('href')).toBe(
+      '/classify/groups'
+    );
+    expect(screen.queryByRole('table')).toBeNull();
+  });
+
+  it('All empty shows no-groups state with no action', async () => {
+    renderAt('/classify/groups/all');
+    await waitFor(() => expect(screen.getByText('No groups yet')).toBeTruthy());
+    expect(screen.getByText(/only groups of 3 or more sequences/)).toBeTruthy();
+    expect(screen.queryByRole('link', { name: 'Start classifying' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Label groups' })).toBeNull();
+    expect(screen.queryByRole('table')).toBeNull();
+  });
+
   it('renders the groups table when data is present', async () => {
     vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
       items: [group],

--- a/frontend/tests/pages/SequenceGroupsListPage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupsListPage.test.tsx
@@ -112,4 +112,21 @@ describe('SequenceGroupsListPage', () => {
     await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
     expect(screen.getByRole('table')).toBeTruthy();
   });
+
+  it('column headers carry explanatory tooltips', async () => {
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
+      items: [group],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 1,
+    });
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
+    // One tooltip per labeled column (Camera, Azimuth, Sequences, Label, Reviewed, Created)
+    expect(screen.getAllByRole('tooltip')).toHaveLength(6);
+    expect(screen.getByText('Number of sequences in the group')).toBeTruthy();
+    expect(screen.getByText(/propagates to every member/)).toBeTruthy();
+    expect(screen.getByText('Camera viewing direction, in degrees')).toBeTruthy();
+  });
 });

--- a/frontend/tests/pages/SequenceGroupsListPage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupsListPage.test.tsx
@@ -21,7 +21,8 @@ function renderAt(path: string) {
     <QueryClientProvider client={client}>
       <MemoryRouter initialEntries={[path]}>
         <Routes>
-          <Route path="/classify/groups" element={<SequenceGroupsListPage filter="unlabeled" />} />
+          {/* No filter prop: covers the component's 'unlabeled' default, as App.tsx renders it */}
+          <Route path="/classify/groups" element={<SequenceGroupsListPage />} />
           <Route
             path="/classify/groups/labeled"
             element={<SequenceGroupsListPage filter="labeled" />}
@@ -111,6 +112,20 @@ describe('SequenceGroupsListPage', () => {
     renderAt('/classify/groups');
     await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
     expect(screen.getByRole('table')).toBeTruthy();
+  });
+
+  it('an empty page with a non-zero total keeps the table, not the empty state', async () => {
+    // A stale page ≥ 2 can refetch empty while groups still exist elsewhere.
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
+      items: [],
+      page: 2,
+      pages: 2,
+      size: 50,
+      total: 51,
+    });
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getByRole('table')).toBeTruthy());
+    expect(screen.queryByText('All groups labeled')).toBeNull();
   });
 
   it('column headers carry explanatory tooltips', async () => {


### PR DESCRIPTION
## Summary

Completes the empty-state series (#242, #244) for the groups page, and gives the To label / Labeled / All selector real routes. Design spec: `docs/specs/2026-08-03-groups-empty-states-routes-design.md`.

### Filter routes
- `/classify/groups` (To label, canonical default), `/classify/groups/labeled`, `/classify/groups/all` — the selected tab is now shareable and bookmarkable. Static segments are declared before the numeric `/classify/groups/:id` detail route. New `classifyGroups(filter)` builder + `SequenceGroupsFilter` type in `routes.ts`.
- The page's filter moves from `useState` to a route-driven prop; selector buttons become `Link`s with `aria-current` on the active tab. Pagination resets on tab switch (sort intentionally survives, as before).

### Selector restyle
Same segmented shape, migrated to fire-lookout tokens per `DESIGN.md`'s touch-it-migrate-it rule: ash container with hairline border, paper active tab (no shadow), mono counts (`font-data`, ember when active).

### Empty states
When the active tab has zero rows the table card and pagination are not rendered — a centered branded stage replaces them (sortable headers no longer float above zero rows):
- **To label** — pine check, "All groups labeled", ember CTA "Start classifying" → `/classify`
- **Labeled** — ember layers, "No labeled groups yet", ember CTA "Label groups" → `/classify/groups`
- **All** — neutral layers, "No groups yet", no action (groups form automatically from imports)

The "what is a sequence group" education stays in the existing Info popover.

## Test plan

- New `SequenceGroupsListPage.test.tsx` (5 tests): selector hrefs + `aria-current`, the three empty states with CTA targets and table absence, and the happy-path table render.
- Full suite: 746 passed (741 baseline + 5). `type-check` clean; ESLint and Prettier clean on touched files.