### PR TITLE
feat(frontend): show bare object count in classify queue Objects column

### DIFF
--- a/frontend/src/components/sequences/ClassifyAlertQueueTable.tsx
+++ b/frontend/src/components/sequences/ClassifyAlertQueueTable.tsx
@@ -19,11 +19,12 @@ interface ClassifyAlertQueueTableProps {
   onAlertClick: (item: ClassifyQueueItem) => void;
 }
 
-// "3 objects · 1 classified"; drops the classified suffix when nothing is
-// classified yet, and pluralizes "object(s)" correctly.
+// "3 · 1 classified"; drops the classified suffix when nothing is
+// classified yet.
 function formatObjectsCell(totalObjects: number, classifiedObjects: number): string {
-  const objectsText = `${totalObjects} ${totalObjects === 1 ? 'object' : 'objects'}`;
-  return classifiedObjects > 0 ? `${objectsText} · ${classifiedObjects} classified` : objectsText;
+  return classifiedObjects > 0
+    ? `${totalObjects} · ${classifiedObjects} classified`
+    : `${totalObjects}`;
 }
 
 export function ClassifyAlertQueueTable({ items, onAlertClick }: ClassifyAlertQueueTableProps) {

--- a/frontend/tests/components/sequences/ClassifyAlertQueueTable.test.tsx
+++ b/frontend/tests/components/sequences/ClassifyAlertQueueTable.test.tsx
@@ -121,7 +121,7 @@ describe('ClassifyAlertQueueTable', () => {
     expect(screen.queryByText(/°/)).not.toBeInTheDocument();
   });
 
-  it('renders "N objects · M classified" when some objects are classified', () => {
+  it('renders "N · M classified" when some objects are classified', () => {
     render(
       <ClassifyAlertQueueTable
         items={[createItem({ total_objects: 3, classified_objects: 1 })]}
@@ -129,10 +129,10 @@ describe('ClassifyAlertQueueTable', () => {
       />
     );
 
-    expect(screen.getByText('3 objects · 1 classified')).toBeInTheDocument();
+    expect(screen.getByText('3 · 1 classified')).toBeInTheDocument();
   });
 
-  it('renders "1 object" with no classified suffix for a single unclassified object', () => {
+  it('renders the bare count with no classified suffix for a single unclassified object', () => {
     render(
       <ClassifyAlertQueueTable
         items={[createItem({ total_objects: 1, classified_objects: 0 })]}
@@ -140,11 +140,11 @@ describe('ClassifyAlertQueueTable', () => {
       />
     );
 
-    expect(screen.getByText('1 object')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
     expect(screen.queryByText(/classified/)).not.toBeInTheDocument();
   });
 
-  it('renders "N objects" with no classified suffix when none are classified', () => {
+  it('renders the bare count with no classified suffix when none are classified', () => {
     render(
       <ClassifyAlertQueueTable
         items={[createItem({ total_objects: 3, classified_objects: 0 })]}
@@ -152,7 +152,7 @@ describe('ClassifyAlertQueueTable', () => {
       />
     );
 
-    expect(screen.getByText('3 objects')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
     expect(screen.queryByText(/classified/)).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

In the queue tables' **Objects** column, show just the number (`3`) instead of `3 objects`.

- `/classify` (`ClassifyAlertQueueTable`) was the only table rendering `N object(s)` — its cell now shows the bare count; the classified-progress suffix is kept, so partially classified alerts read `3 · 1 classified`.
- `/localize` already rendered a bare number; `/classify/done` and `/localize/done` have no Objects column — no changes needed there.

## Test plan

- [x] `npm run quality` (type-check, ESLint, Prettier) passes
- [x] `npm test` — 759 tests / 65 files green, with the three `ClassifyAlertQueueTable` copy assertions updated to the new format