### PR TITLE
feat(frontend): classify cockpit — single-screen review for /classify/:id and /classify/done/:id

### DIFF
--- a/docs/specs/2026-08-04-classify-cockpit-revamp-design.md
+++ b/docs/specs/2026-08-04-classify-cockpit-revamp-design.md
@@ -1,0 +1,138 @@
+# Classify Cockpit Revamp — `/classify/{id}` and `/classify/done/{id}`
+
+**Date:** 2026-08-04
+**Status:** Approved
+**Scope:** Frontend only — `ClassifyAlertPage` rendering. No API, state-logic, or
+submit-semantics changes.
+
+## Problem
+
+The classify detail page stacks one screen-tall card per object (two players +
+radio lists + an 18-checkbox false-positive grid each), with the alert-level
+missed-smoke review and its own player at the bottom. Reviewing means scrolling
+through everything; the alert's overall state (which objects are done, what the
+missed-smoke answer is) is never visible at once. The pain points targeted, in
+order: too much scrolling, verbose controls, no at-a-glance state. The two
+players per object (full-frame + cropped) are valued and stay.
+
+Most alerts have one object, sometimes 2–3. Annotators drive the page with a
+mix of keyboard (S/F, 1/2/3, Y/N, Enter) and mouse — every control must remain
+a comfortable click target.
+
+## Design: the cockpit
+
+Below the existing pinned header, the page becomes a two-column layout on
+desktop (`lg+`): a **media column** (~60%) and a **decision rail** (~40%), each
+independently scrollable; the page itself no longer scrolls. Below `lg`, it
+degrades to the natural stacked flow (media, then rail content), fully
+mouse-operable.
+
+### Pinned header (unchanged structure)
+
+Back link, `org · camera`, timestamp, "N of M objects classified" pill,
+workflow prev/next, Submit, keyboard-help button. Submit lives here only — the
+header is always visible.
+
+### Media column — always shows the active thing
+
+- **Active object:** full-frame player (`FullImageSequence`: own box solid in
+  the object's identity color, sibling boxes dimmed), then the
+  `ObjectPresenceStrip` when the alert has ≥2 objects, then the active object's
+  cropped loop (`CroppedImageSequence`).
+- **Missed-smoke section active:** the media column swaps to the primary
+  lane's whole-alert sequence player (`SequencePlayer` with all object
+  overlays). The yes/no controls do NOT live here — they are in the rail.
+
+### Decision rail — the whole alert's state at a glance
+
+- One slim row per object: color dot (matching overlay colors) + `Object N` +
+  a status chip:
+  - `Pending` — ember-soft
+  - `Smoke · Wildfire` (etc.) — pine-soft
+  - `FP · High cloud +1` — neutral (ash/char)
+  - `Unsure` — signal-soft
+  - `Type needed` — ember-soft (smoke chosen, no type yet)
+- Clicking a row activates it (mouse parity with ↑/↓). The active row carries
+  the ember left-bar accent and expands to show:
+  - Chip row **Smoke / False positive / Unsure** — `rounded-full px-3 py-1.5`
+    toggle buttons with visible kbd hints. Selected fill: pine for Smoke, char
+    for False positive.
+  - A contextual second chip wrap: the 3 smoke types, or **all 18 FP types as
+    an inline chip wrap**, each with its shortcut letter. No "More…" tiering.
+- **No emojis anywhere** in classification, smoke-type, FP-type, or status
+  chips — plain text; color and fill carry selection state (consistent with
+  the emoji-free Alert API annotation work).
+- Below the object rows, separated by a hairline: the **Missed smoke?** row
+  with Yes/No chips (Y/N kbd hints). Activating the row (↓ past the last
+  object, or click) swaps the media column to the whole-alert player.
+- Chips are real `<button>`s with `aria-pressed`; the Smoke/FP pair behaves as
+  an exclusive group.
+
+### Keyboard
+
+Bindings and handler are unchanged (`createKeyboardHandler`, the existing
+position↔cardKey adapter, `navigationUtils` section model). ↑/↓ moves the
+active row (and into the missed-smoke section); scroll-into-view now targets
+rail rows within the rail's own scroll container.
+
+## Done mode (`/classify/done/{id}`)
+
+Same cockpit, with:
+
+- Every annotated lane is an editable row regardless of stage (existing rule);
+  each row additionally shows its processing-stage badge, since lanes can sit
+  at different stages. Lanes with no annotation render as a disabled
+  "Not imported yet" row.
+- Entering from the Done list activates that sequence's row directly (replaces
+  today's scroll-to-card).
+- Rows edited since load get an ember **changed dot**; the header button reads
+  **"Save changes (n)"** (n = changed lanes), disabled until `anyLaneChanged`.
+  Diff/PATCH submit logic is untouched. Reset restores the loaded snapshot and
+  clears the dots.
+
+In queue mode, locked lanes (`seq_annotation_done` / `annotated`) are read-only
+rows: stage badge + summary chip, clickable to view media, chips disabled.
+
+## Component architecture
+
+`ClassifyAlertPage` keeps all state, queries, mutations, keyboard adapters,
+and submit semantics. Only the render tree changes:
+
+- `ClassifyMediaPanel` (new) — media column: full-frame player + presence
+  strip + cropped loop for the active object; whole-alert `SequencePlayer`
+  when the missed-smoke section is active.
+- `DecisionRail` (new) — object rows + missed-smoke row.
+- `ObjectRow` (new) — slim row; expanded when active; renders
+  `ClassificationChips`.
+- `ClassificationChips` (new) — Smoke/FP/Unsure group + contextual type chip
+  wrap; same `SequenceBbox` mutation semantics as today's `ObjectCard` radios
+  (smoke keeps existing type, FP clears `smoke_type`, etc.).
+- `ObjectCard` / `SequenceAnnotationGrid` remain untouched (legacy
+  `AnnotationInterface` still uses them; its removal is separate cleanup).
+- The `sequence-annotation/MissedSmokePanel` wrapper is no longer used by this
+  page.
+
+New components live in `src/components/classify/`. All styling uses
+fire-lookout tokens per `DESIGN.md`.
+
+## Error handling
+
+Unchanged: submit guard toasts, group-propagation warning banner (renders
+above the columns, spanning both), post-submit refetch, sequential done-mode
+PATCH abort behavior.
+
+## Testing
+
+- The existing 21 `ClassifyAlertPage` tests stay as behavior specs; selectors
+  migrate from radio labels ("This is smoke") to chip buttons ("Smoke").
+- New tests: row click activates + swaps media; missed-smoke activation swaps
+  the player; done-mode changed dot + "Save changes (n)" count; FP chip wrap
+  toggling; locked-row read-only behavior.
+- Gate: `npm run quality` and full `npm test` green.
+
+## Out of scope
+
+- Any backend or submit-payload change.
+- `AnnotationInterface` / `ObjectCard` cleanup.
+- Localize pages.
+- Mockups from the brainstorm live in `.superpowers/brainstorm/` (untracked).

--- a/frontend/src/components/annotation/FullImageSequence.tsx
+++ b/frontend/src/components/annotation/FullImageSequence.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
 import { Loader2, AlertCircle } from 'lucide-react';
-import { BoundingBox } from '@/types/api';
 import { apiClient } from '@/services/api';
 import { ObjectOverlay } from '@/utils/annotation/objectColors';
 
@@ -9,8 +8,20 @@ import { ObjectOverlay } from '@/utils/annotation/objectColors';
 // SequenceAnnotationGrid, where there's no per-object identity to color by).
 const DEFAULT_OWN_BOX_COLOR = '#ef4444'; // Tailwind red-500
 
+/**
+ * One frame of the sequence: which detection image to show, and (optionally)
+ * the object's own box on it. `xyxyn: null` shows the frame with no own box
+ * drawn — the classify cockpit plays the whole alert's frame union so an
+ * object's absence on a frame is visible instead of the frame being skipped.
+ * `BoundingBox` from the API types is assignable (its `xyxyn` is always set).
+ */
+export interface FullImageFrame {
+  detection_id: number;
+  xyxyn: number[] | null;
+}
+
 interface FullImageSequenceProps {
-  bboxes: BoundingBox[];
+  bboxes: FullImageFrame[];
   sequenceId: number;
   className?: string;
   /** This object's accent color for its own box. Defaults to red (legacy look) when omitted. */
@@ -50,14 +61,21 @@ export default function FullImageSequence({
   const imgRef = useRef<HTMLImageElement>(null);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Clear state immediately when props change to prevent stale data
+  // Value-based identity for the frame list: callers (the classify cockpit)
+  // rebuild the bboxes array every render, so keying the reset/fetch effects
+  // on the array reference would loop them forever. Box coordinates aren't
+  // part of the key on purpose — they only affect drawing, not which images
+  // to fetch.
+  const frameKey = `${sequenceId}:${bboxes.map(b => b.detection_id).join(',')}`;
+
+  // Clear state immediately when the frame list changes to prevent stale data
   useEffect(() => {
     setImages([]);
     setCurrentIndex(0);
     setIsLoading(true);
     setError(null);
     setImageInfo(null); // Clear image positioning info
-  }, [bboxes, sequenceId]);
+  }, [frameKey]);
 
   // Fetch detection image URLs
   useEffect(() => {
@@ -119,7 +137,8 @@ export default function FullImageSequence({
     if (bboxes.length > 0 && sequenceId && images.length === 0) {
       fetchImages();
     }
-  }, [bboxes, sequenceId, images.length]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [frameKey, images.length]);
 
   // Auto-play animation with 200ms interval - only when images are loaded
   useEffect(() => {
@@ -177,6 +196,8 @@ export default function FullImageSequence({
     if (!imageInfo || currentIndex >= bboxes.length) return null;
 
     const currentBbox = bboxes[currentIndex];
+    // A frame the object has no box on renders box-less rather than being skipped.
+    if (!currentBbox.xyxyn) return null;
     const [x1, y1, x2, y2] = currentBbox.xyxyn;
 
     // Ensure valid bbox

--- a/frontend/src/components/annotation/FullImageSequence.tsx
+++ b/frontend/src/components/annotation/FullImageSequence.tsx
@@ -65,8 +65,10 @@ export default function FullImageSequence({
   // rebuild the bboxes array every render, so keying the reset/fetch effects
   // on the array reference would loop them forever. Box coordinates aren't
   // part of the key on purpose — they only affect drawing, not which images
-  // to fetch.
-  const frameKey = `${sequenceId}:${bboxes.map(b => b.detection_id).join(',')}`;
+  // to fetch. Nor is sequenceId: detection ids are globally unique, and in
+  // the cockpit every object of an alert shares the same union frame list —
+  // keying on ids alone means switching objects doesn't reload the images.
+  const frameKey = bboxes.map(b => b.detection_id).join(',');
 
   // Clear state immediately when the frame list changes to prevent stale data
   useEffect(() => {

--- a/frontend/src/components/classify/ClassificationChips.tsx
+++ b/frontend/src/components/classify/ClassificationChips.tsx
@@ -201,7 +201,7 @@ export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
           <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze mb-1.5">
             FP types — select all that apply
           </div>
-          <div aria-label="False positive types" className="flex flex-wrap gap-1.5">
+          <div role="group" aria-label="False positive types" className="flex flex-wrap gap-1.5">
             {FALSE_POSITIVE_TYPES.map(type => {
               const selected = bbox.false_positive_types.includes(type as FalsePositiveType);
               return (

--- a/frontend/src/components/classify/ClassificationChips.tsx
+++ b/frontend/src/components/classify/ClassificationChips.tsx
@@ -36,7 +36,7 @@ const FP_TYPE_KEYS: Record<string, string> = {
   building: 'B',
   cliff: 'C',
   dark: 'D',
-  dust: 'U',
+  dust: 'J',
   high_cloud: 'H',
   low_cloud: 'L',
   lens_flare: 'G',
@@ -133,6 +133,7 @@ export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
       <div role="radiogroup" aria-label="Classification" className="flex flex-wrap gap-1.5">
         <button
           type="button"
+          tabIndex={-1}
           role="radio"
           aria-checked={smokeSelected}
           aria-label="Smoke"
@@ -144,6 +145,7 @@ export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
         </button>
         <button
           type="button"
+          tabIndex={-1}
           role="radio"
           aria-checked={fpSelected}
           aria-label="False positive"
@@ -156,6 +158,7 @@ export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
         {onUnsureChange && (
           <button
             type="button"
+            tabIndex={-1}
             role="radio"
             aria-checked={unsure}
             aria-label="Unsure"
@@ -163,7 +166,7 @@ export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
             className={primaryChip(unsure, 'border-signal bg-signal-soft text-signal')}
           >
             Unsure
-            {showKbdHints && <Kbd label="Q" />}
+            {showKbdHints && <Kbd label="U" />}
           </button>
         )}
       </div>
@@ -178,6 +181,7 @@ export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
               <button
                 key={type}
                 type="button"
+                tabIndex={-1}
                 role="radio"
                 aria-checked={bbox.smoke_type === type}
                 aria-label={formatSmokeType(type)}
@@ -204,6 +208,7 @@ export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
                 <button
                   key={type}
                   type="button"
+                  tabIndex={-1}
                   role="checkbox"
                   aria-checked={selected}
                   aria-label={formatFalsePositiveLabel(type)}

--- a/frontend/src/components/classify/ClassificationChips.tsx
+++ b/frontend/src/components/classify/ClassificationChips.tsx
@@ -11,6 +11,7 @@ import { SequenceBbox, FalsePositiveType, SmokeType } from '@/types/api';
 import { FALSE_POSITIVE_TYPES, SMOKE_TYPES } from '@/utils/constants';
 import { formatSmokeType } from '@/utils/modelAccuracy';
 import { CardClassification } from '@/components/sequence-annotation';
+import { formatFalsePositiveLabel } from './status';
 
 export interface ClassificationChipsProps {
   cardKey: string;
@@ -23,11 +24,6 @@ export interface ClassificationChipsProps {
   /** Omit to hide the Unsure chip. */
   onUnsureChange?: (cardKey: string, unsure: boolean) => void;
 }
-
-export const formatFalsePositiveLabel = (type: string): string => {
-  const [first, ...rest] = type.split('_');
-  return [first.charAt(0).toUpperCase() + first.slice(1), ...rest].join(' ');
-};
 
 // Keyboard letter per FP type — mirrors keyboardUtils' bindings (same map
 // as the legacy ObjectCard, which stays untouched for AnnotationInterface).

--- a/frontend/src/components/classify/ClassificationChips.tsx
+++ b/frontend/src/components/classify/ClassificationChips.tsx
@@ -163,6 +163,7 @@ export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
             className={primaryChip(unsure, 'border-signal bg-signal-soft text-signal')}
           >
             Unsure
+            {showKbdHints && <Kbd label="Q" />}
           </button>
         )}
       </div>

--- a/frontend/src/components/classify/ClassificationChips.tsx
+++ b/frontend/src/components/classify/ClassificationChips.tsx
@@ -20,7 +20,11 @@ export interface ClassificationChipsProps {
   unsure: boolean;
   showKbdHints?: boolean;
   onBboxChange: (cardKey: string, updatedBbox: SequenceBbox) => void;
-  onClassificationChange: (cardKey: string, classification: 'smoke' | 'false_positive') => void;
+  /** 'unselected' is sent when the Unsure chip clears the classification — Smoke / False positive / Unsure are mutually exclusive. */
+  onClassificationChange: (
+    cardKey: string,
+    classification: 'smoke' | 'false_positive' | 'unselected'
+  ) => void;
   /** Omit to hide the Unsure chip. */
   onUnsureChange?: (cardKey: string, unsure: boolean) => void;
 }
@@ -81,14 +85,38 @@ export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
   onClassificationChange,
   onUnsureChange,
 }) => {
+  // Smoke / False positive / Unsure are mutually exclusive: picking either
+  // classification clears unsure, and turning unsure on clears the
+  // classification (and its bbox labels).
   const markSmoke = () => {
+    if (unsure) onUnsureChange?.(cardKey, false);
     onClassificationChange(cardKey, 'smoke');
     onBboxChange(cardKey, { ...bbox, is_smoke: true, false_positive_types: [] });
   };
   const markFalsePositive = () => {
+    if (unsure) onUnsureChange?.(cardKey, false);
     onClassificationChange(cardKey, 'false_positive');
     onBboxChange(cardKey, { ...bbox, is_smoke: false, smoke_type: undefined });
   };
+  const toggleUnsure = () => {
+    const next = !unsure;
+    if (next) {
+      onClassificationChange(cardKey, 'unselected');
+      onBboxChange(cardKey, {
+        ...bbox,
+        is_smoke: false,
+        smoke_type: undefined,
+        false_positive_types: [],
+      });
+    }
+    onUnsureChange?.(cardKey, next);
+  };
+
+  // Display-level guard for the same rule: a lane seeded with both a saved
+  // classification and is_unsure (possible in done mode) renders as Unsure
+  // only — never two selected chips at once.
+  const smokeSelected = !unsure && classification === 'smoke';
+  const fpSelected = !unsure && classification === 'false_positive';
   const setSmokeType = (type: SmokeType) => onBboxChange(cardKey, { ...bbox, smoke_type: type });
   const toggleFpType = (type: FalsePositiveType) => {
     const selected = bbox.false_positive_types.includes(type);
@@ -106,35 +134,32 @@ export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
         <button
           type="button"
           role="radio"
-          aria-checked={classification === 'smoke'}
+          aria-checked={smokeSelected}
           aria-label="Smoke"
           onClick={markSmoke}
-          className={primaryChip(classification === 'smoke', 'border-pine bg-pine text-white')}
+          className={primaryChip(smokeSelected, 'border-pine bg-pine text-white')}
         >
           Smoke
-          {showKbdHints && <Kbd label="S" onDark={classification === 'smoke'} />}
+          {showKbdHints && <Kbd label="S" onDark={smokeSelected} />}
         </button>
         <button
           type="button"
           role="radio"
-          aria-checked={classification === 'false_positive'}
+          aria-checked={fpSelected}
           aria-label="False positive"
           onClick={markFalsePositive}
-          className={primaryChip(
-            classification === 'false_positive',
-            'border-char bg-char text-white'
-          )}
+          className={primaryChip(fpSelected, 'border-char bg-char text-white')}
         >
           False positive
-          {showKbdHints && <Kbd label="F" onDark={classification === 'false_positive'} />}
+          {showKbdHints && <Kbd label="F" onDark={fpSelected} />}
         </button>
         {onUnsureChange && (
           <button
             type="button"
-            role="checkbox"
+            role="radio"
             aria-checked={unsure}
             aria-label="Unsure"
-            onClick={() => onUnsureChange(cardKey, !unsure)}
+            onClick={toggleUnsure}
             className={primaryChip(unsure, 'border-signal bg-signal-soft text-signal')}
           >
             Unsure
@@ -142,7 +167,7 @@ export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
         )}
       </div>
 
-      {classification === 'smoke' && (
+      {smokeSelected && (
         <div>
           <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze mb-1.5">
             Smoke type
@@ -166,7 +191,7 @@ export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
         </div>
       )}
 
-      {classification === 'false_positive' && (
+      {fpSelected && (
         <div>
           <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze mb-1.5">
             FP types — select all that apply

--- a/frontend/src/components/classify/ClassificationChips.tsx
+++ b/frontend/src/components/classify/ClassificationChips.tsx
@@ -1,0 +1,203 @@
+/**
+ * Chip-based classification controls for one object row in the classify
+ * cockpit (ClassifyAlertPage's decision rail). Same SequenceBbox mutation
+ * semantics as the legacy ObjectCard radios; emoji-free by design. Chips
+ * are <button>s with radio/checkbox roles so they read (and test) as the
+ * exclusive/multi groups they are while staying comfortable mouse targets.
+ */
+
+import React from 'react';
+import { SequenceBbox, FalsePositiveType, SmokeType } from '@/types/api';
+import { FALSE_POSITIVE_TYPES, SMOKE_TYPES } from '@/utils/constants';
+import { formatSmokeType } from '@/utils/modelAccuracy';
+import { CardClassification } from '@/components/sequence-annotation';
+
+export interface ClassificationChipsProps {
+  cardKey: string;
+  bbox: SequenceBbox;
+  classification: CardClassification;
+  unsure: boolean;
+  showKbdHints?: boolean;
+  onBboxChange: (cardKey: string, updatedBbox: SequenceBbox) => void;
+  onClassificationChange: (cardKey: string, classification: 'smoke' | 'false_positive') => void;
+  /** Omit to hide the Unsure chip. */
+  onUnsureChange?: (cardKey: string, unsure: boolean) => void;
+}
+
+export const formatFalsePositiveLabel = (type: string): string => {
+  const [first, ...rest] = type.split('_');
+  return [first.charAt(0).toUpperCase() + first.slice(1), ...rest].join(' ');
+};
+
+// Keyboard letter per FP type — mirrors keyboardUtils' bindings (same map
+// as the legacy ObjectCard, which stays untouched for AnnotationInterface).
+const FP_TYPE_KEYS: Record<string, string> = {
+  antenna: 'A',
+  building: 'B',
+  cliff: 'C',
+  dark: 'D',
+  dust: 'U',
+  high_cloud: 'H',
+  low_cloud: 'L',
+  lens_flare: 'G',
+  lens_droplet: 'P',
+  light: 'I',
+  rain: 'R',
+  trail: 'T',
+  road: 'O',
+  sky: 'K',
+  tree: 'E',
+  water_body: 'W',
+  other: 'X',
+  unlabeled: 'M',
+};
+
+const SMOKE_TYPE_KEYS: Record<string, string> = { wildfire: '1', industrial: '2', other: '3' };
+
+const Kbd: React.FC<{ label: string; onDark?: boolean }> = ({ label, onDark }) => (
+  <kbd
+    aria-hidden="true"
+    className={`px-1 py-0.5 rounded font-data text-[10px] font-medium ${
+      onDark ? 'bg-white/20 text-white' : 'bg-ash text-haze'
+    }`}
+  >
+    {label}
+  </kbd>
+);
+
+const primaryChip = (selected: boolean, selectedClasses: string) =>
+  `inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 font-body text-xs font-medium transition-colors ${
+    selected ? selectedClasses : 'border-line bg-paper text-char hover:bg-ash'
+  }`;
+
+const typeChip = (selected: boolean, selectedClasses: string) =>
+  `inline-flex items-center gap-1 rounded-full px-2.5 py-1 font-body text-xs font-medium transition-colors ${
+    selected ? selectedClasses : 'bg-ash text-char hover:bg-ember-soft'
+  }`;
+
+export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
+  cardKey,
+  bbox,
+  classification,
+  unsure,
+  showKbdHints = false,
+  onBboxChange,
+  onClassificationChange,
+  onUnsureChange,
+}) => {
+  const markSmoke = () => {
+    onClassificationChange(cardKey, 'smoke');
+    onBboxChange(cardKey, { ...bbox, is_smoke: true, false_positive_types: [] });
+  };
+  const markFalsePositive = () => {
+    onClassificationChange(cardKey, 'false_positive');
+    onBboxChange(cardKey, { ...bbox, is_smoke: false, smoke_type: undefined });
+  };
+  const setSmokeType = (type: SmokeType) => onBboxChange(cardKey, { ...bbox, smoke_type: type });
+  const toggleFpType = (type: FalsePositiveType) => {
+    const selected = bbox.false_positive_types.includes(type);
+    onBboxChange(cardKey, {
+      ...bbox,
+      false_positive_types: selected
+        ? bbox.false_positive_types.filter(t => t !== type)
+        : [...bbox.false_positive_types, type],
+    });
+  };
+
+  return (
+    <div className="space-y-2.5">
+      <div role="radiogroup" aria-label="Classification" className="flex flex-wrap gap-1.5">
+        <button
+          type="button"
+          role="radio"
+          aria-checked={classification === 'smoke'}
+          aria-label="Smoke"
+          onClick={markSmoke}
+          className={primaryChip(classification === 'smoke', 'border-pine bg-pine text-white')}
+        >
+          Smoke
+          {showKbdHints && <Kbd label="S" onDark={classification === 'smoke'} />}
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={classification === 'false_positive'}
+          aria-label="False positive"
+          onClick={markFalsePositive}
+          className={primaryChip(
+            classification === 'false_positive',
+            'border-char bg-char text-white'
+          )}
+        >
+          False positive
+          {showKbdHints && <Kbd label="F" onDark={classification === 'false_positive'} />}
+        </button>
+        {onUnsureChange && (
+          <button
+            type="button"
+            role="checkbox"
+            aria-checked={unsure}
+            aria-label="Unsure"
+            onClick={() => onUnsureChange(cardKey, !unsure)}
+            className={primaryChip(unsure, 'border-signal bg-signal-soft text-signal')}
+          >
+            Unsure
+          </button>
+        )}
+      </div>
+
+      {classification === 'smoke' && (
+        <div>
+          <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze mb-1.5">
+            Smoke type
+          </div>
+          <div role="radiogroup" aria-label="Smoke type" className="flex flex-wrap gap-1.5">
+            {SMOKE_TYPES.map(type => (
+              <button
+                key={type}
+                type="button"
+                role="radio"
+                aria-checked={bbox.smoke_type === type}
+                aria-label={formatSmokeType(type)}
+                onClick={() => setSmokeType(type as SmokeType)}
+                className={typeChip(bbox.smoke_type === type, 'bg-pine-soft text-pine')}
+              >
+                {formatSmokeType(type)}
+                {showKbdHints && <Kbd label={SMOKE_TYPE_KEYS[type]} />}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {classification === 'false_positive' && (
+        <div>
+          <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze mb-1.5">
+            FP types — select all that apply
+          </div>
+          <div aria-label="False positive types" className="flex flex-wrap gap-1.5">
+            {FALSE_POSITIVE_TYPES.map(type => {
+              const selected = bbox.false_positive_types.includes(type as FalsePositiveType);
+              return (
+                <button
+                  key={type}
+                  type="button"
+                  role="checkbox"
+                  aria-checked={selected}
+                  aria-label={formatFalsePositiveLabel(type)}
+                  onClick={() => toggleFpType(type as FalsePositiveType)}
+                  className={typeChip(selected, 'bg-char text-white')}
+                >
+                  {formatFalsePositiveLabel(type)}
+                  {showKbdHints && FP_TYPE_KEYS[type] && (
+                    <Kbd label={FP_TYPE_KEYS[type]} onDark={selected} />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/classify/ClassifyMediaPanel.tsx
+++ b/frontend/src/components/classify/ClassifyMediaPanel.tsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import { BoundingBox } from '@/types/api';
 import { ObjectOverlay } from '@/utils/annotation/objectColors';
-import FullImageSequence from '@/components/annotation/FullImageSequence';
+import FullImageSequence, { FullImageFrame } from '@/components/annotation/FullImageSequence';
 import CroppedImageSequence from '@/components/annotation/CroppedImageSequence';
 import SequenceReviewer from '@/components/sequence/SequenceReviewer';
 
@@ -18,7 +18,10 @@ export interface ClassifyMediaPanelProps {
   /** Null when the alert has no cards at all (placeholder-only). */
   activeObject: {
     label: string;
-    bboxes: BoundingBox[];
+    /** Frames for the full-frame player — the alert's frame union; `xyxyn: null` frames render box-less. */
+    bboxes: FullImageFrame[];
+    /** The object's own track boxes — the cropped loop needs real boxes to crop around. */
+    croppedBboxes: BoundingBox[];
     sequenceId: number;
     color?: string;
     siblingOverlays: ObjectOverlay[];
@@ -69,7 +72,10 @@ export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
         />
         <div>
           <div className={`${eyebrow} mb-2`}>Cropped · {activeObject.label}</div>
-          <CroppedImageSequence bboxes={activeObject.bboxes} sequenceId={activeObject.sequenceId} />
+          <CroppedImageSequence
+            bboxes={activeObject.croppedBboxes}
+            sequenceId={activeObject.sequenceId}
+          />
         </div>
       </div>
     ) : (

--- a/frontend/src/components/classify/ClassifyMediaPanel.tsx
+++ b/frontend/src/components/classify/ClassifyMediaPanel.tsx
@@ -48,7 +48,10 @@ export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
   annotationLoading,
   objectOverlays,
 }) => (
-  <div data-testid="classify-media-panel" className="rounded-card border border-line bg-paper px-[22px] py-5">
+  <div
+    data-testid="classify-media-panel"
+    className="rounded-card border border-line bg-paper px-[22px] py-5"
+  >
     {activeSection === 'sequence' ? (
       <div className="space-y-3">
         <div className={eyebrow}>Whole alert — watch for smoke the model missed</div>

--- a/frontend/src/components/classify/ClassifyMediaPanel.tsx
+++ b/frontend/src/components/classify/ClassifyMediaPanel.tsx
@@ -29,6 +29,8 @@ export interface ClassifyMediaPanelProps {
     siblingOverlays: ObjectOverlay[];
     frameRecordedAt: (string | undefined)[];
   } | null;
+  /** True while an object exists but hasn't activated yet (initial load / alert switch) — renders a skeleton instead of the empty state. */
+  loading?: boolean;
   primarySequenceId: number;
   missedSmokeReview: 'yes' | 'no' | null;
   onMissedSmokeReviewChange: (review: 'yes' | 'no') => void;
@@ -41,6 +43,7 @@ const eyebrow = 'font-data text-eyebrow font-medium uppercase tracking-eyebrow t
 export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
   activeSection,
   activeObject,
+  loading = false,
   primarySequenceId,
   missedSmokeReview,
   onMissedSmokeReviewChange,
@@ -122,6 +125,11 @@ export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
               sequenceId={activeObject.sequenceId}
             />
           </div>
+        </div>
+      ) : loading ? (
+        <div data-testid="media-panel-skeleton" className="space-y-4">
+          <div className="aspect-video w-full animate-pulse rounded bg-ash" />
+          <div className="h-28 w-full animate-pulse rounded bg-ash" />
         </div>
       ) : (
         <p className="py-16 text-center font-body text-sm text-haze">No objects to review yet</p>

--- a/frontend/src/components/classify/ClassifyMediaPanel.tsx
+++ b/frontend/src/components/classify/ClassifyMediaPanel.tsx
@@ -1,0 +1,83 @@
+/**
+ * The classify cockpit's media column: always shows "the active thing".
+ * Detections section -> the active object's full-frame player (own box
+ * solid, siblings dimmed), the presence strip (self-hides under 2
+ * objects), and the object's cropped loop. Sequence section -> the primary
+ * lane's whole-alert player with every object's overlay, review controls
+ * hidden (the decision rail owns yes/no).
+ */
+
+import React from 'react';
+import { BoundingBox } from '@/types/api';
+import { ObjectOverlay } from '@/utils/annotation/objectColors';
+import FullImageSequence from '@/components/annotation/FullImageSequence';
+import CroppedImageSequence from '@/components/annotation/CroppedImageSequence';
+import SequenceReviewer from '@/components/sequence/SequenceReviewer';
+import { ObjectPresenceStrip, ObjectPresenceStripObject } from '@/components/sequence-annotation';
+
+export interface ClassifyMediaPanelProps {
+  activeSection: 'detections' | 'sequence';
+  /** Null when the alert has no cards at all (placeholder-only). */
+  activeObject: {
+    label: string;
+    bboxes: BoundingBox[];
+    sequenceId: number;
+    color?: string;
+    siblingOverlays: ObjectOverlay[];
+    frameRecordedAt: (string | undefined)[];
+  } | null;
+  presenceObjects: ObjectPresenceStripObject[];
+  onPresenceObjectClick: (objectIndex: number) => void;
+  primarySequenceId: number;
+  missedSmokeReview: 'yes' | 'no' | null;
+  onMissedSmokeReviewChange: (review: 'yes' | 'no') => void;
+  annotationLoading: boolean;
+  objectOverlays: ObjectOverlay[];
+}
+
+const eyebrow = 'font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze';
+
+export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
+  activeSection,
+  activeObject,
+  presenceObjects,
+  onPresenceObjectClick,
+  primarySequenceId,
+  missedSmokeReview,
+  onMissedSmokeReviewChange,
+  annotationLoading,
+  objectOverlays,
+}) => (
+  <div data-testid="classify-media-panel" className="rounded-card border border-line bg-paper px-[22px] py-5">
+    {activeSection === 'sequence' ? (
+      <div className="space-y-3">
+        <div className={eyebrow}>Whole alert — watch for smoke the model missed</div>
+        <SequenceReviewer
+          sequenceId={primarySequenceId}
+          missedSmokeReview={missedSmokeReview}
+          onMissedSmokeReviewChange={onMissedSmokeReviewChange}
+          annotationLoading={annotationLoading}
+          objectOverlays={objectOverlays}
+          hideReviewControls
+        />
+      </div>
+    ) : activeObject ? (
+      <div className="space-y-4">
+        <FullImageSequence
+          bboxes={activeObject.bboxes}
+          sequenceId={activeObject.sequenceId}
+          color={activeObject.color}
+          siblingOverlays={activeObject.siblingOverlays}
+          frameRecordedAt={activeObject.frameRecordedAt}
+        />
+        <ObjectPresenceStrip objects={presenceObjects} onObjectClick={onPresenceObjectClick} />
+        <div>
+          <div className={`${eyebrow} mb-2`}>Cropped · {activeObject.label}</div>
+          <CroppedImageSequence bboxes={activeObject.bboxes} sequenceId={activeObject.sequenceId} />
+        </div>
+      </div>
+    ) : (
+      <p className="py-16 text-center font-body text-sm text-haze">No objects to review yet</p>
+    )}
+  </div>
+);

--- a/frontend/src/components/classify/ClassifyMediaPanel.tsx
+++ b/frontend/src/components/classify/ClassifyMediaPanel.tsx
@@ -1,10 +1,9 @@
 /**
  * The classify cockpit's media column: always shows "the active thing".
  * Detections section -> the active object's full-frame player (own box
- * solid, siblings dimmed), the presence strip (self-hides under 2
- * objects), and the object's cropped loop. Sequence section -> the primary
- * lane's whole-alert player with every object's overlay, review controls
- * hidden (the decision rail owns yes/no).
+ * solid, siblings dimmed) and the object's cropped loop. Sequence section
+ * -> the primary lane's whole-alert player with every object's overlay,
+ * review controls hidden (the decision rail owns yes/no).
  */
 
 import React from 'react';
@@ -13,7 +12,6 @@ import { ObjectOverlay } from '@/utils/annotation/objectColors';
 import FullImageSequence from '@/components/annotation/FullImageSequence';
 import CroppedImageSequence from '@/components/annotation/CroppedImageSequence';
 import SequenceReviewer from '@/components/sequence/SequenceReviewer';
-import { ObjectPresenceStrip, ObjectPresenceStripObject } from '@/components/sequence-annotation';
 
 export interface ClassifyMediaPanelProps {
   activeSection: 'detections' | 'sequence';
@@ -26,8 +24,6 @@ export interface ClassifyMediaPanelProps {
     siblingOverlays: ObjectOverlay[];
     frameRecordedAt: (string | undefined)[];
   } | null;
-  presenceObjects: ObjectPresenceStripObject[];
-  onPresenceObjectClick: (objectIndex: number) => void;
   primarySequenceId: number;
   missedSmokeReview: 'yes' | 'no' | null;
   onMissedSmokeReviewChange: (review: 'yes' | 'no') => void;
@@ -40,8 +36,6 @@ const eyebrow = 'font-data text-eyebrow font-medium uppercase tracking-eyebrow t
 export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
   activeSection,
   activeObject,
-  presenceObjects,
-  onPresenceObjectClick,
   primarySequenceId,
   missedSmokeReview,
   onMissedSmokeReviewChange,
@@ -73,7 +67,6 @@ export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
           siblingOverlays={activeObject.siblingOverlays}
           frameRecordedAt={activeObject.frameRecordedAt}
         />
-        <ObjectPresenceStrip objects={presenceObjects} onObjectClick={onPresenceObjectClick} />
         <div>
           <div className={`${eyebrow} mb-2`}>Cropped · {activeObject.label}</div>
           <CroppedImageSequence bboxes={activeObject.bboxes} sequenceId={activeObject.sequenceId} />

--- a/frontend/src/components/classify/ClassifyMediaPanel.tsx
+++ b/frontend/src/components/classify/ClassifyMediaPanel.tsx
@@ -3,10 +3,12 @@
  * Detections section -> the active object's full-frame player (own box
  * solid, siblings dimmed) and the object's cropped loop. Sequence section
  * -> the primary lane's whole-alert player with every object's overlay,
- * review controls hidden (the decision rail owns yes/no).
+ * review controls hidden (the decision rail owns yes/no), with a
+ * fullscreen toggle for easier missed-smoke assessment.
  */
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { Maximize2, Minimize2 } from 'lucide-react';
 import { BoundingBox } from '@/types/api';
 import { ObjectOverlay } from '@/utils/annotation/objectColors';
 import FullImageSequence, { FullImageFrame } from '@/components/annotation/FullImageSequence';
@@ -44,42 +46,86 @@ export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
   onMissedSmokeReviewChange,
   annotationLoading,
   objectOverlays,
-}) => (
-  <div
-    data-testid="classify-media-panel"
-    className="rounded-card border border-line bg-paper px-[22px] py-5"
-  >
-    {activeSection === 'sequence' ? (
-      <div className="space-y-3">
-        <div className={eyebrow}>Whole alert — watch for smoke the model missed</div>
-        <SequenceReviewer
-          sequenceId={primarySequenceId}
-          missedSmokeReview={missedSmokeReview}
-          onMissedSmokeReviewChange={onMissedSmokeReviewChange}
-          annotationLoading={annotationLoading}
-          objectOverlays={objectOverlays}
-          hideReviewControls
-        />
-      </div>
-    ) : activeObject ? (
-      <div className="space-y-4">
-        <FullImageSequence
-          bboxes={activeObject.bboxes}
-          sequenceId={activeObject.sequenceId}
-          color={activeObject.color}
-          siblingOverlays={activeObject.siblingOverlays}
-          frameRecordedAt={activeObject.frameRecordedAt}
-        />
-        <div>
-          <div className={`${eyebrow} mb-2`}>Cropped · {activeObject.label}</div>
-          <CroppedImageSequence
-            bboxes={activeObject.croppedBboxes}
-            sequenceId={activeObject.sequenceId}
+}) => {
+  // Fullscreen for the whole-alert (missed-smoke) view. Tracks the browser
+  // state so Esc / browser chrome exits stay in sync with the toggle icon.
+  const sequenceViewRef = useRef<HTMLDivElement | null>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    const onFullscreenChange = () =>
+      setIsFullscreen(document.fullscreenElement === sequenceViewRef.current);
+    document.addEventListener('fullscreenchange', onFullscreenChange);
+    return () => document.removeEventListener('fullscreenchange', onFullscreenChange);
+  }, []);
+
+  const toggleFullscreen = () => {
+    if (document.fullscreenElement) {
+      void document.exitFullscreen?.();
+    } else {
+      void sequenceViewRef.current?.requestFullscreen?.();
+    }
+  };
+
+  return (
+    <div
+      data-testid="classify-media-panel"
+      className="rounded-card border border-line bg-paper px-[22px] py-5"
+    >
+      {activeSection === 'sequence' ? (
+        <div
+          ref={sequenceViewRef}
+          className={
+            isFullscreen ? 'flex h-full flex-col justify-center overflow-auto bg-char p-6' : ''
+          }
+        >
+          <div className="mb-3 flex items-center justify-between gap-2">
+            <div className={isFullscreen ? `${eyebrow} !text-paper` : eyebrow}>
+              Whole alert — watch for smoke the model missed
+            </div>
+            <button
+              type="button"
+              onClick={toggleFullscreen}
+              aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+              title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen the player'}
+              className={`inline-flex items-center rounded-lg border p-1.5 transition-colors ${
+                isFullscreen
+                  ? 'border-paper/30 bg-transparent text-paper hover:bg-paper/10'
+                  : 'border-line bg-paper text-haze hover:bg-ash'
+              }`}
+            >
+              {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+            </button>
+          </div>
+          <SequenceReviewer
+            sequenceId={primarySequenceId}
+            missedSmokeReview={missedSmokeReview}
+            onMissedSmokeReviewChange={onMissedSmokeReviewChange}
+            annotationLoading={annotationLoading}
+            objectOverlays={objectOverlays}
+            hideReviewControls
           />
         </div>
-      </div>
-    ) : (
-      <p className="py-16 text-center font-body text-sm text-haze">No objects to review yet</p>
-    )}
-  </div>
-);
+      ) : activeObject ? (
+        <div className="space-y-4">
+          <FullImageSequence
+            bboxes={activeObject.bboxes}
+            sequenceId={activeObject.sequenceId}
+            color={activeObject.color}
+            siblingOverlays={activeObject.siblingOverlays}
+            frameRecordedAt={activeObject.frameRecordedAt}
+          />
+          <div>
+            <div className={`${eyebrow} mb-2`}>Cropped · {activeObject.label}</div>
+            <CroppedImageSequence
+              bboxes={activeObject.croppedBboxes}
+              sequenceId={activeObject.sequenceId}
+            />
+          </div>
+        </div>
+      ) : (
+        <p className="py-16 text-center font-body text-sm text-haze">No objects to review yet</p>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/classify/DecisionRail.tsx
+++ b/frontend/src/components/classify/DecisionRail.tsx
@@ -1,0 +1,115 @@
+/**
+ * The classify cockpit's right-hand column: the whole alert's decision
+ * state. Object rows come in as children (the page owns their ordering and
+ * wiring); the rail itself owns only the frame and the alert-level
+ * missed-smoke row. Clicking the row body activates the missed-smoke
+ * section (the page swaps the media column to the whole-alert player);
+ * the Yes/No chips are always answerable directly.
+ */
+
+import React from 'react';
+
+export interface DecisionRailProps {
+  missedSmokeReview: 'yes' | 'no' | null;
+  onMissedSmokeReviewChange: (review: 'yes' | 'no') => void;
+  /** True when the missed-smoke section is the active one (activeSection === 'sequence'). */
+  missedSmokeActive: boolean;
+  /** Called when the row is clicked — the page sets activeSection to 'sequence' (swaps the player). */
+  onMissedSmokeActivate: () => void;
+  /** Disables Yes/No (e.g. no open lane to carry the flag). */
+  missedSmokeDisabled?: boolean;
+  missedSmokeRowRef?: React.RefObject<HTMLDivElement>;
+  /** Object rows / placeholders, already ordered. */
+  children: React.ReactNode;
+}
+
+const chip = (selected: boolean, selectedClasses: string, disabled: boolean) =>
+  `inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 font-body text-xs font-medium transition-colors ${
+    selected ? selectedClasses : 'border-line bg-paper text-char hover:bg-ash'
+  } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`;
+
+export const DecisionRail: React.FC<DecisionRailProps> = ({
+  missedSmokeReview,
+  onMissedSmokeReviewChange,
+  missedSmokeActive,
+  onMissedSmokeActivate,
+  missedSmokeDisabled = false,
+  missedSmokeRowRef,
+  children,
+}) => (
+  <div className="rounded-card border border-line bg-paper px-[22px] py-5">
+    <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze mb-3">
+      Objects
+    </div>
+    <div className="space-y-2">{children}</div>
+
+    <hr className="border-0 border-t border-line my-4" />
+
+    <div
+      ref={missedSmokeRowRef}
+      data-testid="missed-smoke-row"
+      onClick={onMissedSmokeActivate}
+      className={`rounded-lg border border-line px-3.5 py-2.5 cursor-pointer transition-colors ${
+        missedSmokeActive ? 'border-l-[3px] border-l-ember' : 'hover:bg-ash'
+      }`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-body text-sm font-semibold text-char">Missed smoke?</span>
+        <span
+          role="radiogroup"
+          aria-label="Missed smoke review"
+          className="flex items-center gap-1.5"
+          onClick={e => e.stopPropagation()}
+        >
+          <button
+            type="button"
+            role="radio"
+            aria-checked={missedSmokeReview === 'yes'}
+            aria-label="Yes"
+            disabled={missedSmokeDisabled}
+            onClick={() => onMissedSmokeReviewChange('yes')}
+            className={chip(
+              missedSmokeReview === 'yes',
+              'border-ember bg-ember-soft text-ember',
+              missedSmokeDisabled
+            )}
+          >
+            Yes
+            <kbd
+              aria-hidden="true"
+              className="px-1 py-0.5 rounded bg-ash font-data text-[10px] font-medium text-haze"
+            >
+              Y
+            </kbd>
+          </button>
+          <button
+            type="button"
+            role="radio"
+            aria-checked={missedSmokeReview === 'no'}
+            aria-label="No"
+            disabled={missedSmokeDisabled}
+            onClick={() => onMissedSmokeReviewChange('no')}
+            className={chip(
+              missedSmokeReview === 'no',
+              'border-pine bg-pine text-white',
+              missedSmokeDisabled
+            )}
+          >
+            No
+            <kbd
+              aria-hidden="true"
+              className="px-1 py-0.5 rounded bg-ash font-data text-[10px] font-medium text-haze"
+            >
+              N
+            </kbd>
+          </button>
+        </span>
+      </div>
+      {missedSmokeActive && (
+        <p className="mt-1.5 font-body text-detail text-haze">
+          The player is showing the whole alert sequence — answer once you've watched it.
+        </p>
+      )}
+    </div>
+  </div>
+);

--- a/frontend/src/components/classify/DecisionRail.tsx
+++ b/frontend/src/components/classify/DecisionRail.tsx
@@ -19,6 +19,8 @@ export interface DecisionRailProps {
   /** Disables Yes/No (e.g. no open lane to carry the flag). */
   missedSmokeDisabled?: boolean;
   missedSmokeRowRef?: React.RefObject<HTMLDivElement>;
+  /** Rendered after the missed-smoke row — the page passes its rail-level Submit button here. */
+  footer?: React.ReactNode;
   /** Object rows / placeholders, already ordered. */
   children: React.ReactNode;
 }
@@ -35,6 +37,7 @@ export const DecisionRail: React.FC<DecisionRailProps> = ({
   onMissedSmokeActivate,
   missedSmokeDisabled = false,
   missedSmokeRowRef,
+  footer,
   children,
 }) => (
   <div className="rounded-card border border-line bg-paper px-[22px] py-5">
@@ -111,5 +114,7 @@ export const DecisionRail: React.FC<DecisionRailProps> = ({
         </p>
       )}
     </div>
+
+    {footer && <div className="mt-4">{footer}</div>}
   </div>
 );

--- a/frontend/src/components/classify/DecisionRail.tsx
+++ b/frontend/src/components/classify/DecisionRail.tsx
@@ -73,6 +73,7 @@ export const DecisionRail: React.FC<DecisionRailProps> = ({
         >
           <button
             type="button"
+            tabIndex={-1}
             role="radio"
             aria-checked={missedSmokeReview === 'yes'}
             aria-label="Yes"
@@ -94,6 +95,7 @@ export const DecisionRail: React.FC<DecisionRailProps> = ({
           </button>
           <button
             type="button"
+            tabIndex={-1}
             role="radio"
             aria-checked={missedSmokeReview === 'no'}
             aria-label="No"

--- a/frontend/src/components/classify/DecisionRail.tsx
+++ b/frontend/src/components/classify/DecisionRail.tsx
@@ -51,8 +51,15 @@ export const DecisionRail: React.FC<DecisionRailProps> = ({
     <div
       ref={missedSmokeRowRef}
       data-testid="missed-smoke-row"
+      // Tab stop: tabbing to the row activates the missed-smoke section
+      // (media swaps to the whole-alert player). Guarded to direct focus so
+      // tabbing/clicking onto the Yes/No chips answers without swapping.
+      tabIndex={0}
+      onFocus={e => {
+        if (e.target === e.currentTarget) onMissedSmokeActivate();
+      }}
       onClick={onMissedSmokeActivate}
-      className={`rounded-lg border border-line px-3.5 py-2.5 cursor-pointer transition-colors ${
+      className={`rounded-lg border border-line px-3.5 py-2.5 cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-ember ${
         missedSmokeActive ? 'border-l-[3px] border-l-ember' : 'hover:bg-ash'
       }`}
     >

--- a/frontend/src/components/classify/ObjectRow.tsx
+++ b/frontend/src/components/classify/ObjectRow.tsx
@@ -77,7 +77,11 @@ export const ObjectRow: React.FC<ObjectRowProps> = ({
       data-testid={`object-card-${cardKey}`}
       // Tab stop: tabbing to a row activates it (chips expand, media panel
       // follows), same as clicking. Guarded to direct focus so focusing a
-      // chip inside the row doesn't re-fire activation.
+      // chip inside the row doesn't re-fire activation. role="group" +
+      // aria-label give the focused row an accessible name (it can't be a
+      // button — it contains the chip buttons).
+      role="group"
+      aria-label={`Object ${objectNumber}`}
       tabIndex={0}
       onFocus={e => {
         if (e.target === e.currentTarget) onRowClick?.(cardKey);

--- a/frontend/src/components/classify/ObjectRow.tsx
+++ b/frontend/src/components/classify/ObjectRow.tsx
@@ -65,7 +65,7 @@ export const ObjectRow: React.FC<ObjectRowProps> = ({
   const frame = locked
     ? 'border border-line bg-paper opacity-60 cursor-pointer'
     : isActive
-      ? 'border border-line border-l-[3px] border-l-ember bg-paper cursor-pointer'
+      ? 'border border-line border-l-[3px] border-l-pine bg-paper cursor-pointer'
       : 'border border-line bg-paper hover:bg-ash cursor-pointer';
 
   return (

--- a/frontend/src/components/classify/ObjectRow.tsx
+++ b/frontend/src/components/classify/ObjectRow.tsx
@@ -1,0 +1,153 @@
+/**
+ * One object's row in the classify cockpit's decision rail. Collapsed rows
+ * are a one-line summary (color dot + name + status chip); the active,
+ * unlocked row expands to the classification chips. Locked rows stay
+ * activatable (click shows their media in the panel) but never render
+ * chips — the page's mutation handlers guard `card.locked` independently.
+ * Keeps the legacy `object-card-${cardKey}` testid so the page test suite
+ * tracks rows the same way it tracked cards.
+ */
+
+import React from 'react';
+import { SequenceBbox } from '@/types/api';
+import { formatSmokeType } from '@/utils/modelAccuracy';
+import { CardClassification } from '@/components/sequence-annotation';
+import { ClassificationChips, formatFalsePositiveLabel } from './ClassificationChips';
+
+export interface ObjectRowStatus {
+  label: string;
+  tone: 'pending' | 'positive' | 'neutral' | 'unsure';
+}
+
+export function getObjectRowStatus(args: {
+  bbox: SequenceBbox;
+  classification: CardClassification;
+  unsure: boolean;
+  locked: boolean;
+  stageBadge?: string;
+}): ObjectRowStatus {
+  const { bbox, classification, unsure, locked, stageBadge } = args;
+  if (locked) return { label: stageBadge ?? 'Locked', tone: 'neutral' };
+  if (unsure) return { label: 'Unsure', tone: 'unsure' };
+  if (classification === 'smoke' && bbox.smoke_type !== undefined) {
+    return { label: `Smoke · ${formatSmokeType(bbox.smoke_type)}`, tone: 'positive' };
+  }
+  if (classification === 'smoke') return { label: 'Type needed', tone: 'pending' };
+  if (bbox.false_positive_types.length > 0) {
+    const extra = bbox.false_positive_types.length - 1;
+    const first = formatFalsePositiveLabel(bbox.false_positive_types[0]);
+    return { label: `FP · ${first}${extra > 0 ? ` +${extra}` : ''}`, tone: 'neutral' };
+  }
+  return { label: 'Pending', tone: 'pending' };
+}
+
+const TONE_CLASSES: Record<ObjectRowStatus['tone'], string> = {
+  pending: 'bg-ember-soft text-ember',
+  positive: 'bg-pine-soft text-pine',
+  neutral: 'bg-ash text-haze',
+  unsure: 'bg-signal-soft text-signal',
+};
+
+export interface ObjectRowProps {
+  objectNumber: number;
+  cardKey: string;
+  color?: string;
+  bbox: SequenceBbox;
+  classification: CardClassification;
+  unsure: boolean;
+  isActive: boolean;
+  locked: boolean;
+  stageBadge?: string;
+  changed?: boolean;
+  rowRef?: (el: HTMLDivElement | null) => void;
+  onRowClick?: (cardKey: string) => void;
+  onBboxChange: (cardKey: string, updatedBbox: SequenceBbox) => void;
+  onClassificationChange: (cardKey: string, classification: 'smoke' | 'false_positive') => void;
+  onUnsureChange?: (cardKey: string, unsure: boolean) => void;
+}
+
+export const ObjectRow: React.FC<ObjectRowProps> = ({
+  objectNumber,
+  cardKey,
+  color,
+  bbox,
+  classification,
+  unsure,
+  isActive,
+  locked,
+  stageBadge,
+  changed = false,
+  rowRef,
+  onRowClick,
+  onBboxChange,
+  onClassificationChange,
+  onUnsureChange,
+}) => {
+  const status = getObjectRowStatus({ bbox, classification, unsure, locked, stageBadge });
+  const expanded = isActive && !locked;
+
+  const frame = locked
+    ? 'border border-line bg-paper opacity-60 cursor-pointer'
+    : isActive
+      ? 'border border-line border-l-[3px] border-l-ember bg-paper cursor-pointer'
+      : 'border border-line bg-paper hover:bg-ash cursor-pointer';
+
+  return (
+    <div
+      ref={rowRef}
+      data-testid={`object-card-${cardKey}`}
+      className={`rounded-lg px-3.5 py-2.5 transition-colors ${frame}`}
+      onClick={() => onRowClick?.(cardKey)}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="flex items-center gap-2 min-w-0">
+          {color && (
+            <span
+              data-testid={`object-color-swatch-${cardKey}`}
+              className="inline-block w-2.5 h-2.5 rounded-full ring-1 ring-char/10 shrink-0"
+              style={{ backgroundColor: color }}
+              aria-hidden="true"
+            />
+          )}
+          <span className="font-body text-sm font-semibold text-char truncate">
+            Object {objectNumber}
+          </span>
+          {changed && (
+            <span
+              data-testid={`object-row-changed-${cardKey}`}
+              title="Changed since load"
+              className="inline-block w-1.5 h-1.5 rounded-full bg-ember shrink-0"
+            />
+          )}
+        </span>
+        <span className="flex items-center gap-1.5 shrink-0">
+          {!locked && stageBadge && (
+            <span className="rounded-full px-2 py-0.5 font-body text-xs font-semibold bg-ash text-haze whitespace-nowrap">
+              {stageBadge}
+            </span>
+          )}
+          <span
+            className={`rounded-full px-2 py-0.5 font-body text-xs font-semibold whitespace-nowrap ${TONE_CLASSES[status.tone]}`}
+          >
+            {status.label}
+          </span>
+        </span>
+      </div>
+
+      {expanded && (
+        <div className="mt-2.5">
+          <ClassificationChips
+            cardKey={cardKey}
+            bbox={bbox}
+            classification={classification}
+            unsure={unsure}
+            showKbdHints
+            onBboxChange={onBboxChange}
+            onClassificationChange={onClassificationChange}
+            onUnsureChange={onUnsureChange}
+          />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/classify/ObjectRow.tsx
+++ b/frontend/src/components/classify/ObjectRow.tsx
@@ -38,7 +38,10 @@ export interface ObjectRowProps {
   rowRef?: (el: HTMLDivElement | null) => void;
   onRowClick?: (cardKey: string) => void;
   onBboxChange: (cardKey: string, updatedBbox: SequenceBbox) => void;
-  onClassificationChange: (cardKey: string, classification: 'smoke' | 'false_positive') => void;
+  onClassificationChange: (
+    cardKey: string,
+    classification: 'smoke' | 'false_positive' | 'unselected'
+  ) => void;
   onUnsureChange?: (cardKey: string, unsure: boolean) => void;
 }
 
@@ -72,7 +75,14 @@ export const ObjectRow: React.FC<ObjectRowProps> = ({
     <div
       ref={rowRef}
       data-testid={`object-card-${cardKey}`}
-      className={`rounded-lg px-3.5 py-2.5 transition-colors ${frame}`}
+      // Tab stop: tabbing to a row activates it (chips expand, media panel
+      // follows), same as clicking. Guarded to direct focus so focusing a
+      // chip inside the row doesn't re-fire activation.
+      tabIndex={0}
+      onFocus={e => {
+        if (e.target === e.currentTarget) onRowClick?.(cardKey);
+      }}
+      className={`rounded-lg px-3.5 py-2.5 transition-colors focus:outline-none focus:ring-2 focus:ring-pine ${frame}`}
       onClick={() => onRowClick?.(cardKey)}
     >
       <div className="flex items-center justify-between gap-2">

--- a/frontend/src/components/classify/ObjectRow.tsx
+++ b/frontend/src/components/classify/ObjectRow.tsx
@@ -1,45 +1,21 @@
 /**
  * One object's row in the classify cockpit's decision rail. Collapsed rows
- * are a one-line summary (color dot + name + status chip); the active,
- * unlocked row expands to the classification chips. Locked rows stay
- * activatable (click shows their media in the panel) but never render
- * chips — the page's mutation handlers guard `card.locked` independently.
- * Keeps the legacy `object-card-${cardKey}` testid so the page test suite
- * tracks rows the same way it tracked cards.
+ * are a one-line summary (color dot + name + optional stage badge + status
+ * chip); the active, unlocked row expands to the classification chips.
+ * Locked rows stay activatable (click shows their media in the panel) but
+ * never render chips — the page's mutation handlers guard `card.locked`
+ * independently. The status chip is always computed from the object's data
+ * (a locked lane is genuinely labeled, so its classification still shows);
+ * the processing-stage badge renders alongside whenever `stageBadge` is
+ * given. Keeps the legacy `object-card-${cardKey}` testid so the page test
+ * suite tracks rows the same way it tracked cards.
  */
 
 import React from 'react';
 import { SequenceBbox } from '@/types/api';
-import { formatSmokeType } from '@/utils/modelAccuracy';
 import { CardClassification } from '@/components/sequence-annotation';
-import { ClassificationChips, formatFalsePositiveLabel } from './ClassificationChips';
-
-export interface ObjectRowStatus {
-  label: string;
-  tone: 'pending' | 'positive' | 'neutral' | 'unsure';
-}
-
-export function getObjectRowStatus(args: {
-  bbox: SequenceBbox;
-  classification: CardClassification;
-  unsure: boolean;
-  locked: boolean;
-  stageBadge?: string;
-}): ObjectRowStatus {
-  const { bbox, classification, unsure, locked, stageBadge } = args;
-  if (locked) return { label: stageBadge ?? 'Locked', tone: 'neutral' };
-  if (unsure) return { label: 'Unsure', tone: 'unsure' };
-  if (classification === 'smoke' && bbox.smoke_type !== undefined) {
-    return { label: `Smoke · ${formatSmokeType(bbox.smoke_type)}`, tone: 'positive' };
-  }
-  if (classification === 'smoke') return { label: 'Type needed', tone: 'pending' };
-  if (bbox.false_positive_types.length > 0) {
-    const extra = bbox.false_positive_types.length - 1;
-    const first = formatFalsePositiveLabel(bbox.false_positive_types[0]);
-    return { label: `FP · ${first}${extra > 0 ? ` +${extra}` : ''}`, tone: 'neutral' };
-  }
-  return { label: 'Pending', tone: 'pending' };
-}
+import { ClassificationChips } from './ClassificationChips';
+import { getObjectRowStatus, ObjectRowStatus } from './status';
 
 const TONE_CLASSES: Record<ObjectRowStatus['tone'], string> = {
   pending: 'bg-ember-soft text-ember',
@@ -83,7 +59,7 @@ export const ObjectRow: React.FC<ObjectRowProps> = ({
   onClassificationChange,
   onUnsureChange,
 }) => {
-  const status = getObjectRowStatus({ bbox, classification, unsure, locked, stageBadge });
+  const status = getObjectRowStatus({ bbox, classification, unsure });
   const expanded = isActive && !locked;
 
   const frame = locked
@@ -121,7 +97,7 @@ export const ObjectRow: React.FC<ObjectRowProps> = ({
           )}
         </span>
         <span className="flex items-center gap-1.5 shrink-0">
-          {!locked && stageBadge && (
+          {stageBadge && (
             <span className="rounded-full px-2 py-0.5 font-body text-xs font-semibold bg-ash text-haze whitespace-nowrap">
               {stageBadge}
             </span>

--- a/frontend/src/components/classify/index.ts
+++ b/frontend/src/components/classify/index.ts
@@ -1,2 +1,4 @@
 export { ClassificationChips, formatFalsePositiveLabel } from './ClassificationChips';
 export type { ClassificationChipsProps } from './ClassificationChips';
+export { ObjectRow, getObjectRowStatus } from './ObjectRow';
+export type { ObjectRowProps, ObjectRowStatus } from './ObjectRow';

--- a/frontend/src/components/classify/index.ts
+++ b/frontend/src/components/classify/index.ts
@@ -1,7 +1,9 @@
-export { ClassificationChips, formatFalsePositiveLabel } from './ClassificationChips';
+export { ClassificationChips } from './ClassificationChips';
 export type { ClassificationChipsProps } from './ClassificationChips';
-export { ObjectRow, getObjectRowStatus } from './ObjectRow';
-export type { ObjectRowProps, ObjectRowStatus } from './ObjectRow';
+export { ObjectRow } from './ObjectRow';
+export type { ObjectRowProps } from './ObjectRow';
+export { formatFalsePositiveLabel, getObjectRowStatus } from './status';
+export type { ObjectRowStatus } from './status';
 export { DecisionRail } from './DecisionRail';
 export type { DecisionRailProps } from './DecisionRail';
 export { ClassifyMediaPanel } from './ClassifyMediaPanel';

--- a/frontend/src/components/classify/index.ts
+++ b/frontend/src/components/classify/index.ts
@@ -1,0 +1,2 @@
+export { ClassificationChips, formatFalsePositiveLabel } from './ClassificationChips';
+export type { ClassificationChipsProps } from './ClassificationChips';

--- a/frontend/src/components/classify/index.ts
+++ b/frontend/src/components/classify/index.ts
@@ -4,3 +4,5 @@ export { ObjectRow, getObjectRowStatus } from './ObjectRow';
 export type { ObjectRowProps, ObjectRowStatus } from './ObjectRow';
 export { DecisionRail } from './DecisionRail';
 export type { DecisionRailProps } from './DecisionRail';
+export { ClassifyMediaPanel } from './ClassifyMediaPanel';
+export type { ClassifyMediaPanelProps } from './ClassifyMediaPanel';

--- a/frontend/src/components/classify/index.ts
+++ b/frontend/src/components/classify/index.ts
@@ -2,3 +2,5 @@ export { ClassificationChips, formatFalsePositiveLabel } from './ClassificationC
 export type { ClassificationChipsProps } from './ClassificationChips';
 export { ObjectRow, getObjectRowStatus } from './ObjectRow';
 export type { ObjectRowProps, ObjectRowStatus } from './ObjectRow';
+export { DecisionRail } from './DecisionRail';
+export type { DecisionRailProps } from './DecisionRail';

--- a/frontend/src/components/classify/status.ts
+++ b/frontend/src/components/classify/status.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure display helpers for the classify cockpit's decision rail — kept out
+ * of the component files so those stay fast-refresh-safe (component-only
+ * exports).
+ */
+
+import { SequenceBbox } from '@/types/api';
+import { formatSmokeType } from '@/utils/modelAccuracy';
+import { CardClassification } from '@/components/sequence-annotation';
+
+export const formatFalsePositiveLabel = (type: string): string => {
+  const [first, ...rest] = type.split('_');
+  return [first.charAt(0).toUpperCase() + first.slice(1), ...rest].join(' ');
+};
+
+export interface ObjectRowStatus {
+  label: string;
+  tone: 'pending' | 'positive' | 'neutral' | 'unsure';
+}
+
+export function getObjectRowStatus(args: {
+  bbox: SequenceBbox;
+  classification: CardClassification;
+  unsure: boolean;
+}): ObjectRowStatus {
+  const { bbox, classification, unsure } = args;
+  if (unsure) return { label: 'Unsure', tone: 'unsure' };
+  if (classification === 'smoke' && bbox.smoke_type !== undefined) {
+    return { label: `Smoke · ${formatSmokeType(bbox.smoke_type)}`, tone: 'positive' };
+  }
+  if (classification === 'smoke') return { label: 'Type needed', tone: 'pending' };
+  if (bbox.false_positive_types.length > 0) {
+    const extra = bbox.false_positive_types.length - 1;
+    const first = formatFalsePositiveLabel(bbox.false_positive_types[0]);
+    return { label: `FP · ${first}${extra > 0 ? ` +${extra}` : ''}`, tone: 'neutral' };
+  }
+  return { label: 'Pending', tone: 'pending' };
+}

--- a/frontend/src/components/sequence-annotation/ObjectCard.tsx
+++ b/frontend/src/components/sequence-annotation/ObjectCard.tsx
@@ -61,7 +61,7 @@ const getKeyForType = (type: string) => {
     building: 'B',
     cliff: 'C',
     dark: 'D',
-    dust: 'U',
+    dust: 'J', // 'u' toggles Unsure in the shared keyboard handler
     high_cloud: 'H',
     low_cloud: 'L',
     lens_flare: 'G',

--- a/frontend/src/components/sequence-annotation/ObjectPresenceStrip.tsx
+++ b/frontend/src/components/sequence-annotation/ObjectPresenceStrip.tsx
@@ -64,18 +64,18 @@ export const ObjectPresenceStrip: React.FC<ObjectPresenceStripProps> = ({
             aria-label={`Go to ${object.label}`}
             aria-current={isRowActive || undefined}
             onClick={() => onObjectClick?.(objectIndex)}
-            className={`flex w-full items-center gap-2 rounded py-1 pr-1.5 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-ember ${
-              isRowActive ? 'bg-ash' : 'hover:bg-ash'
+            className={`flex w-full items-center gap-2 rounded py-1 pr-1.5 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-pine ${
+              isRowActive ? 'bg-pine-soft' : 'hover:bg-ash'
             }`}
           >
             <span
               data-testid={`object-presence-swatch-${objectIndex}`}
-              className={`h-2.5 w-2.5 shrink-0 rounded-full ${isRowActive ? 'ring-2 ring-char/20' : ''}`}
+              className={`h-2.5 w-2.5 shrink-0 rounded-full ${isRowActive ? 'ring-2 ring-pine/30' : ''}`}
               style={{ backgroundColor: object.color }}
             />
             <span
               className={`w-20 shrink-0 truncate font-body text-detail ${
-                isRowActive ? 'font-medium text-char' : 'text-haze'
+                isRowActive ? 'font-medium text-pine' : 'text-haze'
               }`}
             >
               {object.label}

--- a/frontend/src/components/sequence-annotation/ObjectPresenceStrip.tsx
+++ b/frontend/src/components/sequence-annotation/ObjectPresenceStrip.tsx
@@ -3,16 +3,12 @@
  * (ClassifyAlertPage). Temporal context + color legend, not an editor: one
  * clickable row per object — color swatch + label + a presence bar across
  * the union of the alert's frame timestamps, filled where that object's
- * lane has a detection at that timestamp, gap otherwise — plus a real axis
- * beneath the rows: a hairline axis line with a directional arrowhead,
- * tick marks + frame numbers at the same adaptive columns, and a "Frame"
- * axis label. The axis is deliberately recessive (all `line`/`haze`
- * tokens, never an object color) so the presence bars stay the dominant
- * layer. Pure presentational — the union is computed from props, no data
- * fetching or app state; clicking a row calls back to the page rather than
- * navigating itself, so this component never touches page internals like
- * card refs or active-card state. Presence bar segments are not
- * individually interactive — only the row as a whole.
+ * lane has a detection at that timestamp, gap otherwise. Pure
+ * presentational — the union is computed from props, no data fetching or
+ * app state; clicking a row calls back to the page rather than navigating
+ * itself, so this component never touches page internals like card refs or
+ * active-card state. Presence bar segments are not individually
+ * interactive — only the row as a whole.
  *
  * Renders nothing for fewer than 2 objects (single-object alerts have no
  * legend to disambiguate).
@@ -33,46 +29,14 @@ interface ObjectPresenceStripProps {
   objects: ObjectPresenceStripObject[];
   /** Called with an object's position in `objects` when its row is clicked — the caller (ClassifyAlertPage) owns turning that into "scroll to and activate that object's card." Omit to render rows non-interactively. */
   onObjectClick?: (objectIndex: number) => void;
-}
-
-// Leading columns every row (object rows and the axis row alike) shares, so
-// the axis's tick columns line up under the presence bars' frame columns:
-// the color swatch's width, then the label's width, matching the `gap-2`
-// rhythm of an object row exactly (see the swatch/label spans below).
-const LEADING_SPACER = (
-  <>
-    <span className="h-2.5 w-2.5 shrink-0" aria-hidden="true" />
-    <span className="w-20 shrink-0" aria-hidden="true" />
-  </>
-);
-
-/**
- * Which frame indices (0-based) get a tick label: the first and last frame
- * always, plus intermediate ticks at a step that grows with the frame count
- * — so labels stay legible instead of crowding at typical strip widths.
- * The last tick before the final one is dropped if it would land within one
- * step of it (avoids two labels touching at the right edge).
- */
-function computeAxisTickIndices(frameCount: number): number[] {
-  if (frameCount <= 0) return [];
-  if (frameCount === 1) return [0];
-
-  const maxTicks = 8;
-  const step = Math.max(1, Math.ceil((frameCount - 1) / (maxTicks - 1)));
-  const indices: number[] = [];
-  for (let i = 0; i < frameCount - 1; i += step) indices.push(i);
-
-  const last = frameCount - 1;
-  if (indices.length > 0 && last - indices[indices.length - 1] < step) {
-    indices.pop();
-  }
-  indices.push(last);
-  return indices;
+  /** Position in `objects` of the currently active object — its row renders highlighted, mirroring the rail's active row. Omit/null for no highlight. */
+  activeIndex?: number | null;
 }
 
 export const ObjectPresenceStrip: React.FC<ObjectPresenceStripProps> = ({
   objects,
   onObjectClick,
+  activeIndex = null,
 }) => {
   if (objects.length < 2) return null;
 
@@ -83,7 +47,6 @@ export const ObjectPresenceStrip: React.FC<ObjectPresenceStripProps> = ({
   const frameUnion = Array.from(new Set(objects.flatMap(o => o.timestamps))).sort(
     (a, b) => new Date(a).getTime() - new Date(b).getTime()
   );
-  const tickIndices = new Set(computeAxisTickIndices(frameUnion.length));
 
   return (
     <div className="space-y-2.5 rounded-lg border border-line bg-paper p-4">
@@ -93,20 +56,28 @@ export const ObjectPresenceStrip: React.FC<ObjectPresenceStripProps> = ({
 
       {objects.map((object, objectIndex) => {
         const presentAt = new Set(object.timestamps);
+        const isRowActive = objectIndex === activeIndex;
         return (
           <button
             key={object.label}
             type="button"
             aria-label={`Go to ${object.label}`}
+            aria-current={isRowActive || undefined}
             onClick={() => onObjectClick?.(objectIndex)}
-            className="flex w-full items-center gap-2 rounded py-1 text-left transition-colors hover:bg-ash focus:outline-none focus:ring-2 focus:ring-ember"
+            className={`flex w-full items-center gap-2 rounded py-1 pr-1.5 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-ember ${
+              isRowActive ? 'bg-ash' : 'hover:bg-ash'
+            }`}
           >
             <span
               data-testid={`object-presence-swatch-${objectIndex}`}
-              className="h-2.5 w-2.5 shrink-0 rounded-full"
+              className={`h-2.5 w-2.5 shrink-0 rounded-full ${isRowActive ? 'ring-2 ring-char/20' : ''}`}
               style={{ backgroundColor: object.color }}
             />
-            <span className="w-20 shrink-0 truncate font-body text-detail text-haze">
+            <span
+              className={`w-20 shrink-0 truncate font-body text-detail ${
+                isRowActive ? 'font-medium text-char' : 'text-haze'
+              }`}
+            >
               {object.label}
             </span>
             <div className="flex h-1.5 flex-1 gap-px overflow-hidden rounded-full bg-ash">
@@ -122,59 +93,6 @@ export const ObjectPresenceStrip: React.FC<ObjectPresenceStripProps> = ({
           </button>
         );
       })}
-
-      {/* Frame axis — hairline + arrowhead + ticks + numbers share the
-          object rows' column layout; the "Frame" caption centers under the
-          plot area only (excludes the swatch/label spacer, standard
-          axis-label placement). Every stroke and label is a recessive
-          line/haze token — never an object color — so the presence bars
-          above stay the dominant layer. */}
-      <div data-testid="presence-axis" className="pt-2">
-        <div className="flex items-center gap-2">
-          {LEADING_SPACER}
-          <div
-            data-testid="presence-axis-line"
-            className="h-px flex-1 bg-line"
-            aria-hidden="true"
-          />
-          {/* Directional arrowhead — a CSS border-triangle, not an image,
-              kept a few px so it stays subordinate to the data bars. */}
-          <span
-            data-testid="presence-axis-arrow"
-            aria-hidden="true"
-            className="block h-0 w-0 shrink-0 border-y-[3px] border-l-[4px] border-y-transparent border-l-line"
-          />
-        </div>
-        <div className="flex items-start gap-2 mt-1">
-          {LEADING_SPACER}
-          <div className="flex flex-1">
-            {frameUnion.map((timestamp, frameIndex) => (
-              <div key={timestamp} className="flex flex-1 flex-col items-center">
-                {tickIndices.has(frameIndex) && (
-                  <>
-                    <span className="h-[3px] w-px bg-line" aria-hidden="true" />
-                    <span
-                      data-testid={`presence-axis-tick-${frameIndex}`}
-                      className="mt-0.5 font-data text-[10px] leading-none text-haze"
-                    >
-                      {frameIndex + 1}
-                    </span>
-                  </>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-        <div className="flex items-center gap-2 mt-1.5">
-          {LEADING_SPACER}
-          <div
-            data-testid="presence-axis-label"
-            className="flex-1 text-center font-data text-[9px] leading-none text-haze"
-          >
-            Frame
-          </div>
-        </div>
-      </div>
     </div>
   );
 };

--- a/frontend/src/components/sequence/SequencePlayer.tsx
+++ b/frontend/src/components/sequence/SequencePlayer.tsx
@@ -34,6 +34,8 @@ interface SequencePlayerProps {
   onSeek: (index: number) => void;
   onSpeedChange: (speed: number) => void;
   onReset: () => void;
+  /** Hide the embedded "Did the model miss any smoke?" overlay — used by the classify cockpit, where the decision rail owns the yes/no controls. */
+  hideReviewControls?: boolean;
   className?: string;
 }
 
@@ -53,6 +55,7 @@ export default function SequencePlayer({
   onSpeedChange,
   onReset,
   objectOverlays,
+  hideReviewControls = false,
   className = '',
 }: SequencePlayerProps) {
   const [imageInfo, setImageInfo] = useState<{
@@ -473,6 +476,7 @@ export default function SequencePlayer({
               </div>
 
               {/* Center - Missed Smoke Review */}
+              {!hideReviewControls && (
               <div className="flex items-center space-x-4 bg-black/40 px-4 py-2 rounded-lg border border-white/20">
                 <span className="text-sm font-medium text-white">
                   Did the model miss any smoke?
@@ -513,6 +517,7 @@ export default function SequencePlayer({
                   <Info className="w-4 h-4 text-white" />
                 </button>
               </div>
+              )}
 
               {/* Right - Predictions + sibling toggle */}
               <div className="flex-1 flex items-center justify-end space-x-3">

--- a/frontend/src/components/sequence/SequencePlayer.tsx
+++ b/frontend/src/components/sequence/SequencePlayer.tsx
@@ -477,46 +477,50 @@ export default function SequencePlayer({
 
               {/* Center - Missed Smoke Review */}
               {!hideReviewControls && (
-              <div className="flex items-center space-x-4 bg-black/40 px-4 py-2 rounded-lg border border-white/20">
-                <span className="text-sm font-medium text-white">
-                  Did the model miss any smoke?
-                </span>
-                <label className="flex items-center cursor-pointer hover:bg-white/10 px-2 py-1 rounded transition-colors">
-                  <input
-                    type="radio"
-                    name="missedSmokeOverlay"
-                    value="yes"
-                    checked={missedSmokeReview === 'yes'}
-                    onChange={() => onMissedSmokeReviewChange('yes')}
-                    className="w-4 h-4 text-orange-500 focus:ring-orange-500 border-gray-300 bg-white/20 mr-2"
-                  />
+                <div className="flex items-center space-x-4 bg-black/40 px-4 py-2 rounded-lg border border-white/20">
                   <span className="text-sm font-medium text-white">
-                    Yes{' '}
-                    <kbd className="ml-1 px-1 py-0.5 bg-white/20 rounded text-xs font-mono">Y</kbd>
+                    Did the model miss any smoke?
                   </span>
-                </label>
-                <label className="flex items-center cursor-pointer hover:bg-white/10 px-2 py-1 rounded transition-colors">
-                  <input
-                    type="radio"
-                    name="missedSmokeOverlay"
-                    value="no"
-                    checked={missedSmokeReview === 'no'}
-                    onChange={() => onMissedSmokeReviewChange('no')}
-                    className="w-4 h-4 text-green-500 focus:ring-green-500 border-gray-300 bg-white/20 mr-2"
-                  />
-                  <span className="text-sm font-medium text-white">
-                    No{' '}
-                    <kbd className="ml-1 px-1 py-0.5 bg-white/20 rounded text-xs font-mono">N</kbd>
-                  </span>
-                </label>
-                <button
-                  onClick={() => setShowInstructionsModal(true)}
-                  className="p-1.5 hover:bg-white/20 rounded transition-colors"
-                  title="Show review instructions"
-                >
-                  <Info className="w-4 h-4 text-white" />
-                </button>
-              </div>
+                  <label className="flex items-center cursor-pointer hover:bg-white/10 px-2 py-1 rounded transition-colors">
+                    <input
+                      type="radio"
+                      name="missedSmokeOverlay"
+                      value="yes"
+                      checked={missedSmokeReview === 'yes'}
+                      onChange={() => onMissedSmokeReviewChange('yes')}
+                      className="w-4 h-4 text-orange-500 focus:ring-orange-500 border-gray-300 bg-white/20 mr-2"
+                    />
+                    <span className="text-sm font-medium text-white">
+                      Yes{' '}
+                      <kbd className="ml-1 px-1 py-0.5 bg-white/20 rounded text-xs font-mono">
+                        Y
+                      </kbd>
+                    </span>
+                  </label>
+                  <label className="flex items-center cursor-pointer hover:bg-white/10 px-2 py-1 rounded transition-colors">
+                    <input
+                      type="radio"
+                      name="missedSmokeOverlay"
+                      value="no"
+                      checked={missedSmokeReview === 'no'}
+                      onChange={() => onMissedSmokeReviewChange('no')}
+                      className="w-4 h-4 text-green-500 focus:ring-green-500 border-gray-300 bg-white/20 mr-2"
+                    />
+                    <span className="text-sm font-medium text-white">
+                      No{' '}
+                      <kbd className="ml-1 px-1 py-0.5 bg-white/20 rounded text-xs font-mono">
+                        N
+                      </kbd>
+                    </span>
+                  </label>
+                  <button
+                    onClick={() => setShowInstructionsModal(true)}
+                    className="p-1.5 hover:bg-white/20 rounded transition-colors"
+                    title="Show review instructions"
+                  >
+                    <Info className="w-4 h-4 text-white" />
+                  </button>
+                </div>
               )}
 
               {/* Right - Predictions + sibling toggle */}

--- a/frontend/src/components/sequence/SequenceReviewer.tsx
+++ b/frontend/src/components/sequence/SequenceReviewer.tsx
@@ -13,6 +13,8 @@ interface SequenceReviewerProps {
   className?: string;
   /** Every classified object's track boxes, color-coded per object — see SequencePlayer. */
   objectOverlays?: ObjectOverlay[];
+  /** Hide the player's embedded "Did the model miss any smoke?" overlay — used by the classify cockpit, where the decision rail owns the yes/no controls. */
+  hideReviewControls?: boolean;
 }
 
 export default function SequenceReviewer({
@@ -22,6 +24,7 @@ export default function SequenceReviewer({
   annotationLoading = false,
   className = '',
   objectOverlays,
+  hideReviewControls,
 }: SequenceReviewerProps) {
   // Playback state
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -182,6 +185,7 @@ export default function SequenceReviewer({
         onSpeedChange={handleSpeedChange}
         onReset={handleReset}
         objectOverlays={objectOverlays}
+        hideReviewControls={hideReviewControls}
       />
     </div>
   );

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -437,16 +437,47 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
   const activeOverlay = activeCard
     ? cardOverlayData.find(o => o.cardKey === activeCard.cardKey)
     : undefined;
+
+  // Frame union across every lane, deduped by recorded_at (sibling lanes
+  // materialize the same physical frame as their own detection). The active
+  // object's full-frame player runs over this union so frames its own track
+  // has no box on still play — just without the box — instead of being
+  // skipped. Falls back to the track's own frames until detections resolve.
+  const unionFrames: { detection_id: number; recorded_at: string }[] = [];
+  {
+    const seenFrames = new Set<string>();
+    Object.values(detectionsByLaneId)
+      .flat()
+      .forEach(d => {
+        if (seenFrames.has(d.recorded_at)) return;
+        seenFrames.add(d.recorded_at);
+        unionFrames.push({ detection_id: d.id, recorded_at: d.recorded_at });
+      });
+    unionFrames.sort(
+      (a, b) => new Date(a.recorded_at).getTime() - new Date(b.recorded_at).getTime()
+    );
+  }
+
   const activeMediaObject = activeCard
     ? {
         label: activeOverlay?.label ?? 'Object',
-        bboxes: getBbox(activeCard).bboxes,
+        bboxes:
+          unionFrames.length > 0
+            ? unionFrames.map(f => ({
+                detection_id: f.detection_id,
+                xyxyn: activeOverlay?.boxesByRecordedAt[f.recorded_at] ?? null,
+              }))
+            : getBbox(activeCard).bboxes,
+        croppedBboxes: getBbox(activeCard).bboxes,
         sequenceId: activeCard.laneSequenceId,
         color: activeOverlay?.color,
         siblingOverlays: cardOverlayData
           .filter(o => o.cardKey !== activeCard.cardKey)
           .map(o => ({ color: o.color, label: o.label, boxesByRecordedAt: o.boxesByRecordedAt })),
-        frameRecordedAt: activeOverlay?.frameRecordedAt ?? [],
+        frameRecordedAt:
+          unionFrames.length > 0
+            ? unionFrames.map(f => f.recorded_at)
+            : (activeOverlay?.frameRecordedAt ?? []),
       }
     : null;
 

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -1068,6 +1068,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
             <ClassifyMediaPanel
               activeSection={activeSection}
               activeObject={activeMediaObject}
+              loading={cards.length > 0 && !activeMediaObject}
               primarySequenceId={primaryLane.sequence.id}
               missedSmokeReview={missedSmokeReview}
               onMissedSmokeReviewChange={handleMissedSmokeReviewChange}

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -783,7 +783,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
       handleMissedSmokeReviewChange,
       handleBboxChange: handleBboxChangeAdapter,
       onPrimaryClassificationChange: handlePrimaryClassificationChangeAdapter,
-      // Q: toggle the active object's Unsure — same mutual exclusivity as
+      // U: toggle the active object's Unsure — same mutual exclusivity as
       // the Unsure chip (turning it on clears the classification).
       onUnsureToggle: index => {
         const card = cards[index];
@@ -1131,7 +1131,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="font-body text-sm text-char">Mark active object as unsure</span>
-                  <span className="font-data text-detail text-haze">Q</span>
+                  <span className="font-data text-detail text-haze">U</span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="font-body text-sm text-char">Missed smoke yes / no</span>

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -20,15 +20,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
-import {
-  AlertCircle,
-  ArrowLeft,
-  ChevronLeft,
-  ChevronRight,
-  Keyboard,
-  Upload,
-  X,
-} from 'lucide-react';
+import { ArrowLeft, ChevronLeft, ChevronRight, Keyboard, Upload, X } from 'lucide-react';
 import { apiClient } from '@/services/api';
 import { QUERY_KEYS } from '@/utils/constants';
 import {
@@ -50,12 +42,8 @@ import {
 } from '@/utils/annotation/navigationUtils';
 import { getObjectColor, ObjectOverlay } from '@/utils/annotation/objectColors';
 import { getProcessingStageLabel } from '@/utils/processingStage';
-import {
-  MissedSmokePanel,
-  ObjectCard,
-  CardClassification,
-  ObjectPresenceStrip,
-} from '@/components/sequence-annotation';
+import { CardClassification } from '@/components/sequence-annotation';
+import { ClassifyMediaPanel, DecisionRail, ObjectRow } from '@/components/classify';
 import { NotificationSystem } from '@/components/ui/NotificationSystem';
 import { useToastNotifications } from '@/utils/notification/toastUtils';
 import { ROUTES, classifyDetail, classifyGroup } from '@/utils/routes';
@@ -343,6 +331,18 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
 
   const editableCards = cards.filter(c => !c.locked);
 
+  // Cockpit: the media column always shows the active thing, so an object
+  // must be active from the start. Queue mode activates the first editable
+  // card (first card as fallback for fully-locked deep links); done mode
+  // keeps its own entry-sequence activation effect below.
+  useEffect(() => {
+    if (mode === 'done' || activeCardKey !== null || cards.length === 0) return;
+    const first = cards.find(c => !c.locked) ?? cards[0];
+    setActiveCardKey(first.cardKey);
+    setActiveSection('detections');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, cards]);
+
   // Done mode only: the sequence the annotator clicked in the Done list is
   // its own card's lane — scroll-activate that card once the alert's cards
   // are on screen, so they land exactly where they came from.
@@ -421,6 +421,26 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     boxesByRecordedAt: o.boxesByRecordedAt,
     isActive: o.cardKey === activeCardKey,
   }));
+
+  // The media panel always shows the active object's players (the panel
+  // itself swaps to the whole-alert player when the missed-smoke section is
+  // active). Null only when the alert has no cards at all.
+  const activeCard = activeCardKey ? cards.find(c => c.cardKey === activeCardKey) : undefined;
+  const activeOverlay = activeCard
+    ? cardOverlayData.find(o => o.cardKey === activeCard.cardKey)
+    : undefined;
+  const activeMediaObject = activeCard
+    ? {
+        label: activeOverlay?.label ?? 'Object',
+        bboxes: getBbox(activeCard).bboxes,
+        sequenceId: activeCard.laneSequenceId,
+        color: activeOverlay?.color,
+        siblingOverlays: cardOverlayData
+          .filter(o => o.cardKey !== activeCard.cardKey)
+          .map(o => ({ color: o.color, label: o.label, boxesByRecordedAt: o.boxesByRecordedAt })),
+        frameRecordedAt: activeOverlay?.frameRecordedAt ?? [],
+      }
+    : null;
 
   // Presence strip: temporal context + color legend, keyed off the same
   // per-object color/label identity as the overlays above. Renders nothing
@@ -564,15 +584,16 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     const missedSmokeChanged = carriesMissedSmoke && hasMissedSmoke !== snapshot.hasMissedSmoke;
     return bboxesChanged || unsureChanged || missedSmokeChanged;
   };
-  const anyLaneChanged =
-    mode === 'done' &&
-    !!alertDetail &&
-    alertDetail.lanes.some(
-      lane =>
-        !isLaneLocked(lane, mode) &&
-        !!lane.annotation &&
-        isLaneChanged(lane.sequence.id, lane.sequence.id === missedSmokeCarrierLaneId)
-    );
+  const changedLaneCount =
+    mode === 'done' && alertDetail
+      ? alertDetail.lanes.filter(
+          lane =>
+            !isLaneLocked(lane, mode) &&
+            !!lane.annotation &&
+            isLaneChanged(lane.sequence.id, lane.sequence.id === missedSmokeCarrierLaneId)
+        ).length
+      : 0;
+  const anyLaneChanged = mode === 'done' && changedLaneCount > 0;
 
   // Deep-linking a fully-classified alert leaves zero editable cards —
   // `isComplete` is vacuously true over an empty list, so it alone can't
@@ -865,14 +886,16 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
               onClick={handleSubmit}
               disabled={!canSubmit || submitMutation.isPending}
               className="inline-flex items-center rounded-lg bg-ember px-4 py-2 font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
-              title="Submit alert (Enter)"
+              title={mode === 'done' ? 'Save changes (Enter)' : 'Submit alert (Enter)'}
             >
               {submitMutation.isPending ? (
                 <div className="w-3.5 h-3.5 mr-1.5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
               ) : (
                 <Upload className="w-3.5 h-3.5 mr-1.5" />
               )}
-              Submit alert ({editableCards.length} objects)
+              {mode === 'done'
+                ? `Save changes (${changedLaneCount})`
+                : `Submit alert (${editableCards.length} objects)`}
             </button>
 
             <button
@@ -886,12 +909,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
         </div>
       </div>
 
-      <div className="space-y-6 pt-20">
-        <ObjectPresenceStrip
-          objects={presenceStripObjects}
-          onObjectClick={handlePresenceObjectClick}
-        />
-
+      <div className="space-y-4 pt-20">
         {groupConflictWarnings.length > 0 && (
           <div className="sticky top-20 z-30 bg-signal-soft border-b-2 border-signal px-4 py-3">
             <div className="max-w-7xl mx-auto space-y-2">
@@ -924,81 +942,92 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
           </div>
         )}
 
-        <div className="space-y-8">
-          {renderItems.map((item, i) => {
-            const objectNumber = i + 1;
+        {/* Cockpit: media column (the active thing) + decision rail (the
+            whole alert's state). Desktop pins both columns to the viewport
+            below the fixed header and scrolls each internally; below lg
+            they stack in natural flow. */}
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:h-[calc(100vh-7rem)]">
+          <div className="lg:flex-[1.5] lg:min-w-0 lg:overflow-y-auto lg:h-full">
+            <ClassifyMediaPanel
+              activeSection={activeSection}
+              activeObject={activeMediaObject}
+              presenceObjects={presenceStripObjects}
+              onPresenceObjectClick={handlePresenceObjectClick}
+              primarySequenceId={primaryLane.sequence.id}
+              missedSmokeReview={missedSmokeReview}
+              onMissedSmokeReviewChange={handleMissedSmokeReviewChange}
+              annotationLoading={isLoading}
+              objectOverlays={playerObjectOverlays}
+            />
+          </div>
+          <div className="lg:flex-1 lg:min-w-0 lg:overflow-y-auto lg:h-full">
+            <DecisionRail
+              missedSmokeReview={missedSmokeReview}
+              onMissedSmokeReviewChange={handleMissedSmokeReviewChange}
+              missedSmokeActive={activeSection === 'sequence'}
+              onMissedSmokeActivate={() => setActiveSection('sequence')}
+              missedSmokeDisabled={missedSmokeCarrierLaneId === undefined}
+              missedSmokeRowRef={sequenceReviewerRef}
+            >
+              {renderItems.map((item, i) => {
+                const objectNumber = i + 1;
 
-            if (item.kind === 'placeholder') {
-              return (
-                <div
-                  key={`placeholder-${item.laneSequenceId}`}
-                  data-testid={`object-card-placeholder-${item.laneSequenceId}`}
-                  className="border border-dashed border-line bg-ash px-[22px] py-5 text-center"
-                >
-                  <h4 className="font-display text-heading font-semibold text-char mb-2">
-                    Object {objectNumber}
-                  </h4>
-                  <AlertCircle className="w-8 h-8 text-haze mx-auto mb-2" />
-                  <p className="font-body text-sm text-haze">Not imported yet</p>
-                </div>
-              );
-            }
+                if (item.kind === 'placeholder') {
+                  return (
+                    <div
+                      key={`placeholder-${item.laneSequenceId}`}
+                      data-testid={`object-card-placeholder-${item.laneSequenceId}`}
+                      className="rounded-lg border border-dashed border-line bg-ash px-3.5 py-2.5 flex items-center justify-between"
+                    >
+                      <span className="font-body text-sm font-semibold text-char">
+                        Object {objectNumber}
+                      </span>
+                      <span className="font-body text-xs text-haze">Not imported yet</span>
+                    </div>
+                  );
+                }
 
-            const { card } = item;
-            const lane = alertDetail.lanes.find(l => l.sequence.id === card.laneSequenceId)!;
-            const bbox = getBbox(card);
-            const stageBadge = card.locked
-              ? getProcessingStageLabel(lane.annotation!.processing_stage)
-              : undefined;
-            const overlay = cardOverlayData.find(o => o.cardKey === card.cardKey);
-            const siblingOverlays: ObjectOverlay[] = cardOverlayData
-              .filter(o => o.cardKey !== card.cardKey)
-              .map(o => ({
-                color: o.color,
-                label: o.label,
-                boxesByRecordedAt: o.boxesByRecordedAt,
-              }));
+                const { card } = item;
+                const lane = alertDetail.lanes.find(l => l.sequence.id === card.laneSequenceId)!;
+                const stageBadge =
+                  card.locked || mode === 'done'
+                    ? getProcessingStageLabel(lane.annotation!.processing_stage)
+                    : undefined;
+                const overlay = cardOverlayData.find(o => o.cardKey === card.cardKey);
 
-            return (
-              <ObjectCard
-                key={card.cardKey}
-                cardRef={el => (cardRefs.current[card.cardKey] = el)}
-                objectNumber={objectNumber}
-                cardKey={card.cardKey}
-                bbox={bbox}
-                sequenceId={card.laneSequenceId}
-                classification={primaryClassification[card.cardKey] ?? 'unselected'}
-                isActive={activeCardKey === card.cardKey}
-                isAnnotated={card.locked || hasUserAnnotations(bbox)}
-                locked={card.locked}
-                stageBadge={stageBadge}
-                unsure={laneUnsure[card.laneSequenceId] ?? false}
-                color={overlay?.color}
-                siblingOverlays={siblingOverlays}
-                frameRecordedAt={overlay?.frameRecordedAt}
-                onCardClick={key => {
-                  setActiveCardKey(key);
-                  setActiveSection('detections');
-                }}
-                onBboxChange={handleBboxChangeByCardKey}
-                onClassificationChange={handleClassificationChangeByCardKey}
-                onUnsureChange={card.locked ? undefined : handleUnsureChangeByCardKey}
-              />
-            );
-          })}
-        </div>
-
-        {/* Alert-level missed smoke review — shared player over the primary lane, footer control. */}
-        <div ref={sequenceReviewerRef}>
-          <MissedSmokePanel
-            sequenceId={primaryLane.sequence.id}
-            missedSmokeReview={missedSmokeReview}
-            onMissedSmokeReviewChange={handleMissedSmokeReviewChange}
-            annotationLoading={isLoading}
-            activeSection={activeSection}
-            sequenceReviewerRef={sequenceReviewerRef}
-            objectOverlays={playerObjectOverlays}
-          />
+                return (
+                  <ObjectRow
+                    key={card.cardKey}
+                    rowRef={el => (cardRefs.current[card.cardKey] = el)}
+                    objectNumber={objectNumber}
+                    cardKey={card.cardKey}
+                    color={overlay?.color}
+                    bbox={getBbox(card)}
+                    classification={primaryClassification[card.cardKey] ?? 'unselected'}
+                    unsure={laneUnsure[card.laneSequenceId] ?? false}
+                    isActive={activeCardKey === card.cardKey && activeSection === 'detections'}
+                    locked={card.locked}
+                    stageBadge={stageBadge}
+                    changed={
+                      mode === 'done' &&
+                      !card.locked &&
+                      isLaneChanged(
+                        card.laneSequenceId,
+                        card.laneSequenceId === missedSmokeCarrierLaneId
+                      )
+                    }
+                    onRowClick={key => {
+                      setActiveCardKey(key);
+                      setActiveSection('detections');
+                    }}
+                    onBboxChange={handleBboxChangeByCardKey}
+                    onClassificationChange={handleClassificationChangeByCardKey}
+                    onUnsureChange={card.locked ? undefined : handleUnsureChangeByCardKey}
+                  />
+                );
+              })}
+            </DecisionRail>
+          </div>
         </div>
 
         <NotificationSystem

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -766,7 +766,11 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
   // Keyboard shortcuts over the flattened card list.
   useEffect(() => {
     const handleKeyDown = createKeyboardHandler({
-      activeDetectionIndex: activeIndex,
+      // Classification shortcuts (S/F, types, Q) only apply while the
+      // object section is active — a null index makes them inert when the
+      // missed-smoke section is selected. The navigators keep their own
+      // (ungated) state, so ArrowUp still leaves the sequence section.
+      activeDetectionIndex: activeSection === 'detections' ? activeIndex : null,
       bboxes: adapterBboxes,
       showKeyboardModal,
       missedSmokeReview,
@@ -779,6 +783,23 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
       handleMissedSmokeReviewChange,
       handleBboxChange: handleBboxChangeAdapter,
       onPrimaryClassificationChange: handlePrimaryClassificationChangeAdapter,
+      // Q: toggle the active object's Unsure — same mutual exclusivity as
+      // the Unsure chip (turning it on clears the classification).
+      onUnsureToggle: index => {
+        const card = cards[index];
+        if (!card || card.locked) return;
+        const next = !(laneUnsure[card.laneSequenceId] ?? false);
+        if (next) {
+          handleClassificationChangeByCardKey(card.cardKey, 'unselected');
+          handleBboxChangeByCardKey(card.cardKey, {
+            ...getBbox(card),
+            is_smoke: false,
+            smoke_type: undefined,
+            false_positive_types: [],
+          });
+        }
+        handleUnsureChangeByCardKey(card.cardKey, next);
+      },
     });
 
     document.addEventListener('keydown', handleKeyDown, true);
@@ -786,8 +807,10 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     activeIndex,
+    activeSection,
     cards,
     laneBboxes,
+    laneUnsure,
     showKeyboardModal,
     missedSmokeReview,
     primaryClassification,
@@ -1105,6 +1128,10 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
                     Smoke type (wildfire / industrial / other)
                   </span>
                   <span className="font-data text-detail text-haze">1 / 2 / 3</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="font-body text-sm text-char">Mark active object as unsure</span>
+                  <span className="font-data text-detail text-haze">Q</span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="font-body text-sm text-char">Missed smoke yes / no</span>

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -482,7 +482,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
 
   const handleClassificationChangeByCardKey = (
     cardKey: string,
-    classification: 'smoke' | 'false_positive'
+    classification: CardClassification
   ) => {
     const card = cards.find(c => c.cardKey === cardKey);
     if (!card || card.locked) return;
@@ -549,6 +549,9 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
       const card = cards[Number(idxStr)];
       if (card && value !== 'unselected') {
         handleClassificationChangeByCardKey(card.cardKey, value);
+        // Classification and Unsure are mutually exclusive — the S/F
+        // keyboard path must clear unsure exactly like the chips do.
+        handleUnsureChangeByCardKey(card.cardKey, false);
       }
     });
   };

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -166,6 +166,20 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
   const sequenceReviewerRef = useRef<HTMLDivElement | null>(null);
   const railSubmitRef = useRef<HTMLButtonElement | null>(null);
 
+  // Post-submit auto-advance bookkeeping: the deferred navigation must not
+  // fire after unmount or an alert switch, and no re-submit may slip into
+  // the window between success and navigation (Enter isn't disabled the
+  // way the buttons are).
+  const advanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const advancingRef = useRef(false);
+  useEffect(
+    () => () => {
+      if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current);
+      advancingRef.current = false;
+    },
+    []
+  );
+
   // Done mode only: snapshot of the just-loaded (or just-reset) state, used
   // to diff against current state at submit time so only lanes the
   // annotator actually touched get PATCHed.
@@ -216,6 +230,9 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     setHasMissedSmoke(false);
     setActiveCardKey(null);
     setGroupConflictWarnings([]);
+    if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current);
+    advanceTimerRef.current = null;
+    advancingRef.current = false;
   }, [sequenceId]);
 
   const initializeFromAlertDetail = (detail: AlertDetail) => {
@@ -755,7 +772,15 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
       setGroupConflictWarnings([]);
       showToastNotification('Alert submitted successfully', 'success');
 
-      setTimeout(async () => {
+      // The app-wide 5-minute staleTime would otherwise re-serve this
+      // alert's PRE-submit detail from the cache — e.g. opening
+      // /classify/done/:id right after submitting here would show the lanes
+      // unclassified. Mark it stale so any future mount refetches.
+      queryClient.invalidateQueries({ queryKey: alertDetailQueryKey });
+
+      advancingRef.current = true;
+      advanceTimerRef.current = setTimeout(async () => {
+        advanceTimerRef.current = null;
         const nextAlert = getNextSequenceInWorkflow();
         if (nextAlert) {
           const currentIndex = annotationWorkflow?.currentIndex || 0;
@@ -773,6 +798,10 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
         if (mode !== 'done') {
           try {
             const queue = await apiClient.getClassifyQueue({ page: 1, size: 2 });
+            // The user may have navigated elsewhere while the lookup was in
+            // flight (unmount / alert switch reset the flag) — don't yank
+            // them into another alert.
+            if (!advancingRef.current) return;
             const next = queue.items.find(item => item.primary_sequence_id !== sequenceId);
             if (next) {
               clearAnnotationWorkflow();
@@ -784,6 +813,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
             // Queue lookup failed — fall through to the completed path.
           }
         }
+        if (!advancingRef.current) return;
 
         const totalCompleted = annotationWorkflow?.sequences?.length || 1;
         clearAnnotationWorkflow();
@@ -805,6 +835,10 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
   });
 
   const handleSubmit = () => {
+    // The buttons disable themselves while pending, but the Enter shortcut
+    // doesn't — and after a success the 1s auto-advance window would accept
+    // a second Enter and re-submit already-advanced lanes.
+    if (submitMutation.isPending || advancingRef.current) return;
     if (!canSubmit) {
       if (mode === 'done') {
         showToastNotification(
@@ -884,7 +918,11 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
   // shortcuts modal is open so its close button stays reachable.
   useEffect(() => {
     const handleTab = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab' || showKeyboardModal) return;
+      // Suspended while the shortcuts modal or the group-propagation
+      // warning banner is up — both carry focusables (close button, "Open
+      // group" link, Dismiss) that the trap would otherwise make
+      // keyboard-unreachable.
+      if (e.key !== 'Tab' || showKeyboardModal || groupConflictWarnings.length > 0) return;
       const stops = (
         [
           ...cards.map(c => cardRefs.current[c.cardKey]),
@@ -901,7 +939,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     };
     document.addEventListener('keydown', handleTab, true);
     return () => document.removeEventListener('keydown', handleTab, true);
-  }, [cards, showKeyboardModal]);
+  }, [cards, showKeyboardModal, groupConflictWarnings]);
 
   const handlePreviousAlert = () => {
     const prev = navigateToPreviousInWorkflow();
@@ -1168,19 +1206,22 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
             </DecisionRail>
 
             {/* Temporal context + color legend for the rail's objects
-                (self-hides under 2 objects). Highlights the active object's
-                row in sync with the rail. */}
-            <div className="mt-4">
-              <ObjectPresenceStrip
-                objects={presenceStripObjects}
-                onObjectClick={handlePresenceObjectClick}
-                activeIndex={
-                  activeSection === 'detections' && activeCard
-                    ? cardOverlayData.findIndex(o => o.cardKey === activeCard.cardKey)
-                    : null
-                }
-              />
-            </div>
+                (the strip self-hides under 2 objects — the wrapper's margin
+                must go with it). Highlights the active object's row in sync
+                with the rail. */}
+            {presenceStripObjects.length >= 2 && (
+              <div className="mt-4">
+                <ObjectPresenceStrip
+                  objects={presenceStripObjects}
+                  onObjectClick={handlePresenceObjectClick}
+                  activeIndex={
+                    activeSection === 'detections' && activeCard
+                      ? cardOverlayData.findIndex(o => o.cardKey === activeCard.cardKey)
+                      : null
+                  }
+                />
+              </div>
+            )}
           </div>
         </div>
 

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -755,22 +755,43 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
       setGroupConflictWarnings([]);
       showToastNotification('Alert submitted successfully', 'success');
 
-      setTimeout(() => {
+      setTimeout(async () => {
         const nextAlert = getNextSequenceInWorkflow();
         if (nextAlert) {
           const currentIndex = annotationWorkflow?.currentIndex || 0;
           const totalAlerts = annotationWorkflow?.sequences?.length || 0;
           showToastNotification(`Moving to alert ${currentIndex + 2} of ${totalAlerts}`, 'info');
           navigate(classifyDetail(nextAlert.id, mode === 'done'));
-        } else {
-          const totalCompleted = annotationWorkflow?.sequences?.length || 1;
-          clearAnnotationWorkflow();
-          showToastNotification(
-            `Workflow completed! Classified ${totalCompleted} alert${totalCompleted === 1 ? '' : 's'}.`,
-            'success'
-          );
-          navigate(backUrl);
+          return;
         }
+
+        // Queue mode with no (or an exhausted) table workflow: pull the next
+        // alert straight from the classify queue so submitting flows
+        // continuously — deep links included. The just-submitted alert has
+        // left the queue server-side (all its lanes moved past
+        // ready_to_annotate), but guard against it anyway.
+        if (mode !== 'done') {
+          try {
+            const queue = await apiClient.getClassifyQueue({ page: 1, size: 2 });
+            const next = queue.items.find(item => item.primary_sequence_id !== sequenceId);
+            if (next) {
+              clearAnnotationWorkflow();
+              showToastNotification('Moving to the next alert in the queue', 'info');
+              navigate(classifyDetail(next.primary_sequence_id, false));
+              return;
+            }
+          } catch {
+            // Queue lookup failed — fall through to the completed path.
+          }
+        }
+
+        const totalCompleted = annotationWorkflow?.sequences?.length || 1;
+        clearAnnotationWorkflow();
+        showToastNotification(
+          `Workflow completed! Classified ${totalCompleted} alert${totalCompleted === 1 ? '' : 's'}.`,
+          'success'
+        );
+        navigate(backUrl);
       }, 1000);
     },
     onError: err => {

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -164,6 +164,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
 
   const cardRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const sequenceReviewerRef = useRef<HTMLDivElement | null>(null);
+  const railSubmitRef = useRef<HTMLButtonElement | null>(null);
 
   // Done mode only: snapshot of the just-loaded (or just-reset) state, used
   // to diff against current state at submit time so only lanes the
@@ -340,11 +341,10 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     const first = cards.find(c => !c.locked) ?? cards[0];
     setActiveCardKey(first.cardKey);
     setActiveSection('detections');
-    // Seed focus on the row so Tab / Shift+Tab cycle the rail immediately,
-    // without first tabbing through the header and media panel.
-    requestAnimationFrame(() => {
-      cardRefs.current[first.cardKey]?.focus({ preventScroll: true });
-    });
+    // Seed focus on the row so Tab / Shift+Tab cycle the rail immediately.
+    // Synchronous (the row is already committed) — a deferred focus could
+    // fire AFTER the user activates another row and steal activation back.
+    cardRefs.current[first.cardKey]?.focus({ preventScroll: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, cards]);
 
@@ -357,10 +357,11 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     if (!cards.some(c => c.cardKey === cardKey)) return;
     setActiveCardKey(cardKey);
     setActiveSection('detections');
+    // Focus synchronously (see the queue-mode effect above); only the
+    // scroll is deferred a frame.
+    cardRefs.current[cardKey]?.focus({ preventScroll: true });
     requestAnimationFrame(() => {
       cardRefs.current[cardKey]?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      // Seed focus so Tab / Shift+Tab cycle the rail immediately on load.
-      cardRefs.current[cardKey]?.focus({ preventScroll: true });
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, sequenceId, alertDetail]);
@@ -824,6 +825,32 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     canSubmit,
   ]);
 
+  // Focus cycle: Tab / Shift+Tab move strictly between the rail's stops —
+  // object rows, the missed-smoke row, the rail Submit — wrapping at the
+  // ends and never escaping to the header/media chrome. Focus landing on a
+  // row activates it (its own onFocus handler). Suspended while the
+  // shortcuts modal is open so its close button stays reachable.
+  useEffect(() => {
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || showKeyboardModal) return;
+      const stops = (
+        [
+          ...cards.map(c => cardRefs.current[c.cardKey]),
+          sequenceReviewerRef.current,
+          railSubmitRef.current,
+        ] as (HTMLElement | null)[]
+      ).filter((el): el is HTMLElement => el !== null && !(el as HTMLButtonElement).disabled);
+      if (stops.length === 0) return;
+      e.preventDefault();
+      const current = stops.indexOf(document.activeElement as HTMLElement);
+      const delta = e.shiftKey ? -1 : 1;
+      const next = current === -1 ? 0 : (current + delta + stops.length) % stops.length;
+      stops[next].focus();
+    };
+    document.addEventListener('keydown', handleTab, true);
+    return () => document.removeEventListener('keydown', handleTab, true);
+  }, [cards, showKeyboardModal]);
+
   const handlePreviousAlert = () => {
     const prev = navigateToPreviousInWorkflow();
     if (prev) navigate(classifyDetail(prev.id, mode === 'done'));
@@ -1006,6 +1033,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
               missedSmokeRowRef={sequenceReviewerRef}
               footer={
                 <button
+                  ref={railSubmitRef}
                   onClick={handleSubmit}
                   disabled={!canSubmit || submitMutation.isPending}
                   data-testid="rail-submit"
@@ -1018,6 +1046,12 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
                     <Upload className="w-3.5 h-3.5 mr-1.5" />
                   )}
                   {submitLabel}
+                  <kbd
+                    aria-hidden="true"
+                    className="ml-2 px-1 py-0.5 rounded bg-white/20 font-data text-[10px] font-medium text-white"
+                  >
+                    Enter
+                  </kbd>
                 </button>
               }
             >

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -340,6 +340,11 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     const first = cards.find(c => !c.locked) ?? cards[0];
     setActiveCardKey(first.cardKey);
     setActiveSection('detections');
+    // Seed focus on the row so Tab / Shift+Tab cycle the rail immediately,
+    // without first tabbing through the header and media panel.
+    requestAnimationFrame(() => {
+      cardRefs.current[first.cardKey]?.focus({ preventScroll: true });
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, cards]);
 
@@ -354,6 +359,8 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     setActiveSection('detections');
     requestAnimationFrame(() => {
       cardRefs.current[cardKey]?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      // Seed focus so Tab / Shift+Tab cycle the rail immediately on load.
+      cardRefs.current[cardKey]?.focus({ preventScroll: true });
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, sequenceId, alertDetail]);

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -42,7 +42,7 @@ import {
 } from '@/utils/annotation/navigationUtils';
 import { getObjectColor, ObjectOverlay } from '@/utils/annotation/objectColors';
 import { getProcessingStageLabel } from '@/utils/processingStage';
-import { CardClassification } from '@/components/sequence-annotation';
+import { CardClassification, ObjectPresenceStrip } from '@/components/sequence-annotation';
 import { ClassifyMediaPanel, DecisionRail, ObjectRow } from '@/components/classify';
 import { NotificationSystem } from '@/components/ui/NotificationSystem';
 import { useToastNotifications } from '@/utils/notification/toastUtils';
@@ -951,8 +951,6 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
             <ClassifyMediaPanel
               activeSection={activeSection}
               activeObject={activeMediaObject}
-              presenceObjects={presenceStripObjects}
-              onPresenceObjectClick={handlePresenceObjectClick}
               primarySequenceId={primaryLane.sequence.id}
               missedSmokeReview={missedSmokeReview}
               onMissedSmokeReviewChange={handleMissedSmokeReviewChange}
@@ -1027,6 +1025,21 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
                 );
               })}
             </DecisionRail>
+
+            {/* Temporal context + color legend for the rail's objects
+                (self-hides under 2 objects). Highlights the active object's
+                row in sync with the rail. */}
+            <div className="mt-4">
+              <ObjectPresenceStrip
+                objects={presenceStripObjects}
+                onObjectClick={handlePresenceObjectClick}
+                activeIndex={
+                  activeSection === 'detections' && activeCard
+                    ? cardOverlayData.findIndex(o => o.cardKey === activeCard.cardKey)
+                    : null
+                }
+              />
+            </div>
           </div>
         </div>
 

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -602,6 +602,13 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     editableCards.length > 0 &&
     (mode === 'done' ? isComplete && anyLaneChanged : isComplete && missedSmokeReview !== null);
 
+  // Shared by the header submit and its rail-footer mirror.
+  const submitLabel =
+    mode === 'done'
+      ? `Save changes (${changedLaneCount})`
+      : `Submit alert (${editableCards.length} objects)`;
+  const submitTitle = mode === 'done' ? 'Save changes (Enter)' : 'Submit alert (Enter)';
+
   const submitMutation = useMutation({
     mutationFn: async (): Promise<{ results: ClassifySubmitResult[] }> => {
       if (mode === 'done') {
@@ -886,16 +893,14 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
               onClick={handleSubmit}
               disabled={!canSubmit || submitMutation.isPending}
               className="inline-flex items-center rounded-lg bg-ember px-4 py-2 font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
-              title={mode === 'done' ? 'Save changes (Enter)' : 'Submit alert (Enter)'}
+              title={submitTitle}
             >
               {submitMutation.isPending ? (
                 <div className="w-3.5 h-3.5 mr-1.5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
               ) : (
                 <Upload className="w-3.5 h-3.5 mr-1.5" />
               )}
-              {mode === 'done'
-                ? `Save changes (${changedLaneCount})`
-                : `Submit alert (${editableCards.length} objects)`}
+              {submitLabel}
             </button>
 
             <button
@@ -966,6 +971,22 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
               onMissedSmokeActivate={() => setActiveSection('sequence')}
               missedSmokeDisabled={missedSmokeCarrierLaneId === undefined}
               missedSmokeRowRef={sequenceReviewerRef}
+              footer={
+                <button
+                  onClick={handleSubmit}
+                  disabled={!canSubmit || submitMutation.isPending}
+                  data-testid="rail-submit"
+                  className="w-full inline-flex items-center justify-center rounded-lg bg-ember px-4 py-2.5 font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                  title={submitTitle}
+                >
+                  {submitMutation.isPending ? (
+                    <div className="w-3.5 h-3.5 mr-1.5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+                  ) : (
+                    <Upload className="w-3.5 h-3.5 mr-1.5" />
+                  )}
+                  {submitLabel}
+                </button>
+              }
             >
               {renderItems.map((item, i) => {
                 const objectNumber = i + 1;

--- a/frontend/src/utils/annotation/annotationHandlers.ts
+++ b/frontend/src/utils/annotation/annotationHandlers.ts
@@ -201,7 +201,7 @@ export const getTypeIndexForKey = (key: string): number => {
     b: FALSE_POSITIVE_TYPES.indexOf('building'),
     c: FALSE_POSITIVE_TYPES.indexOf('cliff'),
     d: FALSE_POSITIVE_TYPES.indexOf('dark'),
-    u: FALSE_POSITIVE_TYPES.indexOf('dust'), // 'd' taken by dark
+    j: FALSE_POSITIVE_TYPES.indexOf('dust'), // 'd' taken by dark, 'u' by the Unsure toggle
     h: FALSE_POSITIVE_TYPES.indexOf('high_cloud'),
     l: FALSE_POSITIVE_TYPES.indexOf('low_cloud'),
     g: FALSE_POSITIVE_TYPES.indexOf('lens_flare'),

--- a/frontend/src/utils/annotation/keyboardUtils.ts
+++ b/frontend/src/utils/annotation/keyboardUtils.ts
@@ -56,7 +56,7 @@ export interface KeyboardHandlerDependencies {
   onPrimaryClassificationChange: (
     updates: Record<number, 'unselected' | 'smoke' | 'false_positive'>
   ) => void;
-  /** Optional: toggle the active detection's Unsure state (Q key) — wired only by the classify cockpit. */
+  /** Optional: toggle the active detection's Unsure state (U key) — wired only by the classify cockpit. */
   onUnsureToggle?: (detectionIndex: number) => void;
 }
 
@@ -219,9 +219,10 @@ export const createKeyboardHandler = (deps: KeyboardHandlerDependencies) => {
       return;
     }
 
-    // Unsure toggle (Q key) — optional, classify cockpit only. Handled
-    // before the FP-type letters so it works in every classification mode.
-    if ((e.key === 'q' || e.key === 'Q') && onUnsureToggle) {
+    // Unsure toggle (U key) — optional, classify cockpit only. Handled
+    // before the FP-type letters so it works in every classification mode
+    // (Dust moved to J to free the mnemonic).
+    if ((e.key === 'u' || e.key === 'U') && onUnsureToggle) {
       onUnsureToggle(activeDetectionIndex);
       e.preventDefault();
       return;

--- a/frontend/src/utils/annotation/keyboardUtils.ts
+++ b/frontend/src/utils/annotation/keyboardUtils.ts
@@ -56,6 +56,8 @@ export interface KeyboardHandlerDependencies {
   onPrimaryClassificationChange: (
     updates: Record<number, 'unselected' | 'smoke' | 'false_positive'>
   ) => void;
+  /** Optional: toggle the active detection's Unsure state (Q key) — wired only by the classify cockpit. */
+  onUnsureToggle?: (detectionIndex: number) => void;
 }
 
 /**
@@ -111,6 +113,7 @@ export const createKeyboardHandler = (deps: KeyboardHandlerDependencies) => {
       handleMissedSmokeReviewChange,
       handleBboxChange,
       onPrimaryClassificationChange,
+      onUnsureToggle,
     } = deps;
 
     // Handle help modal first (works regardless of focus)
@@ -212,6 +215,14 @@ export const createKeyboardHandler = (deps: KeyboardHandlerDependencies) => {
         updatedBbox.smoke_type = undefined; // Clear smoke type
         handleBboxChange(activeDetectionIndex, updatedBbox);
       }
+      e.preventDefault();
+      return;
+    }
+
+    // Unsure toggle (Q key) — optional, classify cockpit only. Handled
+    // before the FP-type letters so it works in every classification mode.
+    if ((e.key === 'q' || e.key === 'Q') && onUnsureToggle) {
+      onUnsureToggle(activeDetectionIndex);
       e.preventDefault();
       return;
     }

--- a/frontend/tests/components/classify/ClassificationChips.test.tsx
+++ b/frontend/tests/components/classify/ClassificationChips.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ClassificationChips, formatFalsePositiveLabel } from '@/components/classify';
+import type { SequenceBbox } from '@/types/api';
+
+const baseBbox: SequenceBbox = { is_smoke: false, false_positive_types: [], bboxes: [] };
+
+function renderChips(overrides: Partial<React.ComponentProps<typeof ClassificationChips>> = {}) {
+  const onBboxChange = vi.fn();
+  const onClassificationChange = vi.fn();
+  const onUnsureChange = vi.fn();
+  render(
+    <ClassificationChips
+      cardKey="101:0"
+      bbox={baseBbox}
+      classification="unselected"
+      unsure={false}
+      onBboxChange={onBboxChange}
+      onClassificationChange={onClassificationChange}
+      onUnsureChange={onUnsureChange}
+      {...overrides}
+    />
+  );
+  return { onBboxChange, onClassificationChange, onUnsureChange };
+}
+
+describe('ClassificationChips', () => {
+  it('marks smoke: sets is_smoke, clears FP types, keeps smoke_type', () => {
+    const { onBboxChange, onClassificationChange } = renderChips({
+      bbox: { ...baseBbox, false_positive_types: ['antenna'], smoke_type: 'wildfire' },
+    });
+    fireEvent.click(screen.getByRole('radio', { name: 'Smoke' }));
+    expect(onClassificationChange).toHaveBeenCalledWith('101:0', 'smoke');
+    expect(onBboxChange).toHaveBeenCalledWith('101:0', {
+      ...baseBbox,
+      is_smoke: true,
+      false_positive_types: [],
+      smoke_type: 'wildfire',
+    });
+  });
+
+  it('marks false positive: clears smoke_type, keeps existing FP types', () => {
+    const { onBboxChange, onClassificationChange } = renderChips({
+      bbox: { ...baseBbox, is_smoke: true, smoke_type: 'wildfire', false_positive_types: ['sky'] },
+      classification: 'smoke',
+    });
+    fireEvent.click(screen.getByRole('radio', { name: 'False positive' }));
+    expect(onClassificationChange).toHaveBeenCalledWith('101:0', 'false_positive');
+    expect(onBboxChange).toHaveBeenCalledWith('101:0', {
+      ...baseBbox,
+      is_smoke: false,
+      smoke_type: undefined,
+      false_positive_types: ['sky'],
+    });
+  });
+
+  it('shows smoke-type chips only for smoke, and sets the type', () => {
+    const { onBboxChange } = renderChips({
+      bbox: { ...baseBbox, is_smoke: true },
+      classification: 'smoke',
+    });
+    fireEvent.click(screen.getByRole('radio', { name: 'Industrial' }));
+    expect(onBboxChange).toHaveBeenCalledWith('101:0', {
+      ...baseBbox,
+      is_smoke: true,
+      smoke_type: 'industrial',
+    });
+    expect(screen.queryByRole('checkbox', { name: 'High cloud' })).not.toBeInTheDocument();
+  });
+
+  it('renders all 18 FP type chips for false_positive and toggles membership both ways', () => {
+    const { onBboxChange } = renderChips({
+      bbox: { ...baseBbox, false_positive_types: ['high_cloud'] },
+      classification: 'false_positive',
+    });
+    // 18 FP chips + the Unsure chip = 19 checkboxes
+    expect(screen.getAllByRole('checkbox')).toHaveLength(19);
+    expect(screen.getByRole('checkbox', { name: 'High cloud' })).toBeChecked();
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Antenna' }));
+    expect(onBboxChange).toHaveBeenCalledWith('101:0', {
+      ...baseBbox,
+      false_positive_types: ['high_cloud', 'antenna'],
+    });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'High cloud' }));
+    expect(onBboxChange).toHaveBeenCalledWith('101:0', {
+      ...baseBbox,
+      false_positive_types: [],
+    });
+  });
+
+  it('toggles unsure and reflects checked state', () => {
+    const { onUnsureChange } = renderChips({ unsure: true });
+    expect(screen.getByRole('checkbox', { name: 'Unsure' })).toBeChecked();
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Unsure' }));
+    expect(onUnsureChange).toHaveBeenCalledWith('101:0', false);
+  });
+
+  it('hides the Unsure chip when no handler is wired', () => {
+    render(
+      <ClassificationChips
+        cardKey="101:0"
+        bbox={baseBbox}
+        classification="unselected"
+        unsure={false}
+        onBboxChange={vi.fn()}
+        onClassificationChange={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('checkbox', { name: 'Unsure' })).not.toBeInTheDocument();
+  });
+
+  it('contains no emojis anywhere', () => {
+    const { container } = render(
+      <ClassificationChips
+        cardKey="101:0"
+        bbox={{ ...baseBbox, is_smoke: true }}
+        classification="smoke"
+        unsure={false}
+        onBboxChange={vi.fn()}
+        onClassificationChange={vi.fn()}
+      />
+    );
+    expect(container.textContent).not.toMatch(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/u);
+  });
+
+  it('formats FP labels', () => {
+    expect(formatFalsePositiveLabel('high_cloud')).toBe('High cloud');
+    expect(formatFalsePositiveLabel('water_body')).toBe('Water body');
+  });
+});

--- a/frontend/tests/components/classify/ClassificationChips.test.tsx
+++ b/frontend/tests/components/classify/ClassificationChips.test.tsx
@@ -157,6 +157,16 @@ describe('ClassificationChips', () => {
     expect(container.textContent).not.toMatch(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/u);
   });
 
+  it('keeps every chip out of the tab order — rows own tab navigation', () => {
+    renderChips({
+      bbox: { ...baseBbox, false_positive_types: ['high_cloud'] },
+      classification: 'false_positive',
+    });
+    [...screen.getAllByRole('radio'), ...screen.getAllByRole('checkbox')].forEach(chip =>
+      expect(chip).toHaveAttribute('tabindex', '-1')
+    );
+  });
+
   it('formats FP labels', () => {
     expect(formatFalsePositiveLabel('high_cloud')).toBe('High cloud');
     expect(formatFalsePositiveLabel('water_body')).toBe('Water body');

--- a/frontend/tests/components/classify/ClassificationChips.test.tsx
+++ b/frontend/tests/components/classify/ClassificationChips.test.tsx
@@ -73,8 +73,8 @@ describe('ClassificationChips', () => {
       bbox: { ...baseBbox, false_positive_types: ['high_cloud'] },
       classification: 'false_positive',
     });
-    // 18 FP chips + the Unsure chip = 19 checkboxes
-    expect(screen.getAllByRole('checkbox')).toHaveLength(19);
+    // 18 FP chips (Unsure is a radio in the exclusive classification group)
+    expect(screen.getAllByRole('checkbox')).toHaveLength(18);
     expect(screen.getByRole('checkbox', { name: 'High cloud' })).toBeChecked();
     fireEvent.click(screen.getByRole('checkbox', { name: 'Antenna' }));
     expect(onBboxChange).toHaveBeenCalledWith('101:0', {
@@ -88,11 +88,45 @@ describe('ClassificationChips', () => {
     });
   });
 
-  it('toggles unsure and reflects checked state', () => {
+  it('toggles unsure off and reflects checked state', () => {
     const { onUnsureChange } = renderChips({ unsure: true });
-    expect(screen.getByRole('checkbox', { name: 'Unsure' })).toBeChecked();
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Unsure' }));
+    expect(screen.getByRole('radio', { name: 'Unsure' })).toBeChecked();
+    fireEvent.click(screen.getByRole('radio', { name: 'Unsure' }));
     expect(onUnsureChange).toHaveBeenCalledWith('101:0', false);
+  });
+
+  it('turning unsure on clears the classification and its bbox labels (mutual exclusivity)', () => {
+    const { onUnsureChange, onClassificationChange, onBboxChange } = renderChips({
+      bbox: { ...baseBbox, is_smoke: true, smoke_type: 'wildfire' },
+      classification: 'smoke',
+    });
+    fireEvent.click(screen.getByRole('radio', { name: 'Unsure' }));
+    expect(onUnsureChange).toHaveBeenCalledWith('101:0', true);
+    expect(onClassificationChange).toHaveBeenCalledWith('101:0', 'unselected');
+    expect(onBboxChange).toHaveBeenCalledWith('101:0', {
+      ...baseBbox,
+      is_smoke: false,
+      smoke_type: undefined,
+      false_positive_types: [],
+    });
+  });
+
+  it('picking a classification clears unsure (mutual exclusivity)', () => {
+    const { onUnsureChange } = renderChips({ unsure: true });
+    fireEvent.click(screen.getByRole('radio', { name: 'Smoke' }));
+    expect(onUnsureChange).toHaveBeenCalledWith('101:0', false);
+  });
+
+  it('renders Unsure as the only selected chip when a stale classification coexists with unsure', () => {
+    renderChips({
+      bbox: { ...baseBbox, is_smoke: true, smoke_type: 'wildfire' },
+      classification: 'smoke',
+      unsure: true,
+    });
+    expect(screen.getByRole('radio', { name: 'Unsure' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Smoke' })).not.toBeChecked();
+    // The smoke-type row stays hidden while unsure is on.
+    expect(screen.queryByRole('radio', { name: 'Wildfire' })).not.toBeInTheDocument();
   });
 
   it('hides the Unsure chip when no handler is wired', () => {
@@ -106,7 +140,7 @@ describe('ClassificationChips', () => {
         onClassificationChange={vi.fn()}
       />
     );
-    expect(screen.queryByRole('checkbox', { name: 'Unsure' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: 'Unsure' })).not.toBeInTheDocument();
   });
 
   it('contains no emojis anywhere', () => {

--- a/frontend/tests/components/classify/ClassifyMediaPanel.test.tsx
+++ b/frontend/tests/components/classify/ClassifyMediaPanel.test.tsx
@@ -15,8 +15,6 @@ vi.mock('@/components/sequence/SequenceReviewer', () => ({
 }));
 
 const baseProps = {
-  presenceObjects: [],
-  onPresenceObjectClick: vi.fn(),
   primarySequenceId: 101,
   missedSmokeReview: null,
   onMissedSmokeReviewChange: vi.fn(),

--- a/frontend/tests/components/classify/ClassifyMediaPanel.test.tsx
+++ b/frontend/tests/components/classify/ClassifyMediaPanel.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ClassifyMediaPanel } from '@/components/classify';
+
+vi.mock('@/components/annotation/FullImageSequence', () => ({
+  default: () => <div data-testid="full-image-sequence" />,
+}));
+vi.mock('@/components/annotation/CroppedImageSequence', () => ({
+  default: () => <div data-testid="cropped-image-sequence" />,
+}));
+vi.mock('@/components/sequence/SequenceReviewer', () => ({
+  default: (props: { hideReviewControls?: boolean }) => (
+    <div data-testid="sequence-reviewer" data-hide-controls={String(props.hideReviewControls)} />
+  ),
+}));
+
+const baseProps = {
+  presenceObjects: [],
+  onPresenceObjectClick: vi.fn(),
+  primarySequenceId: 101,
+  missedSmokeReview: null,
+  onMissedSmokeReviewChange: vi.fn(),
+  annotationLoading: false,
+  objectOverlays: [],
+};
+
+const activeObject = {
+  label: 'Object 1',
+  bboxes: [],
+  sequenceId: 101,
+  color: '#E4572E',
+  siblingOverlays: [],
+  frameRecordedAt: [],
+};
+
+describe('ClassifyMediaPanel', () => {
+  it('renders the active object players in detections mode', () => {
+    render(
+      <ClassifyMediaPanel {...baseProps} activeSection="detections" activeObject={activeObject} />
+    );
+    expect(screen.getByTestId('full-image-sequence')).toBeInTheDocument();
+    expect(screen.getByTestId('cropped-image-sequence')).toBeInTheDocument();
+    expect(screen.getByText(/Cropped · Object 1/)).toBeInTheDocument();
+    expect(screen.queryByTestId('sequence-reviewer')).not.toBeInTheDocument();
+  });
+
+  it('renders the whole-alert reviewer (without its own yes/no) in sequence mode', () => {
+    render(
+      <ClassifyMediaPanel {...baseProps} activeSection="sequence" activeObject={activeObject} />
+    );
+    expect(screen.getByTestId('sequence-reviewer')).toHaveAttribute('data-hide-controls', 'true');
+    expect(screen.queryByTestId('full-image-sequence')).not.toBeInTheDocument();
+  });
+
+  it('renders an empty state when there is no active object', () => {
+    render(<ClassifyMediaPanel {...baseProps} activeSection="detections" activeObject={null} />);
+    expect(screen.getByText('No objects to review yet')).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/classify/ClassifyMediaPanel.test.tsx
+++ b/frontend/tests/components/classify/ClassifyMediaPanel.test.tsx
@@ -25,6 +25,7 @@ const baseProps = {
 const activeObject = {
   label: 'Object 1',
   bboxes: [],
+  croppedBboxes: [],
   sequenceId: 101,
   color: '#E4572E',
   siblingOverlays: [],

--- a/frontend/tests/components/classify/ClassifyMediaPanel.test.tsx
+++ b/frontend/tests/components/classify/ClassifyMediaPanel.test.tsx
@@ -56,6 +56,14 @@ describe('ClassifyMediaPanel', () => {
     expect(screen.getByText('No objects to review yet')).toBeInTheDocument();
   });
 
+  it('renders a skeleton instead of the empty state while loading', () => {
+    render(
+      <ClassifyMediaPanel {...baseProps} activeSection="detections" activeObject={null} loading />
+    );
+    expect(screen.getByTestId('media-panel-skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('No objects to review yet')).not.toBeInTheDocument();
+  });
+
   it('offers a fullscreen toggle in sequence mode and requests fullscreen on click', () => {
     const requestSpy = vi.fn().mockResolvedValue(undefined);
     HTMLElement.prototype.requestFullscreen = requestSpy;

--- a/frontend/tests/components/classify/ClassifyMediaPanel.test.tsx
+++ b/frontend/tests/components/classify/ClassifyMediaPanel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ClassifyMediaPanel } from '@/components/classify';
 
 vi.mock('@/components/annotation/FullImageSequence', () => ({
@@ -54,5 +54,20 @@ describe('ClassifyMediaPanel', () => {
   it('renders an empty state when there is no active object', () => {
     render(<ClassifyMediaPanel {...baseProps} activeSection="detections" activeObject={null} />);
     expect(screen.getByText('No objects to review yet')).toBeInTheDocument();
+  });
+
+  it('offers a fullscreen toggle in sequence mode and requests fullscreen on click', () => {
+    const requestSpy = vi.fn().mockResolvedValue(undefined);
+    HTMLElement.prototype.requestFullscreen = requestSpy;
+    render(
+      <ClassifyMediaPanel {...baseProps} activeSection="sequence" activeObject={activeObject} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Enter fullscreen' }));
+    expect(requestSpy).toHaveBeenCalled();
+    // No fullscreen toggle in the per-object (detections) view.
+    render(
+      <ClassifyMediaPanel {...baseProps} activeSection="detections" activeObject={activeObject} />
+    );
+    expect(screen.queryAllByRole('button', { name: 'Enter fullscreen' })).toHaveLength(1);
   });
 });

--- a/frontend/tests/components/classify/DecisionRail.test.tsx
+++ b/frontend/tests/components/classify/DecisionRail.test.tsx
@@ -49,6 +49,25 @@ describe('DecisionRail', () => {
     expect(onMissedSmokeReviewChange).not.toHaveBeenCalled();
   });
 
+  it('renders the footer after the missed-smoke row when provided', () => {
+    render(
+      <DecisionRail
+        missedSmokeReview={null}
+        onMissedSmokeReviewChange={vi.fn()}
+        missedSmokeActive={false}
+        onMissedSmokeActivate={vi.fn()}
+        footer={<button data-testid="footer-button">Submit</button>}
+      >
+        <div />
+      </DecisionRail>
+    );
+    const footerButton = screen.getByTestId('footer-button');
+    expect(
+      screen.getByTestId('missed-smoke-row').compareDocumentPosition(footerButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
   it('disables the chips when missedSmokeDisabled', () => {
     const { onMissedSmokeReviewChange } = renderRail({ missedSmokeDisabled: true });
     const row = within(screen.getByTestId('missed-smoke-row'));

--- a/frontend/tests/components/classify/DecisionRail.test.tsx
+++ b/frontend/tests/components/classify/DecisionRail.test.tsx
@@ -68,6 +68,16 @@ describe('DecisionRail', () => {
     ).toBeTruthy();
   });
 
+  it('is a tab stop: direct focus activates the section, but focusing a chip does not', () => {
+    const { onMissedSmokeActivate } = renderRail();
+    const row = screen.getByTestId('missed-smoke-row');
+    expect(row).toHaveAttribute('tabindex', '0');
+    fireEvent.focus(row);
+    expect(onMissedSmokeActivate).toHaveBeenCalledTimes(1);
+    fireEvent.focus(within(row).getByRole('radio', { name: 'No' }));
+    expect(onMissedSmokeActivate).toHaveBeenCalledTimes(1);
+  });
+
   it('disables the chips when missedSmokeDisabled', () => {
     const { onMissedSmokeReviewChange } = renderRail({ missedSmokeDisabled: true });
     const row = within(screen.getByTestId('missed-smoke-row'));

--- a/frontend/tests/components/classify/DecisionRail.test.tsx
+++ b/frontend/tests/components/classify/DecisionRail.test.tsx
@@ -76,6 +76,9 @@ describe('DecisionRail', () => {
     expect(onMissedSmokeActivate).toHaveBeenCalledTimes(1);
     fireEvent.focus(within(row).getByRole('radio', { name: 'No' }));
     expect(onMissedSmokeActivate).toHaveBeenCalledTimes(1);
+    // The Yes/No chips themselves stay out of the tab order.
+    expect(within(row).getByRole('radio', { name: 'Yes' })).toHaveAttribute('tabindex', '-1');
+    expect(within(row).getByRole('radio', { name: 'No' })).toHaveAttribute('tabindex', '-1');
   });
 
   it('disables the chips when missedSmokeDisabled', () => {

--- a/frontend/tests/components/classify/DecisionRail.test.tsx
+++ b/frontend/tests/components/classify/DecisionRail.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { DecisionRail } from '@/components/classify';
+
+function renderRail(overrides: Partial<React.ComponentProps<typeof DecisionRail>> = {}) {
+  const onMissedSmokeReviewChange = vi.fn();
+  const onMissedSmokeActivate = vi.fn();
+  render(
+    <DecisionRail
+      missedSmokeReview={null}
+      onMissedSmokeReviewChange={onMissedSmokeReviewChange}
+      missedSmokeActive={false}
+      onMissedSmokeActivate={onMissedSmokeActivate}
+      {...overrides}
+    >
+      <div data-testid="row-child" />
+    </DecisionRail>
+  );
+  return { onMissedSmokeReviewChange, onMissedSmokeActivate };
+}
+
+describe('DecisionRail', () => {
+  it('renders children and the missed-smoke row', () => {
+    renderRail();
+    expect(screen.getByTestId('row-child')).toBeInTheDocument();
+    expect(screen.getByText('Missed smoke?')).toBeInTheDocument();
+  });
+
+  it('answers yes/no via chips without requiring activation first', () => {
+    const { onMissedSmokeReviewChange } = renderRail();
+    const row = within(screen.getByTestId('missed-smoke-row'));
+    fireEvent.click(row.getByRole('radio', { name: 'No' }));
+    expect(onMissedSmokeReviewChange).toHaveBeenCalledWith('no');
+    fireEvent.click(row.getByRole('radio', { name: 'Yes' }));
+    expect(onMissedSmokeReviewChange).toHaveBeenCalledWith('yes');
+  });
+
+  it('reflects the current answer via aria-checked', () => {
+    renderRail({ missedSmokeReview: 'no' });
+    const row = within(screen.getByTestId('missed-smoke-row'));
+    expect(row.getByRole('radio', { name: 'No' })).toBeChecked();
+    expect(row.getByRole('radio', { name: 'Yes' })).not.toBeChecked();
+  });
+
+  it('clicking the row body activates the missed-smoke section', () => {
+    const { onMissedSmokeActivate, onMissedSmokeReviewChange } = renderRail();
+    fireEvent.click(screen.getByText('Missed smoke?'));
+    expect(onMissedSmokeActivate).toHaveBeenCalled();
+    expect(onMissedSmokeReviewChange).not.toHaveBeenCalled();
+  });
+
+  it('disables the chips when missedSmokeDisabled', () => {
+    const { onMissedSmokeReviewChange } = renderRail({ missedSmokeDisabled: true });
+    const row = within(screen.getByTestId('missed-smoke-row'));
+    fireEvent.click(row.getByRole('radio', { name: 'No' }));
+    expect(onMissedSmokeReviewChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/components/classify/ObjectRow.test.tsx
+++ b/frontend/tests/components/classify/ObjectRow.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ObjectRow, getObjectRowStatus } from '@/components/classify';
+import type { SequenceBbox } from '@/types/api';
+
+const baseBbox: SequenceBbox = { is_smoke: false, false_positive_types: [], bboxes: [] };
+
+function renderRow(overrides: Partial<React.ComponentProps<typeof ObjectRow>> = {}) {
+  const onRowClick = vi.fn();
+  render(
+    <ObjectRow
+      objectNumber={1}
+      cardKey="101:0"
+      color="#E4572E"
+      bbox={baseBbox}
+      classification="unselected"
+      unsure={false}
+      isActive={false}
+      locked={false}
+      onRowClick={onRowClick}
+      onBboxChange={vi.fn()}
+      onClassificationChange={vi.fn()}
+      onUnsureChange={vi.fn()}
+      {...overrides}
+    />
+  );
+  return { onRowClick };
+}
+
+describe('getObjectRowStatus', () => {
+  it('maps states to labels and tones', () => {
+    expect(
+      getObjectRowStatus({
+        bbox: baseBbox,
+        classification: 'unselected',
+        unsure: false,
+        locked: false,
+      })
+    ).toEqual({ label: 'Pending', tone: 'pending' });
+    expect(
+      getObjectRowStatus({
+        bbox: { ...baseBbox, is_smoke: true, smoke_type: 'wildfire' },
+        classification: 'smoke',
+        unsure: false,
+        locked: false,
+      })
+    ).toEqual({ label: 'Smoke · Wildfire', tone: 'positive' });
+    expect(
+      getObjectRowStatus({
+        bbox: { ...baseBbox, is_smoke: true },
+        classification: 'smoke',
+        unsure: false,
+        locked: false,
+      })
+    ).toEqual({ label: 'Type needed', tone: 'pending' });
+    expect(
+      getObjectRowStatus({
+        bbox: { ...baseBbox, false_positive_types: ['high_cloud', 'sky'] },
+        classification: 'false_positive',
+        unsure: false,
+        locked: false,
+      })
+    ).toEqual({ label: 'FP · High cloud +1', tone: 'neutral' });
+    expect(
+      getObjectRowStatus({
+        bbox: baseBbox,
+        classification: 'unselected',
+        unsure: true,
+        locked: false,
+      })
+    ).toEqual({ label: 'Unsure', tone: 'unsure' });
+    expect(
+      getObjectRowStatus({
+        bbox: baseBbox,
+        classification: 'unselected',
+        unsure: false,
+        locked: true,
+        stageBadge: 'Fully annotated',
+      })
+    ).toEqual({ label: 'Fully annotated', tone: 'neutral' });
+  });
+});
+
+describe('ObjectRow', () => {
+  it('collapsed row shows name + status chip and no chips', () => {
+    renderRow();
+    expect(screen.getByText('Object 1')).toBeInTheDocument();
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: 'Smoke' })).not.toBeInTheDocument();
+  });
+
+  it('active unlocked row renders classification chips', () => {
+    renderRow({ isActive: true });
+    expect(screen.getByRole('radio', { name: 'Smoke' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'False positive' })).toBeInTheDocument();
+  });
+
+  it('locked row never renders chips, even when active, but still activates on click (to view its media)', () => {
+    const { onRowClick } = renderRow({
+      locked: true,
+      isActive: true,
+      stageBadge: 'Fully annotated',
+    });
+    expect(screen.queryByRole('radio', { name: 'Smoke' })).not.toBeInTheDocument();
+    expect(screen.getByText('Fully annotated')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('object-card-101:0'));
+    expect(onRowClick).toHaveBeenCalledWith('101:0');
+  });
+
+  it('click activates via onRowClick', () => {
+    const { onRowClick } = renderRow();
+    fireEvent.click(screen.getByTestId('object-card-101:0'));
+    expect(onRowClick).toHaveBeenCalledWith('101:0');
+  });
+
+  it('shows the changed dot only when changed', () => {
+    renderRow({ changed: true });
+    expect(screen.getByTestId('object-row-changed-101:0')).toBeInTheDocument();
+  });
+
+  it('omits the changed dot by default', () => {
+    renderRow();
+    expect(screen.queryByTestId('object-row-changed-101:0')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/classify/ObjectRow.test.tsx
+++ b/frontend/tests/components/classify/ObjectRow.test.tsx
@@ -95,6 +95,14 @@ describe('ObjectRow', () => {
     expect(onRowClick).toHaveBeenCalledWith('101:0');
   });
 
+  it('is a tab stop and activates when focused directly', () => {
+    const { onRowClick } = renderRow();
+    const row = screen.getByTestId('object-card-101:0');
+    expect(row).toHaveAttribute('tabindex', '0');
+    fireEvent.focus(row);
+    expect(onRowClick).toHaveBeenCalledWith('101:0');
+  });
+
   it('shows the changed dot only when changed', () => {
     renderRow({ changed: true });
     expect(screen.getByTestId('object-row-changed-101:0')).toBeInTheDocument();

--- a/frontend/tests/components/classify/ObjectRow.test.tsx
+++ b/frontend/tests/components/classify/ObjectRow.test.tsx
@@ -30,19 +30,13 @@ function renderRow(overrides: Partial<React.ComponentProps<typeof ObjectRow>> = 
 describe('getObjectRowStatus', () => {
   it('maps states to labels and tones', () => {
     expect(
-      getObjectRowStatus({
-        bbox: baseBbox,
-        classification: 'unselected',
-        unsure: false,
-        locked: false,
-      })
+      getObjectRowStatus({ bbox: baseBbox, classification: 'unselected', unsure: false })
     ).toEqual({ label: 'Pending', tone: 'pending' });
     expect(
       getObjectRowStatus({
         bbox: { ...baseBbox, is_smoke: true, smoke_type: 'wildfire' },
         classification: 'smoke',
         unsure: false,
-        locked: false,
       })
     ).toEqual({ label: 'Smoke · Wildfire', tone: 'positive' });
     expect(
@@ -50,7 +44,6 @@ describe('getObjectRowStatus', () => {
         bbox: { ...baseBbox, is_smoke: true },
         classification: 'smoke',
         unsure: false,
-        locked: false,
       })
     ).toEqual({ label: 'Type needed', tone: 'pending' });
     expect(
@@ -58,26 +51,11 @@ describe('getObjectRowStatus', () => {
         bbox: { ...baseBbox, false_positive_types: ['high_cloud', 'sky'] },
         classification: 'false_positive',
         unsure: false,
-        locked: false,
       })
     ).toEqual({ label: 'FP · High cloud +1', tone: 'neutral' });
     expect(
-      getObjectRowStatus({
-        bbox: baseBbox,
-        classification: 'unselected',
-        unsure: true,
-        locked: false,
-      })
+      getObjectRowStatus({ bbox: baseBbox, classification: 'unselected', unsure: true })
     ).toEqual({ label: 'Unsure', tone: 'unsure' });
-    expect(
-      getObjectRowStatus({
-        bbox: baseBbox,
-        classification: 'unselected',
-        unsure: false,
-        locked: true,
-        stageBadge: 'Fully annotated',
-      })
-    ).toEqual({ label: 'Fully annotated', tone: 'neutral' });
   });
 });
 
@@ -100,9 +78,13 @@ describe('ObjectRow', () => {
       locked: true,
       isActive: true,
       stageBadge: 'Fully annotated',
+      bbox: { ...baseBbox, is_smoke: true, smoke_type: 'wildfire' },
+      classification: 'smoke',
     });
     expect(screen.queryByRole('radio', { name: 'Smoke' })).not.toBeInTheDocument();
+    // Stage badge AND the data-derived classification summary both render.
     expect(screen.getByText('Fully annotated')).toBeInTheDocument();
+    expect(screen.getByText('Smoke · Wildfire')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('object-card-101:0'));
     expect(onRowClick).toHaveBeenCalledWith('101:0');
   });

--- a/frontend/tests/components/sequence-annotation/ObjectPresenceStrip.test.tsx
+++ b/frontend/tests/components/sequence-annotation/ObjectPresenceStrip.test.tsx
@@ -170,9 +170,9 @@ describe('ObjectPresenceStrip', () => {
 
     const row0 = screen.getByRole('button', { name: 'Go to Object 1' });
     const row1 = screen.getByRole('button', { name: 'Go to Object 2' });
-    expect(row1).toHaveClass('bg-ash');
+    expect(row1).toHaveClass('bg-pine-soft');
     expect(row1).toHaveAttribute('aria-current', 'true');
-    expect(row0).not.toHaveClass('bg-ash');
+    expect(row0).not.toHaveClass('bg-pine-soft');
     expect(row0).not.toHaveAttribute('aria-current');
   });
 

--- a/frontend/tests/components/sequence-annotation/ObjectPresenceStrip.test.tsx
+++ b/frontend/tests/components/sequence-annotation/ObjectPresenceStrip.test.tsx
@@ -115,61 +115,20 @@ describe('ObjectPresenceStrip', () => {
     expect(screen.getByTestId('presence-segment-2-2')).toHaveStyle({ backgroundColor: '#a855f7' });
   });
 
-  it('renders a real axis: hairline, tick marks + numbers at the first/last frame, and a "Frame" axis label', () => {
-    // 12 distinct frames, one per object timestamp — enough to exercise the
-    // axis's adaptive intermediate-tick step, not just the always-shown ends.
-    const frames = Array.from(
-      { length: 12 },
-      (_, i) => `2024-01-01T00:00:${String(i).padStart(2, '0')}Z`
-    );
-
+  it('renders no frame axis — just the rows (cockpit keeps the strip minimal)', () => {
     render(
       <ObjectPresenceStrip
         objects={[
-          { label: 'Object 1', color: '#3b82f6', timestamps: frames },
-          { label: 'Object 2', color: '#f97316', timestamps: frames },
+          { label: 'Object 1', color: '#3b82f6', timestamps: [t1, t2] },
+          { label: 'Object 2', color: '#f97316', timestamps: [t2, t3] },
         ]}
       />
     );
 
-    expect(screen.getByTestId('presence-axis')).toBeInTheDocument();
-
-    // The axis line is a recessive hairline (the `line` token), not styled
-    // with any object color.
-    const axisLine = screen.getByTestId('presence-axis-line');
-    expect(axisLine).toHaveClass('bg-line');
-    expect(axisLine).not.toHaveAttribute('style');
-
-    // First frame is always ticked, labeled "1".
-    const tick0 = screen.getByTestId('presence-axis-tick-0');
-    expect(tick0).toHaveTextContent('1');
-    // Last frame (index 11) is always ticked, labeled "12".
-    const tick11 = screen.getByTestId('presence-axis-tick-11');
-    expect(tick11).toHaveTextContent('12');
-    // Tick labels wear a muted text token, never an inline (object) color —
-    // text always wears text tokens, per DESIGN.md.
-    expect(tick0).toHaveClass('text-haze');
-    expect(tick0).not.toHaveAttribute('style');
-    expect(tick11).toHaveClass('text-haze');
-    expect(tick11).not.toHaveAttribute('style');
-
-    // Not every one of the 12 columns gets a label — intermediate ticks are
-    // spaced out, not one per frame.
-    expect(screen.queryAllByText(/^\d+$/).length).toBeLessThan(frames.length);
-
-    // The "Frame" axis label renders once, muted, no object color.
-    const axisLabel = screen.getByTestId('presence-axis-label');
-    expect(axisLabel).toHaveTextContent('Frame');
-    expect(axisLabel).toHaveClass('text-haze');
-    expect(axisLabel).not.toHaveAttribute('style');
-
-    // A directional arrowhead marker sits at the line's right end, styled
-    // with the same recessive `line` token as the axis line — never an
-    // object color.
-    const axisArrow = screen.getByTestId('presence-axis-arrow');
-    expect(axisArrow).toBeInTheDocument();
-    expect(axisArrow).toHaveClass('border-l-line');
-    expect(axisArrow).not.toHaveAttribute('style');
+    expect(screen.queryByTestId('presence-axis')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('presence-axis-arrow')).not.toBeInTheDocument();
+    expect(screen.queryByText('Frame')).not.toBeInTheDocument();
+    expect(screen.queryByText(/^\d+$/)).not.toBeInTheDocument();
   });
 
   it("renders each row as an accessible button and fires onObjectClick with that row's index", () => {
@@ -196,6 +155,25 @@ describe('ObjectPresenceStrip', () => {
 
     fireEvent.click(row0);
     expect(onObjectClick).toHaveBeenCalledWith(0);
+  });
+
+  it('highlights the activeIndex row and only that row', () => {
+    render(
+      <ObjectPresenceStrip
+        activeIndex={1}
+        objects={[
+          { label: 'Object 1', color: '#3b82f6', timestamps: [t1] },
+          { label: 'Object 2', color: '#f97316', timestamps: [t2] },
+        ]}
+      />
+    );
+
+    const row0 = screen.getByRole('button', { name: 'Go to Object 1' });
+    const row1 = screen.getByRole('button', { name: 'Go to Object 2' });
+    expect(row1).toHaveClass('bg-ash');
+    expect(row1).toHaveAttribute('aria-current', 'true');
+    expect(row0).not.toHaveClass('bg-ash');
+    expect(row0).not.toHaveAttribute('aria-current');
   });
 
   it('does not throw when a row is clicked without an onObjectClick handler', () => {

--- a/frontend/tests/components/sequence/SequencePlayerHideControls.test.tsx
+++ b/frontend/tests/components/sequence/SequencePlayerHideControls.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Focused coverage for SequencePlayer's `hideReviewControls` prop (used by
+ * the classify cockpit, where the decision rail owns the yes/no controls).
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SequencePlayer from '@/components/sequence/SequencePlayer';
+import type { Detection } from '@/types/api';
+
+vi.mock('@/hooks/useImagePreloader', () => ({
+  useImagePreloader: () => ({
+    currentImage: null,
+    isInitialLoading: false,
+    getPreloadProgress: () => ({ loaded: 0, total: 0, percentage: 0 }),
+  }),
+}));
+
+function makeDetection(): Detection {
+  return {
+    id: 1,
+    sequence_id: 101,
+    alert_api_id: 9001,
+    created_at: '2026-01-01T09:00:00Z',
+    recorded_at: '2026-01-01T10:00:00Z',
+    algo_predictions: { predictions: [] },
+    last_modified_at: null,
+  };
+}
+
+const noop = () => {};
+const baseProps = {
+  currentIndex: 0,
+  onIndexChange: noop,
+  missedSmokeReview: null,
+  onMissedSmokeReviewChange: noop,
+  isPlaying: false,
+  playbackSpeed: 1,
+  onPlay: noop,
+  onPause: noop,
+  onSeek: noop,
+  onSpeedChange: noop,
+  onReset: noop,
+};
+
+describe('SequencePlayer hideReviewControls', () => {
+  it('shows the embedded missed-smoke overlay by default', () => {
+    render(<SequencePlayer {...baseProps} detections={[makeDetection()]} />);
+    expect(screen.getByText(/Did the model miss any smoke/i)).toBeInTheDocument();
+  });
+
+  it('hides the embedded missed-smoke overlay when hideReviewControls', () => {
+    render(<SequencePlayer {...baseProps} detections={[makeDetection()]} hideReviewControls />);
+    expect(screen.queryByText(/Did the model miss any smoke/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -19,6 +19,7 @@ vi.mock('@/services/api', () => ({
     classifySubmit: vi.fn(),
     getSequenceDetections: vi.fn(),
     updateSequenceAnnotation: vi.fn(),
+    getClassifyQueue: vi.fn(),
   },
 }));
 
@@ -243,6 +244,15 @@ describe('ClassifyAlertPage', () => {
     // resolve against without erroring; overridden per-test where the
     // overlay content itself is under test.
     vi.mocked(apiClient.getSequenceDetections).mockResolvedValue([]);
+    // Default: empty queue, so post-submit auto-advance falls through to the
+    // "workflow completed" path most tests assert.
+    vi.mocked(apiClient.getClassifyQueue).mockResolvedValue({
+      items: [],
+      page: 1,
+      pages: 0,
+      size: 2,
+      total: 0,
+    });
     vi.mocked(apiClient.classifySubmit).mockResolvedValue({
       results: [
         {
@@ -1076,6 +1086,46 @@ describe('ClassifyAlertPage', () => {
     const row = within(screen.getByTestId('object-card-101:0'));
     expect(row.getByRole('radio', { name: 'False positive' })).not.toBeChecked();
     expect(row.getByText('Pending')).toBeInTheDocument();
+  });
+
+  it('auto-advances to the next alert in the classify queue after submit when no table workflow is active', async () => {
+    vi.mocked(apiClient.getClassifyQueue).mockResolvedValue({
+      items: [
+        {
+          source_api: 'pyronear_french',
+          platform_alert_id: 900,
+          camera_name: 'CAM-2',
+          organisation_name: 'Org',
+          azimuth: null,
+          recorded_at: '2026-01-01T11:00:00Z',
+          is_wildfire_alertapi: null,
+          primary_sequence_id: 555,
+          total_objects: 1,
+          classified_objects: 0,
+        },
+      ],
+      page: 1,
+      pages: 1,
+      size: 2,
+      total: 1,
+    });
+
+    await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+    const cardA = openRow('101:0');
+    fireEvent.click(cardA.getByRole('radio', { name: 'Smoke' }));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Wildfire' }));
+    const cardB = openRow('102:0');
+    fireEvent.click(cardB.getByRole('radio', { name: 'False positive' }));
+    fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
+    fireEvent.click(missedSmokeChip('No'));
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Submit alert/i })[0]);
+    await waitFor(() => expect(apiClient.classifySubmit).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/classify/555'), {
+      timeout: 2000,
+    });
   });
 
   it('shows the FP type chips as a full inline wrap on the active row', async () => {

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -1,7 +1,8 @@
 /**
- * Tests for ClassifyAlertPage: the collocated classify screen that renders
- * every object (lane) of one alert and submits them all in a single
- * classifySubmit call.
+ * Tests for ClassifyAlertPage: the collocated classify cockpit that renders
+ * every object (lane) of one alert — a media panel for the active object
+ * plus a decision rail of per-object rows — and submits them all in a
+ * single classifySubmit call (queue mode) or per-lane PATCHes (done mode).
  */
 
 import React from 'react';
@@ -27,41 +28,32 @@ vi.mock('react-router-dom', async importOriginal => {
   return { ...actual, useNavigate: () => navigateMock };
 });
 
+// The media panel's full-frame player stand-in exposes the bbox count it
+// was handed — renderAndSettle keys on it as the "seeded state has
+// committed" signal (see its comment).
 vi.mock('@/components/annotation/FullImageSequence', () => ({
-  default: () => <div data-testid="full-image-sequence" />,
+  default: ({ bboxes }: { bboxes?: unknown[] }) => (
+    <div data-testid="full-image-sequence" data-bbox-count={bboxes?.length ?? 0} />
+  ),
 }));
 vi.mock('@/components/annotation/CroppedImageSequence', () => ({
   default: () => <div data-testid="cropped-image-sequence" />,
 }));
 
-// The primary-lane player (SequenceReviewer -> SequencePlayer) fetches
+// The whole-alert player (SequenceReviewer -> SequencePlayer) fetches
 // detections and renders a full playback UI unrelated to this page's own
-// logic; swap it for a trivial stand-in that exposes the missed-smoke
-// review callback so tests can drive it directly. `objectOverlaysSpy`
-// captures the `objectOverlays` prop the page builds for it so overlay
-// wiring can be asserted without rendering the real player.
+// logic; swap it for a trivial stand-in. It only mounts once the
+// missed-smoke section is activated (the media panel swaps to it).
+// `objectOverlaysSpy` captures the `objectOverlays` prop the page builds
+// for it so overlay wiring can be asserted without rendering the real
+// player.
 const objectOverlaysSpy = vi.fn();
-vi.mock('@/components/sequence-annotation', async importOriginal => {
-  const actual = await importOriginal<typeof import('@/components/sequence-annotation')>();
-  return {
-    ...actual,
-    MissedSmokePanel: ({
-      onMissedSmokeReviewChange,
-      objectOverlays,
-    }: {
-      onMissedSmokeReviewChange: (review: 'yes' | 'no') => void;
-      objectOverlays?: unknown;
-    }) => {
-      objectOverlaysSpy(objectOverlays);
-      return (
-        <div>
-          <button onClick={() => onMissedSmokeReviewChange('no')}>Mock: No missed smoke</button>
-          <button onClick={() => onMissedSmokeReviewChange('yes')}>Mock: Missed smoke</button>
-        </div>
-      );
-    },
-  };
-});
+vi.mock('@/components/sequence/SequenceReviewer', () => ({
+  default: (props: { objectOverlays?: unknown }) => {
+    objectOverlaysSpy(props.objectOverlays);
+    return <div data-testid="sequence-reviewer" />;
+  },
+}));
 
 import { apiClient } from '@/services/api';
 import ClassifyAlertPage from '@/pages/ClassifyAlertPage';
@@ -194,33 +186,27 @@ function makeAlertDetail(): AlertDetail {
 }
 
 /**
- * Renders the page and waits for card 101:0's SEEDED state to have
+ * Renders the page and waits for the entry row's SEEDED state to have
  * committed — not just its presence. Used by every test in this file
  * instead of `render(...)` + a bare `waitFor(testid present)`.
  *
- * The page settles in two separate React commits: (1) alert-detail
- * arrives and `renderItems`/cards render structurally (testid, "Object N"
- * title, locked/disabled attributes — all derived straight from
- * `alertDetail`), then (2) a *separate* `useEffect`
- * (`initializeFromAlertDetail`) seeds classification/bbox/unsure/missed-
- * smoke local state from that same data — which is what actually drives
- * checked radios, Reviewed/Pending badges, displayed smoke/FP text, and
- * bbox counts. Under slow/CI scheduling, `waitFor` can observe the DOM in
- * the gap between those two commits: a card can be "present" with none of
- * its seeded content painted yet. This caused two separate CI-only test
- * failures (asserting a radio was checked / "Reviewed" was rendered
- * immediately after only waiting for the card's testid). Interacting with
- * a card before commit (2) lands is also unsafe for a different reason:
- * click handlers spread the CURRENT bbox prop, which is still the
- * `EMPTY_BBOX` placeholder pre-commit-(2), silently discarding the card's
- * real bbox data.
+ * The page settles across separate React commits: (1) alert-detail arrives
+ * and rows render structurally, (2) a `useEffect` activates the entry row
+ * (queue: first editable; done: the clicked sequence), and (3) another
+ * `useEffect` (`initializeFromAlertDetail`) seeds classification/bbox/
+ * unsure/missed-smoke local state from that same data — which is what
+ * actually drives checked chips, status labels, and the media panel's bbox
+ * data. Under slow/CI scheduling, `waitFor` can observe the DOM in the gap
+ * between those commits. Interacting with a row before the seed commit
+ * lands is also unsafe: chip handlers spread the CURRENT bbox prop, which
+ * is still the `EMPTY_BBOX` placeholder pre-seed, silently discarding the
+ * row's real bbox data.
  *
- * Every real lane in every fixture in this file seeds >= 1 bbox entry,
- * and a card's bbox-count text reads the `EMPTY_BBOX` default
- * ("0 bboxes") until commit (2) lands — so waiting for card 101's count to
- * move off "0 bboxes" is a settle signal common to every scenario here
- * (editable, locked, or alongside an unrelated placeholder lane), without
- * depending on any particular classification outcome.
+ * Every fixture's entry lane seeds >= 1 bbox entry, and the (mocked)
+ * full-frame player reports the bbox count it was handed — so waiting for
+ * that count to move off "0" is a settle signal common to every scenario
+ * here: it proves an object is active AND its seeded (non-EMPTY_BBOX) data
+ * reached the media panel.
  */
 async function renderAndSettle(
   ui: React.ReactElement,
@@ -228,9 +214,19 @@ async function renderAndSettle(
 ): Promise<void> {
   render(ui, options);
   await waitFor(() => {
-    const card = within(screen.getByTestId('object-card-101:0'));
-    expect(card.queryByText('0 bboxes')).not.toBeInTheDocument();
+    expect(screen.getByTestId('full-image-sequence').getAttribute('data-bbox-count')).not.toBe('0');
   });
+}
+
+/** Activate a row, then return a `within` scope for it (chips only render on the active row). */
+function openRow(cardKey: string) {
+  fireEvent.click(screen.getByTestId(`object-card-${cardKey}`));
+  return within(screen.getByTestId(`object-card-${cardKey}`));
+}
+
+/** The missed-smoke rail row's Yes/No chips. */
+function missedSmokeChip(name: 'Yes' | 'No') {
+  return within(screen.getByTestId('missed-smoke-row')).getByRole('radio', { name });
 }
 
 describe('ClassifyAlertPage', () => {
@@ -239,7 +235,7 @@ describe('ClassifyAlertPage', () => {
     // like `toHaveBeenCalledTimes` aren't polluted by earlier tests' calls.
     vi.clearAllMocks();
     // jsdom doesn't implement scrollIntoView; the presence-strip click
-    // handler calls it on the target card, so stub it as a no-op.
+    // handler calls it on the target row, so stub it as a no-op.
     Element.prototype.scrollIntoView = vi.fn();
     vi.mocked(apiClient.getSequence).mockResolvedValue(makeSequence());
     vi.mocked(apiClient.getAlertDetail).mockResolvedValue(makeAlertDetail());
@@ -265,7 +261,7 @@ describe('ClassifyAlertPage', () => {
     });
   });
 
-  it('renders one card per lane-track for a 3-lane alert', async () => {
+  it('renders one rail row per lane-track for a 3-lane alert', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
     expect(
       within(screen.getByTestId('object-card-101:0')).getByText('Object 1')
@@ -278,42 +274,45 @@ describe('ClassifyAlertPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the locked lane card read-only with a stage badge', async () => {
+  it('renders the locked lane row read-only with a stage badge and its classification summary', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
-    const lockedCard = within(screen.getByTestId('object-card-103:0'));
-    expect(lockedCard.getByText('Fully annotated')).toBeInTheDocument();
-    expect(lockedCard.getByRole('radio', { name: /This is smoke/i })).toBeDisabled();
+    const lockedRow = within(screen.getByTestId('object-card-103:0'));
+    expect(lockedRow.getByText('Fully annotated')).toBeInTheDocument();
     // Its existing (already-submitted) classification renders, not blank.
-    expect(lockedCard.getByRole('radio', { name: /This is smoke/i })).toBeChecked();
-    expect(lockedCard.getAllByText(/Wildfire/).length).toBeGreaterThan(0);
+    expect(lockedRow.getByText('Smoke · Wildfire')).toBeInTheDocument();
 
-    const editableCard = within(screen.getByTestId('object-card-101:0'));
-    expect(editableCard.getByRole('radio', { name: /This is smoke/i })).not.toBeDisabled();
+    // Activating the locked row shows its media but never chips.
+    fireEvent.click(screen.getByTestId('object-card-103:0'));
+    expect(lockedRow.queryByRole('radio', { name: 'Smoke' })).not.toBeInTheDocument();
+
+    // An editable row does render enabled chips once active.
+    const editableRow = openRow('101:0');
+    expect(editableRow.getByRole('radio', { name: 'Smoke' })).not.toBeDisabled();
   });
 
-  it('disables submit until every editable card is classified and missed smoke is answered', async () => {
+  it('disables submit until every editable row is classified and missed smoke is answered', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
     const submitButton = screen.getByRole('button', { name: /Submit alert/i });
     expect(submitButton).toBeDisabled();
 
     // Classify object 1 as smoke + wildfire
-    const cardA = within(screen.getByTestId('object-card-101:0'));
-    fireEvent.click(cardA.getByRole('radio', { name: /This is smoke/i }));
-    fireEvent.click(cardA.getByRole('radio', { name: /Wildfire/i }));
+    const cardA = openRow('101:0');
+    fireEvent.click(cardA.getByRole('radio', { name: 'Smoke' }));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Wildfire' }));
 
     expect(submitButton).toBeDisabled();
 
     // Classify object 2 as false positive + a type
-    const cardB = within(screen.getByTestId('object-card-102:0'));
-    fireEvent.click(cardB.getByRole('radio', { name: /false positive/i }));
-    fireEvent.click(cardB.getByRole('checkbox', { name: /Antenna/i }));
+    const cardB = openRow('102:0');
+    fireEvent.click(cardB.getByRole('radio', { name: 'False positive' }));
+    fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
 
     // Still missing the missed-smoke review
     expect(submitButton).toBeDisabled();
 
-    fireEvent.click(screen.getByText('Mock: No missed smoke'));
+    fireEvent.click(missedSmokeChip('No'));
 
     expect(submitButton).not.toBeDisabled();
   });
@@ -351,15 +350,16 @@ describe('ClassifyAlertPage', () => {
 
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
+    // The single editable row auto-activates, so its chips are on screen.
     const card = within(screen.getByTestId('object-card-101:0'));
-    expect(card.getByRole('radio', { name: /This is smoke/i })).not.toBeChecked();
-    expect(card.getByRole('radio', { name: /false positive/i })).not.toBeChecked();
+    expect(card.getByRole('radio', { name: 'Smoke' })).not.toBeChecked();
+    expect(card.getByRole('radio', { name: 'False positive' })).not.toBeChecked();
     expect(card.getByText('Pending')).toBeInTheDocument();
-    expect(card.queryByText('Reviewed')).not.toBeInTheDocument();
+    expect(card.queryByText(/Smoke ·/)).not.toBeInTheDocument();
 
     // Even after answering missed smoke, submit stays disabled — the
     // placeholder track alone doesn't count as classified.
-    fireEvent.click(screen.getByText('Mock: No missed smoke'));
+    fireEvent.click(missedSmokeChip('No'));
     expect(screen.getByRole('button', { name: /Submit alert/i })).toBeDisabled();
   });
 
@@ -392,26 +392,25 @@ describe('ClassifyAlertPage', () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
     const card = within(screen.getByTestId('object-card-101:0'));
-    expect(card.getByRole('radio', { name: /This is smoke/i })).toBeChecked();
-    expect(card.getAllByText(/Wildfire/).length).toBeGreaterThan(0);
-    expect(card.getByText('Reviewed')).toBeInTheDocument();
+    expect(card.getByRole('radio', { name: 'Smoke' })).toBeChecked();
+    expect(card.getByText('Smoke · Wildfire')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText('Mock: No missed smoke'));
+    fireEvent.click(missedSmokeChip('No'));
     expect(screen.getByRole('button', { name: /Submit alert/i })).not.toBeDisabled();
   });
 
   it('submits with per-lane stages: FP-only lane annotated, smoke lane seq_annotation_done, primary carries has_missed_smoke', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
-    const cardA = within(screen.getByTestId('object-card-101:0'));
-    fireEvent.click(cardA.getByRole('radio', { name: /This is smoke/i }));
-    fireEvent.click(cardA.getByRole('radio', { name: /Wildfire/i }));
+    const cardA = openRow('101:0');
+    fireEvent.click(cardA.getByRole('radio', { name: 'Smoke' }));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Wildfire' }));
 
-    const cardB = within(screen.getByTestId('object-card-102:0'));
-    fireEvent.click(cardB.getByRole('radio', { name: /false positive/i }));
-    fireEvent.click(cardB.getByRole('checkbox', { name: /Antenna/i }));
+    const cardB = openRow('102:0');
+    fireEvent.click(cardB.getByRole('radio', { name: 'False positive' }));
+    fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
 
-    fireEvent.click(screen.getByText('Mock: Missed smoke'));
+    fireEvent.click(missedSmokeChip('Yes'));
 
     const submitButton = screen.getByRole('button', { name: /Submit alert/i });
     expect(submitButton).not.toBeDisabled();
@@ -447,7 +446,7 @@ describe('ClassifyAlertPage', () => {
   });
 
   it('renders Submit disabled when every lane is already locked (deep-linking a fully-classified alert)', async () => {
-    // Zero editable cards: `isComplete` (`.every()` over an empty list) is
+    // Zero editable rows: `isComplete` (`.every()` over an empty list) is
     // vacuously true, and the primary lane's own submitted missed-smoke
     // answer makes `missedSmokeReview !== null` true too — without an
     // explicit "something to submit" guard, Submit would stay enabled and
@@ -544,11 +543,11 @@ describe('ClassifyAlertPage', () => {
 
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
-    const cardB = within(screen.getByTestId('object-card-102:0'));
-    fireEvent.click(cardB.getByRole('radio', { name: /false positive/i }));
-    fireEvent.click(cardB.getByRole('checkbox', { name: /Antenna/i }));
+    const cardB = openRow('102:0');
+    fireEvent.click(cardB.getByRole('radio', { name: 'False positive' }));
+    fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
 
-    fireEvent.click(screen.getByText('Mock: Missed smoke'));
+    fireEvent.click(missedSmokeChip('Yes'));
 
     const submitButton = screen.getByRole('button', { name: /Submit alert/i });
     expect(submitButton).not.toBeDisabled();
@@ -568,15 +567,15 @@ describe('ClassifyAlertPage', () => {
   it('pluralizes the workflow-completion toast correctly for a single alert', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
-    const cardA = within(screen.getByTestId('object-card-101:0'));
-    fireEvent.click(cardA.getByRole('radio', { name: /This is smoke/i }));
-    fireEvent.click(cardA.getByRole('radio', { name: /Wildfire/i }));
+    const cardA = openRow('101:0');
+    fireEvent.click(cardA.getByRole('radio', { name: 'Smoke' }));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Wildfire' }));
 
-    const cardB = within(screen.getByTestId('object-card-102:0'));
-    fireEvent.click(cardB.getByRole('radio', { name: /false positive/i }));
-    fireEvent.click(cardB.getByRole('checkbox', { name: /Antenna/i }));
+    const cardB = openRow('102:0');
+    fireEvent.click(cardB.getByRole('radio', { name: 'False positive' }));
+    fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
 
-    fireEvent.click(screen.getByText('Mock: No missed smoke'));
+    fireEvent.click(missedSmokeChip('No'));
     fireEvent.click(screen.getByRole('button', { name: /Submit alert/i }));
 
     await waitFor(() => expect(apiClient.classifySubmit).toHaveBeenCalledTimes(1));
@@ -596,15 +595,15 @@ describe('ClassifyAlertPage', () => {
 
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
-    const cardA = within(screen.getByTestId('object-card-101:0'));
-    fireEvent.click(cardA.getByRole('radio', { name: /This is smoke/i }));
-    fireEvent.click(cardA.getByRole('radio', { name: /Wildfire/i }));
+    const cardA = openRow('101:0');
+    fireEvent.click(cardA.getByRole('radio', { name: 'Smoke' }));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Wildfire' }));
 
-    const cardB = within(screen.getByTestId('object-card-102:0'));
-    fireEvent.click(cardB.getByRole('radio', { name: /false positive/i }));
-    fireEvent.click(cardB.getByRole('checkbox', { name: /Antenna/i }));
+    const cardB = openRow('102:0');
+    fireEvent.click(cardB.getByRole('radio', { name: 'False positive' }));
+    fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
 
-    fireEvent.click(screen.getByText('Mock: No missed smoke'));
+    fireEvent.click(missedSmokeChip('No'));
     fireEvent.click(screen.getByRole('button', { name: /Submit alert/i }));
 
     await waitFor(() =>
@@ -681,38 +680,42 @@ describe('ClassifyAlertPage', () => {
 
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
-    const cardA = within(screen.getByTestId('object-card-101:0'));
-    fireEvent.click(cardA.getByRole('radio', { name: /This is smoke/i }));
-    fireEvent.click(cardA.getByRole('radio', { name: /Wildfire/i }));
+    const cardA = openRow('101:0');
+    fireEvent.click(cardA.getByRole('radio', { name: 'Smoke' }));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Wildfire' }));
 
-    const cardB = within(screen.getByTestId('object-card-102:0'));
-    fireEvent.click(cardB.getByRole('radio', { name: /false positive/i }));
-    fireEvent.click(cardB.getByRole('checkbox', { name: /Antenna/i }));
+    const cardB = openRow('102:0');
+    fireEvent.click(cardB.getByRole('radio', { name: 'False positive' }));
+    fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
 
-    fireEvent.click(screen.getByText('Mock: No missed smoke'));
+    fireEvent.click(missedSmokeChip('No'));
     fireEvent.click(screen.getByRole('button', { name: /Submit alert/i }));
 
     await waitFor(() => expect(screen.getByText(/Group propagation skipped/)).toBeInTheDocument());
 
     // The submitted lanes are still on screen (no auto-advance on the
     // warning path) — the page must refetch alert-detail so they redraw
-    // locked/read-only instead of staying editable with stale state.
+    // locked/read-only instead of staying editable with stale state. Row
+    // 102 was left active by the interactions above; once its lane comes
+    // back locked its chips must unmount, and both lanes' new stage badges
+    // must render.
     await waitFor(() => expect(apiClient.getAlertDetail).toHaveBeenCalledTimes(2));
     await waitFor(() =>
       expect(
-        within(screen.getByTestId('object-card-101:0')).getByRole('radio', {
-          name: /This is smoke/i,
+        within(screen.getByTestId('object-card-102:0')).queryByRole('radio', {
+          name: 'False positive',
         })
-      ).toBeDisabled()
+      ).not.toBeInTheDocument()
     );
     expect(
-      within(screen.getByTestId('object-card-102:0')).getByRole('radio', {
-        name: /false positive/i,
-      })
-    ).toBeDisabled();
+      within(screen.getByTestId('object-card-101:0')).getByText('Awaiting localization')
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('object-card-102:0')).getByText('Fully annotated')
+    ).toBeInTheDocument();
   });
 
-  it('gives every object a distinct color, matching between its card swatch and the shared player overlay', async () => {
+  it('gives every object a distinct color, matching between its row swatch and the shared player overlay', async () => {
     // Each lane's own detections carry the recorded_at the page joins its
     // track boxes against — lane A and B share a frame (t1), lane C only
     // has a later frame (t2), matching each lane's makeAnnotation bboxes
@@ -745,7 +748,7 @@ describe('ClassifyAlertPage', () => {
       expect(screen.getByTestId('object-color-swatch-103:0')).toBeInTheDocument();
     });
 
-    // Every object gets its own color, matching card swatch <-> palette index.
+    // Every object gets its own color, matching row swatch <-> palette index.
     expect(screen.getByTestId('object-color-swatch-101:0')).toHaveStyle({
       backgroundColor: getObjectColor(0),
     });
@@ -756,8 +759,13 @@ describe('ClassifyAlertPage', () => {
       backgroundColor: getObjectColor(2),
     });
 
+    // The whole-alert player only mounts once the missed-smoke section is
+    // active — activate it so the (mocked) reviewer starts receiving the
+    // objectOverlays prop.
+    fireEvent.click(screen.getByTestId('missed-smoke-row'));
+
     // `objectOverlaysSpy` is called on every render of the (mocked)
-    // MissedSmokePanel, including earlier ones where the three lanes'
+    // reviewer, including earlier ones where the three lanes'
     // `getSequenceDetections` queries haven't all resolved yet — waiting
     // for "called at least once" and then reading `.at(-1)` right after
     // can race an in-flight query. Wait for the actual settled content
@@ -771,7 +779,7 @@ describe('ClassifyAlertPage', () => {
     const lastOverlays = objectOverlaysSpy.mock.calls.at(-1)![0] as Overlay[];
 
     expect(lastOverlays.map(o => o.label)).toEqual(['Object 1', 'Object 2', 'Object 3']);
-    // Colors match the card swatches for the same object, in the same order.
+    // Colors match the row swatches for the same object, in the same order.
     expect(lastOverlays[0].color).toBe(getObjectColor(0));
     expect(lastOverlays[1].color).toBe(getObjectColor(1));
     expect(lastOverlays[2].color).toBe(getObjectColor(2));
@@ -823,41 +831,43 @@ describe('ClassifyAlertPage', () => {
     );
   });
 
-  it('renders the presence strip as the first thing under the header, above the cards grid and the shared player', async () => {
+  it('renders the presence strip inside the media panel, between the full-frame player and the cropped loop', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
+    const panel = screen.getByTestId('classify-media-panel');
     const strip = screen.getByTestId('object-presence-swatch-0');
-    const card = screen.getByTestId('object-card-101:0');
-    const player = screen.getByText('Mock: No missed smoke');
+    expect(panel.contains(strip)).toBe(true);
 
-    // DOCUMENT_POSITION_FOLLOWING: the compared node comes *after* `strip`
-    // in document order.
-    expect(strip.compareDocumentPosition(card) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(strip.compareDocumentPosition(player) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    const full = screen.getByTestId('full-image-sequence');
+    const cropped = screen.getByTestId('cropped-image-sequence');
+    // DOCUMENT_POSITION_FOLLOWING: the compared node comes *after* the
+    // receiver in document order.
+    expect(full.compareDocumentPosition(strip) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(strip.compareDocumentPosition(cropped) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  it("clicking a presence-strip row scrolls to and activates that object's card", async () => {
+  it("clicking a presence-strip row scrolls to and activates that object's rail row", async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
     // Lane B (sequence 102) is "Object 2" — see makeAlertDetail's laneB.
     fireEvent.click(screen.getByRole('button', { name: 'Go to Object 2' }));
 
-    // The page owns turning the strip's click into "activate that card":
-    // Object 2's card shows the same "Active" pill a direct card click
-    // would produce, and no other card does.
+    // The page owns turning the strip's click into "activate that row":
+    // Object 2's row expands its chips exactly as a direct row click would,
+    // and no other row is expanded.
     await waitFor(() =>
       expect(
-        within(screen.getByTestId('object-card-102:0')).getByText('Active')
+        within(screen.getByTestId('object-card-102:0')).getByRole('radio', { name: 'Smoke' })
       ).toBeInTheDocument()
     );
     expect(
-      within(screen.getByTestId('object-card-101:0')).queryByText('Active')
+      within(screen.getByTestId('object-card-101:0')).queryByRole('radio', { name: 'Smoke' })
     ).not.toBeInTheDocument();
     expect(
-      within(screen.getByTestId('object-card-103:0')).queryByText('Active')
+      within(screen.getByTestId('object-card-103:0')).queryByRole('radio', { name: 'Smoke' })
     ).not.toBeInTheDocument();
 
-    // And it scrolled the card into view — the handler defers the actual
+    // And it scrolled the row into view — the handler defers the actual
     // scroll a frame (requestAnimationFrame), so wait for it (jsdom stub —
     // see beforeEach).
     await waitFor(() =>
@@ -1008,18 +1018,19 @@ describe('ClassifyAlertPage done mode', () => {
     }));
   });
 
-  it('renders lanes with existing annotations as editable and pre-filled "Reviewed", regardless of processing stage', async () => {
+  it('renders lanes with existing annotations as editable and pre-filled, regardless of processing stage', async () => {
     await renderAndSettle(<ClassifyAlertPage mode="done" />, { wrapper: makeDoneWrapper(101) });
 
-    const cardA = within(screen.getByTestId('object-card-101:0')); // seq_annotation_done
-    expect(cardA.getByText('Reviewed')).toBeInTheDocument();
-    expect(cardA.getByRole('radio', { name: /This is smoke/i })).not.toBeDisabled();
-    expect(cardA.getByRole('radio', { name: /This is smoke/i })).toBeChecked();
+    const cardA = within(screen.getByTestId('object-card-101:0')); // seq_annotation_done, entry-activated
+    expect(cardA.getByText('Smoke · Wildfire')).toBeInTheDocument();
+    expect(cardA.getByText('Awaiting localization')).toBeInTheDocument(); // stage badge stays visible
+    expect(cardA.getByRole('radio', { name: 'Smoke' })).not.toBeDisabled();
+    expect(cardA.getByRole('radio', { name: 'Smoke' })).toBeChecked();
 
-    const cardB = within(screen.getByTestId('object-card-102:0')); // annotated
-    expect(cardB.getByText('Reviewed')).toBeInTheDocument();
-    expect(cardB.getByRole('radio', { name: /false positive/i })).not.toBeDisabled();
-    expect(cardB.getByRole('radio', { name: /false positive/i })).toBeChecked();
+    const cardB = openRow('102:0'); // annotated — still editable in done mode
+    expect(cardB.getByText('Fully annotated')).toBeInTheDocument();
+    expect(cardB.getByRole('radio', { name: 'False positive' })).not.toBeDisabled();
+    expect(cardB.getByRole('radio', { name: 'False positive' })).toBeChecked();
 
     // The annotation-less lane still renders the read-only placeholder —
     // done mode only changes the meaning of "has an annotation", not the
@@ -1028,15 +1039,15 @@ describe('ClassifyAlertPage done mode', () => {
     expect(screen.getByText('Not imported yet')).toBeInTheDocument();
   });
 
-  it('keeps submit disabled until a lane actually changes, even though every card is already validly classified', async () => {
+  it('keeps save disabled until a lane actually changes, even though every row is already validly classified', async () => {
     await renderAndSettle(<ClassifyAlertPage mode="done" />, { wrapper: makeDoneWrapper(101) });
 
-    const submitButton = screen.getByRole('button', { name: /Submit alert/i });
+    const submitButton = screen.getByRole('button', { name: /Save changes/ });
     expect(submitButton).toBeDisabled();
 
     // Change lane A's smoke type — a real edit.
     const cardA = within(screen.getByTestId('object-card-101:0'));
-    fireEvent.click(cardA.getByRole('radio', { name: /Industrial/i }));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Industrial' }));
 
     expect(submitButton).not.toBeDisabled();
   });
@@ -1045,9 +1056,9 @@ describe('ClassifyAlertPage done mode', () => {
     await renderAndSettle(<ClassifyAlertPage mode="done" />, { wrapper: makeDoneWrapper(101) });
 
     const cardA = within(screen.getByTestId('object-card-101:0'));
-    fireEvent.click(cardA.getByRole('radio', { name: /Industrial/i }));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Industrial' }));
 
-    const submitButton = screen.getByRole('button', { name: /Submit alert/i });
+    const submitButton = screen.getByRole('button', { name: /Save changes/ });
     expect(submitButton).not.toBeDisabled();
     fireEvent.click(submitButton);
 
@@ -1075,11 +1086,13 @@ describe('ClassifyAlertPage done mode', () => {
   it('an alert-level missed-smoke-only change makes the primary lane "changed" and is saved on its PATCH', async () => {
     await renderAndSettle(<ClassifyAlertPage mode="done" />, { wrapper: makeDoneWrapper(101) });
 
-    const submitButton = screen.getByRole('button', { name: /Submit alert/i });
+    const submitButton = screen.getByRole('button', { name: /Save changes/ });
     expect(submitButton).toBeDisabled();
 
-    // No card edits at all — only the alert-level missed-smoke review changes.
-    fireEvent.click(screen.getByText('Mock: Missed smoke'));
+    // No row edits at all — only the alert-level missed-smoke review changes.
+    fireEvent.click(
+      within(screen.getByTestId('missed-smoke-row')).getByRole('radio', { name: 'Yes' })
+    );
     expect(submitButton).not.toBeDisabled();
 
     fireEvent.click(submitButton);
@@ -1095,16 +1108,18 @@ describe('ClassifyAlertPage done mode', () => {
     await waitFor(() => expect(navigateMock).toHaveBeenCalled(), { timeout: 2000 });
   });
 
-  it('scroll-activates the clicked object on load', async () => {
+  it('activates the clicked object on load (chips expand on its row, not the primary)', async () => {
     await renderAndSettle(<ClassifyAlertPage mode="done" />, { wrapper: makeDoneWrapper(102) });
 
     await waitFor(() =>
       expect(
-        within(screen.getByTestId('object-card-102:0')).getByText('Active')
+        within(screen.getByTestId('object-card-102:0')).getByRole('radio', {
+          name: 'False positive',
+        })
       ).toBeInTheDocument()
     );
     expect(
-      within(screen.getByTestId('object-card-101:0')).queryByText('Active')
+      within(screen.getByTestId('object-card-101:0')).queryByRole('radio', { name: 'Smoke' })
     ).not.toBeInTheDocument();
   });
 
@@ -1124,15 +1139,15 @@ describe('ClassifyAlertPage done mode', () => {
     // loop is sequential (not Promise.all firing every lane at once) and
     // that it stops immediately on the first rejection.
     const cardA = within(screen.getByTestId('object-card-101:0'));
-    fireEvent.click(cardA.getByRole('radio', { name: /Industrial/i }));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Industrial' }));
 
-    const cardB = within(screen.getByTestId('object-card-102:0'));
-    fireEvent.click(cardB.getByRole('checkbox', { name: /Building/i }));
+    const cardB = openRow('102:0');
+    fireEvent.click(cardB.getByRole('checkbox', { name: 'Building' }));
 
-    const cardD = within(screen.getByTestId('object-card-104:0'));
-    fireEvent.click(cardD.getByRole('radio', { name: /Wildfire/i }));
+    const cardD = openRow('104:0');
+    fireEvent.click(cardD.getByRole('radio', { name: 'Wildfire' }));
 
-    const submitButton = screen.getByRole('button', { name: /Submit alert/i });
+    const submitButton = screen.getByRole('button', { name: /Save changes/ });
     expect(submitButton).not.toBeDisabled();
     fireEvent.click(submitButton);
 

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -963,10 +963,10 @@ describe('ClassifyAlertPage', () => {
     await waitFor(() => expect(navigateMock).toHaveBeenCalled(), { timeout: 2000 });
   });
 
-  it('Q toggles unsure on the active object, mutually exclusive with S', async () => {
+  it('U toggles unsure on the active object, mutually exclusive with S', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
-    fireEvent.keyDown(document, { key: 'q' });
+    fireEvent.keyDown(document, { key: 'u' });
     const row = within(screen.getByTestId('object-card-101:0'));
     expect(row.getByRole('radio', { name: 'Unsure' })).toBeChecked();
 

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -294,7 +294,7 @@ describe('ClassifyAlertPage', () => {
   it('disables submit until every editable row is classified and missed smoke is answered', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
-    const submitButton = screen.getByRole('button', { name: /Submit alert/i });
+    const submitButton = screen.getAllByRole('button', { name: /Submit alert/i })[0];
     expect(submitButton).toBeDisabled();
 
     // Classify object 1 as smoke + wildfire
@@ -360,7 +360,7 @@ describe('ClassifyAlertPage', () => {
     // Even after answering missed smoke, submit stays disabled — the
     // placeholder track alone doesn't count as classified.
     fireEvent.click(missedSmokeChip('No'));
-    expect(screen.getByRole('button', { name: /Submit alert/i })).toBeDisabled();
+    expect(screen.getAllByRole('button', { name: /Submit alert/i })[0]).toBeDisabled();
   });
 
   it('still pre-fills a genuinely labeled track (e.g. group inheritance) that carries a real smoke_type', async () => {
@@ -396,7 +396,7 @@ describe('ClassifyAlertPage', () => {
     expect(card.getByText('Smoke · Wildfire')).toBeInTheDocument();
 
     fireEvent.click(missedSmokeChip('No'));
-    expect(screen.getByRole('button', { name: /Submit alert/i })).not.toBeDisabled();
+    expect(screen.getAllByRole('button', { name: /Submit alert/i })[0]).not.toBeDisabled();
   });
 
   it('submits with per-lane stages: FP-only lane annotated, smoke lane seq_annotation_done, primary carries has_missed_smoke', async () => {
@@ -412,7 +412,7 @@ describe('ClassifyAlertPage', () => {
 
     fireEvent.click(missedSmokeChip('Yes'));
 
-    const submitButton = screen.getByRole('button', { name: /Submit alert/i });
+    const submitButton = screen.getAllByRole('button', { name: /Submit alert/i })[0];
     expect(submitButton).not.toBeDisabled();
     fireEvent.click(submitButton);
 
@@ -497,7 +497,7 @@ describe('ClassifyAlertPage', () => {
 
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
-    expect(screen.getByRole('button', { name: /Submit alert/i })).toBeDisabled();
+    expect(screen.getAllByRole('button', { name: /Submit alert/i })[0]).toBeDisabled();
   });
 
   it('routes alert-level missed smoke to the first still-open lane when the primary lane is already locked', async () => {
@@ -549,7 +549,7 @@ describe('ClassifyAlertPage', () => {
 
     fireEvent.click(missedSmokeChip('Yes'));
 
-    const submitButton = screen.getByRole('button', { name: /Submit alert/i });
+    const submitButton = screen.getAllByRole('button', { name: /Submit alert/i })[0];
     expect(submitButton).not.toBeDisabled();
     fireEvent.click(submitButton);
 
@@ -576,7 +576,7 @@ describe('ClassifyAlertPage', () => {
     fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
 
     fireEvent.click(missedSmokeChip('No'));
-    fireEvent.click(screen.getByRole('button', { name: /Submit alert/i }));
+    fireEvent.click(screen.getAllByRole('button', { name: /Submit alert/i })[0]);
 
     await waitFor(() => expect(apiClient.classifySubmit).toHaveBeenCalledTimes(1));
     // No active workflow in this test (annotationWorkflow defaults to null
@@ -604,7 +604,7 @@ describe('ClassifyAlertPage', () => {
     fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
 
     fireEvent.click(missedSmokeChip('No'));
-    fireEvent.click(screen.getByRole('button', { name: /Submit alert/i }));
+    fireEvent.click(screen.getAllByRole('button', { name: /Submit alert/i })[0]);
 
     await waitFor(() =>
       expect(screen.getByText(/Submit failed: Lane 103 is locked/)).toBeInTheDocument()
@@ -689,7 +689,7 @@ describe('ClassifyAlertPage', () => {
     fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
 
     fireEvent.click(missedSmokeChip('No'));
-    fireEvent.click(screen.getByRole('button', { name: /Submit alert/i }));
+    fireEvent.click(screen.getAllByRole('button', { name: /Submit alert/i })[0]);
 
     await waitFor(() => expect(screen.getByText(/Group propagation skipped/)).toBeInTheDocument());
 
@@ -934,6 +934,35 @@ describe('ClassifyAlertPage', () => {
     );
   });
 
+  it('mirrors Submit in the rail below the missed-smoke row, tracking the same enablement, and submits from there', async () => {
+    await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+    const railSubmit = screen.getByTestId('rail-submit');
+    // Sits after the missed-smoke row in document order.
+    expect(
+      screen.getByTestId('missed-smoke-row').compareDocumentPosition(railSubmit) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(railSubmit).toBeDisabled();
+
+    const cardA = openRow('101:0');
+    fireEvent.click(cardA.getByRole('radio', { name: 'Smoke' }));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Wildfire' }));
+    const cardB = openRow('102:0');
+    fireEvent.click(cardB.getByRole('radio', { name: 'False positive' }));
+    fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
+    expect(railSubmit).toBeDisabled();
+
+    fireEvent.click(missedSmokeChip('No'));
+    expect(railSubmit).not.toBeDisabled();
+
+    fireEvent.click(railSubmit);
+    await waitFor(() => expect(apiClient.classifySubmit).toHaveBeenCalledTimes(1));
+
+    // Drain the success path's deferred navigate (see the submit tests above).
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled(), { timeout: 2000 });
+  });
+
   it('shows the FP type chips as a full inline wrap on the active row', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
@@ -1107,7 +1136,7 @@ describe('ClassifyAlertPage done mode', () => {
   it('keeps save disabled until a lane actually changes, even though every row is already validly classified', async () => {
     await renderAndSettle(<ClassifyAlertPage mode="done" />, { wrapper: makeDoneWrapper(101) });
 
-    const submitButton = screen.getByRole('button', { name: /Save changes/ });
+    const submitButton = screen.getAllByRole('button', { name: /Save changes/ })[0];
     expect(submitButton).toBeDisabled();
 
     // Change lane A's smoke type — a real edit.
@@ -1123,7 +1152,7 @@ describe('ClassifyAlertPage done mode', () => {
     const cardA = within(screen.getByTestId('object-card-101:0'));
     fireEvent.click(cardA.getByRole('radio', { name: 'Industrial' }));
 
-    const submitButton = screen.getByRole('button', { name: /Save changes/ });
+    const submitButton = screen.getAllByRole('button', { name: /Save changes/ })[0];
     expect(submitButton).not.toBeDisabled();
     fireEvent.click(submitButton);
 
@@ -1151,7 +1180,7 @@ describe('ClassifyAlertPage done mode', () => {
   it('an alert-level missed-smoke-only change makes the primary lane "changed" and is saved on its PATCH', async () => {
     await renderAndSettle(<ClassifyAlertPage mode="done" />, { wrapper: makeDoneWrapper(101) });
 
-    const submitButton = screen.getByRole('button', { name: /Save changes/ });
+    const submitButton = screen.getAllByRole('button', { name: /Save changes/ })[0];
     expect(submitButton).toBeDisabled();
 
     // No row edits at all — only the alert-level missed-smoke review changes.
@@ -1212,7 +1241,7 @@ describe('ClassifyAlertPage done mode', () => {
     const cardD = openRow('104:0');
     fireEvent.click(cardD.getByRole('radio', { name: 'Wildfire' }));
 
-    const submitButton = screen.getByRole('button', { name: /Save changes/ });
+    const submitButton = screen.getAllByRole('button', { name: /Save changes/ })[0];
     expect(submitButton).not.toBeDisabled();
     fireEvent.click(submitButton);
 
@@ -1235,7 +1264,7 @@ describe('ClassifyAlertPage done mode', () => {
   it('shows the changed dot on edited rows and counts changed lanes in the Save button', async () => {
     await renderAndSettle(<ClassifyAlertPage mode="done" />, { wrapper: makeDoneWrapper(101) });
 
-    expect(screen.getByRole('button', { name: /Save changes \(0\)/ })).toBeDisabled();
+    expect(screen.getAllByRole('button', { name: /Save changes \(0\)/ })[0]).toBeDisabled();
     expect(screen.queryByTestId('object-row-changed-101:0')).not.toBeInTheDocument();
 
     const cardA = within(screen.getByTestId('object-card-101:0'));
@@ -1243,6 +1272,6 @@ describe('ClassifyAlertPage done mode', () => {
 
     expect(screen.getByTestId('object-row-changed-101:0')).toBeInTheDocument();
     expect(screen.queryByTestId('object-row-changed-102:0')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Save changes \(1\)/ })).toBeEnabled();
+    expect(screen.getAllByRole('button', { name: /Save changes \(1\)/ })[0]).toBeEnabled();
   });
 });

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -963,6 +963,31 @@ describe('ClassifyAlertPage', () => {
     await waitFor(() => expect(navigateMock).toHaveBeenCalled(), { timeout: 2000 });
   });
 
+  it('Q toggles unsure on the active object, mutually exclusive with S', async () => {
+    await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+    fireEvent.keyDown(document, { key: 'q' });
+    const row = within(screen.getByTestId('object-card-101:0'));
+    expect(row.getByRole('radio', { name: 'Unsure' })).toBeChecked();
+
+    fireEvent.keyDown(document, { key: 's' });
+    expect(row.getByRole('radio', { name: 'Unsure' })).not.toBeChecked();
+    expect(row.getByRole('radio', { name: 'Smoke' })).toBeChecked();
+  });
+
+  it('classification shortcuts are inert while the missed-smoke section is active', async () => {
+    await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+    fireEvent.click(screen.getByTestId('missed-smoke-row'));
+    fireEvent.keyDown(document, { key: 'f' });
+
+    // Back to the object view: the active object was never classified.
+    fireEvent.click(screen.getByTestId('object-card-101:0'));
+    const row = within(screen.getByTestId('object-card-101:0'));
+    expect(row.getByRole('radio', { name: 'False positive' })).not.toBeChecked();
+    expect(row.getByText('Pending')).toBeInTheDocument();
+  });
+
   it('shows the FP type chips as a full inline wrap on the active row', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -963,6 +963,11 @@ describe('ClassifyAlertPage', () => {
     await waitFor(() => expect(navigateMock).toHaveBeenCalled(), { timeout: 2000 });
   });
 
+  it('focuses the active row on load so Tab cycles the rail immediately', async () => {
+    await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+    await waitFor(() => expect(screen.getByTestId('object-card-101:0')).toHaveFocus());
+  });
+
   it('U toggles unsure on the active object, mutually exclusive with S', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -1088,6 +1088,34 @@ describe('ClassifyAlertPage', () => {
     expect(row.getByText('Pending')).toBeInTheDocument();
   });
 
+  it('blocks re-submission during the post-submit window and invalidates the cached alert detail', async () => {
+    await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+    const cardA = openRow('101:0');
+    fireEvent.click(cardA.getByRole('radio', { name: 'Smoke' }));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Wildfire' }));
+    const cardB = openRow('102:0');
+    fireEvent.click(cardB.getByRole('radio', { name: 'False positive' }));
+    fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
+    fireEvent.click(missedSmokeChip('No'));
+
+    fireEvent.keyDown(document, { key: 'Enter' });
+    await waitFor(() => expect(apiClient.classifySubmit).toHaveBeenCalledTimes(1));
+
+    // Enter again inside the 1s auto-advance window must not re-submit the
+    // already-submitted lanes.
+    fireEvent.keyDown(document, { key: 'Enter' });
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(apiClient.classifySubmit).toHaveBeenCalledTimes(1);
+
+    // The success path invalidates the alert-detail cache (5-minute global
+    // staleTime would otherwise re-serve the PRE-submit lanes to
+    // /classify/done/:id) — the still-mounted query refetches.
+    await waitFor(() => expect(apiClient.getAlertDetail).toHaveBeenCalledTimes(2));
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled(), { timeout: 2000 });
+  });
+
   it('auto-advances to the next alert in the classify queue after submit when no table workflow is active', async () => {
     vi.mocked(apiClient.getClassifyQueue).mockResolvedValue({
       items: [

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -831,6 +831,41 @@ describe('ClassifyAlertPage', () => {
     );
   });
 
+  it("plays the alert's full frame union for the active object, including frames its own track has no box on", async () => {
+    // Same shape as the presence-strip fixture: lane 101 is captured on two
+    // frames (t1, t2) but its track only references detection 1 (t1) —
+    // the full-frame player must still play both frames.
+    const t1 = '2026-01-01T10:00:00Z';
+    const t2 = '2026-01-01T10:00:05Z';
+    vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (sequenceId: number) => {
+      const bySequence: Record<number, { id: number; recorded_at: string }[]> = {
+        101: [
+          { id: 1, recorded_at: t1 },
+          { id: 4, recorded_at: t2 },
+        ],
+        102: [{ id: 2, recorded_at: t1 }],
+        103: [{ id: 3, recorded_at: t1 }],
+      };
+      return bySequence[sequenceId].map(d => ({
+        id: d.id,
+        sequence_id: sequenceId,
+        alert_api_id: 9000 + sequenceId,
+        created_at: '2026-01-01T09:00:00Z',
+        recorded_at: d.recorded_at,
+        algo_predictions: { predictions: [] },
+        last_modified_at: null,
+      }));
+    });
+
+    await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+    // Union is [t1, t2] -> 2 frames handed to the player, though the active
+    // track only has 1 box.
+    await waitFor(() =>
+      expect(screen.getByTestId('full-image-sequence').getAttribute('data-bbox-count')).toBe('2')
+    );
+  });
+
   it('renders the presence strip in the rail column, below the objects and missed-smoke row — not in the media panel', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -877,6 +877,53 @@ describe('ClassifyAlertPage', () => {
       })
     );
   });
+
+  it('auto-activates the first editable object on load', async () => {
+    await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+    // Chips only render on the active row — their presence proves activation.
+    const row = within(screen.getByTestId('object-card-101:0'));
+    expect(row.getByRole('radio', { name: 'Smoke' })).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('object-card-102:0')).queryByRole('radio', { name: 'Smoke' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('clicking another row moves the chips and the media panel to it', async () => {
+    await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+    fireEvent.click(screen.getByTestId('object-card-102:0'));
+
+    expect(
+      within(screen.getByTestId('object-card-102:0')).getByRole('radio', { name: 'Smoke' })
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('object-card-101:0')).queryByRole('radio', { name: 'Smoke' })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/Cropped · Object 2/)).toBeInTheDocument();
+  });
+
+  it('activating the missed-smoke row swaps the media panel to the whole-alert player, and an object row swaps it back', async () => {
+    await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+    expect(screen.queryByTestId('sequence-reviewer')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('missed-smoke-row'));
+    expect(screen.getByTestId('sequence-reviewer')).toBeInTheDocument();
+    expect(screen.queryByTestId('cropped-image-sequence')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('object-card-101:0'));
+    expect(screen.queryByTestId('sequence-reviewer')).not.toBeInTheDocument();
+    expect(screen.getByTestId('cropped-image-sequence')).toBeInTheDocument();
+  });
+
+  it('shows the FP type chips as a full inline wrap on the active row', async () => {
+    await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+    const row = openRow('101:0');
+    fireEvent.click(row.getByRole('radio', { name: 'False positive' }));
+    // 18 FP type chips + the Unsure chip = 19 checkboxes on the row.
+    expect(row.getAllByRole('checkbox')).toHaveLength(19);
+  });
 });
 
 describe('ClassifyAlertPage done mode', () => {
@@ -1165,5 +1212,19 @@ describe('ClassifyAlertPage done mode', () => {
     // onError refetches alert-detail so lane 201 (already patched on the
     // server) redraws with server truth rather than staying on stale local state.
     await waitFor(() => expect(apiClient.getAlertDetail).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows the changed dot on edited rows and counts changed lanes in the Save button', async () => {
+    await renderAndSettle(<ClassifyAlertPage mode="done" />, { wrapper: makeDoneWrapper(101) });
+
+    expect(screen.getByRole('button', { name: /Save changes \(0\)/ })).toBeDisabled();
+    expect(screen.queryByTestId('object-row-changed-101:0')).not.toBeInTheDocument();
+
+    const cardA = within(screen.getByTestId('object-card-101:0'));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Industrial' }));
+
+    expect(screen.getByTestId('object-row-changed-101:0')).toBeInTheDocument();
+    expect(screen.queryByTestId('object-row-changed-102:0')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Save changes \(1\)/ })).toBeEnabled();
   });
 });

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -831,19 +831,18 @@ describe('ClassifyAlertPage', () => {
     );
   });
 
-  it('renders the presence strip inside the media panel, between the full-frame player and the cropped loop', async () => {
+  it('renders the presence strip in the rail column, below the objects and missed-smoke row — not in the media panel', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
-    const panel = screen.getByTestId('classify-media-panel');
     const strip = screen.getByTestId('object-presence-swatch-0');
-    expect(panel.contains(strip)).toBe(true);
+    expect(screen.getByTestId('classify-media-panel').contains(strip)).toBe(false);
 
-    const full = screen.getByTestId('full-image-sequence');
-    const cropped = screen.getByTestId('cropped-image-sequence');
     // DOCUMENT_POSITION_FOLLOWING: the compared node comes *after* the
-    // receiver in document order.
-    expect(full.compareDocumentPosition(strip) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(strip.compareDocumentPosition(cropped) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // receiver in document order — the strip follows the whole rail.
+    const missedSmokeRow = screen.getByTestId('missed-smoke-row');
+    expect(
+      missedSmokeRow.compareDocumentPosition(strip) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
   });
 
   it("clicking a presence-strip row scrolls to and activates that object's rail row", async () => {
@@ -914,6 +913,25 @@ describe('ClassifyAlertPage', () => {
     fireEvent.click(screen.getByTestId('object-card-101:0'));
     expect(screen.queryByTestId('sequence-reviewer')).not.toBeInTheDocument();
     expect(screen.getByTestId('cropped-image-sequence')).toBeInTheDocument();
+  });
+
+  it("keeps the timeline's highlighted row in sync with the active rail row", async () => {
+    await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+    // Object 1 auto-activates -> its timeline row is highlighted.
+    expect(screen.getByRole('button', { name: 'Go to Object 1' })).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+
+    fireEvent.click(screen.getByTestId('object-card-102:0'));
+    expect(screen.getByRole('button', { name: 'Go to Object 2' })).toHaveAttribute(
+      'aria-current',
+      'true'
+    );
+    expect(screen.getByRole('button', { name: 'Go to Object 1' })).not.toHaveAttribute(
+      'aria-current'
+    );
   });
 
   it('shows the FP type chips as a full inline wrap on the active row', async () => {

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -968,8 +968,8 @@ describe('ClassifyAlertPage', () => {
 
     const row = openRow('101:0');
     fireEvent.click(row.getByRole('radio', { name: 'False positive' }));
-    // 18 FP type chips + the Unsure chip = 19 checkboxes on the row.
-    expect(row.getAllByRole('checkbox')).toHaveLength(19);
+    // 18 FP type chips (Unsure is a radio in the exclusive group).
+    expect(row.getAllByRole('checkbox')).toHaveLength(18);
   });
 });
 

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -968,6 +968,56 @@ describe('ClassifyAlertPage', () => {
     await waitFor(() => expect(screen.getByTestId('object-card-101:0')).toHaveFocus());
   });
 
+  it('Tab cycles rows -> missed smoke and wraps both ways, never escaping the rail; the disabled submit is skipped until enabled', async () => {
+    await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+    await waitFor(() => expect(screen.getByTestId('object-card-101:0')).toHaveFocus());
+
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(screen.getByTestId('object-card-102:0')).toHaveFocus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(screen.getByTestId('object-card-103:0')).toHaveFocus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(screen.getByTestId('missed-smoke-row')).toHaveFocus();
+    // Submit is disabled (nothing classified) so the cycle wraps straight
+    // back to the first row instead of escaping the rail.
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(screen.getByTestId('object-card-101:0')).toHaveFocus();
+    // Backward from the first row wraps to the missed-smoke row.
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(screen.getByTestId('missed-smoke-row')).toHaveFocus();
+
+    // Classify everything — the now-enabled submit joins the cycle.
+    const cardA = openRow('101:0');
+    fireEvent.click(cardA.getByRole('radio', { name: 'Smoke' }));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Wildfire' }));
+    const cardB = openRow('102:0');
+    fireEvent.click(cardB.getByRole('radio', { name: 'False positive' }));
+    fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
+    fireEvent.click(missedSmokeChip('No'));
+
+    fireEvent.keyDown(document, { key: 'Tab' }); // 102 -> 103 (row 102 was last activated by openRow's click? focus is unchanged by clicks in jsdom)
+    fireEvent.keyDown(document, { key: 'Tab' });
+    fireEvent.keyDown(document, { key: 'Tab' });
+    // Wherever the cycle started, within four Tabs it must reach the
+    // enabled submit without ever leaving the rail.
+    fireEvent.keyDown(document, { key: 'Tab' });
+    const focusable = [
+      screen.getByTestId('object-card-101:0'),
+      screen.getByTestId('object-card-102:0'),
+      screen.getByTestId('object-card-103:0'),
+      screen.getByTestId('missed-smoke-row'),
+      screen.getByTestId('rail-submit'),
+    ];
+    expect(focusable).toContain(document.activeElement);
+    // Cycle a full loop: the enabled submit must be visited.
+    const visited = new Set<Element | null>();
+    for (let i = 0; i < 5; i += 1) {
+      visited.add(document.activeElement);
+      fireEvent.keyDown(document, { key: 'Tab' });
+    }
+    expect(visited.has(screen.getByTestId('rail-submit'))).toBe(true);
+  });
+
   it('U toggles unsure on the active object, mutually exclusive with S', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 


### PR DESCRIPTION
## Summary

Visual revamp of `/classify/:id` (queue) and `/classify/done/:id` (done): the stacked screen-tall object cards become a two-column **cockpit** so an alert is reviewable on one screen. Spec: `docs/specs/2026-08-04-classify-cockpit-revamp-design.md`.

- **Media column** — full-frame player for the active object over the alert's **frame union** (frames the object has no box on play box-less instead of being skipped), plus its cropped loop. Activating the missed-smoke row swaps to the whole-alert player (all overlays, embedded yes/no removed) with a **fullscreen toggle**.
- **Decision rail** — one slim row per object (color dot, stage badge, glanceable status chip), the active row expands to emoji-free chip controls (Smoke / False positive / Unsure, smoke types, full 18-type FP wrap), a Missed smoke Yes/No row, the object-timeline strip (axis removed, active-row highlight synced), and a mirrored Submit button.
- Submit semantics unchanged: queue mode keeps the atomic `classifySubmit`, done mode keeps per-lane diff PATCHes (button reads "Save changes (n)" with per-row changed dots).

## Interaction model

- **Keyboard**: S / F / 1-3 / FP letters / **U for Unsure** (Dust remapped to J), gated to the object section; Y/N for missed smoke; Enter submits (hint shown on the rail button); `?` for the shortcut modal.
- **Smoke / False positive / Unsure are mutually exclusive** — picking one clears the others, including stale done-mode seeds.
- **Tab / Shift+Tab cycle only the rail** (object rows → missed smoke → submit), wrap at the ends, skip the disabled submit, and start on the active row at load. The trap suspends while the shortcuts modal or group-propagation banner is up.
- **Mouse parity** throughout: rows click-activate, chips are comfortable targets, presence-strip rows jump to their object.
- Post-submit **auto-advance**: workflow next-alert as before, otherwise the next classify-queue alert; back to the list only when the queue is empty.

## Fixes along the way

- Post-submit staleness: the success path now invalidates the cached alert detail, so `/classify/done/:id` no longer shows the pre-submit lanes for up to the global 5-minute `staleTime`.
- Enter can no longer double-submit during the in-flight/auto-advance window; the advance timer is cancelled on unmount/alert switch.
- `FullImageSequence` effects are keyed by frame identity (fixes reload loops with per-render arrays; switching objects no longer refetches the shared union images).

## New/changed components

`src/components/classify/` — `ClassificationChips`, `ObjectRow`, `DecisionRail`, `ClassifyMediaPanel`, `status.ts`. `SequencePlayer`/`SequenceReviewer` gain optional `hideReviewControls`. `ObjectPresenceStrip` drops its axis and gains `activeIndex`. Legacy `ObjectCard`/`AnnotationInterface` untouched except the Dust J hint.

## Testing

- 808 tests green (`npm test`), `npm run quality` clean, production build clean.
- All 21 pre-existing `ClassifyAlertPage` behavior specs migrated to the new DOM (payload shapes, done-mode PATCH diffing/abort, missed-smoke carrier routing, group-warning refetch) + 13 new cockpit tests (activation, media swap, tab trap, exclusivity, auto-advance, re-submit guard) + new component suites.
- Manually verified against real data and via screenshot passes (1/3-object alerts, FP wrap, missed-smoke swap, narrow viewport).

## Follow-ups (not in this PR)

- Full roving-tabindex/radio a11y semantics for the chip groups (rows/groups are labeled; chips are keyboard-driven via letters for now).
- Cross-alert `others_bboxes` provenance — investigation filed as #262.
