### PR TITLE
feat(frontend): hover tooltips on classify groups filter tabs

### DIFF
--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -28,12 +28,26 @@ const DEFAULT_DIRECTION: Record<OrderBy, OrderDirection> = {
   created_at: 'desc',
 };
 
-const FILTERS: { value: SequenceGroupsFilter; label: string; countOf: keyof SequenceGroupStats }[] =
-  [
-    { value: 'unlabeled', label: 'To label', countOf: 'unlabeled' },
-    { value: 'labeled', label: 'Labeled', countOf: 'labeled' },
-    { value: 'all', label: 'All', countOf: 'total' },
-  ];
+const FILTERS: {
+  value: SequenceGroupsFilter;
+  label: string;
+  countOf: keyof SequenceGroupStats;
+  tip: string;
+}[] = [
+  {
+    value: 'unlabeled',
+    label: 'To label',
+    countOf: 'unlabeled',
+    tip: "Groups that don't have a label yet",
+  },
+  {
+    value: 'labeled',
+    label: 'Labeled',
+    countOf: 'labeled',
+    tip: 'Groups that already have a label',
+  },
+  { value: 'all', label: 'All', countOf: 'total', tip: 'Every group, labeled or not' },
+];
 
 // Same hover-tooltip bubble as components/sequences/ColumnHeader.tsx, kept
 // local because these headers are sortable and use this table's padding.
@@ -190,25 +204,29 @@ export default function SequenceGroupsListPage({
             const active = filter === f.value;
             const count = stats?.[f.countOf];
             return (
-              <Link
-                key={f.value}
-                to={classifyGroups(f.value)}
-                aria-current={active ? 'page' : undefined}
-                className={`inline-flex items-baseline px-3.5 py-1.5 rounded-md ${
-                  active
-                    ? 'border border-line bg-paper font-semibold text-char'
-                    : 'border border-transparent font-medium text-haze hover:text-char'
-                }`}
-              >
-                {f.label}
-                {count !== undefined && (
-                  <span
-                    className={`ml-1.5 font-data text-xs ${active ? 'text-ember' : 'text-haze'}`}
-                  >
-                    {count}
-                  </span>
-                )}
-              </Link>
+              // Tooltip lives on a wrapper, not inside the Link, so its text
+              // stays out of the link's accessible name.
+              <span key={f.value} className="group relative flex">
+                <Link
+                  to={classifyGroups(f.value)}
+                  aria-current={active ? 'page' : undefined}
+                  className={`inline-flex items-baseline px-3.5 py-1.5 rounded-md ${
+                    active
+                      ? 'border border-line bg-paper font-semibold text-char'
+                      : 'border border-transparent font-medium text-haze hover:text-char'
+                  }`}
+                >
+                  {f.label}
+                  {count !== undefined && (
+                    <span
+                      className={`ml-1.5 font-data text-xs ${active ? 'text-ember' : 'text-haze'}`}
+                    >
+                      {count}
+                    </span>
+                  )}
+                </Link>
+                {headerTip(f.tip)}
+              </span>
             );
           })}
         </div>

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -51,6 +51,7 @@ const FILTERS: {
 
 // Same hover-tooltip bubble as components/sequences/ColumnHeader.tsx, kept
 // local because these headers are sortable and use this table's padding.
+// Also reused by the filter tabs above the table.
 function headerTip(tip: string, align: 'left' | 'right' = 'left') {
   return (
     <span

--- a/frontend/tests/pages/SequenceGroupsListPage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupsListPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import React from 'react';
@@ -128,6 +128,16 @@ describe('SequenceGroupsListPage', () => {
     expect(screen.queryByText('All groups labeled')).toBeNull();
   });
 
+  it('filter tabs carry explanatory tooltips', async () => {
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getByRole('link', { name: /To label/ })).toBeTruthy());
+    expect(screen.getByText("Groups that don't have a label yet")).toBeTruthy();
+    expect(screen.getByText('Groups that already have a label')).toBeTruthy();
+    expect(screen.getByText('Every group, labeled or not')).toBeTruthy();
+    // Tooltip text must not leak into the tab links' accessible names.
+    expect(screen.getByRole('link', { name: /To label/ }).textContent).not.toMatch(/Groups/);
+  });
+
   it('column headers carry explanatory tooltips', async () => {
     vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
       items: [group],
@@ -139,7 +149,7 @@ describe('SequenceGroupsListPage', () => {
     renderAt('/classify/groups');
     await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
     // One tooltip per labeled column (Camera, Azimuth, Sequences, Label, Reviewed, Created)
-    expect(screen.getAllByRole('tooltip')).toHaveLength(6);
+    expect(within(screen.getByRole('table')).getAllByRole('tooltip')).toHaveLength(6);
     expect(screen.getByText('Number of sequences in the group')).toBeTruthy();
     expect(screen.getByText(/propagates to every member/)).toBeTruthy();
     expect(screen.getByText('Camera viewing direction, in degrees')).toBeTruthy();

--- a/frontend/tests/pages/SequenceGroupsListPage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupsListPage.test.tsx
@@ -134,8 +134,11 @@ describe('SequenceGroupsListPage', () => {
     expect(screen.getByText("Groups that don't have a label yet")).toBeTruthy();
     expect(screen.getByText('Groups that already have a label')).toBeTruthy();
     expect(screen.getByText('Every group, labeled or not')).toBeTruthy();
-    // Tooltip text must not leak into the tab links' accessible names.
-    expect(screen.getByRole('link', { name: /To label/ }).textContent).not.toMatch(/Groups/);
+    // Tooltip text must not leak into the tab links' accessible names
+    // (exact names: label + mocked zero count).
+    expect(screen.getByRole('link', { name: 'To label 0' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Labeled 0' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'All 0' })).toBeTruthy();
   });
 
   it('column headers carry explanatory tooltips', async () => {


### PR DESCRIPTION
## Summary
- Add explanatory hover tooltips to the **To label / Labeled / All** filter tabs on `/classify/groups`:
  - To label → "Groups that don't have a label yet"
  - Labeled → "Groups that already have a label"
  - All → "Every group, labeled or not"
- Reuses the page's existing `headerTip` dark-bubble pattern (pure CSS `group-hover`, no new dependencies), rendered on a wrapper span so the tooltip text stays out of each tab link's accessible name.

## Test plan
- New test: filter tabs render the three tooltips and tooltip text does not leak into link accessible names
- Existing column-header tooltip test scoped to the table so counts stay meaningful
- `npm test` (745 tests), `npm run type-check`, format check all pass; visually verified the hover bubble in the browser