### PR TITLE
Restyle classify group detail page to fire-lookout

### DIFF
--- a/docs/specs/2026-08-03-classify-group-detail-restyle-design.md
+++ b/docs/specs/2026-08-03-classify-group-detail-restyle-design.md
@@ -1,0 +1,86 @@
+# Classify Group Detail Restyle — Design
+
+**Date:** 2026-08-03
+**Status:** Approved
+
+## Problem
+
+`/classify/groups/:id` (`SequenceGroupAnnotatePage`) still runs entirely on the
+legacy palette (`gray-*`, `blue-*`, `green-*`, `orange-*`, `yellow-*`) while
+its sibling list page and the rest of the recently converted UI use the
+fire-lookout system defined in `frontend/DESIGN.md`. The page also spends a
+large vertical slab on the always-visible blue "How to label this group"
+callout.
+
+## Decision
+
+Restyle the page in place onto the fire-lookout tokens and compact the layout.
+No behavior changes: data fetching, mutations, grid auto-fill, card-size
+persistence, and the remove-confirmation flow stay exactly as they are.
+
+### Pinned header
+
+Keeps the fixed-past-sidebar idiom and the root's `pt-20` reservation.
+
+- Bar: `bg-paper/85 backdrop-blur-sm border-b border-line`, no shadow.
+- Back link: tertiary recipe — `font-body text-detail text-haze
+  hover:text-char`.
+- Title: `font-display text-title font-semibold tracking-tight text-char`.
+- Badges:
+  - `N seq` count → neutral mono pill: `bg-ash text-char font-data`.
+  - `smoke · <type>` and `false positive · <type>` → neutral paper pill with
+    hairline border (`border-line bg-paper text-char`).
+  - `to label` → `bg-ember-soft text-ember`, matching the list page (accent
+    only where action is pending).
+- Help: an `Info` icon after the badges replaces the removed blue callout.
+  Hover shows the three-line Label / Validate / Eject explanation using the
+  `bg-char` tooltip-bubble idiom from `SequenceGroupsListPage.headerTip`.
+- Prev/next chevrons: secondary-button styling (`border-line bg-paper
+  text-haze hover:bg-ash`); disabled state fades to `text-line`.
+- `Validate group`: ember primary button recipe (primary CTA in the Classify
+  lane; pine buttons are reserved for Localize contexts).
+- `Validated` pill: `bg-pine-soft text-pine` + ShieldCheck, matching the list
+  page's Reviewed column. `Unvalidate`: secondary button recipe.
+
+### Legend / card-size toolbar
+
+- Row: hairline card — `border border-line bg-paper`; text `font-body
+  text-detail text-haze`.
+- Legend swatches keep red/fuchsia so they match the overlays.
+- S/M/L segmented control mirrors the list page's tab pills: `bg-ash p-0.5`
+  track, active `bg-paper border-line text-char`, inactive `text-haze
+  hover:text-char`.
+
+### Member cards
+
+- Card: `rounded-card border border-line bg-paper overflow-hidden` (hairline
+  replaces `border-2 border-gray-300`); annotated members keep `opacity-60`.
+- Image wells `bg-ash`, center divider `border-line`, spinners `text-haze`,
+  card-link hover `hover:bg-ash`.
+- Footer: `seq #id` and relative time in `font-data text-detail` (counts and
+  timestamps are always mono), time in `text-haze`; annotated check
+  `text-pine`; pending clock `text-haze`.
+- Eject ✕: paper/hairline at rest; hover is destructive-signal —
+  `hover:bg-signal-soft hover:border-signal hover:text-signal`. The
+  `window.confirm` flow is unchanged.
+
+### Page states
+
+- Loading: `text-haze` copy with ember spinner tone.
+- Error: `text-signal`.
+- Empty group: dashed `border-line`, `text-haze`.
+
+### Explicitly unchanged
+
+- Bbox overlay colors: red solid (detected object) and fuchsia dashed (group
+  reference region) are functional marker colors on imagery — `signal` is
+  reserved for errors and neither palette accent has the needed contrast on
+  photos. Legend swatches stay matching.
+- Grid auto-fill behavior and `CARD_MIN_WIDTH` steps.
+- All queries, mutations, and invalidation keys.
+
+## Verification
+
+- `npm run quality` passes; full vitest suite stays green (686 baseline).
+- Before/after screenshot of the page via the playwright recipe to eyeball the
+  restyle.

--- a/docs/specs/2026-08-03-classify-group-detail-restyle-design.md
+++ b/docs/specs/2026-08-03-classify-group-detail-restyle-design.md
@@ -58,9 +58,10 @@ Keeps the fixed-past-sidebar idiom and the root's `pt-20` reservation.
   image grid reads as a contact sheet); annotated members keep `opacity-60`.
 - Image wells `bg-ash`, center divider `border-line`, spinners `text-haze`,
   card-link hover `hover:bg-ash`.
-- Footer: `seq #id` and relative time in `font-data text-detail` (counts and
-  timestamps are always mono), time in `text-haze`; annotated check
-  `text-pine`; pending clock `text-haze`.
+- Footer: the full recorded timestamp (`toLocaleString()`, the queue-table
+  convention) in `font-data text-detail text-haze` — the sequence id is
+  dropped (meaningless to annotators); relative time moves to the hover
+  title; annotated check `text-pine`; pending clock `text-haze`.
 - Eject ✕: paper/hairline at rest; hover is destructive-signal —
   `hover:bg-signal-soft hover:border-signal hover:text-signal`. The
   `window.confirm` flow is unchanged.

--- a/docs/specs/2026-08-03-classify-group-detail-restyle-design.md
+++ b/docs/specs/2026-08-03-classify-group-detail-restyle-design.md
@@ -53,8 +53,9 @@ Keeps the fixed-past-sidebar idiom and the root's `pt-20` reservation.
 
 ### Member cards
 
-- Card: `rounded-card border border-line bg-paper overflow-hidden` (hairline
-  replaces `border-2 border-gray-300`); annotated members keep `opacity-60`.
+- Card: `border border-line bg-paper overflow-hidden` (hairline replaces
+  `border-2 border-gray-300`; square corners — no `rounded-card` — so the
+  image grid reads as a contact sheet); annotated members keep `opacity-60`.
 - Image wells `bg-ash`, center divider `border-line`, spinners `text-haze`,
   card-link hover `hover:bg-ash`.
 - Footer: `seq #id` and relative time in `font-data text-detail` (counts and

--- a/docs/specs/2026-08-03-classify-group-detail-restyle-design.md
+++ b/docs/specs/2026-08-03-classify-group-detail-restyle-design.md
@@ -25,7 +25,9 @@ Keeps the fixed-past-sidebar idiom and the root's `pt-20` reservation.
 - Bar: `bg-paper/85 backdrop-blur-sm border-b border-line`, no shadow.
 - Back link: tertiary recipe — `font-body text-detail text-haze
   hover:text-char`.
-- Title: `font-display text-title font-semibold tracking-tight text-char`.
+- Title: `font-display text-heading font-semibold text-char` — heading scale,
+  not `text-title`: the pinned bar is a working toolbar, so the camera name
+  anchors it without page-h1 size.
 - Badges:
   - `N seq` count → neutral mono pill: `bg-ash text-char font-data`.
   - `smoke · <type>` and `false positive · <type>` → neutral paper pill with

--- a/docs/specs/2026-08-03-classify-group-detail-restyle-design.md
+++ b/docs/specs/2026-08-03-classify-group-detail-restyle-design.md
@@ -85,6 +85,8 @@ Keeps the fixed-past-sidebar idiom and the root's `pt-20` reservation.
 
 ## Verification
 
-- `npm run quality` passes; full vitest suite stays green (686 baseline).
+- Type-check, Prettier, and the full vitest suite stay green (686 baseline).
+  (`npm run lint` fails repo-wide on 2 pre-existing `no-console` warnings in
+  `DetectionSequenceAnnotatePage.tsx` — untouched by this work.)
 - Before/after screenshot of the page via the playwright recipe to eyeball the
   restyle.

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -115,7 +115,7 @@ function MemberCard({
 
   return (
     <div
-      className={`relative rounded-card border border-line bg-paper overflow-hidden ${
+      className={`relative border border-line bg-paper overflow-hidden ${
         memberIsAnnotated(member) ? 'opacity-60' : ''
       }`}
     >

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -115,7 +115,7 @@ function MemberCard({
 
   return (
     <div
-      className={`relative rounded-lg border-2 border-gray-300 bg-white overflow-hidden ${
+      className={`relative rounded-card border border-line bg-paper overflow-hidden ${
         memberIsAnnotated(member) ? 'opacity-60' : ''
       }`}
     >
@@ -135,19 +135,19 @@ function MemberCard({
           }
         }}
         disabled={removeMutation.isPending}
-        className="absolute top-2 right-2 z-20 p-1 rounded-full bg-white/90 border border-gray-300 hover:bg-red-50 hover:border-red-400 hover:text-red-600 disabled:opacity-50"
+        className="absolute top-2 right-2 z-20 p-1 rounded-full bg-paper/90 border border-line text-haze hover:bg-signal-soft hover:border-signal hover:text-signal disabled:opacity-50"
       >
         <X className="w-4 h-4" />
       </button>
 
       <Link
         to={classifyDetail(member.sequence_id)}
-        className="block hover:bg-blue-50"
+        className="block hover:bg-ash"
         title="Open the per-sequence annotation page"
       >
         <div className="grid grid-cols-2">
           {/* Full frame with bbox overlays. */}
-          <div className="relative aspect-video bg-gray-100 overflow-hidden flex items-center justify-center border-r border-gray-200">
+          <div className="relative aspect-video bg-ash overflow-hidden flex items-center justify-center border-r border-line">
             {image?.url ? (
               <>
                 <img
@@ -193,18 +193,18 @@ function MemberCard({
                 )}
               </>
             ) : (
-              <Loader2 className="animate-spin w-5 h-5 text-gray-400" />
+              <Loader2 className="animate-spin w-5 h-5 text-haze" />
             )}
           </div>
           {/* Zoomed crop so small objects stay legible. Falls back to the
               plain frame when neither a prediction nor the group region
               yields a valid box to zoom into. */}
-          <div className="relative aspect-video bg-gray-100 overflow-hidden flex items-center justify-center">
+          <div className="relative aspect-video bg-ash overflow-hidden flex items-center justify-center">
             {image?.url ? (
               isValidBox(cropBox) ? (
                 <>
                   <BboxCrop url={image.url} box={cropBox} />
-                  <span className="absolute bottom-1 right-1 z-10 px-1 rounded bg-black/50 text-white text-[10px] leading-tight pointer-events-none">
+                  <span className="absolute bottom-1 right-1 z-10 px-1 rounded bg-char/70 text-white text-[10px] leading-tight pointer-events-none">
                     zoom
                   </span>
                 </>
@@ -212,22 +212,22 @@ function MemberCard({
                 <img src={image.url} alt="" className="w-full h-full object-cover" />
               )
             ) : (
-              <Loader2 className="animate-spin w-5 h-5 text-gray-400" />
+              <Loader2 className="animate-spin w-5 h-5 text-haze" />
             )}
           </div>
         </div>
-        <div className="px-2 py-1 text-xs text-gray-700 flex items-center justify-between">
+        <div className="px-2 py-1 font-data text-detail text-char flex items-center justify-between">
           <span>
             <span className="font-medium">seq #{member.sequence_id}</span>
-            <span className="text-gray-500" title={new Date(member.recorded_at).toLocaleString()}>
+            <span className="text-haze" title={new Date(member.recorded_at).toLocaleString()}>
               {' · '}
               {formatRelativeTime(member.recorded_at)}
             </span>
           </span>
           {memberIsAnnotated(member) ? (
-            <CheckCircle className="w-3 h-3 text-green-500" aria-label="annotated" />
+            <CheckCircle className="w-3 h-3 text-pine" aria-label="annotated" />
           ) : (
-            <Clock className="w-3 h-3 text-orange-400" />
+            <Clock className="w-3 h-3 text-haze" />
           )}
         </div>
       </Link>
@@ -285,14 +285,14 @@ export default function SequenceGroupAnnotatePage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-96 text-gray-500">
-        <Loader2 className="animate-spin w-6 h-6 mr-2" /> Loading group…
+      <div className="flex items-center justify-center h-96 font-body text-haze">
+        <Loader2 className="animate-spin w-6 h-6 mr-2 text-ember" /> Loading group…
       </div>
     );
   }
   if (error || !group) {
     return (
-      <div className="flex items-center justify-center h-96 text-red-600">
+      <div className="flex items-center justify-center h-96 font-body text-signal">
         <AlertCircle className="w-6 h-6 mr-2" />
         Failed to load group {groupId}
       </div>
@@ -420,7 +420,7 @@ export default function SequenceGroupAnnotatePage() {
       </div>
 
       <div>
-        <div className="mb-2 flex flex-wrap items-center justify-between gap-x-5 gap-y-1 rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 text-xs text-gray-600">
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-x-5 gap-y-1 rounded-lg border border-line bg-paper px-3 py-1.5 font-body text-detail text-haze">
           <div className="flex flex-wrap items-center gap-x-5 gap-y-1">
             <span className="inline-flex items-center gap-1.5">
               <span className="inline-block w-4 h-3 border-2 border-red-500" />
@@ -434,7 +434,7 @@ export default function SequenceGroupAnnotatePage() {
           </div>
           <div className="inline-flex items-center gap-1.5">
             <span>Card size</span>
-            <div className="inline-flex rounded-md bg-gray-200 p-0.5 gap-0.5">
+            <div className="inline-flex rounded-md border border-line bg-ash p-0.5 gap-0.5">
               {CARD_SIZES.map(s => (
                 <button
                   key={s.value}
@@ -442,10 +442,8 @@ export default function SequenceGroupAnnotatePage() {
                   title={s.title}
                   aria-pressed={cardSize === s.value}
                   onClick={() => setCardSize(s.value)}
-                  className={`px-2 py-0.5 rounded font-semibold ${
-                    cardSize === s.value
-                      ? 'bg-white text-gray-900 shadow-sm'
-                      : 'text-gray-500 hover:text-gray-900'
+                  className={`px-2 py-0.5 rounded font-data font-semibold ${
+                    cardSize === s.value ? 'bg-paper text-char' : 'text-haze hover:text-char'
                   }`}
                 >
                   {s.label}
@@ -456,7 +454,7 @@ export default function SequenceGroupAnnotatePage() {
         </div>
 
         {group.members.length === 0 ? (
-          <div className="px-4 py-12 text-center text-gray-500 border border-dashed border-gray-300 rounded">
+          <div className="px-4 py-12 text-center font-body text-haze border border-dashed border-line rounded-card">
             This group has no members.
           </div>
         ) : (

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -216,13 +216,11 @@ function MemberCard({
             )}
           </div>
         </div>
-        <div className="px-2 py-1 font-data text-detail text-char flex items-center justify-between">
-          <span>
-            <span className="font-medium">seq #{member.sequence_id}</span>
-            <span className="text-haze" title={new Date(member.recorded_at).toLocaleString()}>
-              {' · '}
-              {formatRelativeTime(member.recorded_at)}
-            </span>
+        <div className="px-2 py-1 font-data text-detail text-haze flex items-center justify-between">
+          {/* Full timestamp like the queue tables — the sequence id means
+              nothing to annotators; relative time lives in the tooltip. */}
+          <span title={formatRelativeTime(member.recorded_at)}>
+            {new Date(member.recorded_at).toLocaleString()}
           </span>
           {memberIsAnnotated(member) ? (
             <CheckCircle className="w-3 h-3 text-pine" aria-label="annotated" />

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -314,7 +314,9 @@ export default function SequenceGroupAnnotatePage() {
         </Link>
         <div className="mt-1 flex items-center justify-between gap-4">
           <div className="flex items-center gap-2.5 min-w-0">
-            <h1 className="font-display text-title font-semibold tracking-tight text-char truncate">
+            {/* text-heading, not text-title — this pinned bar is a working
+                toolbar, so the camera name anchors it without page-h1 scale. */}
+            <h1 className="font-display text-heading font-semibold text-char truncate">
               {cameraName} · {group.azimuth}°
             </h1>
             <span className="flex-none rounded-full bg-ash px-2.5 py-0.5 font-data text-xs font-semibold text-char">
@@ -418,7 +420,9 @@ export default function SequenceGroupAnnotatePage() {
       </div>
 
       <div>
-        <div className="mb-2 flex flex-wrap items-center justify-between gap-x-5 gap-y-1 rounded-lg border border-line bg-paper px-3 py-1.5 font-body text-detail text-haze">
+        {/* mb-4 matches the grid's gap-4 so the legend row and card rows
+            share one vertical rhythm. */}
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-x-5 gap-y-1 rounded-lg border border-line bg-paper px-3 py-1.5 font-body text-detail text-haze">
           <div className="flex flex-wrap items-center gap-x-5 gap-y-1">
             <span className="inline-flex items-center gap-1.5">
               <span className="inline-block w-4 h-3 border-2 border-red-500" />

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -337,11 +337,13 @@ export default function SequenceGroupAnnotatePage() {
             )}
             {/* Hover help replaces the old always-visible callout — same
                 bubble idiom as SequenceGroupsListPage.headerTip. */}
-            <span className="group relative flex-none">
+            {/* tabIndex + focus-within keep the workflow help reachable by
+                keyboard now that the always-visible callout is gone. */}
+            <span tabIndex={0} className="group relative flex-none">
               <Info className="w-4 h-4 text-haze hover:text-char cursor-help" />
               <span
                 role="tooltip"
-                className="pointer-events-none absolute left-0 top-full z-40 mt-1 hidden w-max max-w-[20rem] whitespace-normal rounded bg-char px-2.5 py-2 font-body text-xs font-normal text-white group-hover:block"
+                className="pointer-events-none absolute left-0 top-full z-40 mt-1 hidden w-max max-w-[20rem] whitespace-normal rounded bg-char px-2.5 py-2 font-body text-xs font-normal text-white group-hover:block group-focus-within:block"
               >
                 <span className="block">
                   <span className="font-semibold">Label</span> — open any sequence below and label

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -307,45 +307,70 @@ export default function SequenceGroupAnnotatePage() {
           page: fixed to the viewport past the sidebar (md:left-64) so the
           primary action (validate) stays reachable while scrolling the
           member grid. The root's pt-20 reserves its space. */}
-      <div className="fixed top-0 left-0 md:left-64 right-0 z-30 px-6 pt-3 pb-2.5 bg-white/85 border-b border-gray-200 backdrop-blur-sm shadow-sm">
-        <Link to={ROUTES.CLASSIFY_GROUPS} className="text-sm text-gray-500 hover:text-gray-800">
+      <div className="fixed top-0 left-0 md:left-64 right-0 z-30 px-6 pt-3 pb-2.5 bg-paper/85 border-b border-line backdrop-blur-sm">
+        <Link
+          to={ROUTES.CLASSIFY_GROUPS}
+          className="font-body text-detail text-haze hover:text-char"
+        >
           ← Sequence groups
         </Link>
         <div className="mt-1 flex items-center justify-between gap-4">
           <div className="flex items-center gap-2.5 min-w-0">
-            <h1 className="text-2xl font-bold text-gray-900 truncate">
+            <h1 className="font-display text-title font-semibold tracking-tight text-char truncate">
               {cameraName} · {group.azimuth}°
             </h1>
-            <span className="flex-none rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-semibold text-blue-700">
+            <span className="flex-none rounded-full bg-ash px-2.5 py-0.5 font-data text-xs font-semibold text-char">
               {group.members.length} seq
             </span>
             {group.smoke_type ? (
-              <span className="flex-none rounded-full bg-orange-100 px-2.5 py-0.5 text-xs font-semibold text-orange-700">
+              <span className="flex-none rounded-full border border-line bg-paper px-2.5 py-0.5 font-body text-xs font-semibold text-char">
                 smoke · {group.smoke_type}
               </span>
             ) : group.false_positive_type ? (
-              <span className="flex-none rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-700">
+              <span className="flex-none rounded-full border border-line bg-paper px-2.5 py-0.5 font-body text-xs font-semibold text-char">
                 false positive · {group.false_positive_type.replace(/_/g, ' ')}
               </span>
             ) : (
-              <span className="flex-none rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-semibold text-yellow-800">
+              <span className="flex-none rounded-full bg-ember-soft px-2.5 py-0.5 font-body text-xs font-semibold text-ember">
                 to label
               </span>
             )}
+            {/* Hover help replaces the old always-visible callout — same
+                bubble idiom as SequenceGroupsListPage.headerTip. */}
+            <span className="group relative flex-none">
+              <Info className="w-4 h-4 text-haze hover:text-char cursor-help" />
+              <span
+                role="tooltip"
+                className="pointer-events-none absolute left-0 top-full z-40 mt-1 hidden w-max max-w-[20rem] whitespace-normal rounded bg-char px-2.5 py-2 font-body text-xs font-normal text-white group-hover:block"
+              >
+                <span className="block">
+                  <span className="font-semibold">Label</span> — open any sequence below and label
+                  it.
+                </span>
+                <span className="mt-1 block">
+                  <span className="font-semibold">Validate</span> — confirms every sequence shows
+                  the same object; one label then propagates to all unannotated members.
+                </span>
+                <span className="mt-1 block">
+                  <span className="font-semibold">Eject</span> — ✕ removes a sequence that doesn't
+                  belong. Do it before validating.
+                </span>
+              </span>
+            </span>
           </div>
           <div className="flex flex-none items-center gap-2">
             {prevId ? (
               <Link
                 to={classifyGroup(prevId)}
                 title="Previous group"
-                className="p-1.5 rounded-lg border border-gray-300 bg-white text-gray-600 hover:bg-gray-50"
+                className="p-1.5 rounded-lg border border-line bg-paper text-haze hover:bg-ash"
               >
                 <ChevronLeft className="w-4 h-4" />
               </Link>
             ) : (
               <span
                 aria-disabled="true"
-                className="p-1.5 rounded-lg border border-gray-200 bg-white text-gray-300"
+                className="p-1.5 rounded-lg border border-line bg-paper text-line"
               >
                 <ChevronLeft className="w-4 h-4" />
               </span>
@@ -354,28 +379,28 @@ export default function SequenceGroupAnnotatePage() {
               <Link
                 to={classifyGroup(nextId)}
                 title="Next group"
-                className="p-1.5 rounded-lg border border-gray-300 bg-white text-gray-600 hover:bg-gray-50"
+                className="p-1.5 rounded-lg border border-line bg-paper text-haze hover:bg-ash"
               >
                 <ChevronRight className="w-4 h-4" />
               </Link>
             ) : (
               <span
                 aria-disabled="true"
-                className="p-1.5 rounded-lg border border-gray-200 bg-white text-gray-300"
+                className="p-1.5 rounded-lg border border-line bg-paper text-line"
               >
                 <ChevronRight className="w-4 h-4" />
               </span>
             )}
             {group.is_validated ? (
               <>
-                <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-green-100 text-green-700 text-sm">
+                <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-pine-soft font-body text-sm font-semibold text-pine">
                   <ShieldCheck className="w-4 h-4" /> Validated
                 </span>
                 <button
                   onClick={() => validateMutation.mutate(false)}
                   disabled={validateMutation.isPending}
                   title="Re-open the group — labels stop propagating to members"
-                  className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg bg-white hover:bg-gray-50 disabled:opacity-50"
+                  className="rounded-lg border border-line bg-paper px-3 py-1.5 font-body text-sm font-medium text-char hover:bg-ash disabled:opacity-50"
                 >
                   <ShieldOff className="w-3 h-3 inline mr-1" /> Unvalidate
                 </button>
@@ -385,33 +410,12 @@ export default function SequenceGroupAnnotatePage() {
                 onClick={() => validateMutation.mutate(true)}
                 disabled={validateMutation.isPending}
                 title="Confirms every sequence shows the same object and enables label propagation"
-                className="px-3 py-1.5 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:bg-gray-300"
+                className="rounded-lg bg-ember px-3.5 py-1.5 font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:opacity-50"
               >
                 <ShieldCheck className="w-4 h-4 inline mr-1" /> Validate group
               </button>
             )}
           </div>
-        </div>
-      </div>
-
-      <div className="flex gap-2.5 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
-        <Info className="w-4 h-4 flex-none mt-0.5 text-blue-600" />
-        <div>
-          <p className="font-semibold">How to label this group</p>
-          <ul className="mt-1 space-y-0.5 list-disc list-inside">
-            <li>
-              <span className="font-medium">Label</span> — open any sequence below and label it.
-            </li>
-            <li>
-              <span className="font-medium">Validate</span> — "Validate group" confirms every
-              sequence shows the same object; once validated, one label propagates to all
-              unannotated members.
-            </li>
-            <li>
-              <span className="font-medium">Eject</span> — use ✕ on a card to remove a sequence that
-              doesn't belong. Do this before validating.
-            </li>
-          </ul>
         </div>
       </div>
 

--- a/frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx
@@ -101,4 +101,33 @@ describe('SequenceGroupAnnotatePage', () => {
     expect(pill?.className).toContain('text-pine');
     expect(screen.getByRole('button', { name: /Unvalidate/ }).className).toContain('border-line');
   });
+
+  it('member cards use the hairline card recipe with a mono footer', async () => {
+    await renderGroup();
+    const card = screen.getByText('seq #101').closest('a')?.parentElement;
+    expect(card?.className).toContain('rounded-card');
+    expect(card?.className).toContain('border-line');
+    expect(card?.className).not.toContain('border-2');
+    const footer = screen.getByText('seq #101').closest('div');
+    expect(footer?.className).toContain('font-data');
+  });
+
+  it('card-size segmented control uses ash track with paper active pill', async () => {
+    await renderGroup();
+    const active = screen.getByRole('button', { name: 'M' });
+    expect(active.getAttribute('aria-pressed')).toBe('true');
+    expect(active.className).toContain('bg-paper');
+    expect(screen.getByRole('button', { name: 'S' }).className).toContain('text-haze');
+  });
+
+  it('empty groups get the dashed hairline empty state', async () => {
+    // With no members the title falls back to `camera #3 · 120°`, so this
+    // test can't go through renderGroup (which waits for CAM_07).
+    vi.mocked(apiClient.getSequenceGroup).mockResolvedValue({ ...baseGroup, members: [] });
+    renderAt('/classify/groups/7');
+    await waitFor(() => expect(screen.getByText('This group has no members.')).toBeTruthy());
+    const empty = screen.getByText('This group has no members.');
+    expect(empty.className).toContain('border-line');
+    expect(empty.className).toContain('text-haze');
+  });
 });

--- a/frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx
@@ -80,6 +80,18 @@ describe('SequenceGroupAnnotatePage', () => {
     const tip = screen.getByRole('tooltip');
     expect(within(tip).getByText(/propagates/)).toBeTruthy();
     expect(within(tip).getByText(/Eject/)).toBeTruthy();
+    // The callout it replaces was always-visible text, so the trigger must
+    // stay keyboard-reachable (focus opens the bubble via focus-within).
+    expect(tip.parentElement?.getAttribute('tabindex')).toBe('0');
+    expect(tip.className).toContain('group-focus-within:block');
+  });
+
+  it('smoke and false-positive labels render as neutral paper pills', async () => {
+    await renderGroup({ smoke_type: 'wildfire' });
+    const pill = screen.getByText('smoke · wildfire');
+    expect(pill.className).toContain('border-line');
+    expect(pill.className).toContain('bg-paper');
+    expect(pill.className).not.toContain('bg-orange-100');
   });
 
   it('renders the "to label" badge with ember tones', async () => {

--- a/frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx
@@ -105,7 +105,9 @@ describe('SequenceGroupAnnotatePage', () => {
   it('member cards use the hairline card recipe with a mono footer', async () => {
     await renderGroup();
     const card = screen.getByText('seq #101').closest('a')?.parentElement;
-    expect(card?.className).toContain('rounded-card');
+    // Square corners on member cards — deliberate deviation from the card
+    // recipe so dense image grids read as a contact sheet.
+    expect(card?.className).not.toContain('rounded');
     expect(card?.className).toContain('border-line');
     expect(card?.className).not.toContain('border-2');
     const footer = screen.getByText('seq #101').closest('div');

--- a/frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx
@@ -102,16 +102,20 @@ describe('SequenceGroupAnnotatePage', () => {
     expect(screen.getByRole('button', { name: /Unvalidate/ }).className).toContain('border-line');
   });
 
-  it('member cards use the hairline card recipe with a mono footer', async () => {
+  it('member cards use the hairline card recipe with a mono timestamp footer', async () => {
     await renderGroup();
-    const card = screen.getByText('seq #101').closest('a')?.parentElement;
+    const recorded = new Date(member.recorded_at).toLocaleString();
+    const card = screen.getByText(recorded).closest('a')?.parentElement;
     // Square corners on member cards — deliberate deviation from the card
     // recipe so dense image grids read as a contact sheet.
     expect(card?.className).not.toContain('rounded');
     expect(card?.className).toContain('border-line');
     expect(card?.className).not.toContain('border-2');
-    const footer = screen.getByText('seq #101').closest('div');
+    const footer = screen.getByText(recorded).closest('div');
     expect(footer?.className).toContain('font-data');
+    // The sequence id means nothing to annotators — footer shows the
+    // full timestamp instead, like the queue tables.
+    expect(screen.queryByText(/seq #/)).toBeNull();
   });
 
   it('card-size segmented control uses ash track with paper active pill', async () => {

--- a/frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import React from 'react';
+
+vi.mock('@/services/api', () => ({
+  apiClient: {
+    getSequenceGroup: vi.fn(),
+    getSequenceGroups: vi.fn(),
+    getDetectionImageUrl: vi.fn(),
+    removeSequenceFromGroup: vi.fn(),
+    patchSequenceGroup: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/services/api';
+import SequenceGroupAnnotatePage from '@/pages/SequenceGroupAnnotatePage';
+
+function renderAt(path: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/classify/groups/:id" element={<SequenceGroupAnnotatePage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// first_detection_id: null keeps useDetectionImage disabled — no image fetch.
+const member = {
+  sequence_id: 101,
+  alert_api_id: 1,
+  camera_name: 'CAM_07',
+  recorded_at: '2026-08-01T10:00:00Z',
+  last_seen_at: '2026-08-01T10:05:00Z',
+  annotation_processing_stage: null,
+  first_detection_id: null,
+  first_detection_algo_predictions: null,
+};
+
+const baseGroup = {
+  id: 7,
+  camera_id: 3,
+  azimuth: 120,
+  representative_bbox: {
+    xyxyn: [0.4, 0.4, 0.6, 0.6] as [number, number, number, number],
+    confidence: 0.9,
+  },
+  smoke_type: null,
+  false_positive_type: null,
+  is_unsure: false,
+  is_validated: false,
+  labeled_at: null,
+  labeled_by_user_id: null,
+  created_at: '2026-08-01T10:00:00Z',
+  updated_at: null,
+  members: [member],
+};
+
+const emptyNeighbors = { items: [], page: 1, pages: 0, size: 100, total: 0 };
+
+async function renderGroup(overrides = {}) {
+  vi.mocked(apiClient.getSequenceGroup).mockResolvedValue({ ...baseGroup, ...overrides });
+  renderAt('/classify/groups/7');
+  await waitFor(() => expect(screen.getByText('CAM_07 · 120°')).toBeTruthy());
+}
+
+describe('SequenceGroupAnnotatePage', () => {
+  beforeEach(() => {
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue(emptyNeighbors);
+  });
+
+  it('replaces the help callout with a header info tooltip', async () => {
+    await renderGroup();
+    expect(screen.queryByText('How to label this group')).toBeNull();
+    const tip = screen.getByRole('tooltip');
+    expect(within(tip).getByText(/propagates/)).toBeTruthy();
+    expect(within(tip).getByText(/Eject/)).toBeTruthy();
+  });
+
+  it('renders the "to label" badge with ember tones', async () => {
+    await renderGroup();
+    expect(screen.getByText('to label')).toHaveClass('bg-ember-soft', 'text-ember');
+  });
+
+  it('Validate group is the ember primary button', async () => {
+    await renderGroup();
+    const btn = screen.getByRole('button', { name: /Validate group/ });
+    expect(btn.className).toContain('bg-ember');
+    expect(btn.className).not.toContain('bg-green-600');
+  });
+
+  it('validated groups show a pine pill and a secondary Unvalidate button', async () => {
+    await renderGroup({ is_validated: true });
+    const pill = screen.getByText(/Validated/).closest('span');
+    expect(pill?.className).toContain('bg-pine-soft');
+    expect(pill?.className).toContain('text-pine');
+    expect(screen.getByRole('button', { name: /Unvalidate/ }).className).toContain('border-line');
+  });
+});


### PR DESCRIPTION
## Summary

Migrates `/classify/groups/:id` (`SequenceGroupAnnotatePage`) — the last classify surface on the legacy palette — to the fire-lookout system defined in `frontend/DESIGN.md`, and compacts the layout.

Spec: `docs/specs/2026-08-03-classify-group-detail-restyle-design.md`

- **Pinned header**: paper/hairline bar, display-font camera-name title at heading scale, neutral mono `N seq` pill, ember `to label` pill (list-page convention), pine `Validated` pill, ember primary `Validate group` button, hairline chevrons.
- **Help callout → tooltip**: the always-visible blue "How to label this group" slab is now an `(i)` hover tooltip in the header (same bubble idiom as the list page), freeing a full row of vertical space.
- **Legend/card-size toolbar**: paper hairline row, ash segmented S/M/L control; `mb-4` so it shares the grid's vertical rhythm.
- **Member cards**: hairline square-cornered cards (contact-sheet feel), ash image wells, mono full-timestamp footer (`toLocaleString()`, the queue-table convention) replacing the unhelpful `seq #` — relative time in the hover title; pine check / haze clock status icons; eject ✕ goes signal-toned on hover.
- **States**: haze loading with ember spinner, signal error, hairline dashed empty state.

Unchanged: all queries/mutations, grid auto-fill + card-size persistence, remove-confirmation flow, and the red/fuchsia bbox overlay colors (functional markers on imagery).

## Test plan

- 7 new tests in `frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx` (tooltip replaces callout, badge/button tones, card recipe, segmented control, empty state)
- Full suite: 693 passed; type-check + Prettier clean (the 2 pre-existing `no-console` lint warnings in `DetectionSequenceAnnotatePage.tsx` predate this branch)
- Screenshot-verified via the playwright recipe