### PR TITLE
feat(frontend): clarify Reviewed and to-label tooltips on groups page

### DIFF
--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -51,7 +51,7 @@ const FILTERS: {
 
 // Same hover-tooltip bubble as components/sequences/ColumnHeader.tsx, kept
 // local because these headers are sortable and use this table's padding.
-// Also reused by the filter tabs above the table.
+// Also reused by the filter tabs above the table and the rows' "to label" badge.
 function headerTip(tip: string, align: 'left' | 'right' = 'left') {
   return (
     <span
@@ -338,7 +338,10 @@ export default function SequenceGroupsListPage({
                     label="Label"
                     tip="Group label — propagates to every member once the group is validated"
                   />
-                  <PlainHeader label="Reviewed" tip="Whether a human validated the group's label" />
+                  <PlainHeader
+                    label="Reviewed"
+                    tip="Whether a human confirmed the group's sequences show the same object — the label propagates once confirmed"
+                  />
                   <SortableHeader
                     column="created_at"
                     label="Created"
@@ -388,8 +391,17 @@ export default function SequenceGroupsListPage({
                           false positive · {g.false_positive_type.replace(/_/g, ' ')}
                         </span>
                       ) : (
-                        <span className="inline-block rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-semibold text-yellow-800">
-                          to label
+                        <span className="group relative inline-block">
+                          <span className="inline-block rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-semibold text-yellow-800">
+                            to label
+                          </span>
+                          {/* Propagation only fires for validated groups, so
+                              tell unvalidated ones to validate first. */}
+                          {headerTip(
+                            g.is_validated
+                              ? 'Classify any sequence in this group — its label will propagate to all members'
+                              : 'Validate the group, then classify any sequence — its label will propagate to all members'
+                          )}
                         </span>
                       )}
                     </td>

--- a/frontend/tests/pages/SequenceGroupsListPage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupsListPage.test.tsx
@@ -151,10 +151,30 @@ describe('SequenceGroupsListPage', () => {
     });
     renderAt('/classify/groups');
     await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
-    // One tooltip per labeled column (Camera, Azimuth, Sequences, Label, Reviewed, Created)
-    expect(within(screen.getByRole('table')).getAllByRole('tooltip')).toHaveLength(6);
+    // One tooltip per labeled column (Camera, Azimuth, Sequences, Label,
+    // Reviewed, Created) plus one on the row's "to label" badge.
+    expect(within(screen.getByRole('table')).getAllByRole('tooltip')).toHaveLength(7);
     expect(screen.getByText('Number of sequences in the group')).toBeTruthy();
     expect(screen.getByText(/propagates to every member/)).toBeTruthy();
     expect(screen.getByText('Camera viewing direction, in degrees')).toBeTruthy();
+    // Reviewed means the grouping was confirmed, not the label — a group can
+    // be validated while still unlabeled.
+    expect(screen.getByText(/confirmed the group's sequences show the same object/)).toBeTruthy();
+  });
+
+  it('the "to label" badge explains how to get the group labeled, per validation state', async () => {
+    // Propagation only fires for validated groups, so the unvalidated badge
+    // must lead with the missing step instead of promising propagation.
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
+      items: [group, { ...group, id: 8, camera_name: 'CAM_08', is_validated: true }],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 2,
+    });
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getAllByText('to label')).toHaveLength(2));
+    expect(screen.getByText(/^Classify any sequence in this group/)).toBeTruthy();
+    expect(screen.getByText(/^Validate the group, then classify any sequence/)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Problem

On `/classify/groups`, a validated-but-unlabeled group shows a yellow **to label** badge right next to a green **validated** state, which reads as contradictory. The Reviewed header tooltip made it worse by claiming a human "validated the group's label" — false for these rows, since validation only confirms the grouping (`PATCH` sets `is_validated` and nothing else) while the label arrives later by propagation.

## Changes

- **Reviewed header tooltip** now describes what validation actually means: *"Whether a human confirmed the group's sequences show the same object — the label propagates once confirmed"*.
- **The row-level "to label" badge** gains a hover tooltip (reusing the existing `headerTip` helper) telling the annotator how to get the group labeled. The copy branches on `is_validated`, because propagation is hard-gated on it (`sequence_annotations.py` `propagate_group_label`):
  - validated: *"Classify any sequence in this group — its label will propagate to all members"*
  - not validated: *"Validate the group, then classify any sequence — its label will propagate to all members"*

## Tests

- Tooltip-count assertion bumped 6→7; both new copy strings pinned.
- New test rendering a validated and an unvalidated unlabeled row, asserting each gets its variant.
- Full suite: 746/746 passing; type-check and format clean.

## Out of scope (known follow-up)

Classify-then-validate ordering still leaves a group permanently unlabeled — the `PATCH` doesn't re-derive the label from already-annotated members. That's a backend fix, tracked in #253.
