### PR TITLE
Classify cockpit polish: decluttered player, single submit, stable square cropped view

### DIFF
--- a/docs/specs/2026-08-04-cropped-view-stable-square-design.md
+++ b/docs/specs/2026-08-04-cropped-view-stable-square-design.md
@@ -51,9 +51,11 @@ No variant prop; one behavior everywhere.
 
 ### Viewport & rendering
 
-- Fixed square viewport: responsive width capped at ~420px, centered,
-  `aspect-square`. The canvas is sized to the viewport once (DPR-aware) and
-  **never changes size with zoom** — the source rect changes instead.
+- Fixed square viewport: responsive width capped at `min(380px, 33vh)`
+  (amended 2026-08-04 from ~420px so the full frame + crop fit the viewport
+  together), centered, `aspect-square`. The canvas has a constant 840px
+  backing resolution (≥2× the CSS cap, covering hiDPI) and **never changes
+  size with zoom** — the source rect changes instead.
 - Image fetching, preloading, frame looping, and loading/error states are
   unchanged.
 

--- a/docs/specs/2026-08-04-cropped-view-stable-square-design.md
+++ b/docs/specs/2026-08-04-cropped-view-stable-square-design.md
@@ -42,7 +42,9 @@ No variant prop; one behavior everywhere.
 - **Zoom** divides the side: visible side = `defaultSide / zoom`.
   - `zoom = 1` is the default wide framing — the minimum, and the implicit
     "reset" state.
-  - Max zoom keeps the full bbox + small pad visible, capped at 8×.
+  - Max zoom is a flat 8× cap (amended 2026-08-04: the original
+    keep-bbox-visible ceiling ≈2.5× was too shallow for pixel-peeping —
+    zooming may crop into the bbox).
 - Geometry lives in a pure function in `frontend/src/utils/annotation/`
   (e.g. `computeSquareCrop(avgBbox, imageDims, zoom)` returning the source
   rect in normalized coordinates), unit-tested independently of the canvas.
@@ -68,8 +70,8 @@ No variant prop; one behavior everywhere.
 ## Testing
 
 - Unit tests for the geometry function: centering, edge clamping (shift not
-  shrink), default side, zoom bounds (min 1, bbox-visible max, 8× cap),
-  degenerate bboxes.
+  shrink), default side, zoom bounds (min 1, flat 8× cap), degenerate
+  bboxes.
 - Component tests updated: square viewport renders, zoom buttons clamp at
   both ends, no reset control present.
 - Existing consumer tests (`ClassifyMediaPanel`, page tests) keep passing —

--- a/docs/specs/2026-08-04-cropped-view-stable-square-design.md
+++ b/docs/specs/2026-08-04-cropped-view-stable-square-design.md
@@ -1,0 +1,83 @@
+# Cropped View: Stable Square Viewport — Design
+
+**Date:** 2026-08-04
+**Status:** Approved
+**Component:** `frontend/src/components/annotation/CroppedImageSequence.tsx`
+
+## Problem
+
+The cropped loop shown in each object section of the classify cockpit (and in
+the localize page's lane view) has three UX defects:
+
+1. **Too little context.** The crop is the track's average bbox plus 20%
+   padding — a tight, arbitrary-aspect sliver. Smoke is judged against its
+   surroundings (terrain, horizon, sky), which the crop mostly excludes.
+2. **Layout jumps.** The canvas element is sized `crop × zoom`, so changing
+   zoom resizes the element and pushes the controls below it around.
+3. **Control clutter.** A slider plus −/+/reset strip below the canvas for
+   what is essentially one gesture (zoom in/out).
+
+## Decision
+
+Rework `CroppedImageSequence` in place (all consumers inherit the change):
+
+- **Classify cockpit** (`ClassifyMediaPanel`) — the target.
+- **Localize page** (`DetectionSequenceAnnotatePage`) — has the same
+  layout-jump problem; inherits the fix deliberately.
+- Legacy `ObjectCard` / `AnnotationInterface` — unrouted, irrelevant.
+
+No variant prop; one behavior everywhere.
+
+## Design
+
+### Framing model
+
+- Keep the existing average-bbox computation over the track's `xyxyn` boxes.
+- The visible region is always a **square** centered on the bbox center:
+  - Default side: `max(bboxWidth, bboxHeight) × CONTEXT_FACTOR`, with
+    `CONTEXT_FACTOR = 3` (object occupies roughly a third of the window, so
+    surroundings dominate).
+  - Clamped inside the image by **shifting** the square (never shrinking),
+    and capped at the image's shorter dimension.
+- **Zoom** divides the side: visible side = `defaultSide / zoom`.
+  - `zoom = 1` is the default wide framing — the minimum, and the implicit
+    "reset" state.
+  - Max zoom keeps the full bbox + small pad visible, capped at 8×.
+- Geometry lives in a pure function in `frontend/src/utils/annotation/`
+  (e.g. `computeSquareCrop(avgBbox, imageDims, zoom)` returning the source
+  rect in normalized coordinates), unit-tested independently of the canvas.
+
+### Viewport & rendering
+
+- Fixed square viewport: responsive width capped at ~420px, centered,
+  `aspect-square`. The canvas is sized to the viewport once (DPR-aware) and
+  **never changes size with zoom** — the source rect changes instead.
+- Image fetching, preloading, frame looping, and loading/error states are
+  unchanged.
+
+### Controls
+
+- The below-canvas strip (−, slider, +, value, reset) is removed.
+- A corner pill overlays the viewport bottom-right: **− / current zoom / +**,
+  styled like the whole-alert player's overlay chrome.
+- **Scroll-wheel zoom** over the viewport (preventDefault while hovering so
+  the page doesn't scroll).
+- No reset control — min zoom is the default framing.
+- Zoom resets to 1× when the object (bboxes/sequence) changes, as today.
+
+## Testing
+
+- Unit tests for the geometry function: centering, edge clamping (shift not
+  shrink), default side, zoom bounds (min 1, bbox-visible max, 8× cap),
+  degenerate bboxes.
+- Component tests updated: square viewport renders, zoom buttons clamp at
+  both ends, no reset control present.
+- Existing consumer tests (`ClassifyMediaPanel`, page tests) keep passing —
+  the component mock boundary is unchanged.
+
+## Out of scope
+
+- Fullscreen for the cropped view (Option B) — revisit if inline size proves
+  insufficient in practice.
+- Any layout change of the object section (Option C).
+- Pan/drag inside the viewport.

--- a/frontend/src/components/annotation/CroppedImageSequence.tsx
+++ b/frontend/src/components/annotation/CroppedImageSequence.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Loader2, AlertCircle, Minus, Plus } from 'lucide-react';
 import { BoundingBox } from '@/types/api';
 import { apiClient } from '@/services/api';
-import { computeSquareCrop, maxSquareZoom, MIN_ZOOM } from '@/utils/annotation/squareCropUtils';
+import { computeSquareCrop, MAX_ZOOM, MIN_ZOOM } from '@/utils/annotation/squareCropUtils';
 
 /** Constant canvas backing resolution — CSS scales it; zoom never resizes the element. */
 const CANVAS_RES = 840;
@@ -182,17 +182,6 @@ export default function CroppedImageSequence({
     ctx.drawImage(img, crop.x, crop.y, crop.size, crop.size, 0, 0, CANVAS_RES, CANVAS_RES);
   }, [bboxes, currentIndex, images, zoomLevel]);
 
-  // Zoom range: the wide default framing (1x) up to bbox+pad, from the
-  // first loaded frame's dimensions (all frames of a sequence share them).
-  const loadedImage = images.find(img => img.loaded && img.imageElement)?.imageElement;
-  const maxZoom = loadedImage
-    ? maxSquareZoom(
-        calculateAverageBbox(bboxes),
-        loadedImage.naturalWidth,
-        loadedImage.naturalHeight
-      )
-    : MIN_ZOOM;
-
   // Wheel-zoom must preventDefault so the page doesn't scroll — React's
   // onWheel is passive, so attach the listener manually.
   useEffect(() => {
@@ -201,11 +190,11 @@ export default function CroppedImageSequence({
     const onWheel = (e: WheelEvent) => {
       e.preventDefault();
       const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
-      setZoomLevel(prev => Math.min(maxZoom, Math.max(MIN_ZOOM, prev * factor)));
+      setZoomLevel(prev => Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, prev * factor)));
     };
     el.addEventListener('wheel', onWheel, { passive: false });
     return () => el.removeEventListener('wheel', onWheel);
-  }, [maxZoom]);
+  }, []);
 
   // Redraw canvas when current index or zoom level changes
   useEffect(() => {
@@ -282,8 +271,8 @@ export default function CroppedImageSequence({
                 {zoomLevel.toFixed(1)}x
               </span>
               <button
-                onClick={() => setZoomLevel(prev => Math.min(maxZoom, prev + 0.5))}
-                disabled={zoomLevel >= maxZoom}
+                onClick={() => setZoomLevel(prev => Math.min(MAX_ZOOM, prev + 0.5))}
+                disabled={zoomLevel >= MAX_ZOOM}
                 title="Zoom in"
                 aria-label="Zoom in"
                 className="p-0.5 hover:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed"

--- a/frontend/src/components/annotation/CroppedImageSequence.tsx
+++ b/frontend/src/components/annotation/CroppedImageSequence.tsx
@@ -10,6 +10,8 @@ const CANVAS_RES = 840;
 interface CroppedImageSequenceProps {
   bboxes: BoundingBox[];
   sequenceId: number;
+  /** Ties the crop to its object: a thin viewport frame in the object's overlay color. */
+  accentColor?: string;
   className?: string;
 }
 
@@ -23,6 +25,7 @@ interface ImageData {
 export default function CroppedImageSequence({
   bboxes,
   sequenceId,
+  accentColor,
   className = '',
 }: CroppedImageSequenceProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -239,7 +242,10 @@ export default function CroppedImageSequence({
       <div
         ref={containerRef}
         data-testid="cropped-viewport"
-        className="relative mx-auto w-full max-w-[420px] aspect-square overflow-hidden bg-gray-900"
+        className={`relative mx-auto w-full max-w-[min(380px,33vh)] aspect-square overflow-hidden bg-gray-900 ${
+          accentColor ? 'border-2' : ''
+        }`}
+        style={accentColor ? { borderColor: accentColor } : undefined}
       >
         {showLoadingState && (
           <div className="absolute inset-0 flex items-center justify-center bg-gray-100 z-10">

--- a/frontend/src/components/annotation/CroppedImageSequence.tsx
+++ b/frontend/src/components/annotation/CroppedImageSequence.tsx
@@ -34,7 +34,10 @@ export default function CroppedImageSequence({
   const [error, setError] = useState<string | null>(null);
   const [zoomLevel, setZoomLevel] = useState(MIN_ZOOM); // 1x = wide default framing
 
-  const containerRef = useRef<HTMLDivElement>(null);
+  // Callback-ref state, not a plain ref: the viewport doesn't exist during
+  // the loading/error branches, so the wheel listener must (re)bind when
+  // the element actually mounts, not on component mount.
+  const [viewportEl, setViewportEl] = useState<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -176,8 +179,11 @@ export default function CroppedImageSequence({
       zoomLevel
     );
 
-    canvas.width = CANVAS_RES;
-    canvas.height = CANVAS_RES;
+    // Size once — reassigning width/height reallocates the buffer per draw.
+    if (canvas.width !== CANVAS_RES) {
+      canvas.width = CANVAS_RES;
+      canvas.height = CANVAS_RES;
+    }
     ctx.clearRect(0, 0, CANVAS_RES, CANVAS_RES);
     ctx.drawImage(img, crop.x, crop.y, crop.size, crop.size, 0, 0, CANVAS_RES, CANVAS_RES);
   }, [bboxes, currentIndex, images, zoomLevel]);
@@ -185,16 +191,15 @@ export default function CroppedImageSequence({
   // Wheel-zoom must preventDefault so the page doesn't scroll — React's
   // onWheel is passive, so attach the listener manually.
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
+    if (!viewportEl) return;
     const onWheel = (e: WheelEvent) => {
       e.preventDefault();
       const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
       setZoomLevel(prev => Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, prev * factor)));
     };
-    el.addEventListener('wheel', onWheel, { passive: false });
-    return () => el.removeEventListener('wheel', onWheel);
-  }, []);
+    viewportEl.addEventListener('wheel', onWheel, { passive: false });
+    return () => viewportEl.removeEventListener('wheel', onWheel);
+  }, [viewportEl]);
 
   // Redraw canvas when current index or zoom level changes
   useEffect(() => {
@@ -229,7 +234,7 @@ export default function CroppedImageSequence({
       {/* Fixed square viewport — the element never resizes; zoom changes the
           drawn source rect instead (see squareCropUtils). */}
       <div
-        ref={containerRef}
+        ref={setViewportEl}
         data-testid="cropped-viewport"
         className={`relative mx-auto w-full max-w-[min(380px,33vh)] aspect-square overflow-hidden bg-gray-900 ${
           accentColor ? 'border-2' : ''

--- a/frontend/src/components/annotation/CroppedImageSequence.tsx
+++ b/frontend/src/components/annotation/CroppedImageSequence.tsx
@@ -1,7 +1,11 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Loader2, AlertCircle, Minus, Plus, RotateCcw } from 'lucide-react';
+import { Loader2, AlertCircle, Minus, Plus } from 'lucide-react';
 import { BoundingBox } from '@/types/api';
 import { apiClient } from '@/services/api';
+import { computeSquareCrop, maxSquareZoom, MIN_ZOOM } from '@/utils/annotation/squareCropUtils';
+
+/** Constant canvas backing resolution — CSS scales it; zoom never resizes the element. */
+const CANVAS_RES = 840;
 
 interface CroppedImageSequenceProps {
   bboxes: BoundingBox[];
@@ -25,7 +29,7 @@ export default function CroppedImageSequence({
   const [images, setImages] = useState<ImageData[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [zoomLevel, setZoomLevel] = useState(4); // Default 4x zoom
+  const [zoomLevel, setZoomLevel] = useState(MIN_ZOOM); // 1x = wide default framing
 
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -50,7 +54,7 @@ export default function CroppedImageSequence({
     setCurrentIndex(0);
     setIsLoading(true);
     setError(null);
-    setZoomLevel(4); // Reset zoom to default
+    setZoomLevel(MIN_ZOOM); // Reset zoom to default
   }, [bboxes, sequenceId]);
 
   // Fetch detection image URLs
@@ -162,58 +166,43 @@ export default function CroppedImageSequence({
 
     const img = currentImage.imageElement;
 
-    // Calculate crop coordinates
-    const avgBbox = calculateAverageBbox(bboxes);
-    const [avgX1, avgY1, avgX2, avgY2] = avgBbox;
-
-    // 20% padding around the bbox to show surrounding context.
-    const padding = 0.2;
-    const padX = (avgX2 - avgX1) * padding;
-    const padY = (avgY2 - avgY1) * padding;
-
-    const cropX1 = Math.max(0, avgX1 - padX);
-    const cropY1 = Math.max(0, avgY1 - padY);
-    const cropX2 = Math.min(1, avgX2 + padX);
-    const cropY2 = Math.min(1, avgY2 + padY);
-
-    // Convert normalized coordinates to pixels
-    const imgWidth = img.naturalWidth;
-    const imgHeight = img.naturalHeight;
-
-    const sourceX = cropX1 * imgWidth;
-    const sourceY = cropY1 * imgHeight;
-    const sourceWidth = (cropX2 - cropX1) * imgWidth;
-    const sourceHeight = (cropY2 - cropY1) * imgHeight;
-
-    // Calculate maximum allowed zoom based on original image dimensions
-    const maxZoomX = imgWidth / sourceWidth;
-    const maxZoomY = imgHeight / sourceHeight;
-    const maxAllowedZoom = Math.min(maxZoomX, maxZoomY, 8); // Cap at 8x
-
-    // Use effective zoom (user's choice or maximum allowed)
-    const effectiveZoom = Math.min(zoomLevel, maxAllowedZoom);
-
-    // Set canvas size to cropped area × effective zoom
-    const canvasWidth = Math.round(sourceWidth * effectiveZoom);
-    const canvasHeight = Math.round(sourceHeight * effectiveZoom);
-
-    canvas.width = canvasWidth;
-    canvas.height = canvasHeight;
-
-    // Clear canvas and draw cropped image
-    ctx.clearRect(0, 0, canvasWidth, canvasHeight);
-    ctx.drawImage(
-      img,
-      sourceX,
-      sourceY,
-      sourceWidth,
-      sourceHeight, // source rectangle
-      0,
-      0,
-      canvasWidth,
-      canvasHeight // destination rectangle
+    const crop = computeSquareCrop(
+      calculateAverageBbox(bboxes),
+      img.naturalWidth,
+      img.naturalHeight,
+      zoomLevel
     );
+
+    canvas.width = CANVAS_RES;
+    canvas.height = CANVAS_RES;
+    ctx.clearRect(0, 0, CANVAS_RES, CANVAS_RES);
+    ctx.drawImage(img, crop.x, crop.y, crop.size, crop.size, 0, 0, CANVAS_RES, CANVAS_RES);
   }, [bboxes, currentIndex, images, zoomLevel]);
+
+  // Zoom range: the wide default framing (1x) up to bbox+pad, from the
+  // first loaded frame's dimensions (all frames of a sequence share them).
+  const loadedImage = images.find(img => img.loaded && img.imageElement)?.imageElement;
+  const maxZoom = loadedImage
+    ? maxSquareZoom(
+        calculateAverageBbox(bboxes),
+        loadedImage.naturalWidth,
+        loadedImage.naturalHeight
+      )
+    : MIN_ZOOM;
+
+  // Wheel-zoom must preventDefault so the page doesn't scroll — React's
+  // onWheel is passive, so attach the listener manually.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
+      setZoomLevel(prev => Math.min(maxZoom, Math.max(MIN_ZOOM, prev * factor)));
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [maxZoom]);
 
   // Redraw canvas when current index or zoom level changes
   useEffect(() => {
@@ -245,19 +234,13 @@ export default function CroppedImageSequence({
 
   return (
     <div className={className}>
-      {/* Cropped Image Container */}
+      {/* Fixed square viewport — the element never resizes; zoom changes the
+          drawn source rect instead (see squareCropUtils). */}
       <div
         ref={containerRef}
-        className="relative mx-auto overflow-hidden"
-        style={{
-          width: '900px',
-          maxWidth: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
+        data-testid="cropped-viewport"
+        className="relative mx-auto w-full max-w-[420px] aspect-square overflow-hidden bg-gray-900"
       >
-        {/* Loading State */}
         {showLoadingState && (
           <div className="absolute inset-0 flex items-center justify-center bg-gray-100 z-10">
             <div className="flex flex-col items-center space-y-3">
@@ -267,7 +250,6 @@ export default function CroppedImageSequence({
           </div>
         )}
 
-        {/* Error State */}
         {currentImage?.error && (
           <div className="absolute inset-0 flex items-center justify-center bg-gray-100 z-10">
             <div className="flex flex-col items-center space-y-2">
@@ -277,64 +259,35 @@ export default function CroppedImageSequence({
           </div>
         )}
 
-        {/* Cropped Canvas */}
         {currentImage?.loaded && currentImage.imageElement && (
-          <canvas
-            ref={canvasRef}
-            className="max-w-full h-auto"
-            style={{
-              display: 'block',
-              margin: '0 auto',
-            }}
-          />
+          <>
+            <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />
+            <div className="absolute bottom-2 right-2 z-20 flex items-center gap-1.5 rounded-full bg-black/55 px-2.5 py-1 text-white">
+              <button
+                onClick={() => setZoomLevel(prev => Math.max(MIN_ZOOM, prev - 0.5))}
+                disabled={zoomLevel <= MIN_ZOOM}
+                title="Zoom out"
+                aria-label="Zoom out"
+                className="p-0.5 hover:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <Minus className="w-3.5 h-3.5" />
+              </button>
+              <span className="font-data text-[11px] font-medium w-8 text-center">
+                {zoomLevel.toFixed(1)}x
+              </span>
+              <button
+                onClick={() => setZoomLevel(prev => Math.min(maxZoom, prev + 0.5))}
+                disabled={zoomLevel >= maxZoom}
+                title="Zoom in"
+                aria-label="Zoom in"
+                className="p-0.5 hover:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <Plus className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          </>
         )}
       </div>
-
-      {/* Zoom controls — compact strip matching the grid's ViewToolbar */}
-      {currentImage?.loaded && currentImage.imageElement && (
-        <div className="mt-2 flex items-center justify-center">
-          <div className="inline-flex items-center rounded-md bg-gray-200 p-0.5 gap-1">
-            <button
-              onClick={() => setZoomLevel(prev => Math.max(1, prev - 0.5))}
-              disabled={zoomLevel <= 1}
-              title="Zoom out"
-              aria-label="Zoom out"
-              className="px-1.5 py-0.5 rounded text-xs font-semibold text-gray-600 hover:text-gray-900 hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
-            >
-              <Minus className="w-3.5 h-3.5" />
-            </button>
-            <input
-              type="range"
-              min="1"
-              max="8"
-              step="0.5"
-              value={zoomLevel}
-              onChange={e => setZoomLevel(parseFloat(e.target.value))}
-              className="w-24 h-1.5 bg-gray-300 rounded-lg appearance-none cursor-pointer"
-            />
-            <button
-              onClick={() => setZoomLevel(prev => Math.min(8, prev + 0.5))}
-              disabled={zoomLevel >= 8}
-              title="Zoom in"
-              aria-label="Zoom in"
-              className="px-1.5 py-0.5 rounded text-xs font-semibold text-gray-600 hover:text-gray-900 hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
-            >
-              <Plus className="w-3.5 h-3.5" />
-            </button>
-            <span className="text-xs font-medium text-gray-700 w-8 text-center">
-              {zoomLevel.toFixed(1)}x
-            </span>
-            <button
-              onClick={() => setZoomLevel(4)}
-              title="Reset zoom"
-              aria-label="Reset zoom"
-              className="px-1.5 py-0.5 rounded text-xs text-gray-600 hover:text-gray-900 hover:bg-white"
-            >
-              <RotateCcw className="w-3.5 h-3.5" />
-            </button>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/classify/ClassifyMediaPanel.tsx
+++ b/frontend/src/components/classify/ClassifyMediaPanel.tsx
@@ -3,12 +3,12 @@
  * Detections section -> the active object's full-frame player (own box
  * solid, siblings dimmed) and the object's cropped loop. Sequence section
  * -> the primary lane's whole-alert player with every object's overlay,
- * review controls hidden (the decision rail owns yes/no), with a
- * fullscreen toggle for easier missed-smoke assessment.
+ * the player's embedded review controls hidden in favor of the guidance
+ * copy + Yes/No CTAs below the strip (mirroring the rail chips' state),
+ * with a fullscreen toggle for easier missed-smoke assessment.
  */
 
 import React, { useEffect, useRef, useState } from 'react';
-import { Maximize2, Minimize2 } from 'lucide-react';
 import { BoundingBox } from '@/types/api';
 import { ObjectOverlay } from '@/utils/annotation/objectColors';
 import FullImageSequence, { FullImageFrame } from '@/components/annotation/FullImageSequence';
@@ -34,6 +34,8 @@ export interface ClassifyMediaPanelProps {
   primarySequenceId: number;
   missedSmokeReview: 'yes' | 'no' | null;
   onMissedSmokeReviewChange: (review: 'yes' | 'no') => void;
+  /** Disables the Yes/No CTAs (e.g. no open lane to carry the flag) — mirrors the rail chips. */
+  missedSmokeDisabled?: boolean;
   annotationLoading: boolean;
   objectOverlays: ObjectOverlay[];
 }
@@ -47,6 +49,7 @@ export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
   primarySequenceId,
   missedSmokeReview,
   onMissedSmokeReviewChange,
+  missedSmokeDisabled = false,
   annotationLoading,
   objectOverlays,
 }) => {
@@ -62,6 +65,21 @@ export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
     return () => document.removeEventListener('fullscreenchange', onFullscreenChange);
   }, []);
 
+  // Browsers exit native fullscreen on Escape themselves, but the page's
+  // capture-phase key handlers also see the event — handle it explicitly so
+  // the exit is guaranteed and nothing else reacts to that Escape press.
+  useEffect(() => {
+    if (!isFullscreen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && document.fullscreenElement) {
+        e.stopPropagation();
+        void document.exitFullscreen?.();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [isFullscreen]);
+
   const toggleFullscreen = () => {
     if (document.fullscreenElement) {
       void document.exitFullscreen?.();
@@ -71,35 +89,17 @@ export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
   };
 
   return (
-    <div
-      data-testid="classify-media-panel"
-      className="rounded-card border border-line bg-paper px-[22px] py-5"
-    >
+    // No card chrome — the players are the panel, and every saved vertical
+    // pixel helps the object view (full frame + crop) fit without scrolling.
+    <div data-testid="classify-media-panel">
       {activeSection === 'sequence' ? (
         <div
           ref={sequenceViewRef}
           className={
-            isFullscreen ? 'flex h-full flex-col justify-center overflow-auto bg-char p-6' : ''
+            isFullscreen ? 'flex h-full flex-col justify-center overflow-hidden bg-char p-6' : ''
           }
         >
-          <div className="mb-3 flex items-center justify-between gap-2">
-            <div className={isFullscreen ? `${eyebrow} !text-paper` : eyebrow}>
-              Whole alert — watch for smoke the model missed
-            </div>
-            <button
-              type="button"
-              onClick={toggleFullscreen}
-              aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
-              title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen the player'}
-              className={`inline-flex items-center rounded-lg border p-1.5 transition-colors ${
-                isFullscreen
-                  ? 'border-paper/30 bg-transparent text-paper hover:bg-paper/10'
-                  : 'border-line bg-paper text-haze hover:bg-ash'
-              }`}
-            >
-              {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
-            </button>
-          </div>
+          {!isFullscreen && <div className={`mb-3 ${eyebrow}`}>Missed smoke review</div>}
           <SequenceReviewer
             sequenceId={primarySequenceId}
             missedSmokeReview={missedSmokeReview}
@@ -107,10 +107,72 @@ export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
             annotationLoading={annotationLoading}
             objectOverlays={objectOverlays}
             hideReviewControls
+            onToggleFullscreen={toggleFullscreen}
+            isFullscreen={isFullscreen}
           />
+          {!isFullscreen && (
+            <div className="mt-6 flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+              <p className="flex-1 min-w-[16rem] font-body text-sm text-haze">
+                Did the model miss any smoke? Every tracked object is boxed — watch the loop for
+                smoke without a box: faint plumes, rising columns, drifting haze.
+              </p>
+              <span
+                role="radiogroup"
+                aria-label="Missed smoke review"
+                className="flex flex-none items-center gap-2"
+              >
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={missedSmokeReview === 'yes'}
+                  disabled={missedSmokeDisabled}
+                  onClick={() => onMissedSmokeReviewChange('yes')}
+                  className={`inline-flex items-center gap-1.5 rounded-lg border px-4 py-2 font-body text-sm font-semibold transition-colors ${
+                    missedSmokeReview === 'yes'
+                      ? 'border-ember bg-ember-soft text-ember'
+                      : 'border-line bg-paper text-char hover:bg-ash'
+                  } ${missedSmokeDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                >
+                  Yes
+                  <kbd
+                    aria-hidden="true"
+                    className="px-1 py-0.5 rounded bg-ash font-data text-[10px] font-medium text-haze"
+                  >
+                    Y
+                  </kbd>
+                </button>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={missedSmokeReview === 'no'}
+                  disabled={missedSmokeDisabled}
+                  onClick={() => onMissedSmokeReviewChange('no')}
+                  className={`inline-flex items-center gap-1.5 rounded-lg border px-4 py-2 font-body text-sm font-semibold transition-colors ${
+                    missedSmokeReview === 'no'
+                      ? 'border-pine bg-pine text-white'
+                      : 'border-line bg-paper text-char hover:bg-ash'
+                  } ${missedSmokeDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                >
+                  No
+                  <kbd
+                    aria-hidden="true"
+                    className="px-1 py-0.5 rounded bg-ash font-data text-[10px] font-medium text-haze"
+                  >
+                    N
+                  </kbd>
+                </button>
+              </span>
+            </div>
+          )}
         </div>
       ) : activeObject ? (
-        <div className="space-y-4">
+        // Untitled on purpose: the active rail row already names the object,
+        // and the saved rows keep the crop above the fold.
+        <div
+          className="space-y-3"
+          data-testid="object-media"
+          data-object-label={activeObject.label}
+        >
           <FullImageSequence
             bboxes={activeObject.bboxes}
             sequenceId={activeObject.sequenceId}
@@ -118,13 +180,11 @@ export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
             siblingOverlays={activeObject.siblingOverlays}
             frameRecordedAt={activeObject.frameRecordedAt}
           />
-          <div>
-            <div className={`${eyebrow} mb-2`}>Cropped · {activeObject.label}</div>
-            <CroppedImageSequence
-              bboxes={activeObject.croppedBboxes}
-              sequenceId={activeObject.sequenceId}
-            />
-          </div>
+          <CroppedImageSequence
+            bboxes={activeObject.croppedBboxes}
+            sequenceId={activeObject.sequenceId}
+            accentColor={activeObject.color}
+          />
         </div>
       ) : loading ? (
         <div data-testid="media-panel-skeleton" className="space-y-4">

--- a/frontend/src/components/classify/ClassifyMediaPanel.tsx
+++ b/frontend/src/components/classify/ClassifyMediaPanel.tsx
@@ -63,14 +63,16 @@ export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
     return () => document.removeEventListener('fullscreenchange', onFullscreenChange);
   }, []);
 
-  // Browsers exit native fullscreen on Escape themselves, but the page's
-  // capture-phase key handlers also see the event — handle it explicitly so
-  // the exit is guaranteed and nothing else reacts to that Escape press.
+  // Browsers exit native fullscreen on Escape themselves; this handler
+  // makes the exit explicit. stopImmediatePropagation keeps other
+  // same-node capture listeners (the page's shortcut handlers) from also
+  // reacting — best-effort only, since it can't suppress listeners
+  // registered before this one.
   useEffect(() => {
     if (!isFullscreen) return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && document.fullscreenElement) {
-        e.stopPropagation();
+        e.stopImmediatePropagation();
         void document.exitFullscreen?.();
       }
     };
@@ -115,7 +117,7 @@ export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
               </p>
               <span
                 role="radiogroup"
-                aria-label="Missed smoke review"
+                aria-label="Missed smoke review (player)"
                 className="flex flex-none items-center gap-2"
               >
                 <button

--- a/frontend/src/components/classify/ClassifyMediaPanel.tsx
+++ b/frontend/src/components/classify/ClassifyMediaPanel.tsx
@@ -110,7 +110,7 @@ export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
             isFullscreen={isFullscreen}
           />
           {!isFullscreen && (
-            <div className="mt-6 flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+            <div className="mt-6 rounded-card border border-line bg-paper px-[18px] py-3.5 flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
               <p className="flex-1 min-w-[16rem] font-body text-sm text-haze">
                 Did the model miss any smoke? Every tracked object is boxed — watch the loop for
                 smoke without a box: faint plumes, rising columns, drifting haze.

--- a/frontend/src/components/classify/ClassifyMediaPanel.tsx
+++ b/frontend/src/components/classify/ClassifyMediaPanel.tsx
@@ -40,8 +40,6 @@ export interface ClassifyMediaPanelProps {
   objectOverlays: ObjectOverlay[];
 }
 
-const eyebrow = 'font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze';
-
 export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
   activeSection,
   activeObject,
@@ -99,7 +97,6 @@ export const ClassifyMediaPanel: React.FC<ClassifyMediaPanelProps> = ({
             isFullscreen ? 'flex h-full flex-col justify-center overflow-hidden bg-char p-6' : ''
           }
         >
-          {!isFullscreen && <div className={`mb-3 ${eyebrow}`}>Missed smoke review</div>}
           <SequenceReviewer
             sequenceId={primarySequenceId}
             missedSmokeReview={missedSmokeReview}

--- a/frontend/src/components/classify/ClassifyShortcutsModal.tsx
+++ b/frontend/src/components/classify/ClassifyShortcutsModal.tsx
@@ -1,0 +1,76 @@
+/**
+ * Keyboard shortcuts help for the classify cockpit. Static copy — the
+ * actual bindings live in utils/annotation/keyboardUtils (global keys) and
+ * ClassifyAlertPage's Tab focus cycle; keep this list in sync with them.
+ */
+
+import React from 'react';
+import { X } from 'lucide-react';
+
+const Key: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <kbd className="px-1.5 py-0.5 rounded border border-line bg-ash font-data text-[11px] font-medium text-char">
+    {children}
+  </kbd>
+);
+
+const Row: React.FC<{ label: string; keys: string[] }> = ({ label, keys }) => (
+  <div className="flex items-center justify-between gap-4 py-1">
+    <span className="font-body text-sm text-char">{label}</span>
+    <span className="flex flex-none items-center gap-1">
+      {keys.map(k => (
+        <Key key={k}>{k}</Key>
+      ))}
+    </span>
+  </div>
+);
+
+const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
+  <div>
+    <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze mb-1.5">
+      {title}
+    </div>
+    {children}
+  </div>
+);
+
+export interface ClassifyShortcutsModalProps {
+  onClose: () => void;
+}
+
+export const ClassifyShortcutsModal: React.FC<ClassifyShortcutsModalProps> = ({ onClose }) => (
+  <div className="fixed inset-0 bg-char/50 flex items-center justify-center z-50" onClick={onClose}>
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      className="bg-paper border border-line rounded-card w-full max-w-md max-h-[90vh] overflow-y-auto m-4"
+      onClick={e => e.stopPropagation()}
+    >
+      <div className="flex items-center justify-between px-6 py-4 border-b border-line">
+        <h2 className="font-display text-heading font-semibold text-char">Keyboard shortcuts</h2>
+        <button onClick={onClose} aria-label="Close" className="p-2 hover:bg-ash rounded-md">
+          <X className="w-5 h-5 text-haze" />
+        </button>
+      </div>
+      <div className="px-6 py-5 space-y-5">
+        <Section title="Navigate">
+          <Row label="Cycle objects → missed smoke → submit" keys={['Tab', 'Shift + Tab']} />
+        </Section>
+        <Section title="Classify the active object">
+          <Row label="Smoke / false positive" keys={['S', 'F']} />
+          <Row label="Smoke type — wildfire / industrial / other" keys={['1', '2', '3']} />
+          <Row label="False-positive type — letter shown on each chip" keys={['A', '…']} />
+          <Row label="Toggle unsure" keys={['U']} />
+        </Section>
+        <Section title="Missed smoke">
+          <Row label="Yes / no" keys={['Y', 'N']} />
+        </Section>
+        <Section title="Alert">
+          <Row label="Submit" keys={['Enter']} />
+          <Row label="Reset to last saved state" keys={['Ctrl + Z']} />
+          <Row label="Toggle this help" keys={['?']} />
+        </Section>
+      </div>
+    </div>
+  </div>
+);

--- a/frontend/src/components/classify/DecisionRail.tsx
+++ b/frontend/src/components/classify/DecisionRail.tsx
@@ -19,6 +19,8 @@ export interface DecisionRailProps {
   /** Disables Yes/No (e.g. no open lane to carry the flag). */
   missedSmokeDisabled?: boolean;
   missedSmokeRowRef?: React.RefObject<HTMLDivElement>;
+  /** Rendered top-right of the Objects header (e.g. the keyboard-shortcuts button). */
+  headerAction?: React.ReactNode;
   /** Rendered after the missed-smoke row — the page passes its rail-level Submit button here. */
   footer?: React.ReactNode;
   /** Object rows / placeholders, already ordered. */
@@ -37,12 +39,16 @@ export const DecisionRail: React.FC<DecisionRailProps> = ({
   onMissedSmokeActivate,
   missedSmokeDisabled = false,
   missedSmokeRowRef,
+  headerAction,
   footer,
   children,
 }) => (
   <div className="rounded-card border border-line bg-paper px-[22px] py-5">
-    <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze mb-3">
-      Objects
+    <div className="mb-3 flex items-center justify-between">
+      <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
+        Objects
+      </div>
+      {headerAction}
     </div>
     <div className="space-y-2">{children}</div>
 

--- a/frontend/src/components/classify/DecisionRail.tsx
+++ b/frontend/src/components/classify/DecisionRail.tsx
@@ -28,7 +28,7 @@ export interface DecisionRailProps {
 }
 
 const chip = (selected: boolean, selectedClasses: string, disabled: boolean) =>
-  `inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 font-body text-xs font-medium transition-colors ${
+  `inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 font-body text-xs font-medium transition-colors ${
     selected ? selectedClasses : 'border-line bg-paper text-char hover:bg-ash'
   } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`;
 

--- a/frontend/src/components/classify/index.ts
+++ b/frontend/src/components/classify/index.ts
@@ -8,3 +8,5 @@ export { DecisionRail } from './DecisionRail';
 export type { DecisionRailProps } from './DecisionRail';
 export { ClassifyMediaPanel } from './ClassifyMediaPanel';
 export type { ClassifyMediaPanelProps } from './ClassifyMediaPanel';
+export { ClassifyShortcutsModal } from './ClassifyShortcutsModal';
+export type { ClassifyShortcutsModalProps } from './ClassifyShortcutsModal';

--- a/frontend/src/components/sequence/SequencePlayer.tsx
+++ b/frontend/src/components/sequence/SequencePlayer.tsx
@@ -8,9 +8,8 @@ import {
   Pause,
   SkipBack,
   SkipForward,
-  RotateCcw,
-  Clock,
-  CheckCircle,
+  Maximize2,
+  Minimize2,
 } from 'lucide-react';
 import { Detection, AlgoPrediction } from '@/types/api';
 import { useImagePreloader } from '@/hooks/useImagePreloader';
@@ -33,9 +32,11 @@ interface SequencePlayerProps {
   onPause: () => void;
   onSeek: (index: number) => void;
   onSpeedChange: (speed: number) => void;
-  onReset: () => void;
   /** Hide the embedded "Did the model miss any smoke?" overlay — used by the classify cockpit, where the decision rail owns the yes/no controls. */
   hideReviewControls?: boolean;
+  /** When set, a fullscreen toggle renders in the control strip (the owner fullscreens its own container). */
+  onToggleFullscreen?: () => void;
+  isFullscreen?: boolean;
   className?: string;
 }
 
@@ -53,9 +54,10 @@ export default function SequencePlayer({
   onPause,
   onSeek,
   onSpeedChange,
-  onReset,
   objectOverlays,
   hideReviewControls = false,
+  onToggleFullscreen,
+  isFullscreen = false,
   className = '',
 }: SequencePlayerProps) {
   const [imageInfo, setImageInfo] = useState<{
@@ -168,11 +170,11 @@ export default function SequencePlayer({
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [isPlaying, currentIndex, detections.length, onPlay, onPause, onSeek]);
 
-  // Player controls utility functions
-  const formatTime = (index: number) => {
-    const minutes = Math.floor(index / 60);
-    const seconds = index % 60;
-    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  // Local time in an ISO-like layout, easy to scan across frames.
+  const formatRecordedAt = (iso: string) => {
+    const d = new Date(iso);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
   };
 
   const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -360,25 +362,8 @@ export default function SequencePlayer({
   const showLoadingState = !currentImage?.loaded;
   const hasError = currentImage?.error;
 
-  const isCompleted = missedSmokeReview !== null;
-
   return (
-    <div
-      className={`relative rounded-lg overflow-hidden transition-all duration-200 ${
-        isCompleted
-          ? 'border-4 border-green-500 bg-green-50 hover:border-green-600 hover:bg-green-100'
-          : 'border-4 border-orange-400 bg-orange-50 hover:border-orange-500 hover:bg-orange-100 animate-pulse-subtle'
-      } ${className}`}
-    >
-      {/* Status Badge Overlay */}
-      <div
-        className={`absolute top-3 right-3 px-2 py-1 rounded-full text-xs font-semibold backdrop-blur-sm z-30 ${
-          isCompleted ? 'bg-green-600/90 text-white' : 'bg-orange-500/90 text-white'
-        }`}
-      >
-        {isCompleted ? 'Reviewed' : 'Pending'}
-      </div>
-
+    <div className={`relative overflow-hidden ${className}`}>
       {/* Preload Progress Bar (only visible during initial load) */}
       {isInitialLoading && preloadProgress.percentage < 100 && (
         <div className="bg-gray-50 px-4 py-2 border-b border-gray-200">
@@ -439,7 +424,7 @@ export default function SequencePlayer({
             <img
               ref={imgRef}
               src={currentImage.url}
-              alt={`Detection ${currentIndex + 1} of ${detections.length}`}
+              alt={`Frame ${currentIndex + 1} of ${detections.length}`}
               className="max-w-full max-h-full object-contain"
               style={{
                 opacity: showLoadingState && !isLoopingBack.current ? 0 : 1,
@@ -449,10 +434,13 @@ export default function SequencePlayer({
               onLoad={handleImageLoad}
             />
 
-            {/* Bounding Boxes Overlay */}
+            {/* Bounding Boxes Overlay. The object-track overlays are derived
+                from the raw algo predictions at import, so when they are
+                shown the red prediction boxes would duplicate them exactly —
+                render one or the other. */}
             {imageInfo && !showLoadingState && (
               <div className="absolute inset-0 pointer-events-none z-20">
-                {renderBoundingBoxes()}
+                {(!objectOverlays || objectOverlays.length === 0) && renderBoundingBoxes()}
                 {showSiblingBboxes && renderSiblingBoxes()}
                 {renderObjectOverlays()}
               </div>
@@ -465,13 +453,10 @@ export default function SequencePlayer({
           <div className="space-y-3 text-white">
             {/* Row 1 - Detection Info & Missed Smoke Review */}
             <div className="flex items-end justify-between">
-              {/* Left - Detection Info */}
+              {/* Left - frame timestamp (the control strip already counts frames) */}
               <div className="flex-1">
-                <p className="text-sm font-medium">
-                  Detection {currentIndex + 1} of {detections.length}
-                </p>
-                <p className="text-xs opacity-90">
-                  {new Date(currentDetection.recorded_at).toLocaleString()}
+                <p className="text-sm font-medium font-mono">
+                  {formatRecordedAt(currentDetection.recorded_at)}
                 </p>
               </div>
 
@@ -527,10 +512,16 @@ export default function SequencePlayer({
               <div className="flex-1 flex items-center justify-end space-x-3">
                 <div className="flex items-center space-x-2">
                   <Eye className="w-4 h-4" />
-                  <span className="text-xs">
-                    {currentDetection.algo_predictions?.predictions?.length || 0} prediction
-                    {currentDetection.algo_predictions?.predictions?.length !== 1 ? 's' : ''}
-                  </span>
+                  {objectOverlays && objectOverlays.length > 0 ? (
+                    <span className="text-xs">
+                      {objectOverlays.length} object{objectOverlays.length !== 1 ? 's' : ''}
+                    </span>
+                  ) : (
+                    <span className="text-xs">
+                      {currentDetection.algo_predictions?.predictions?.length || 0} prediction
+                      {currentDetection.algo_predictions?.predictions?.length !== 1 ? 's' : ''}
+                    </span>
+                  )}
                 </div>
                 {(currentDetection.others_bboxes?.predictions?.length || 0) > 0 && (
                   <label className="flex items-center cursor-pointer hover:bg-white/10 px-2 py-1 rounded transition-colors">
@@ -582,10 +573,6 @@ export default function SequencePlayer({
 
               {/* Progress Slider */}
               <div className="flex-1 flex items-center space-x-3">
-                <span className="text-xs text-white/80 font-mono min-w-[3rem]">
-                  {formatTime(currentIndex)}
-                </span>
-
                 <div className="flex-1 relative">
                   <input
                     ref={sliderRef}
@@ -602,10 +589,6 @@ export default function SequencePlayer({
                     }}
                   />
                 </div>
-
-                <span className="text-xs text-white/80 font-mono min-w-[3rem]">
-                  {formatTime(detections.length - 1)}
-                </span>
               </div>
 
               {/* Frame Counter */}
@@ -631,43 +614,22 @@ export default function SequencePlayer({
                 </select>
               </div>
 
-              {/* Reset Button */}
-              <button
-                onClick={onReset}
-                className="flex-shrink-0 p-2 text-white hover:text-gray-300 border border-white/30 rounded-md hover:bg-white/10"
-                title="Reset to beginning"
-              >
-                <RotateCcw className="w-4 h-4" />
-              </button>
+              {/* Fullscreen Toggle */}
+              {onToggleFullscreen && (
+                <button
+                  onClick={onToggleFullscreen}
+                  className="flex-shrink-0 p-2 text-white hover:text-gray-300 border border-white/30 rounded-md hover:bg-white/10"
+                  title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen the player'}
+                  aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+                >
+                  {isFullscreen ? (
+                    <Minimize2 className="w-4 h-4" />
+                  ) : (
+                    <Maximize2 className="w-4 h-4" />
+                  )}
+                </button>
+              )}
             </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Enhanced Status Bar */}
-      <div
-        className={`px-3 py-2 ${
-          isCompleted
-            ? 'bg-green-100 border-t border-green-300'
-            : 'bg-orange-100 border-t border-orange-300'
-        }`}
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-2">
-            {isCompleted ? (
-              <>
-                <CheckCircle className="w-5 h-5 text-green-600" />
-                <span className="text-sm font-medium text-green-700">Completed</span>
-              </>
-            ) : (
-              <>
-                <Clock className="w-5 h-5 text-orange-600 animate-pulse" />
-                <span className="text-sm font-medium text-orange-700">Needs Review</span>
-              </>
-            )}
-          </div>
-          <div className="text-xs text-gray-600">
-            Missed smoke review: {isCompleted ? 'Complete' : 'Pending'}
           </div>
         </div>
       </div>

--- a/frontend/src/components/sequence/SequencePlayer.tsx
+++ b/frontend/src/components/sequence/SequencePlayer.tsx
@@ -362,6 +362,10 @@ export default function SequencePlayer({
   const showLoadingState = !currentImage?.loaded;
   const hasError = currentImage?.error;
 
+  // With object-track overlays present (the classify whole-alert view), the
+  // raw prediction and sibling layers would only duplicate them.
+  const hasObjectOverlays = !!objectOverlays && objectOverlays.length > 0;
+
   return (
     <div className={`relative overflow-hidden ${className}`}>
       {/* Preload Progress Bar (only visible during initial load) */}
@@ -435,13 +439,14 @@ export default function SequencePlayer({
             />
 
             {/* Bounding Boxes Overlay. The object-track overlays are derived
-                from the raw algo predictions at import, so when they are
-                shown the red prediction boxes would duplicate them exactly —
-                render one or the other. */}
+                from the raw algo predictions at import, and sibling boxes
+                are just the other objects' predictions — with overlays
+                present both layers would duplicate them exactly, so the
+                overlays render alone. */}
             {imageInfo && !showLoadingState && (
               <div className="absolute inset-0 pointer-events-none z-20">
-                {(!objectOverlays || objectOverlays.length === 0) && renderBoundingBoxes()}
-                {showSiblingBboxes && renderSiblingBoxes()}
+                {!hasObjectOverlays && renderBoundingBoxes()}
+                {!hasObjectOverlays && showSiblingBboxes && renderSiblingBoxes()}
                 {renderObjectOverlays()}
               </div>
             )}
@@ -512,9 +517,9 @@ export default function SequencePlayer({
               <div className="flex-1 flex items-center justify-end space-x-3">
                 <div className="flex items-center space-x-2">
                   <Eye className="w-4 h-4" />
-                  {objectOverlays && objectOverlays.length > 0 ? (
+                  {hasObjectOverlays ? (
                     <span className="text-xs">
-                      {objectOverlays.length} object{objectOverlays.length !== 1 ? 's' : ''}
+                      {objectOverlays!.length} object{objectOverlays!.length !== 1 ? 's' : ''}
                     </span>
                   ) : (
                     <span className="text-xs">
@@ -523,20 +528,21 @@ export default function SequencePlayer({
                     </span>
                   )}
                 </div>
-                {(currentDetection.others_bboxes?.predictions?.length || 0) > 0 && (
-                  <label className="flex items-center cursor-pointer hover:bg-white/10 px-2 py-1 rounded transition-colors">
-                    <input
-                      type="checkbox"
-                      checked={showSiblingBboxes}
-                      onChange={e => setShowSiblingBboxes(e.target.checked)}
-                      className="w-3.5 h-3.5 mr-2 accent-gray-300"
-                    />
-                    <span className="text-xs">
-                      {currentDetection.others_bboxes?.predictions?.length} sibling
-                      {(currentDetection.others_bboxes?.predictions?.length || 0) > 1 ? 's' : ''}
-                    </span>
-                  </label>
-                )}
+                {!hasObjectOverlays &&
+                  (currentDetection.others_bboxes?.predictions?.length || 0) > 0 && (
+                    <label className="flex items-center cursor-pointer hover:bg-white/10 px-2 py-1 rounded transition-colors">
+                      <input
+                        type="checkbox"
+                        checked={showSiblingBboxes}
+                        onChange={e => setShowSiblingBboxes(e.target.checked)}
+                        className="w-3.5 h-3.5 mr-2 accent-gray-300"
+                      />
+                      <span className="text-xs">
+                        {currentDetection.others_bboxes?.predictions?.length} sibling
+                        {(currentDetection.others_bboxes?.predictions?.length || 0) > 1 ? 's' : ''}
+                      </span>
+                    </label>
+                  )}
               </div>
             </div>
 

--- a/frontend/src/components/sequence/SequenceReviewer.tsx
+++ b/frontend/src/components/sequence/SequenceReviewer.tsx
@@ -15,6 +15,9 @@ interface SequenceReviewerProps {
   objectOverlays?: ObjectOverlay[];
   /** Hide the player's embedded "Did the model miss any smoke?" overlay — used by the classify cockpit, where the decision rail owns the yes/no controls. */
   hideReviewControls?: boolean;
+  /** Forwarded to the player's control strip — see SequencePlayer. */
+  onToggleFullscreen?: () => void;
+  isFullscreen?: boolean;
 }
 
 export default function SequenceReviewer({
@@ -25,6 +28,8 @@ export default function SequenceReviewer({
   className = '',
   objectOverlays,
   hideReviewControls,
+  onToggleFullscreen,
+  isFullscreen,
 }: SequenceReviewerProps) {
   // Playback state
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -115,11 +120,6 @@ export default function SequenceReviewer({
     setPlaybackSpeed(speed);
   };
 
-  const handleReset = () => {
-    setIsPlaying(false);
-    setCurrentIndex(0);
-  };
-
   if (isLoading || annotationLoading) {
     return (
       <div className={`bg-white border border-gray-200 rounded-lg p-8 ${className}`}>
@@ -183,9 +183,10 @@ export default function SequenceReviewer({
         onPause={handlePause}
         onSeek={handleSeek}
         onSpeedChange={handleSpeedChange}
-        onReset={handleReset}
         objectOverlays={objectOverlays}
         hideReviewControls={hideReviewControls}
+        onToggleFullscreen={onToggleFullscreen}
+        isFullscreen={isFullscreen}
       />
     </div>
   );

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -838,7 +838,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
   // Keyboard shortcuts over the flattened card list.
   useEffect(() => {
     const handleKeyDown = createKeyboardHandler({
-      // Classification shortcuts (S/F, types, Q) only apply while the
+      // Classification shortcuts (S/F, types, U) only apply while the
       // object section is active — a null index makes them inert when the
       // missed-smoke section is selected.
       activeDetectionIndex: activeSection === 'detections' ? activeIndex : null,

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -1130,8 +1130,11 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
 
                 const { card } = item;
                 const lane = alertDetail.lanes.find(l => l.sequence.id === card.laneSequenceId)!;
+                // Queue mode's locked rows explain themselves via the stage
+                // label; done mode's rows are all re-editable, so the label
+                // (Awaiting localization / Fully annotated) is just noise.
                 const stageBadge =
-                  card.locked || mode === 'done'
+                  card.locked && mode !== 'done'
                     ? getProcessingStageLabel(lane.annotation!.processing_stage)
                     : undefined;
                 const overlay = cardOverlayData.find(o => o.cardKey === card.cardKey);

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -20,7 +20,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, ChevronLeft, ChevronRight, Keyboard, Upload, X } from 'lucide-react';
+import { ArrowLeft, ChevronLeft, ChevronRight, Keyboard, Upload } from 'lucide-react';
 import { apiClient } from '@/services/api';
 import { QUERY_KEYS } from '@/utils/constants';
 import {
@@ -36,14 +36,15 @@ import { useSequenceStore } from '@/store/useSequenceStore';
 import { hasUserAnnotations, getInitialMissedSmokeReview } from '@/utils/annotation/sequenceUtils';
 import { determineClassifySubmitStage } from '@/utils/annotation/localizeUtils';
 import { createKeyboardHandler } from '@/utils/annotation/keyboardUtils';
-import {
-  createPreviousDetectionNavigator,
-  createNextDetectionNavigator,
-} from '@/utils/annotation/navigationUtils';
 import { getObjectColor, ObjectOverlay } from '@/utils/annotation/objectColors';
 import { getProcessingStageLabel } from '@/utils/processingStage';
 import { CardClassification, ObjectPresenceStrip } from '@/components/sequence-annotation';
-import { ClassifyMediaPanel, DecisionRail, ObjectRow } from '@/components/classify';
+import {
+  ClassifyMediaPanel,
+  ClassifyShortcutsModal,
+  DecisionRail,
+  ObjectRow,
+} from '@/components/classify';
 import { NotificationSystem } from '@/components/ui/NotificationSystem';
 import { useToastNotifications } from '@/utils/notification/toastUtils';
 import { ROUTES, classifyDetail, classifyGroup } from '@/utils/routes';
@@ -440,11 +441,13 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     });
   });
 
+  // Only consumed by the whole-alert (missed smoke) player, where every
+  // object matters equally — all full-strength, no active-card dimming.
   const playerObjectOverlays: ObjectOverlay[] = cardOverlayData.map(o => ({
     color: o.color,
     label: o.label,
     boxesByRecordedAt: o.boxesByRecordedAt,
-    isActive: o.cardKey === activeCardKey,
+    isActive: true,
   }));
 
   // The media panel always shows the active object's players (the panel
@@ -571,28 +574,6 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
   cards.forEach((c, i) => {
     adapterClassification[i] = primaryClassification[c.cardKey] ?? 'unselected';
   });
-  const detectionRefsAdapter = { current: cards.map(c => cardRefs.current[c.cardKey] ?? null) };
-
-  const navigateToPreviousDetection = createPreviousDetectionNavigator(
-    { activeDetectionIndex: activeIndex, activeSection, bboxes: adapterBboxes, showKeyboardModal },
-    {
-      setActiveDetectionIndex: index =>
-        setActiveCardKey(index === null ? null : (cards[index]?.cardKey ?? null)),
-      setActiveSection,
-    },
-    { detectionRefs: detectionRefsAdapter, sequenceReviewerRef }
-  );
-
-  const navigateToNextDetection = createNextDetectionNavigator(
-    { activeDetectionIndex: activeIndex, activeSection, bboxes: adapterBboxes, showKeyboardModal },
-    {
-      setActiveDetectionIndex: index =>
-        setActiveCardKey(index === null ? null : (cards[index]?.cardKey ?? null)),
-      setActiveSection,
-    },
-    { detectionRefs: detectionRefsAdapter, sequenceReviewerRef }
-  );
-
   const handleBboxChangeAdapter = (index: number, updatedBbox: SequenceBbox) => {
     const card = cards[index];
     if (card) handleBboxChangeByCardKey(card.cardKey, updatedBbox);
@@ -661,11 +642,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     editableCards.length > 0 &&
     (mode === 'done' ? isComplete && anyLaneChanged : isComplete && missedSmokeReview !== null);
 
-  // Shared by the header submit and its rail-footer mirror.
-  const submitLabel =
-    mode === 'done'
-      ? `Save changes (${changedLaneCount})`
-      : `Submit alert (${editableCards.length} objects)`;
+  const submitLabel = mode === 'done' ? `Save changes (${changedLaneCount})` : 'Submit';
   const submitTitle = mode === 'done' ? 'Save changes (Enter)' : 'Submit alert (Enter)';
 
   const submitMutation = useMutation({
@@ -863,8 +840,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     const handleKeyDown = createKeyboardHandler({
       // Classification shortcuts (S/F, types, Q) only apply while the
       // object section is active — a null index makes them inert when the
-      // missed-smoke section is selected. The navigators keep their own
-      // (ungated) state, so ArrowUp still leaves the sequence section.
+      // missed-smoke section is selected.
       activeDetectionIndex: activeSection === 'detections' ? activeIndex : null,
       bboxes: adapterBboxes,
       showKeyboardModal,
@@ -873,8 +849,6 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
       setShowKeyboardModal,
       handleReset,
       handleSave: handleSubmit,
-      navigateToPreviousDetection,
-      navigateToNextDetection,
       handleMissedSmokeReviewChange,
       handleBboxChange: handleBboxChangeAdapter,
       onPrimaryClassificationChange: handlePrimaryClassificationChangeAdapter,
@@ -1039,28 +1013,6 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
                 </button>
               </>
             )}
-
-            <button
-              onClick={handleSubmit}
-              disabled={!canSubmit || submitMutation.isPending}
-              className="inline-flex items-center rounded-lg bg-ember px-4 py-2 font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
-              title={submitTitle}
-            >
-              {submitMutation.isPending ? (
-                <div className="w-3.5 h-3.5 mr-1.5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
-              ) : (
-                <Upload className="w-3.5 h-3.5 mr-1.5" />
-              )}
-              {submitLabel}
-            </button>
-
-            <button
-              onClick={() => setShowKeyboardModal(true)}
-              className="p-2 rounded-lg border border-line bg-paper text-haze hover:bg-ash"
-              title="Show keyboard shortcuts (?)"
-            >
-              <Keyboard className="w-4 h-4" />
-            </button>
           </div>
         </div>
       </div>
@@ -1099,11 +1051,12 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
         )}
 
         {/* Cockpit: media column (the active thing) + decision rail (the
-            whole alert's state). Desktop pins both columns to the viewport
-            below the fixed header and scrolls each internally; below lg
-            they stack in natural flow. */}
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:h-[calc(100vh-7rem)]">
-          <div className="lg:flex-[1.5] lg:min-w-0 lg:overflow-y-auto lg:h-full">
+            whole alert's state). The media column flows with the page (one
+            window-edge scrollbar, no nested one inside the card); the rail
+            sticks below the fixed header on desktop, scrolling internally
+            only if it outgrows the viewport. Below lg they stack. */}
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+          <div className="lg:flex-[1.5] lg:min-w-0">
             <ClassifyMediaPanel
               activeSection={activeSection}
               activeObject={activeMediaObject}
@@ -1111,11 +1064,12 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
               primarySequenceId={primaryLane.sequence.id}
               missedSmokeReview={missedSmokeReview}
               onMissedSmokeReviewChange={handleMissedSmokeReviewChange}
+              missedSmokeDisabled={missedSmokeCarrierLaneId === undefined}
               annotationLoading={isLoading}
               objectOverlays={playerObjectOverlays}
             />
           </div>
-          <div className="lg:flex-1 lg:min-w-0 lg:overflow-y-auto lg:h-full">
+          <div className="lg:flex-1 lg:min-w-0 lg:sticky lg:top-20 lg:max-h-[calc(100vh-6rem)] lg:overflow-y-auto">
             <DecisionRail
               missedSmokeReview={missedSmokeReview}
               onMissedSmokeReviewChange={handleMissedSmokeReviewChange}
@@ -1123,13 +1077,22 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
               onMissedSmokeActivate={() => setActiveSection('sequence')}
               missedSmokeDisabled={missedSmokeCarrierLaneId === undefined}
               missedSmokeRowRef={sequenceReviewerRef}
+              headerAction={
+                <button
+                  onClick={() => setShowKeyboardModal(true)}
+                  className="p-1.5 rounded-lg border border-line bg-paper text-haze hover:bg-ash"
+                  title="Show keyboard shortcuts (?)"
+                >
+                  <Keyboard className="w-4 h-4" />
+                </button>
+              }
               footer={
                 <button
                   ref={railSubmitRef}
                   onClick={handleSubmit}
                   disabled={!canSubmit || submitMutation.isPending}
                   data-testid="rail-submit"
-                  className="w-full inline-flex items-center justify-center rounded-lg bg-ember px-4 py-2.5 font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="mx-auto flex items-center justify-center rounded-lg bg-pine px-5 py-2.5 font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
                   title={submitTitle}
                 >
                   {submitMutation.isPending ? (
@@ -1235,51 +1198,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
         />
 
         {showKeyboardModal && (
-          <div className="fixed inset-0 bg-char/50 flex items-center justify-center z-50">
-            <div className="bg-paper border border-line rounded-lg max-w-2xl max-h-[90vh] overflow-y-auto m-4">
-              <div className="flex items-center justify-between p-6 border-b border-line">
-                <h2 className="font-display text-heading font-semibold text-char">
-                  Keyboard Shortcuts
-                </h2>
-                <button
-                  onClick={() => setShowKeyboardModal(false)}
-                  className="p-2 hover:bg-ash rounded-md"
-                >
-                  <X className="w-5 h-5 text-haze" />
-                </button>
-              </div>
-              <div className="p-6 space-y-3">
-                <div className="flex items-center justify-between">
-                  <span className="font-body text-sm text-char">Previous / next object</span>
-                  <span className="font-data text-detail text-haze">↑ / ↓</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="font-body text-sm text-char">
-                    Mark active object as smoke / false positive
-                  </span>
-                  <span className="font-data text-detail text-haze">S / F</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="font-body text-sm text-char">
-                    Smoke type (wildfire / industrial / other)
-                  </span>
-                  <span className="font-data text-detail text-haze">1 / 2 / 3</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="font-body text-sm text-char">Mark active object as unsure</span>
-                  <span className="font-data text-detail text-haze">U</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="font-body text-sm text-char">Missed smoke yes / no</span>
-                  <span className="font-data text-detail text-haze">Y / N</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="font-body text-sm text-char">Submit alert</span>
-                  <span className="font-data text-detail text-haze">Enter</span>
-                </div>
-              </div>
-            </div>
-          </div>
+          <ClassifyShortcutsModal onClose={() => setShowKeyboardModal(false)} />
         )}
       </div>
     </>

--- a/frontend/src/utils/annotation/keyboardUtils.ts
+++ b/frontend/src/utils/annotation/keyboardUtils.ts
@@ -44,10 +44,10 @@ export interface KeyboardHandlerDependencies {
   handleReset: () => void;
   /** Function to save current annotation */
   handleSave: () => void;
-  /** Function to navigate to previous detection */
-  navigateToPreviousDetection: () => void;
-  /** Function to navigate to next detection */
-  navigateToNextDetection: () => void;
+  /** Unused — Arrow Up/Down navigation was removed (Tab owns navigation); kept optional so legacy AnnotationInterface still type-checks until its removal. */
+  navigateToPreviousDetection?: () => void;
+  /** Unused — see navigateToPreviousDetection. */
+  navigateToNextDetection?: () => void;
   /** Function to handle missed smoke review changes */
   handleMissedSmokeReviewChange: MissedSmokeHandler;
   /** Function to handle bbox changes */
@@ -90,7 +90,6 @@ export interface KeyboardHandlerDependencies {
  * - Escape: Close modal
  * - Ctrl+Z: Reset annotation
  * - Enter: Save annotation
- * - Arrow Up/Down: Navigate between detections
  * - Y/N: Missed smoke review
  * - S: Mark as smoke
  * - F: Mark as false positive
@@ -108,8 +107,6 @@ export const createKeyboardHandler = (deps: KeyboardHandlerDependencies) => {
       setShowKeyboardModal,
       handleReset,
       handleSave,
-      navigateToPreviousDetection,
-      navigateToNextDetection,
       handleMissedSmokeReviewChange,
       handleBboxChange,
       onPrimaryClassificationChange,
@@ -146,19 +143,6 @@ export const createKeyboardHandler = (deps: KeyboardHandlerDependencies) => {
       } else {
         handleSave(); // Use the same error logic as handleSave
       }
-      e.preventDefault();
-      return;
-    }
-
-    // Navigation shortcuts (Arrow Up/Down)
-    if (e.key === 'ArrowUp' && !showKeyboardModal) {
-      navigateToPreviousDetection();
-      e.preventDefault();
-      return;
-    }
-
-    if (e.key === 'ArrowDown' && !showKeyboardModal) {
-      navigateToNextDetection();
       e.preventDefault();
       return;
     }

--- a/frontend/src/utils/annotation/squareCropUtils.ts
+++ b/frontend/src/utils/annotation/squareCropUtils.ts
@@ -1,0 +1,73 @@
+/**
+ * Square crop geometry for CroppedImageSequence's stable viewport.
+ *
+ * The visible region is always a square (in image pixels) centered on the
+ * track's average bbox. Zoom divides the default side; the square is
+ * clamped inside the frame by shifting, never shrinking. See
+ * docs/specs/2026-08-04-cropped-view-stable-square-design.md.
+ */
+
+/** Object occupies ~1/CONTEXT_FACTOR of the window at default framing. */
+export const CONTEXT_FACTOR = 3;
+export const MIN_ZOOM = 1;
+export const MAX_ZOOM = 8;
+/** Pad factor kept around the bbox at max zoom. */
+const BBOX_PAD = 1.2;
+
+export interface SquareCrop {
+  /** Top-left corner and side length, in image pixels. */
+  x: number;
+  y: number;
+  size: number;
+}
+
+const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
+
+const bboxSidePx = (
+  bbox: [number, number, number, number],
+  imgWidth: number,
+  imgHeight: number
+): number => {
+  const w = (bbox[2] - bbox[0]) * imgWidth;
+  const h = (bbox[3] - bbox[1]) * imgHeight;
+  return Math.max(w, h);
+};
+
+const defaultSidePx = (
+  bbox: [number, number, number, number],
+  imgWidth: number,
+  imgHeight: number
+): number => {
+  const side = bboxSidePx(bbox, imgWidth, imgHeight) * CONTEXT_FACTOR;
+  const shortDim = Math.min(imgWidth, imgHeight);
+  // Degenerate (zero-size) bboxes fall back to the whole short side.
+  return side > 0 ? Math.min(side, shortDim) : shortDim;
+};
+
+export function maxSquareZoom(
+  bbox: [number, number, number, number],
+  imgWidth: number,
+  imgHeight: number
+): number {
+  const bboxSide = bboxSidePx(bbox, imgWidth, imgHeight);
+  if (bboxSide <= 0) return MAX_ZOOM;
+  const zoomAtPad = defaultSidePx(bbox, imgWidth, imgHeight) / (bboxSide * BBOX_PAD);
+  return clamp(zoomAtPad, MIN_ZOOM, MAX_ZOOM);
+}
+
+export function computeSquareCrop(
+  bbox: [number, number, number, number],
+  imgWidth: number,
+  imgHeight: number,
+  zoom: number
+): SquareCrop {
+  const effectiveZoom = clamp(zoom, MIN_ZOOM, maxSquareZoom(bbox, imgWidth, imgHeight));
+  const size = defaultSidePx(bbox, imgWidth, imgHeight) / effectiveZoom;
+  const cx = ((bbox[0] + bbox[2]) / 2) * imgWidth;
+  const cy = ((bbox[1] + bbox[3]) / 2) * imgHeight;
+  return {
+    x: clamp(cx - size / 2, 0, imgWidth - size),
+    y: clamp(cy - size / 2, 0, imgHeight - size),
+    size,
+  };
+}

--- a/frontend/src/utils/annotation/squareCropUtils.ts
+++ b/frontend/src/utils/annotation/squareCropUtils.ts
@@ -11,8 +11,6 @@
 export const CONTEXT_FACTOR = 3;
 export const MIN_ZOOM = 1;
 export const MAX_ZOOM = 8;
-/** Pad factor kept around the bbox at max zoom. */
-const BBOX_PAD = 1.2;
 
 export interface SquareCrop {
   /** Top-left corner and side length, in image pixels. */
@@ -44,24 +42,13 @@ const defaultSidePx = (
   return side > 0 ? Math.min(side, shortDim) : shortDim;
 };
 
-export function maxSquareZoom(
-  bbox: [number, number, number, number],
-  imgWidth: number,
-  imgHeight: number
-): number {
-  const bboxSide = bboxSidePx(bbox, imgWidth, imgHeight);
-  if (bboxSide <= 0) return MAX_ZOOM;
-  const zoomAtPad = defaultSidePx(bbox, imgWidth, imgHeight) / (bboxSide * BBOX_PAD);
-  return clamp(zoomAtPad, MIN_ZOOM, MAX_ZOOM);
-}
-
 export function computeSquareCrop(
   bbox: [number, number, number, number],
   imgWidth: number,
   imgHeight: number,
   zoom: number
 ): SquareCrop {
-  const effectiveZoom = clamp(zoom, MIN_ZOOM, maxSquareZoom(bbox, imgWidth, imgHeight));
+  const effectiveZoom = clamp(zoom, MIN_ZOOM, MAX_ZOOM);
   const size = defaultSidePx(bbox, imgWidth, imgHeight) / effectiveZoom;
   const cx = ((bbox[0] + bbox[2]) / 2) * imgWidth;
   const cy = ((bbox[1] + bbox[3]) / 2) * imgHeight;

--- a/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
+++ b/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
@@ -61,10 +61,10 @@ describe('CroppedImageSequence', () => {
     expect(screen.getByText('1.0x')).toBeInTheDocument();
     expect(screen.getByLabelText('Zoom out')).toBeDisabled();
 
-    // bbox 128px in 1280x720: default side 384, max zoom 384 / 153.6 = 2.5.
+    // Zoom runs to the flat MAX_ZOOM cap (8x), 0.5 per click from 1.0.
     const zoomIn = screen.getByLabelText('Zoom in');
-    for (let i = 0; i < 10; i++) fireEvent.click(zoomIn);
-    expect(screen.getByText('2.5x')).toBeInTheDocument();
+    for (let i = 0; i < 20; i++) fireEvent.click(zoomIn);
+    expect(screen.getByText('8.0x')).toBeInTheDocument();
     expect(zoomIn).toBeDisabled();
   });
 });

--- a/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
+++ b/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CroppedImageSequence from '@/components/annotation/CroppedImageSequence';
+import { BoundingBox } from '@/types/api';
+
+vi.mock('@/services/api', () => ({
+  apiClient: {
+    getDetectionImageUrl: vi.fn().mockResolvedValue({ url: 'http://img.test/1.jpg' }),
+  },
+}));
+
+// jsdom has no canvas 2D context — stub what drawToCanvas touches.
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue({
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+  }) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+
+  // Images "load" instantly with fixed dimensions.
+  class InstantImage {
+    naturalWidth = 1280;
+    naturalHeight = 720;
+    onload: null | (() => void) = null;
+    onerror: null | (() => void) = null;
+    set src(_v: string) {
+      queueMicrotask(() => this.onload?.());
+    }
+  }
+  vi.stubGlobal('Image', InstantImage as unknown as typeof Image);
+});
+
+// 128px-wide bbox in a 1280x720 frame, centered — maxSquareZoom is 2.5.
+const BBOXES: BoundingBox[] = [
+  { detection_id: 1, xyxyn: [0.45, 0.45, 0.55, 0.55] },
+  { detection_id: 2, xyxyn: [0.45, 0.45, 0.55, 0.55] },
+];
+
+async function renderLoaded() {
+  render(<CroppedImageSequence bboxes={BBOXES} sequenceId={9} />);
+  await waitFor(() => expect(screen.getByLabelText('Zoom in')).toBeInTheDocument());
+}
+
+describe('CroppedImageSequence', () => {
+  it('renders a fixed square viewport with corner zoom controls and no reset', async () => {
+    await renderLoaded();
+    expect(screen.getByTestId('cropped-viewport').className).toContain('aspect-square');
+    expect(screen.getByLabelText('Zoom out')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Reset zoom')).not.toBeInTheDocument();
+    expect(screen.queryByRole('slider')).not.toBeInTheDocument();
+  });
+
+  it('starts at 1.0x with zoom-out disabled, and clamps zoom-in at the max', async () => {
+    await renderLoaded();
+    expect(screen.getByText('1.0x')).toBeInTheDocument();
+    expect(screen.getByLabelText('Zoom out')).toBeDisabled();
+
+    // bbox 128px in 1280x720: default side 384, max zoom 384 / 153.6 = 2.5.
+    const zoomIn = screen.getByLabelText('Zoom in');
+    for (let i = 0; i < 10; i++) fireEvent.click(zoomIn);
+    expect(screen.getByText('2.5x')).toBeInTheDocument();
+    expect(zoomIn).toBeDisabled();
+  });
+});

--- a/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
+++ b/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
@@ -48,6 +48,15 @@ describe('CroppedImageSequence', () => {
     expect(screen.queryByRole('slider')).not.toBeInTheDocument();
   });
 
+  it('wheel-zooms over the viewport even though it mounts after loading', async () => {
+    // The viewport div does not exist during the loading state — the wheel
+    // listener must bind when it appears (callback-ref state), not on mount.
+    await renderLoaded();
+    expect(screen.getByText('1.0x')).toBeInTheDocument();
+    fireEvent.wheel(screen.getByTestId('cropped-viewport'), { deltaY: -100 });
+    expect(screen.getByText('1.1x')).toBeInTheDocument();
+  });
+
   it('frames the viewport in the object accent color when given', async () => {
     render(<CroppedImageSequence bboxes={BBOXES} sequenceId={9} accentColor="#E4572E" />);
     await waitFor(() => expect(screen.getByLabelText('Zoom in')).toBeInTheDocument());

--- a/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
+++ b/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
@@ -48,6 +48,14 @@ describe('CroppedImageSequence', () => {
     expect(screen.queryByRole('slider')).not.toBeInTheDocument();
   });
 
+  it('frames the viewport in the object accent color when given', async () => {
+    render(<CroppedImageSequence bboxes={BBOXES} sequenceId={9} accentColor="#E4572E" />);
+    await waitFor(() => expect(screen.getByLabelText('Zoom in')).toBeInTheDocument());
+    const viewport = screen.getByTestId('cropped-viewport');
+    expect(viewport.className).toContain('border-2');
+    expect(viewport.style.borderColor).toBe('rgb(228, 87, 46)');
+  });
+
   it('starts at 1.0x with zoom-out disabled, and clamps zoom-in at the max', async () => {
     await renderLoaded();
     expect(screen.getByText('1.0x')).toBeInTheDocument();

--- a/frontend/tests/components/classify/ClassifyMediaPanel.test.tsx
+++ b/frontend/tests/components/classify/ClassifyMediaPanel.test.tsx
@@ -47,7 +47,7 @@ describe('ClassifyMediaPanel', () => {
     expect(screen.queryByTestId('sequence-reviewer')).not.toBeInTheDocument();
   });
 
-  it('renders the whole-alert reviewer (without its own yes/no) in sequence mode', () => {
+  it('renders the whole-alert reviewer (player-embedded yes/no hidden) in sequence mode', () => {
     render(
       <ClassifyMediaPanel {...baseProps} activeSection="sequence" activeObject={activeObject} />
     );
@@ -81,5 +81,78 @@ describe('ClassifyMediaPanel', () => {
       <ClassifyMediaPanel {...baseProps} activeSection="detections" activeObject={activeObject} />
     );
     expect(screen.queryAllByRole('button', { name: 'Enter fullscreen' })).toHaveLength(1);
+  });
+
+  it('answers missed smoke through the panel CTAs, mirroring state and disabled', () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <ClassifyMediaPanel
+        {...baseProps}
+        activeSection="sequence"
+        activeObject={activeObject}
+        onMissedSmokeReviewChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getByRole('radio', { name: /^Yes/ }));
+    expect(onChange).toHaveBeenCalledWith('yes');
+    fireEvent.click(screen.getByRole('radio', { name: /^No/ }));
+    expect(onChange).toHaveBeenCalledWith('no');
+
+    rerender(
+      <ClassifyMediaPanel
+        {...baseProps}
+        activeSection="sequence"
+        activeObject={activeObject}
+        onMissedSmokeReviewChange={onChange}
+        missedSmokeReview="no"
+      />
+    );
+    expect(screen.getByRole('radio', { name: /^No/ })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: /^Yes/ })).toHaveAttribute('aria-checked', 'false');
+
+    onChange.mockClear();
+    rerender(
+      <ClassifyMediaPanel
+        {...baseProps}
+        activeSection="sequence"
+        activeObject={activeObject}
+        onMissedSmokeReviewChange={onChange}
+        missedSmokeDisabled
+      />
+    );
+    expect(screen.getByRole('radio', { name: /^Yes/ })).toBeDisabled();
+    fireEvent.click(screen.getByRole('radio', { name: /^Yes/ }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('hides the guidance copy and CTAs in fullscreen, and Escape exits fullscreen', () => {
+    let fullscreenEl: Element | null = null;
+    HTMLElement.prototype.requestFullscreen = vi.fn(function (this: HTMLElement) {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      fullscreenEl = this;
+      return Promise.resolve();
+    });
+    document.exitFullscreen = vi.fn(() => {
+      fullscreenEl = null;
+      return Promise.resolve();
+    });
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenEl,
+    });
+
+    render(
+      <ClassifyMediaPanel {...baseProps} activeSection="sequence" activeObject={activeObject} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Enter fullscreen' }));
+    fireEvent(document, new Event('fullscreenchange'));
+
+    expect(screen.queryByRole('radio', { name: /^Yes/ })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Did the model miss any smoke/)).not.toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(document.exitFullscreen).toHaveBeenCalled();
+    fireEvent(document, new Event('fullscreenchange'));
+    expect(screen.getByRole('radio', { name: /^Yes/ })).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/classify/ClassifyMediaPanel.test.tsx
+++ b/frontend/tests/components/classify/ClassifyMediaPanel.test.tsx
@@ -9,8 +9,12 @@ vi.mock('@/components/annotation/CroppedImageSequence', () => ({
   default: () => <div data-testid="cropped-image-sequence" />,
 }));
 vi.mock('@/components/sequence/SequenceReviewer', () => ({
-  default: (props: { hideReviewControls?: boolean }) => (
-    <div data-testid="sequence-reviewer" data-hide-controls={String(props.hideReviewControls)} />
+  default: (props: { hideReviewControls?: boolean; onToggleFullscreen?: () => void }) => (
+    <div data-testid="sequence-reviewer" data-hide-controls={String(props.hideReviewControls)}>
+      {props.onToggleFullscreen && (
+        <button aria-label="Enter fullscreen" onClick={props.onToggleFullscreen} />
+      )}
+    </div>
   ),
 }));
 
@@ -39,7 +43,7 @@ describe('ClassifyMediaPanel', () => {
     );
     expect(screen.getByTestId('full-image-sequence')).toBeInTheDocument();
     expect(screen.getByTestId('cropped-image-sequence')).toBeInTheDocument();
-    expect(screen.getByText(/Cropped · Object 1/)).toBeInTheDocument();
+    expect(screen.getByTestId('object-media').getAttribute('data-object-label')).toBe('Object 1');
     expect(screen.queryByTestId('sequence-reviewer')).not.toBeInTheDocument();
   });
 
@@ -64,7 +68,7 @@ describe('ClassifyMediaPanel', () => {
     expect(screen.queryByText('No objects to review yet')).not.toBeInTheDocument();
   });
 
-  it('offers a fullscreen toggle in sequence mode and requests fullscreen on click', () => {
+  it('forwards a fullscreen toggle to the reviewer in sequence mode and requests fullscreen on invoke', () => {
     const requestSpy = vi.fn().mockResolvedValue(undefined);
     HTMLElement.prototype.requestFullscreen = requestSpy;
     render(

--- a/frontend/tests/components/sequence/SequencePlayer.overlays.test.tsx
+++ b/frontend/tests/components/sequence/SequencePlayer.overlays.test.tsx
@@ -59,7 +59,7 @@ function renderPlayer(objectOverlays: ObjectOverlay[], currentIndex = 0) {
   );
   // jsdom never fires a real image load; drive handleImageLoad manually so
   // imageInfo is populated and the overlay layer renders.
-  fireEvent.load(screen.getByAltText(/Detection/));
+  fireEvent.load(screen.getByAltText(/Frame/));
 }
 
 describe('SequencePlayer object overlays', () => {

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -1310,12 +1310,13 @@ describe('ClassifyAlertPage done mode', () => {
 
     const cardA = within(screen.getByTestId('object-card-101:0')); // seq_annotation_done, entry-activated
     expect(cardA.getByText('Smoke · Wildfire')).toBeInTheDocument();
-    expect(cardA.getByText('Awaiting localization')).toBeInTheDocument(); // stage badge stays visible
+    // Done-mode rows are all re-editable, so no stage badge noise.
+    expect(cardA.queryByText('Awaiting localization')).not.toBeInTheDocument();
     expect(cardA.getByRole('radio', { name: 'Smoke' })).not.toBeDisabled();
     expect(cardA.getByRole('radio', { name: 'Smoke' })).toBeChecked();
 
     const cardB = openRow('102:0'); // annotated — still editable in done mode
-    expect(cardB.getByText('Fully annotated')).toBeInTheDocument();
+    expect(cardB.queryByText('Fully annotated')).not.toBeInTheDocument();
     expect(cardB.getByRole('radio', { name: 'False positive' })).not.toBeDisabled();
     expect(cardB.getByRole('radio', { name: 'False positive' })).toBeChecked();
 

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -304,7 +304,7 @@ describe('ClassifyAlertPage', () => {
   it('disables submit until every editable row is classified and missed smoke is answered', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
-    const submitButton = screen.getAllByRole('button', { name: /Submit alert/i })[0];
+    const submitButton = screen.getAllByRole('button', { name: /^Submit$/i })[0];
     expect(submitButton).toBeDisabled();
 
     // Classify object 1 as smoke + wildfire
@@ -370,7 +370,7 @@ describe('ClassifyAlertPage', () => {
     // Even after answering missed smoke, submit stays disabled — the
     // placeholder track alone doesn't count as classified.
     fireEvent.click(missedSmokeChip('No'));
-    expect(screen.getAllByRole('button', { name: /Submit alert/i })[0]).toBeDisabled();
+    expect(screen.getAllByRole('button', { name: /^Submit$/i })[0]).toBeDisabled();
   });
 
   it('still pre-fills a genuinely labeled track (e.g. group inheritance) that carries a real smoke_type', async () => {
@@ -406,7 +406,7 @@ describe('ClassifyAlertPage', () => {
     expect(card.getByText('Smoke · Wildfire')).toBeInTheDocument();
 
     fireEvent.click(missedSmokeChip('No'));
-    expect(screen.getAllByRole('button', { name: /Submit alert/i })[0]).not.toBeDisabled();
+    expect(screen.getAllByRole('button', { name: /^Submit$/i })[0]).not.toBeDisabled();
   });
 
   it('submits with per-lane stages: FP-only lane annotated, smoke lane seq_annotation_done, primary carries has_missed_smoke', async () => {
@@ -422,7 +422,7 @@ describe('ClassifyAlertPage', () => {
 
     fireEvent.click(missedSmokeChip('Yes'));
 
-    const submitButton = screen.getAllByRole('button', { name: /Submit alert/i })[0];
+    const submitButton = screen.getAllByRole('button', { name: /^Submit$/i })[0];
     expect(submitButton).not.toBeDisabled();
     fireEvent.click(submitButton);
 
@@ -507,7 +507,7 @@ describe('ClassifyAlertPage', () => {
 
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
-    expect(screen.getAllByRole('button', { name: /Submit alert/i })[0]).toBeDisabled();
+    expect(screen.getAllByRole('button', { name: /^Submit$/i })[0]).toBeDisabled();
   });
 
   it('routes alert-level missed smoke to the first still-open lane when the primary lane is already locked', async () => {
@@ -559,7 +559,7 @@ describe('ClassifyAlertPage', () => {
 
     fireEvent.click(missedSmokeChip('Yes'));
 
-    const submitButton = screen.getAllByRole('button', { name: /Submit alert/i })[0];
+    const submitButton = screen.getAllByRole('button', { name: /^Submit$/i })[0];
     expect(submitButton).not.toBeDisabled();
     fireEvent.click(submitButton);
 
@@ -586,7 +586,7 @@ describe('ClassifyAlertPage', () => {
     fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
 
     fireEvent.click(missedSmokeChip('No'));
-    fireEvent.click(screen.getAllByRole('button', { name: /Submit alert/i })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: /^Submit$/i })[0]);
 
     await waitFor(() => expect(apiClient.classifySubmit).toHaveBeenCalledTimes(1));
     // No active workflow in this test (annotationWorkflow defaults to null
@@ -614,7 +614,7 @@ describe('ClassifyAlertPage', () => {
     fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
 
     fireEvent.click(missedSmokeChip('No'));
-    fireEvent.click(screen.getAllByRole('button', { name: /Submit alert/i })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: /^Submit$/i })[0]);
 
     await waitFor(() =>
       expect(screen.getByText(/Submit failed: Lane 103 is locked/)).toBeInTheDocument()
@@ -699,7 +699,7 @@ describe('ClassifyAlertPage', () => {
     fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
 
     fireEvent.click(missedSmokeChip('No'));
-    fireEvent.click(screen.getAllByRole('button', { name: /Submit alert/i })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: /^Submit$/i })[0]);
 
     await waitFor(() => expect(screen.getByText(/Group propagation skipped/)).toBeInTheDocument());
 
@@ -943,7 +943,7 @@ describe('ClassifyAlertPage', () => {
     expect(
       within(screen.getByTestId('object-card-101:0')).queryByRole('radio', { name: 'Smoke' })
     ).not.toBeInTheDocument();
-    expect(screen.getByText(/Cropped · Object 2/)).toBeInTheDocument();
+    expect(screen.getByTestId('object-media').getAttribute('data-object-label')).toBe('Object 2');
   });
 
   it('activating the missed-smoke row swaps the media panel to the whole-alert player, and an object row swaps it back', async () => {
@@ -1148,7 +1148,7 @@ describe('ClassifyAlertPage', () => {
     fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
     fireEvent.click(missedSmokeChip('No'));
 
-    fireEvent.click(screen.getAllByRole('button', { name: /Submit alert/i })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: /^Submit$/i })[0]);
     await waitFor(() => expect(apiClient.classifySubmit).toHaveBeenCalledTimes(1));
 
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/classify/555'), {

--- a/frontend/tests/utils/annotation/integration/annotationWorkflow.test.ts
+++ b/frontend/tests/utils/annotation/integration/annotationWorkflow.test.ts
@@ -221,18 +221,16 @@ describe('Annotation Workflow Integration', () => {
       expect(result[0].smoke_type).toBe('wildfire');
     });
 
-    it('should handle navigation shortcuts', () => {
+    it('ignores Arrow Up/Down (navigation is Tab-based now)', () => {
       const handleKeyDown = createKeyboardHandler(mockDeps);
-      
-      // Test arrow down
+
       mockEvent.key = 'ArrowDown';
       handleKeyDown(mockEvent as KeyboardEvent);
-      expect(mockDeps.navigateToNextDetection).toHaveBeenCalled();
+      expect(mockDeps.navigateToNextDetection).not.toHaveBeenCalled();
 
-      // Test arrow up
       mockEvent.key = 'ArrowUp';
       handleKeyDown(mockEvent as KeyboardEvent);
-      expect(mockDeps.navigateToPreviousDetection).toHaveBeenCalled();
+      expect(mockDeps.navigateToPreviousDetection).not.toHaveBeenCalled();
     });
 
     it('should handle save shortcut (Enter)', () => {

--- a/frontend/tests/utils/annotation/squareCropUtils.test.ts
+++ b/frontend/tests/utils/annotation/squareCropUtils.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeSquareCrop,
+  maxSquareZoom,
+  CONTEXT_FACTOR,
+  MAX_ZOOM,
+} from '@/utils/annotation/squareCropUtils';
+
+// 1280x720 frame; bbox 128px wide, 72px tall, centered at (640, 360).
+const IMG_W = 1280;
+const IMG_H = 720;
+const BBOX: [number, number, number, number] = [
+  (640 - 64) / IMG_W,
+  (360 - 36) / IMG_H,
+  (640 + 64) / IMG_W,
+  (360 + 36) / IMG_H,
+];
+
+describe('computeSquareCrop', () => {
+  it('frames the bbox at CONTEXT_FACTOR times its larger side at zoom 1', () => {
+    const crop = computeSquareCrop(BBOX, IMG_W, IMG_H, 1);
+    expect(crop.size).toBeCloseTo(128 * CONTEXT_FACTOR); // 384
+    // Centered on the bbox center.
+    expect(crop.x + crop.size / 2).toBeCloseTo(640);
+    expect(crop.y + crop.size / 2).toBeCloseTo(360);
+  });
+
+  it('caps the default side at the image short dimension', () => {
+    // Huge bbox: side would be 3x its 600px height = 1800 > 720.
+    const big: [number, number, number, number] = [0.1, 0.05, 0.6, 0.9];
+    const crop = computeSquareCrop(big, IMG_W, IMG_H, 1);
+    expect(crop.size).toBeCloseTo(IMG_H); // 720
+  });
+
+  it('shifts (not shrinks) the square when the bbox center is near an edge', () => {
+    // Center near the top-left corner.
+    const corner: [number, number, number, number] = [0, 0, 128 / IMG_W, 72 / IMG_H];
+    const crop = computeSquareCrop(corner, IMG_W, IMG_H, 1);
+    expect(crop.size).toBeCloseTo(384); // unchanged
+    expect(crop.x).toBeCloseTo(0); // clamped into the frame
+    expect(crop.y).toBeCloseTo(0);
+  });
+
+  it('divides the side by zoom, still clamped inside the frame', () => {
+    const z1 = computeSquareCrop(BBOX, IMG_W, IMG_H, 1);
+    const z2 = computeSquareCrop(BBOX, IMG_W, IMG_H, 2);
+    expect(z2.size).toBeCloseTo(z1.size / 2);
+    expect(z2.x + z2.size / 2).toBeCloseTo(640); // stays centered
+  });
+
+  it('clamps zoom below 1 up to 1', () => {
+    const z = computeSquareCrop(BBOX, IMG_W, IMG_H, 0.25);
+    expect(z.size).toBeCloseTo(384);
+  });
+
+  it('never zooms past the bbox+pad framing', () => {
+    const zMax = maxSquareZoom(BBOX, IMG_W, IMG_H);
+    const crop = computeSquareCrop(BBOX, IMG_W, IMG_H, zMax * 2); // over-ask
+    expect(crop.size).toBeCloseTo(384 / zMax);
+    // bbox (128px wide) plus 20% pad still fits.
+    expect(crop.size).toBeGreaterThanOrEqual(128 * 1.2 - 0.001);
+  });
+
+  it('handles a degenerate zero-size bbox with a whole-short-side square', () => {
+    const dot: [number, number, number, number] = [0.5, 0.5, 0.5, 0.5];
+    const crop = computeSquareCrop(dot, IMG_W, IMG_H, 1);
+    expect(crop.size).toBeCloseTo(IMG_H);
+  });
+});
+
+describe('maxSquareZoom', () => {
+  it('is defaultSide / (bboxSide * 1.2), capped at MAX_ZOOM', () => {
+    // defaultSide 384, bbox larger side 128 → 384 / 153.6 = 2.5
+    expect(maxSquareZoom(BBOX, IMG_W, IMG_H)).toBeCloseTo(2.5);
+  });
+
+  it('equals CONTEXT_FACTOR / pad for uncapped framings (tiny boxes) and stays under MAX_ZOOM', () => {
+    // Uncapped default side = bboxSide * CONTEXT_FACTOR, so the ratio to
+    // the bbox+pad framing is CONTEXT_FACTOR / 1.2 regardless of bbox size.
+    const tiny: [number, number, number, number] = [0.5, 0.5, 0.5 + 4 / IMG_W, 0.5 + 4 / IMG_H];
+    expect(maxSquareZoom(tiny, IMG_W, IMG_H)).toBeCloseTo(CONTEXT_FACTOR / 1.2);
+    expect(maxSquareZoom(tiny, IMG_W, IMG_H)).toBeLessThanOrEqual(MAX_ZOOM);
+  });
+
+  it('is at least 1 even for huge boxes', () => {
+    const big: [number, number, number, number] = [0, 0, 1, 1];
+    expect(maxSquareZoom(big, IMG_W, IMG_H)).toBe(1);
+  });
+});

--- a/frontend/tests/utils/annotation/squareCropUtils.test.ts
+++ b/frontend/tests/utils/annotation/squareCropUtils.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  computeSquareCrop,
-  maxSquareZoom,
-  CONTEXT_FACTOR,
-  MAX_ZOOM,
-} from '@/utils/annotation/squareCropUtils';
+import { computeSquareCrop, CONTEXT_FACTOR, MAX_ZOOM } from '@/utils/annotation/squareCropUtils';
 
 // 1280x720 frame; bbox 128px wide, 72px tall, centered at (640, 360).
 const IMG_W = 1280;
@@ -53,37 +48,14 @@ describe('computeSquareCrop', () => {
     expect(z.size).toBeCloseTo(384);
   });
 
-  it('never zooms past the bbox+pad framing', () => {
-    const zMax = maxSquareZoom(BBOX, IMG_W, IMG_H);
-    const crop = computeSquareCrop(BBOX, IMG_W, IMG_H, zMax * 2); // over-ask
-    expect(crop.size).toBeCloseTo(384 / zMax);
-    // bbox (128px wide) plus 20% pad still fits.
-    expect(crop.size).toBeGreaterThanOrEqual(128 * 1.2 - 0.001);
+  it('clamps zoom above MAX_ZOOM to MAX_ZOOM', () => {
+    const crop = computeSquareCrop(BBOX, IMG_W, IMG_H, MAX_ZOOM * 2); // over-ask
+    expect(crop.size).toBeCloseTo(384 / MAX_ZOOM);
   });
 
   it('handles a degenerate zero-size bbox with a whole-short-side square', () => {
     const dot: [number, number, number, number] = [0.5, 0.5, 0.5, 0.5];
     const crop = computeSquareCrop(dot, IMG_W, IMG_H, 1);
     expect(crop.size).toBeCloseTo(IMG_H);
-  });
-});
-
-describe('maxSquareZoom', () => {
-  it('is defaultSide / (bboxSide * 1.2), capped at MAX_ZOOM', () => {
-    // defaultSide 384, bbox larger side 128 → 384 / 153.6 = 2.5
-    expect(maxSquareZoom(BBOX, IMG_W, IMG_H)).toBeCloseTo(2.5);
-  });
-
-  it('equals CONTEXT_FACTOR / pad for uncapped framings (tiny boxes) and stays under MAX_ZOOM', () => {
-    // Uncapped default side = bboxSide * CONTEXT_FACTOR, so the ratio to
-    // the bbox+pad framing is CONTEXT_FACTOR / 1.2 regardless of bbox size.
-    const tiny: [number, number, number, number] = [0.5, 0.5, 0.5 + 4 / IMG_W, 0.5 + 4 / IMG_H];
-    expect(maxSquareZoom(tiny, IMG_W, IMG_H)).toBeCloseTo(CONTEXT_FACTOR / 1.2);
-    expect(maxSquareZoom(tiny, IMG_W, IMG_H)).toBeLessThanOrEqual(MAX_ZOOM);
-  });
-
-  it('is at least 1 even for huge boxes', () => {
-    const big: [number, number, number, number] = [0, 0, 1, 1];
-    expect(maxSquareZoom(big, IMG_W, IMG_H)).toBe(1);
   });
 });


### PR DESCRIPTION
## What

A polish pass over the classify cockpit (`/classify/:id` and `/classify/done/:id`), plus a redesign of the shared cropped-loop component (spec: `docs/specs/2026-08-04-cropped-view-stable-square-design.md`).

### Whole-alert (missed smoke) player
- Removed the pending/reviewed status frame, pill, and footer; removed the synthetic video-time labels, the frame-info line, and the reset-to-beginning control.
- Frame timestamp shown as `YYYY-MM-DD HH:mm:ss`; object count replaces the prediction count when object overlays are present.
- Raw `algo_predictions` boxes and the sibling layer (+ toggle) are hidden when object overlays are present — both are exact duplicates of the overlays there (tracks are derived from those predictions at import).
- Fullscreen toggle moved into the control strip; Escape explicitly exits fullscreen; fullscreen shows only the player (no title/copy/CTAs, no scrollbar).
- Object overlays render full-strength (no active-card dimming) in the whole-alert view.

### Cockpit chrome
- Single teal Submit in the decision rail (header submit removed; label is just "Submit" in queue mode); keyboard-shortcuts button moved into the rail's Objects header.
- Shortcuts modal extracted to `ClassifyShortcutsModal` and rebuilt with grouped sections reflecting the real bindings; ArrowUp/ArrowDown object navigation removed (Tab / Shift+Tab owns navigation).
- Missed-smoke section: guidance copy + inline Yes/No CTAs below the strip (mirroring the rail chips' state and disabled condition).
- Scroll model: media column flows with the page (one window-edge scrollbar) with a sticky decision rail, replacing nested per-column scrollbars.
- Done mode drops the per-row stage badges (every row there is re-editable).

### Cropped view (shared with the localize page — inherits deliberately)
- Fixed square viewport (`min(380px, 33vh)`, constant 840px canvas backing): zoom changes the drawn source rect, never the element — no layout jumps.
- Square framing centered on the track's average bbox at 3× its larger side (surroundings dominate); clamped inside the frame by shifting; zoom 1×–8× via corner −/+ pill and wheel; no reset (min zoom is the default framing).
- Optional `accentColor` frames the viewport in the object's overlay color on the classify cockpit.
- Pure geometry in `squareCropUtils` with unit tests.

## Review
Adversarial review ran pre-PR; its two Important findings are fixed in the last commit (wheel-listener binding via callback-ref state + coverage for the new missed-smoke CTAs / fullscreen Escape). One follow-up worth a look with production data: hiding the sibling layer in the whole-alert view assumes sibling boxes duplicate tracked objects — cross-alert/under-threshold sibling boxes without lanes (#262) would no longer be visible there.

## Testing
- 925 tests pass (`npx vitest run`), `npm run type-check` and strict ESLint clean.
- Visually verified against stubbed data and the local stack (`/classify/68`).