### PR TITLE
fix(frontend): outcome-codes review fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ runs
 
 # Superpowers brainstorming sessions
 .superpowers/
+
+# Node
+node_modules/

--- a/docs/specs/2026-08-03-outcome-codes-tables-design.md
+++ b/docs/specs/2026-08-03-outcome-codes-tables-design.md
@@ -87,6 +87,9 @@ mono for dates/counts, and the legacy blue source pill becomes neutral.
   table gets the multi-object rollup (below) as a trailing Result column:
   dominant outcome over **all** lanes (not just smoke lanes) with the
   `+N` extra count.
+- Its chrome migrates to the fire-lookout recipe alongside the done tables
+  (the shared `ColumnHeader` already did) — the Result column shouldn't sit
+  in a half-legacy table.
 
 **Untouched:** the classify queue (unannotated rows) and the detail pages.
 
@@ -111,8 +114,10 @@ the collocation design.
   `getModelAccuracyType`; `getRowBackgroundClasses` and anything else this
   change orphans is removed. Exports still used by the filter components
   stay.
-- Out of scope but flagged: `DetectionAnnotateTableRow.tsx` is pre-existing
-  dead code (zero usages) — cleanup ticket, not this change.
+- `DetectionAnnotateTableRow.tsx` was pre-existing dead code (zero usages)
+  and the last other consumer of `getRowBackgroundClasses`, so removing the
+  helper forced its deletion here. Its equally-dead sibling
+  `DetectionAnnotateTableHeader.tsx` is untouched — cleanup ticket.
 
 ## Testing
 

--- a/frontend/src/components/sequences/ClassifyDoneTable.tsx
+++ b/frontend/src/components/sequences/ClassifyDoneTable.tsx
@@ -7,6 +7,7 @@ import {
   parseFalsePositiveTypes,
 } from '@/utils/modelAccuracy';
 import DetectionImageThumbnail from '@/components/DetectionImageThumbnail';
+import { ColumnHeader } from './ColumnHeader';
 import { OutcomeCode } from './OutcomeCode';
 import { PlatformAnnotationPill } from './PlatformAnnotationPill';
 
@@ -50,12 +51,18 @@ export function ClassifyDoneTable({ sequences, onSequenceClick }: ClassifyDoneTa
             <th className={HEADER_CLASSES}>Alert API annotation</th>
             <th className={HEADER_CLASSES}>Source</th>
             <th className={HEADER_CLASSES}>Azimuth</th>
-            <th className={HEADER_CLASSES}>Result</th>
+            <ColumnHeader
+              label="Result"
+              tip="Model outcome — TP correct, FP false alarm, ⚑ FN missed smoke, ? unsure — and the classification detail"
+              align="right"
+            />
           </tr>
         </thead>
         <tbody className="bg-paper divide-y divide-line">
           {sequences.map(sequence => {
             const outcome = deriveSequenceOutcome(sequence.annotation);
+            const detail =
+              sequence.annotation && outcome ? resultDetail(sequence.annotation, outcome) : '';
             return (
               <tr
                 key={sequence.id}
@@ -88,12 +95,12 @@ export function ClassifyDoneTable({ sequences, onSequenceClick }: ClassifyDoneTa
                     : ''}
                 </td>
                 <td className={CELL_CLASSES}>
-                  {sequence.annotation && outcome && (
+                  {outcome && (
                     <>
                       <OutcomeCode outcome={outcome} />
-                      <span className="ml-2.5 font-body text-detail text-haze">
-                        {resultDetail(sequence.annotation, outcome)}
-                      </span>
+                      {detail && (
+                        <span className="ml-2.5 font-body text-detail text-haze">{detail}</span>
+                      )}
                     </>
                   )}
                 </td>

--- a/frontend/src/components/sequences/LocalizeDoneTable.tsx
+++ b/frontend/src/components/sequences/LocalizeDoneTable.tsx
@@ -58,6 +58,7 @@ export function LocalizeDoneTable({
           {sequences.map(sequence => {
             const annotation = annotations[sequence.id];
             const outcome = deriveSequenceOutcome(annotation);
+            const detail = annotation ? resultDetail(annotation) : '';
             return (
               <tr
                 key={sequence.id}
@@ -91,13 +92,11 @@ export function LocalizeDoneTable({
                   {sequence.detection_annotation_stats?.total_detections ?? ''}
                 </td>
                 <td className={CELL_CLASSES}>
-                  {annotation && outcome && (
+                  {outcome && (
                     <>
                       <OutcomeCode outcome={outcome} />
-                      {resultDetail(annotation) && (
-                        <span className="ml-2.5 font-body text-detail text-haze">
-                          {resultDetail(annotation)}
-                        </span>
+                      {detail && (
+                        <span className="ml-2.5 font-body text-detail text-haze">{detail}</span>
                       )}
                     </>
                   )}

--- a/frontend/src/components/sequences/LocalizeQueueTable.tsx
+++ b/frontend/src/components/sequences/LocalizeQueueTable.tsx
@@ -11,8 +11,8 @@ interface LocalizeQueueTableProps {
 }
 
 const HEADER_CLASSES =
-  'px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider';
-const CELL_CLASSES = 'px-4 py-2 whitespace-nowrap text-sm';
+  'px-4 py-3 text-left font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze';
+const CELL_CLASSES = 'px-4 py-2 whitespace-nowrap';
 
 // Objects the annotator will draw boxes on (smoke or missed smoke, not unsure).
 function smokeLanes(item: LocalizationQueueItem) {
@@ -45,8 +45,8 @@ function alertOutcome(item: LocalizationQueueItem) {
 export function LocalizeQueueTable({ items, onItemClick }: LocalizeQueueTableProps) {
   return (
     <div className="overflow-x-auto">
-      <table className="min-w-full divide-y divide-gray-200">
-        <thead className="bg-gray-50">
+      <table className="min-w-full divide-y divide-line">
+        <thead className="bg-ash">
           <tr>
             <th className={HEADER_CLASSES}>
               <span className="sr-only">Thumbnail</span>
@@ -74,43 +74,51 @@ export function LocalizeQueueTable({ items, onItemClick }: LocalizeQueueTablePro
             />
           </tr>
         </thead>
-        <tbody className="bg-white divide-y divide-gray-200">
-          {items.map(item => (
-            <tr
-              key={`${item.source_api}-${item.platform_alert_id}`}
-              onClick={() => onItemClick(item)}
-              className="cursor-pointer hover:bg-gray-50"
-            >
-              <td className="px-4 py-2">
-                <DetectionImageThumbnail
-                  sequenceId={item.lanes[0].sequence_id}
-                  className="h-10 w-16"
-                />
-              </td>
-              <td className={`${CELL_CLASSES} font-medium text-gray-900`}>{item.camera_name}</td>
-              <td className={`${CELL_CLASSES} text-gray-500`}>{item.organisation_name}</td>
-              <td className={`${CELL_CLASSES} text-gray-500`}>
-                {new Date(item.recorded_at).toLocaleString()}
-              </td>
-              <td className={`${CELL_CLASSES} text-gray-500`}>{item.source_api}</td>
-              <td className={`${CELL_CLASSES} text-gray-500`}>
-                {item.azimuth !== null && item.azimuth !== undefined ? `${item.azimuth}°` : ''}
-              </td>
-              <td className={`${CELL_CLASSES} text-gray-500`}>
-                {smokeTypes(item).map(formatSmokeType).join(', ')}
-              </td>
-              <td className={`${CELL_CLASSES} text-gray-500`}>{smokeLanes(item).length}</td>
-              <td className={`${CELL_CLASSES} text-gray-500`}>{smokeFrames(item)}</td>
-              <td className={CELL_CLASSES}>
-                {(() => {
-                  const rollup = alertOutcome(item);
-                  return rollup ? (
+        <tbody className="bg-paper divide-y divide-line">
+          {items.map(item => {
+            const rollup = alertOutcome(item);
+            return (
+              <tr
+                key={`${item.source_api}-${item.platform_alert_id}`}
+                onClick={() => onItemClick(item)}
+                className="cursor-pointer hover:bg-ash"
+              >
+                <td className="px-4 py-2">
+                  <DetectionImageThumbnail
+                    sequenceId={item.lanes[0].sequence_id}
+                    className="h-10 w-16"
+                  />
+                </td>
+                <td className={`${CELL_CLASSES} font-body text-sm font-medium text-char`}>
+                  {item.camera_name}
+                </td>
+                <td className={`${CELL_CLASSES} font-body text-sm text-haze`}>
+                  {item.organisation_name}
+                </td>
+                <td className={`${CELL_CLASSES} font-data text-detail text-haze`}>
+                  {new Date(item.recorded_at).toLocaleString()}
+                </td>
+                <td className={`${CELL_CLASSES} font-body text-sm text-haze`}>{item.source_api}</td>
+                <td className={`${CELL_CLASSES} font-data text-detail text-haze`}>
+                  {item.azimuth !== null && item.azimuth !== undefined ? `${item.azimuth}°` : ''}
+                </td>
+                <td className={`${CELL_CLASSES} font-body text-sm text-haze`}>
+                  {smokeTypes(item).map(formatSmokeType).join(', ')}
+                </td>
+                <td className={`${CELL_CLASSES} font-data text-detail text-haze`}>
+                  {smokeLanes(item).length}
+                </td>
+                <td className={`${CELL_CLASSES} font-data text-detail text-haze`}>
+                  {smokeFrames(item)}
+                </td>
+                <td className={CELL_CLASSES}>
+                  {rollup && (
                     <OutcomeCode outcome={rollup.outcome} extraCount={rollup.extraCount} />
-                  ) : null;
-                })()}
-              </td>
-            </tr>
-          ))}
+                  )}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/frontend/tests/components/sequences/ClassifyDoneTable.test.tsx
+++ b/frontend/tests/components/sequences/ClassifyDoneTable.test.tsx
@@ -76,6 +76,36 @@ describe('ClassifyDoneTable', () => {
     }
   });
 
+  it('explains the outcome codes in the Result column tooltip', () => {
+    render(<ClassifyDoneTable sequences={[createSequence()]} onSequenceClick={onSequenceClick} />);
+
+    expect(
+      screen.getByText(
+        'Model outcome — TP correct, FP false alarm, ⚑ FN missed smoke, ? unsure — and the classification detail'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders the code alone when the annotation has no detail text', () => {
+    render(
+      <ClassifyDoneTable
+        sequences={[
+          createSequence({
+            annotation: createAnnotation({
+              has_smoke: false,
+              smoke_types: [],
+              false_positive_types: '',
+            }),
+          }),
+        ]}
+        onSequenceClick={onSequenceClick}
+      />
+    );
+
+    const cell = screen.getByTitle('False positive — model flagged non-smoke').closest('td');
+    expect(cell?.querySelector('.ml-2\\.5')).toBeNull();
+  });
+
   it('shows the absolute recorded timestamp', () => {
     render(<ClassifyDoneTable sequences={[createSequence()]} onSequenceClick={onSequenceClick} />);
 


### PR DESCRIPTION
Follow-ups from the post-merge review of #247.

## What

- **`/classify/done` Result header now explains the codes** — the spec designates the Result `ColumnHeader` tip as the legend's replacement, but only the localize tables got it. Now all three tables share it. *(the review's one Important finding)*
- Empty detail span in `ClassifyDoneTable` guarded, matching `LocalizeDoneTable`.
- Per-row `detail`/`rollup` computations hoisted out of the JSX (removes a double call and an IIFE).
- `LocalizeQueueTable` chrome migrated to the fire-lookout recipe — the new Result column no longer sits in a half-legacy table (`gray-*` body under eyebrow headers).
- Spec amended: records the queue chrome migration and the `DetectionAnnotateTableRow` deletion rationale; its equally-dead sibling `DetectionAnnotateTableHeader` stays flagged for a cleanup ticket.
- Root `.gitignore` now covers `node_modules/` (it covered nothing at the repo root).

## Testing

- New tests pin the classify Result tooltip and the no-detail rendering (both watched fail first).
- 744 tests green; type-check and format clean; lint unchanged (2 pre-existing warnings).
- Queue table visually re-verified via stubbed-API screenshot.