### PR TITLE
fix(frontend): don't let a stale image fetch strand the classify player on alert switch

### DIFF
--- a/frontend/src/components/annotation/CroppedImageSequence.tsx
+++ b/frontend/src/components/annotation/CroppedImageSequence.tsx
@@ -54,23 +54,39 @@ export default function CroppedImageSequence({
     return [avgX1, avgY1, avgX2, avgY2];
   };
 
-  // Clear state immediately when props change to prevent stale data
+  // Value-based identity for the frame list, mirroring FullImageSequence:
+  // which images to fetch depends only on the detection ids, never on the box
+  // coordinates (those drive the crop, and `drawToCanvas` keys on them
+  // separately). Keying the effect below on the `bboxes` array *reference*
+  // instead would make it hostage to caller memoization — and now that the
+  // effect cancels its in-flight fetch, a caller that rebuilt the array each
+  // render would leave this stuck on a permanent spinner rather than merely
+  // flickering.
+  const frameKey = bboxes.map(b => b.detection_id).join(',');
+
+  // Reset + fetch in ONE effect keyed on that frame list, with the in-flight
+  // fetch cancelled on change. Splitting them (reset here, fetch in a second
+  // effect gated on `images.length === 0`) raced: switching alerts while the
+  // previous alert's URL fetch was still in flight let that stale fetch
+  // commit its results afterwards, and the length guard then permanently
+  // blocked a fetch for the current props — the loop stayed on the previous
+  // alert's images until a page reload.
   useEffect(() => {
+    let cancelled = false;
+
     setImages([]);
     setCurrentIndex(0);
     setIsLoading(true);
     setError(null);
     setZoomLevel(MIN_ZOOM); // Reset zoom to default
-  }, [bboxes, sequenceId]);
 
-  // Fetch detection image URLs
-  useEffect(() => {
+    // No frames yet (the classify cockpit renders an object before its
+    // detections resolve). Stay in the loading state rather than falling
+    // through to the "Failed to load" branch — an empty list isn't a failure,
+    // and the effect re-runs with real frames the moment they arrive.
+    if (!bboxes.length || !sequenceId) return;
+
     const fetchImages = async () => {
-      if (!bboxes.length || !sequenceId) {
-        setIsLoading(false);
-        return;
-      }
-
       try {
         // Fetch all detection image URLs
         const imagePromises = bboxes.map(async bbox => {
@@ -92,6 +108,7 @@ export default function CroppedImageSequence({
         });
 
         const imageResults = await Promise.all(imagePromises);
+        if (cancelled) return;
         setImages(imageResults);
 
         // Start preloading images
@@ -100,6 +117,7 @@ export default function CroppedImageSequence({
             const img = new Image();
             // Note: Not setting crossOrigin to avoid CORS issues with local S3
             img.onload = () => {
+              if (cancelled) return;
               setImages(prev =>
                 prev.map((item, i) =>
                   i === index ? { ...item, loaded: true, imageElement: img } : item
@@ -107,6 +125,7 @@ export default function CroppedImageSequence({
               );
             };
             img.onerror = () => {
+              if (cancelled) return;
               setImages(prev =>
                 prev.map((item, i) => (i === index ? { ...item, error: true } : item))
               );
@@ -115,18 +134,20 @@ export default function CroppedImageSequence({
           }
         });
       } catch (err) {
-        setError('Failed to fetch detection images');
+        if (!cancelled) setError('Failed to fetch detection images');
         // Error fetching images
       } finally {
-        setIsLoading(false);
+        if (!cancelled) setIsLoading(false);
       }
     };
 
-    // Only fetch if we have cleared state (prevents duplicate fetching)
-    if (bboxes.length > 0 && sequenceId && images.length === 0) {
-      fetchImages();
-    }
-  }, [bboxes, sequenceId, images.length]);
+    fetchImages();
+    return () => {
+      cancelled = true;
+    };
+    // `bboxes` is read through the closure on purpose — see `frameKey` above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [frameKey, sequenceId]);
 
   // Auto-play animation with 200ms interval - only when images are loaded
   useEffect(() => {

--- a/frontend/src/components/annotation/FullImageSequence.tsx
+++ b/frontend/src/components/annotation/FullImageSequence.tsx
@@ -70,23 +70,29 @@ export default function FullImageSequence({
   // keying on ids alone means switching objects doesn't reload the images.
   const frameKey = bboxes.map(b => b.detection_id).join(',');
 
-  // Clear state immediately when the frame list changes to prevent stale data
+  // Reset + fetch in ONE effect keyed on the frame list, with the in-flight
+  // fetch cancelled on change. Splitting them (reset here, fetch in a second
+  // effect gated on `images.length === 0`) raced: switching alerts while the
+  // previous alert's URL fetch was still in flight let that stale fetch
+  // commit its results afterwards, and the length guard then permanently
+  // blocked a fetch for the current frame list — the player stayed on the
+  // previous alert's images until a page reload.
   useEffect(() => {
+    let cancelled = false;
+
     setImages([]);
     setCurrentIndex(0);
     setIsLoading(true);
     setError(null);
     setImageInfo(null); // Clear image positioning info
-  }, [frameKey]);
 
-  // Fetch detection image URLs
-  useEffect(() => {
+    // No frames yet (the classify cockpit renders an object before its
+    // detections resolve). Stay in the loading state rather than falling
+    // through to the "Failed to load" branch — an empty list isn't a failure,
+    // and the effect re-runs with real frames the moment they arrive.
+    if (!bboxes.length || !sequenceId) return;
+
     const fetchImages = async () => {
-      if (!bboxes.length || !sequenceId) {
-        setIsLoading(false);
-        return;
-      }
-
       try {
         // Fetch all detection image URLs
         const imagePromises = bboxes.map(async bbox => {
@@ -108,6 +114,7 @@ export default function FullImageSequence({
         });
 
         const imageResults = await Promise.all(imagePromises);
+        if (cancelled) return;
         setImages(imageResults);
 
         // Start preloading images
@@ -115,11 +122,13 @@ export default function FullImageSequence({
           if (!image.error && image.url) {
             const img = new Image();
             img.onload = () => {
+              if (cancelled) return;
               setImages(prev =>
                 prev.map((item, i) => (i === index ? { ...item, loaded: true } : item))
               );
             };
             img.onerror = () => {
+              if (cancelled) return;
               setImages(prev =>
                 prev.map((item, i) => (i === index ? { ...item, error: true } : item))
               );
@@ -128,19 +137,21 @@ export default function FullImageSequence({
           }
         });
       } catch (err) {
-        setError('Failed to fetch detection images');
+        if (!cancelled) setError('Failed to fetch detection images');
         // Error fetching images
       } finally {
-        setIsLoading(false);
+        if (!cancelled) setIsLoading(false);
       }
     };
 
-    // Only fetch if we have cleared state (prevents duplicate fetching)
-    if (bboxes.length > 0 && sequenceId && images.length === 0) {
-      fetchImages();
-    }
+    fetchImages();
+    return () => {
+      cancelled = true;
+    };
+    // `bboxes`/`sequenceId` are read through the closure on purpose — see
+    // `frameKey` above for why neither belongs in the dependency list.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [frameKey, images.length]);
+  }, [frameKey]);
 
   // Auto-play animation with 200ms interval - only when images are loaded
   useEffect(() => {

--- a/frontend/tests/components/annotation/FullImageSequence.frameSwitch.test.tsx
+++ b/frontend/tests/components/annotation/FullImageSequence.frameSwitch.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Reproduction: switching the frame list (an alert switch in the classify
+ * cockpit) while the previous frame list's image-URL fetch is still in
+ * flight must not leave the player showing the previous alert's images.
+ */
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('@/services/api', () => ({
+  apiClient: { getDetectionImageUrl: vi.fn() },
+}));
+
+import { apiClient } from '@/services/api';
+import FullImageSequence from '@/components/annotation/FullImageSequence';
+
+/** Deferred promise per detection id, so resolution order is controllable. */
+function makeDeferredUrls() {
+  const resolvers = new Map<number, (v: { url: string }) => void>();
+  vi.mocked(apiClient.getDetectionImageUrl).mockImplementation(
+    (id: number) => new Promise(resolve => resolvers.set(id, resolve))
+  );
+  return {
+    resolve(id: number) {
+      resolvers.get(id)!({ url: `http://img/${id}.jpg` });
+    },
+    has: (id: number) => resolvers.has(id),
+  };
+}
+
+const framesFor = (ids: number[]) => ids.map(id => ({ detection_id: id, xyxyn: [0, 0, 1, 1] }));
+
+describe('FullImageSequence frame-list switch', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows the new frame list even when the previous fetch resolves last', async () => {
+    const urls = makeDeferredUrls();
+
+    const { rerender } = render(<FullImageSequence bboxes={framesFor([1, 2])} sequenceId={101} />);
+    await waitFor(() => expect(urls.has(1)).toBe(true));
+
+    // Alert switch: new frame list while alert A's fetch is still pending.
+    rerender(<FullImageSequence bboxes={framesFor([3, 4])} sequenceId={301} />);
+    await waitFor(() => expect(urls.has(3)).toBe(true));
+
+    // New alert's URLs land first, the stale ones after.
+    urls.resolve(3);
+    urls.resolve(4);
+    await waitFor(() => expect(screen.getByRole('img')).toBeInTheDocument());
+
+    urls.resolve(1);
+    urls.resolve(2);
+    // Let the stale fetch's `Promise.all` and its state updates flush before
+    // asserting — otherwise the assertion passes on the pre-flush DOM.
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(screen.getByRole('img').getAttribute('src')).toMatch(/\/(3|4)\.jpg$/);
+  });
+
+  // Guards the invariant `frameKey` exists for: in the classify cockpit every
+  // object of an alert plays the same union frame list, so activating another
+  // object must NOT refetch 20-40 image URLs. Putting `sequenceId` (or the
+  // `bboxes` reference) back into the effect's dependencies would break this
+  // while still passing the test above.
+  it('does not refetch when only the object changes, not the frame list', async () => {
+    makeDeferredUrls();
+
+    const frames = framesFor([1, 2]);
+    const { rerender } = render(<FullImageSequence bboxes={frames} sequenceId={101} />);
+    await waitFor(() => expect(apiClient.getDetectionImageUrl).toHaveBeenCalledTimes(2));
+
+    // Same frames, different object: new array instance, new lane sequence id.
+    rerender(<FullImageSequence bboxes={framesFor([1, 2])} sequenceId={102} color="#00f" />);
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(apiClient.getDetectionImageUrl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/tests/pages/ClassifyAlertPage.autoAdvance.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.autoAdvance.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * Covers the page's auto-advance navigation path: submitting from
+ * /classify/:id re-drives this same component in place — no remount — with
+ * the destination alert's own sequence, lanes and seeded card state.
+ *
+ * Unlike ClassifyAlertPage.test.tsx, `useNavigate` is NOT mocked here, so the
+ * route param really changes and the destination render is actually
+ * exercised. The media players are still stubbed, so this does NOT cover the
+ * stale-image-fetch race that motivated it — that lives in
+ * tests/components/annotation/FullImageSequence.frameSwitch.test.tsx.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import type { AlertDetail, Sequence, SequenceAnnotation } from '@/types/api';
+
+vi.mock('@/services/api', () => ({
+  apiClient: {
+    getSequence: vi.fn(),
+    getAlertDetail: vi.fn(),
+    classifySubmit: vi.fn(),
+    getSequenceDetections: vi.fn(),
+    updateSequenceAnnotation: vi.fn(),
+    getClassifyQueue: vi.fn(),
+  },
+}));
+
+vi.mock('@/components/annotation/FullImageSequence', () => ({
+  default: ({ bboxes, sequenceId }: { bboxes?: unknown[]; sequenceId?: number }) => (
+    <div
+      data-testid="full-image-sequence"
+      data-bbox-count={bboxes?.length ?? 0}
+      data-sequence-id={sequenceId}
+    />
+  ),
+}));
+vi.mock('@/components/annotation/CroppedImageSequence', () => ({
+  default: () => <div data-testid="cropped-image-sequence" />,
+}));
+vi.mock('@/components/sequence/SequenceReviewer', () => ({
+  default: () => <div data-testid="sequence-reviewer" />,
+}));
+
+import { apiClient } from '@/services/api';
+import ClassifyAlertPage from '@/pages/ClassifyAlertPage';
+
+function makeSequence(overrides: Partial<Sequence> = {}): Sequence {
+  return {
+    id: 101,
+    source_api: 'pyronear_french',
+    alert_api_id: 9001,
+    created_at: '2026-01-01T09:00:00Z',
+    recorded_at: '2026-01-01T10:00:00Z',
+    last_seen_at: '2026-01-01T10:05:00Z',
+    camera_name: 'CAM-1',
+    camera_id: 1,
+    lat: 45,
+    lon: 5,
+    azimuth: 90,
+    is_wildfire_alertapi: null,
+    organisation_name: 'Org',
+    organisation_id: 1,
+    platform_alert_id: 500,
+    sequence_group_id: null,
+    ...overrides,
+  };
+}
+
+function makeAnnotation(overrides: Partial<SequenceAnnotation> = {}): SequenceAnnotation {
+  return {
+    id: 201,
+    sequence_id: 101,
+    has_smoke: false,
+    has_false_positives: false,
+    false_positive_types: '[]',
+    smoke_types: [],
+    has_missed_smoke: false,
+    is_unsure: false,
+    annotation: {
+      sequences_bbox: [
+        {
+          is_smoke: false,
+          false_positive_types: [],
+          bboxes: [{ detection_id: 1, xyxyn: [0, 0, 1, 1] }],
+        },
+      ],
+    },
+    processing_stage: 'ready_to_annotate',
+    created_at: '2026-01-01T09:00:00Z',
+    updated_at: null,
+    ...overrides,
+  };
+}
+
+/** Single-lane alert, so the entry sequence is the only object. */
+function makeAlertDetail(sequenceId: number, platformAlertId: number): AlertDetail {
+  return {
+    source_api: 'pyronear_french',
+    platform_alert_id: platformAlertId,
+    camera_name: `CAM-${platformAlertId}`,
+    organisation_name: 'Org',
+    recorded_at: '2026-01-01T10:00:00Z',
+    lanes: [
+      {
+        sequence: makeSequence({ id: sequenceId, platform_alert_id: platformAlertId }),
+        annotation: makeAnnotation({
+          id: sequenceId + 100,
+          sequence_id: sequenceId,
+          annotation: {
+            sequences_bbox: [
+              {
+                is_smoke: false,
+                false_positive_types: [],
+                bboxes: [{ detection_id: sequenceId, xyxyn: [0, 0, 1, 1] }],
+              },
+            ],
+          },
+        }),
+      },
+    ],
+  };
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/classify/101']}>
+        <Routes>
+          <Route path="/classify/:id" element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('ClassifyAlertPage auto-advance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
+
+    vi.mocked(apiClient.getSequence).mockImplementation(async (id: number) =>
+      id === 101
+        ? makeSequence({ id: 101, platform_alert_id: 500 })
+        : makeSequence({ id: 301, platform_alert_id: 700 })
+    );
+    vi.mocked(apiClient.getAlertDetail).mockImplementation(
+      async (_source: string, platformAlertId: number) =>
+        platformAlertId === 500 ? makeAlertDetail(101, 500) : makeAlertDetail(301, 700)
+    );
+    vi.mocked(apiClient.getSequenceDetections).mockResolvedValue([]);
+    vi.mocked(apiClient.getClassifyQueue).mockResolvedValue({
+      items: [
+        {
+          source_api: 'pyronear_french',
+          platform_alert_id: 700,
+          camera_name: 'CAM-700',
+          organisation_name: 'Org',
+          azimuth: null,
+          recorded_at: '2026-01-01T11:00:00Z',
+          is_wildfire_alertapi: null,
+          primary_sequence_id: 301,
+          total_objects: 1,
+          classified_objects: 0,
+        },
+      ],
+      page: 1,
+      pages: 1,
+      size: 2,
+      total: 1,
+    });
+    vi.mocked(apiClient.classifySubmit).mockResolvedValue({
+      results: [
+        {
+          annotation_id: 201,
+          sequence_id: 101,
+          processing_stage: 'seq_annotation_done',
+          group_propagation_warning: null,
+        },
+      ],
+    });
+  });
+
+  it('renders the destination alert’s objects after auto-advancing', async () => {
+    render(<ClassifyAlertPage />, { wrapper });
+
+    // Entry alert settled: its object is active and seeded.
+    await waitFor(() => {
+      expect(screen.getByTestId('full-image-sequence').getAttribute('data-bbox-count')).not.toBe(
+        '0'
+      );
+    });
+
+    // Classify the only object, answer missed smoke, submit.
+    fireEvent.click(screen.getByTestId('object-card-101:0'));
+    const card = within(screen.getByTestId('object-card-101:0'));
+    fireEvent.click(card.getByRole('radio', { name: 'Smoke' }));
+    fireEvent.click(card.getByRole('radio', { name: 'Wildfire' }));
+    fireEvent.click(
+      within(screen.getByTestId('missed-smoke-row')).getByRole('radio', { name: 'No' })
+    );
+
+    await waitFor(() => {
+      expect((screen.getByTestId('rail-submit') as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId('rail-submit'));
+    await waitFor(() => expect(apiClient.classifySubmit).toHaveBeenCalledTimes(1));
+
+    // Auto-advance fires 1s after a successful submit.
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('object-card-301:0')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    // The destination alert's object must be active with its own seeded data —
+    // not a skeleton, and not the previous alert's sequence.
+    await waitFor(() => {
+      expect(screen.queryByTestId('media-panel-skeleton')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('full-image-sequence').getAttribute('data-sequence-id')).toBe('301');
+    expect(screen.getByTestId('full-image-sequence').getAttribute('data-bbox-count')).not.toBe('0');
+  }, 15000);
+});


### PR DESCRIPTION
## Problem

Submitting from `/classify/:id` auto-advances to the next alert, but the media column often fails to load the new alert's frames — a manual page refresh is the only recovery.

## Root cause

`FullImageSequence` and `CroppedImageSequence` split their work across two effects:

```
effect 1 [frameKey]                → reset state (images = [], isLoading = true)
effect 2 [frameKey, images.length] → fetch URLs, but ONLY if images.length === 0
```

Nothing cancelled an in-flight fetch when the frame list changed. During an alert switch the frame list is rebuilt several times as each lane's detections stream in (`unionFrames` grows per lane in `ClassifyAlertPage`), and every rebuild kicks off a fresh fetch of every frame's image URL — 20–40 parallel `getDetectionImageUrl` calls each.

If an older fetch resolves *after* a newer one, it overwrites `images` with the stale list. The `images.length === 0` guard then permanently blocks any further fetch, so the player is stranded until a reload. Classic last-write-wins with no cancellation, which is why it's intermittent.

## Fix

Merge each reset+fetch pair into a single effect keyed on the frame list, with a `cancelled` flag in the cleanup guarding the result commit, the preload `onload`/`onerror` callbacks, the `catch` and the `finally`. This also drops the `images.length` dependency that made the stuck state permanent, and fixes a pre-existing post-unmount `setState` leak.

Two supporting changes:

- **`CroppedImageSequence` now keys on a value-based `frameKey`** (the joined detection ids), like `FullImageSequence` already did, instead of the `bboxes` array reference. No current caller churns that reference, but now that the effect cancels its in-flight fetch, one that did would leave the component on a *permanent spinner* rather than merely flickering. Removing the footgun also makes the two components read the same way.
- **An empty frame list stays in the loading state** instead of falling through to "Failed to load full sequence". The `!bboxes.length` guard used to be unreachable (it lived inside a function only called when `bboxes.length > 0`); hoisting it out of the merged effect made it live, which would have flashed a red error during the very alert-switch flow this PR fixes.

## Tests

- `tests/components/annotation/FullImageSequence.frameSwitch.test.tsx`
  - **out-of-order resolution** — the regression test. Fails before the fix with `expected 'http://img/1.jpg' to match /\/(3|4)\.jpg$/` (the previous alert's image), passes after.
  - **no refetch on object switch** — pins the invariant `frameKey` exists for: every object of an alert shares the same union frame list, so activating another object must not refetch 20–40 URLs. Putting `sequenceId` or the array reference back into the deps would break this while still passing the test above.
- `tests/pages/ClassifyAlertPage.autoAdvance.test.tsx` — submit → auto-advance with **real** navigation. The existing suite mocks `useNavigate`, so the destination render was never exercised. The media players are still stubbed here, so this covers the page's navigation path, not the fetch race (docstring says so explicitly).

Full suite: 928 passed (84 files). `npm run quality` clean. Rebased onto `main` (#267), which rewrote `CroppedImageSequence`; the merged effect keeps that PR's `MIN_ZOOM` default.

## Follow-up worth filing

Cancellation here is logical, not transport-level: a superseded round still runs all 20–40 requests to completion and its `img.src` assignments keep downloading frames. Threading an `AbortSignal` through `apiClient.getDetectionImageUrl` would make it real — same code path that made this race wide enough to hit.