### PR TITLE
Show who validated a group in the Reviewed column

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
@@ -106,6 +106,8 @@ async def list_sequence_groups(
             SequenceGroup.false_positive_type,
             SequenceGroup.is_unsure,
             SequenceGroup.is_validated,
+            SequenceGroup.validated_at,
+            User.username.label("validated_by_username"),
             SequenceGroup.labeled_at,
             SequenceGroup.created_at,
             member_count_subq.c.member_count,
@@ -113,6 +115,9 @@ async def list_sequence_groups(
         )
         # Inner-join so small groups (no row in the subquery) drop out.
         .join(member_count_subq, member_count_subq.c.group_id == SequenceGroup.id)
+        # Reviewer attribution; LEFT JOIN because legacy validations and
+        # unvalidated groups have no user.
+        .outerjoin(User, User.id == SequenceGroup.validated_by_user_id)
         # Caller-chosen primary sort; created_at/id remain as deterministic
         # tie-breakers so paginated offsets stay stable.
         .order_by(

--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
@@ -282,7 +282,17 @@ async def update_sequence_group(
         )
     changes = payload.model_dump(exclude_unset=True)
     if "is_validated" in changes:
-        group.is_validated = changes["is_validated"]
+        new_value = changes["is_validated"]
+        if new_value and not group.is_validated:
+            # false→true: stamp the reviewer. Re-validating an already
+            # validated group is a no-op — first reviewer stands.
+            group.validated_by_user_id = current_user.id
+            group.validated_at = datetime.now(UTC)
+        elif not new_value:
+            # true→false (or already false): never carry stale attribution.
+            group.validated_by_user_id = None
+            group.validated_at = None
+        group.is_validated = new_value
     if changes:
         group.updated_at = datetime.now(UTC)
     session.add(group)

--- a/annotation_api/src/app/models.py
+++ b/annotation_api/src/app/models.py
@@ -291,6 +291,15 @@ class SequenceGroup(SQLModel, table=True):
     # membership is correct. Annotation propagation to other members only
     # kicks in for validated groups.
     is_validated: bool = Field(default=False)
+    # Who confirmed group membership (the "Reviewed" action) and when.
+    # NULL for groups validated before attribution existed.
+    validated_by_user_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(ForeignKey("users.id", ondelete="SET NULL")),
+    )
+    validated_at: Optional[datetime] = Field(
+        default=None, sa_column=Column(DateTime(timezone=True))
+    )
     labeled_at: Optional[datetime] = Field(
         default=None, sa_column=Column(DateTime(timezone=True))
     )

--- a/annotation_api/src/app/schemas/sequence_group.py
+++ b/annotation_api/src/app/schemas/sequence_group.py
@@ -123,6 +123,8 @@ class SequenceGroupRead(BaseModel):
     false_positive_type: Optional[FalsePositiveType]
     is_unsure: bool
     is_validated: bool
+    validated_at: Optional[datetime]
+    validated_by_user_id: Optional[int]
     labeled_at: Optional[datetime]
     labeled_by_user_id: Optional[int]
     created_at: datetime

--- a/annotation_api/src/app/schemas/sequence_group.py
+++ b/annotation_api/src/app/schemas/sequence_group.py
@@ -88,6 +88,10 @@ class SequenceGroupListItem(BaseModel):
     false_positive_type: Optional[FalsePositiveType]
     is_unsure: bool
     is_validated: bool
+    validated_at: Optional[datetime]
+    # Username of the validating user, LEFT-JOINed in the list query.
+    # None for legacy validations (pre-attribution) or deleted users.
+    validated_by_username: Optional[str]
     labeled_at: Optional[datetime]
     created_at: datetime
     member_count: int

--- a/annotation_api/src/migrations/versions/2026_08_03_1400-f2a3b4c5d6e7_add_group_validated_by.py
+++ b/annotation_api/src/migrations/versions/2026_08_03_1400-f2a3b4c5d6e7_add_group_validated_by.py
@@ -1,0 +1,47 @@
+"""add sequence_groups validation attribution
+
+Revision ID: f2a3b4c5d6e7
+Revises: e1f2a3b4c5d6
+Create Date: 2026-08-03 14:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "f2a3b4c5d6e7"
+down_revision: Union[str, None] = "e1f2a3b4c5d6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sequence_groups",
+        sa.Column("validated_by_user_id", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "sequence_groups",
+        sa.Column("validated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_sequence_groups_validated_by_user_id_users",
+        "sequence_groups",
+        "users",
+        ["validated_by_user_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_sequence_groups_validated_by_user_id_users",
+        "sequence_groups",
+        type_="foreignkey",
+    )
+    op.drop_column("sequence_groups", "validated_at")
+    op.drop_column("sequence_groups", "validated_by_user_id")

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -799,3 +799,77 @@ async def test_stats_counts_only_groups_with_three_plus_members(
         "labeled": 0,
         "unlabeled": 2,
     }
+
+
+@pytest.mark.asyncio
+async def test_validate_records_reviewer(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+    test_user: User,
+):
+    """Flipping is_validated false→true stamps the caller and a timestamp."""
+    gid = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        alert_api_id_start=400,
+    )
+    resp = await authenticated_client.patch(
+        f"/sequence_groups/{gid}", json={"is_validated": True}
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["validated_by_user_id"] == test_user.id
+    assert body["validated_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_unvalidate_clears_reviewer(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """true→false wipes attribution so stale reviewers never linger."""
+    gid = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        alert_api_id_start=410,
+    )
+    resp = await authenticated_client.patch(
+        f"/sequence_groups/{gid}", json={"is_validated": True}
+    )
+    assert resp.status_code == 200, resp.text
+    resp = await authenticated_client.patch(
+        f"/sequence_groups/{gid}", json={"is_validated": False}
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["validated_by_user_id"] is None
+    assert body["validated_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_revalidate_keeps_original_attribution(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """Re-sending is_validated=true on a validated group is a no-op — the
+    first reviewer stands until someone unvalidates."""
+    gid = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        alert_api_id_start=420,
+    )
+    first = await authenticated_client.patch(
+        f"/sequence_groups/{gid}", json={"is_validated": True}
+    )
+    assert first.status_code == 200, first.text
+    second = await authenticated_client.patch(
+        f"/sequence_groups/{gid}", json={"is_validated": True}
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["validated_at"] == first.json()["validated_at"]
+    assert (
+        second.json()["validated_by_user_id"] == first.json()["validated_by_user_id"]
+    )

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -870,6 +870,56 @@ async def test_revalidate_keeps_original_attribution(
     )
     assert second.status_code == 200, second.text
     assert second.json()["validated_at"] == first.json()["validated_at"]
-    assert (
-        second.json()["validated_by_user_id"] == first.json()["validated_by_user_id"]
+    assert second.json()["validated_by_user_id"] == first.json()["validated_by_user_id"]
+
+
+@pytest.mark.asyncio
+async def test_list_includes_validated_by_username(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+    test_user: User,
+):
+    gid = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        alert_api_id_start=430,
     )
+    resp = await authenticated_client.patch(
+        f"/sequence_groups/{gid}", json={"is_validated": True}
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = await authenticated_client.get("/sequence_groups/")
+    assert resp.status_code == 200
+    row = next(i for i in resp.json()["items"] if i["id"] == gid)
+    assert row["validated_by_username"] == test_user.username
+    assert row["validated_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_list_legacy_validated_group_has_null_reviewer(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """Groups validated before attribution existed stay is_validated=true
+    with NULL reviewer fields — the list must return them, not 500."""
+    gid = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        alert_api_id_start=440,
+    )
+    await async_session.exec(
+        text(
+            "UPDATE sequence_groups SET is_validated = true WHERE id = :gid"
+        ).bindparams(gid=gid)
+    )
+    await async_session.commit()
+
+    resp = await authenticated_client.get("/sequence_groups/")
+    assert resp.status_code == 200
+    row = next(i for i in resp.json()["items"] if i["id"] == gid)
+    assert row["is_validated"] is True
+    assert row["validated_by_username"] is None
+    assert row["validated_at"] is None

--- a/docs/specs/2026-08-03-group-validated-by-design.md
+++ b/docs/specs/2026-08-03-group-validated-by-design.md
@@ -1,0 +1,86 @@
+# Group Validation Attribution — Design
+
+**Date:** 2026-08-03
+**Status:** Approved
+
+## Problem
+
+The Reviewed column on `/classify/groups` shows whether a group has been
+validated (`is_validated`), but not by whom. The backend stores no reviewer
+identity: `SequenceGroup.is_validated` is a bare boolean, with no
+`validated_by_user_id` or `validated_at`. Labeling already has attribution
+(`labeled_by_user_id`); validation has none.
+
+**Goals:** accountability (trace a validation decision to a person) and work
+tracking (see who is doing the review work at a glance).
+
+## Scope
+
+Show the validating user's name inline in the Reviewed column of
+`/classify/groups`, plus the validation time on hover.
+
+Out of scope, deliberately:
+
+- Labeler attribution in the UI (`labeled_by_user_id` exists but stays
+  unsurfaced for now).
+- Reviewer display on the group detail page (`/classify/groups/:id`).
+- A check constraint tying `validated_at` to `is_validated` — groups
+  validated before this change are permanently `is_validated = true` with
+  NULL attribution, so a strict iff constraint is impossible.
+
+## Data model
+
+Alembic migration adding two nullable columns to `sequence_groups`,
+mirroring the existing `labeled_by_user_id` / `labeled_at` pair:
+
+- `validated_by_user_id: Optional[int]` — FK `users.id`,
+  `ondelete="SET NULL"`.
+- `validated_at: Optional[datetime]` — timezone-aware.
+
+No backfill: pre-existing validated groups keep NULLs and render the
+legacy badge.
+
+## API
+
+`PATCH /api/v1/sequence_groups/{id}` is the only writer of `is_validated`
+and gains attribution logic:
+
+- **false → true:** set `validated_by_user_id = current_user.id` and
+  `validated_at = now(UTC)`.
+- **true → false:** clear both fields — unvalidated rows never carry stale
+  attribution, and a later re-validation attributes the new reviewer.
+- **true → true (idempotent re-send):** no change — the first reviewer
+  stands until someone unvalidates.
+
+Schema changes:
+
+- `SequenceGroupRead`: add `validated_by_user_id`, `validated_at`.
+- `SequenceGroupPageItem` (list): add
+  `validated_by_username: Optional[str]` and `validated_at`, resolved via a
+  LEFT JOIN on `users` in the list query — same no-N+1 approach as
+  `camera_name`.
+
+## Frontend
+
+`SequenceGroupsListPage.tsx` Reviewed cell (plus matching fields in
+`types/api.ts`):
+
+| State                              | Cell                  |
+| ---------------------------------- | --------------------- |
+| Validated, username present        | `✓ validated · alice` |
+| Validated, no user (legacy or FK user deleted) | `✓ validated` |
+| Not validated                      | `—`                   |
+
+The cell's `title` shows the validation time via `toLocaleString()`, the
+same pattern as the Created column.
+
+## Testing
+
+Backend endpoint tests:
+
+- Validating sets `validated_by_user_id` to the caller and `validated_at`.
+- Unvalidating clears both.
+- Re-sending `is_validated = true` on a validated group leaves attribution
+  untouched.
+- List endpoint returns `validated_by_username` for a validated group and
+  `null` for a legacy row (validated, no user id).

--- a/docs/specs/2026-08-03-group-validated-by-design.md
+++ b/docs/specs/2026-08-03-group-validated-by-design.md
@@ -55,7 +55,7 @@ and gains attribution logic:
 Schema changes:
 
 - `SequenceGroupRead`: add `validated_by_user_id`, `validated_at`.
-- `SequenceGroupPageItem` (list): add
+- `SequenceGroupListItem` (list): add
   `validated_by_username: Optional[str]` and `validated_at`, resolved via a
   LEFT JOIN on `users` in the list query — same no-N+1 approach as
   `camera_name`.

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -369,8 +369,20 @@ export default function SequenceGroupsListPage({
                     </td>
                     <td className={CELL_CLASSES}>
                       {g.is_validated ? (
-                        <span className="inline-flex items-center gap-1 font-body text-xs font-semibold text-pine">
+                        <span
+                          className="inline-flex items-center gap-1 font-body text-xs font-semibold text-pine"
+                          title={
+                            g.validated_at
+                              ? `Validated ${new Date(g.validated_at).toLocaleString()}`
+                              : undefined
+                          }
+                        >
                           <ShieldCheck className="w-3.5 h-3.5" /> validated
+                          {/* Legacy validations (pre-attribution) have no user —
+                              the badge alone is the whole cell for those. */}
+                          {g.validated_by_username && (
+                            <span className="font-normal">· {g.validated_by_username}</span>
+                          )}
                         </span>
                       ) : (
                         <span className="text-haze">—</span>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -181,6 +181,10 @@ export interface SequenceGroupListItem {
   false_positive_type: FalsePositiveType | null;
   is_unsure: boolean;
   is_validated: boolean;
+  validated_at: string | null;
+  // Username of the validating user; null for legacy validations
+  // (pre-attribution) or deleted users.
+  validated_by_username: string | null;
   labeled_at: string | null;
   created_at: string;
   member_count: number;
@@ -203,6 +207,8 @@ export interface SequenceGroup {
   false_positive_type: FalsePositiveType | null;
   is_unsure: boolean;
   is_validated: boolean;
+  validated_at: string | null;
+  validated_by_user_id: number | null;
   labeled_at: string | null;
   labeled_by_user_id: number | null;
   created_at: string;


### PR DESCRIPTION
## Summary

The Reviewed column on `/classify/groups` showed *whether* a group was validated but not *by whom* — `is_validated` was a bare boolean with no attribution (unlike labeling, which already records `labeled_by_user_id`). This PR records who validated a group and when, and surfaces it in the table.

Spec: `docs/specs/2026-08-03-group-validated-by-design.md`

## Changes

**Backend**
- Migration + model: nullable `validated_by_user_id` (FK `users.id`, `ON DELETE SET NULL`) and `validated_at` on `sequence_groups`, mirroring the `labeled_by_*` pair. No backfill — pre-existing validated groups keep NULLs.
- `PATCH /api/v1/sequence_groups/{id}` (sole writer of `is_validated`): false→true stamps `current_user` + timestamp; true→false clears both; re-sending true is a no-op (first reviewer stands).
- List endpoint: `SequenceGroupListItem` gains `validated_at` + `validated_by_username` via a LEFT JOIN on `users` (no N+1; join is on the PK so pagination/counts are unaffected).

**Frontend**
- Reviewed cell renders `✓ validated · <username>`, with the validation time in the hover tooltip. Legacy rows (no recorded user) keep the plain `✓ validated` badge; unvalidated rows keep the dash.

## Testing

- 5 new endpoint tests: stamp on validate, clear on unvalidate, idempotent re-validate, username joined in list, legacy validated row returns nulls.
- Full suites green: 500 backend, 686 frontend.
- Verified end-to-end against a live stack: UI validation stamps the user, list shows `validated · admin`, unvalidate clears attribution.