### PR TITLE
feat(frontend): colored dots in the Result filter

### DIFF
--- a/frontend/src/components/filters/ModelAccuracyFilter.tsx
+++ b/frontend/src/components/filters/ModelAccuracyFilter.tsx
@@ -1,4 +1,5 @@
-import { ModelAccuracyType } from '@/utils/modelAccuracy';
+import { ModelAccuracyType, SequenceOutcome } from '@/utils/modelAccuracy';
+import { OUTCOMES } from '@/components/sequences/outcomeDisplay';
 
 interface ModelAccuracyFilterProps {
   selectedAccuracy: ModelAccuracyType | 'all';
@@ -7,42 +8,66 @@ interface ModelAccuracyFilterProps {
   className?: string;
 }
 
+// Chip options in table-column order. `outcome` pulls the dot and code from
+// OUTCOMES so the filter reads exactly like the Result column it filters.
+const OPTIONS: Array<{
+  value: ModelAccuracyType | 'all';
+  label: string;
+  outcome?: SequenceOutcome;
+}> = [
+  { value: 'all', label: 'All' },
+  { value: 'true_positive', label: 'True positive', outcome: 'tp' },
+  { value: 'false_positive', label: 'False positive', outcome: 'fp' },
+  { value: 'false_negative', label: 'False negative', outcome: 'fn' },
+];
+
+// Selection is a darker border plus a tinted fill rather than a solid one:
+// a filled chip would swallow the outcome dot, which is the whole point here.
+const chipClasses = (selected: boolean) =>
+  `inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 font-body text-xs font-medium transition-colors ${
+    selected ? 'border-char bg-ash text-char' : 'border-line bg-paper text-haze hover:bg-ash'
+  }`;
+
 export default function ModelAccuracyFilter({
   selectedAccuracy,
   onSelectionChange,
-  label = 'Model Accuracy',
+  label = 'Result',
   className = '',
 }: ModelAccuracyFilterProps) {
-  const accuracyOptions: Array<{ value: ModelAccuracyType | 'all'; label: string; icon?: string }> =
-    [
-      { value: 'all', label: 'All Results' },
-      { value: 'true_positive', label: 'True Positive', icon: '✅' },
-      { value: 'false_positive', label: 'False Positive', icon: '❌' },
-      { value: 'false_negative', label: 'False Negative', icon: '🔍' },
-    ];
-
-  const getDisplayText = (value: ModelAccuracyType | 'all') => {
-    const option = accuracyOptions.find(opt => opt.value === value);
-    if (option && option.icon) {
-      return `${option.icon} ${option.label}`;
-    }
-    return option?.label || 'All Results';
-  };
-
   return (
     <div className={className}>
-      {label && <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>}
-      <select
-        value={selectedAccuracy}
-        onChange={e => onSelectionChange(e.target.value as ModelAccuracyType | 'all')}
-        className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-primary-500 focus:border-primary-500"
-      >
-        {accuracyOptions.map(option => (
-          <option key={option.value} value={option.value}>
-            {getDisplayText(option.value)}
-          </option>
-        ))}
-      </select>
+      {label && <span className="block text-sm font-medium text-gray-700 mb-1">{label}</span>}
+      <div role="radiogroup" aria-label={label} className="flex flex-wrap gap-1.5">
+        {OPTIONS.map(option => {
+          const selected = selectedAccuracy === option.value;
+          const display = option.outcome ? OUTCOMES[option.outcome] : null;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              title={display?.title}
+              onClick={() => onSelectionChange(option.value)}
+              className={chipClasses(selected)}
+            >
+              {display &&
+                (display.dotClass ? (
+                  <span
+                    aria-hidden
+                    className={`h-2 w-2 flex-none rounded-full ${display.dotClass}`}
+                  />
+                ) : (
+                  <span aria-hidden className="text-signal">
+                    ⚑
+                  </span>
+                ))}
+              {display && <span className="font-data font-semibold text-char">{display.code}</span>}
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/filters/ModelAccuracyFilter.tsx
+++ b/frontend/src/components/filters/ModelAccuracyFilter.tsx
@@ -1,4 +1,5 @@
-import { ModelAccuracyType, SequenceOutcome } from '@/utils/modelAccuracy';
+import { useId } from 'react';
+import { ModelAccuracyType, SequenceOutcome, getModelAccuracyResult } from '@/utils/modelAccuracy';
 import { OUTCOMES } from '@/components/sequences/outcomeDisplay';
 
 interface ModelAccuracyFilterProps {
@@ -9,23 +10,25 @@ interface ModelAccuracyFilterProps {
 }
 
 // Chip options in table-column order. `outcome` pulls the dot and code from
-// OUTCOMES so the filter reads exactly like the Result column it filters.
+// OUTCOMES so the filter reads exactly like the Result column it filters;
+// names come from getModelAccuracyResult so chip and pill agree.
 const OPTIONS: Array<{
   value: ModelAccuracyType | 'all';
   label: string;
   outcome?: SequenceOutcome;
 }> = [
   { value: 'all', label: 'All' },
-  { value: 'true_positive', label: 'True positive', outcome: 'tp' },
-  { value: 'false_positive', label: 'False positive', outcome: 'fp' },
-  { value: 'false_negative', label: 'False negative', outcome: 'fn' },
+  { value: 'true_positive', label: getModelAccuracyResult('true_positive').label, outcome: 'tp' },
+  { value: 'false_positive', label: getModelAccuracyResult('false_positive').label, outcome: 'fp' },
+  { value: 'false_negative', label: getModelAccuracyResult('false_negative').label, outcome: 'fn' },
 ];
 
-// Selection is a darker border plus a tinted fill rather than a solid one:
-// a filled chip would swallow the outcome dot, which is the whole point here.
+// Selection is a darker border plus a tinted fill rather than a solid one: a
+// filled chip would swallow the outcome dot, which is the whole point here.
+// Hover darkens the border only, so it never reads as selected.
 const chipClasses = (selected: boolean) =>
-  `inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 font-body text-xs font-medium transition-colors ${
-    selected ? 'border-char bg-ash text-char' : 'border-line bg-paper text-haze hover:bg-ash'
+  `inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 font-body text-xs font-medium transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-char peer-focus-visible:ring-offset-2 ${
+    selected ? 'border-char bg-ash text-char' : 'border-line bg-paper text-haze hover:border-haze'
   }`;
 
 export default function ModelAccuracyFilter({
@@ -34,37 +37,53 @@ export default function ModelAccuracyFilter({
   label = 'Result',
   className = '',
 }: ModelAccuracyFilterProps) {
+  // Native radios rather than role="radio" buttons: arrow-key navigation and
+  // the single tab stop come for free, matching the <select> this replaced.
+  const id = useId();
+
   return (
     <div className={className}>
-      {label && <span className="block text-sm font-medium text-gray-700 mb-1">{label}</span>}
-      <div role="radiogroup" aria-label={label} className="flex flex-wrap gap-1.5">
+      {label && (
+        <span id={`${id}-label`} className="block text-sm font-medium text-gray-700 mb-1">
+          {label}
+        </span>
+      )}
+      <div
+        role="radiogroup"
+        aria-labelledby={label ? `${id}-label` : undefined}
+        className="flex flex-wrap gap-1.5"
+      >
         {OPTIONS.map(option => {
           const selected = selectedAccuracy === option.value;
           const display = option.outcome ? OUTCOMES[option.outcome] : null;
           return (
-            <button
-              key={option.value}
-              type="button"
-              role="radio"
-              aria-checked={selected}
-              title={display?.title}
-              onClick={() => onSelectionChange(option.value)}
-              className={chipClasses(selected)}
-            >
-              {display &&
-                (display.dotClass ? (
-                  <span
-                    aria-hidden
-                    className={`h-2 w-2 flex-none rounded-full ${display.dotClass}`}
-                  />
-                ) : (
-                  <span aria-hidden className="text-signal">
-                    ⚑
-                  </span>
-                ))}
-              {display && <span className="font-data font-semibold text-char">{display.code}</span>}
-              {option.label}
-            </button>
+            <label key={option.value} className="cursor-pointer">
+              <input
+                type="radio"
+                name={id}
+                value={option.value}
+                checked={selected}
+                onChange={() => onSelectionChange(option.value)}
+                className="peer sr-only"
+              />
+              <span title={display?.title} className={chipClasses(selected)}>
+                {display &&
+                  (display.dotClass ? (
+                    <span
+                      aria-hidden
+                      className={`h-2 w-2 flex-none rounded-full ${display.dotClass}`}
+                    />
+                  ) : (
+                    <span aria-hidden className="text-signal">
+                      ⚑
+                    </span>
+                  ))}
+                {display && (
+                  <span className="font-data font-semibold text-char">{display.code}</span>
+                )}
+                {option.label}
+              </span>
+            </label>
           );
         })}
       </div>

--- a/frontend/src/components/sequences/OutcomeCode.tsx
+++ b/frontend/src/components/sequences/OutcomeCode.tsx
@@ -1,32 +1,11 @@
 import { SequenceOutcome } from '@/utils/modelAccuracy';
+import { OUTCOMES } from './outcomeDisplay';
 
 interface OutcomeCodeProps {
   outcome: SequenceOutcome;
   /** Number of other objects in the alert, rendered as a muted "+N" (multi-object rollup). */
   extraCount?: number;
 }
-
-const OUTCOMES: Record<SequenceOutcome, { code: string; dotClass?: string; title: string }> = {
-  tp: {
-    code: 'TP',
-    dotClass: 'bg-pine',
-    title: 'True positive — model correctly detected smoke',
-  },
-  fp: {
-    code: 'FP',
-    dotClass: 'bg-haze',
-    title: 'False positive — model flagged non-smoke',
-  },
-  fn: {
-    code: 'FN',
-    title: 'False negative — smoke was missed',
-  },
-  unsure: {
-    code: '?',
-    dotClass: 'bg-ember',
-    title: 'Unsure — needs review',
-  },
-};
 
 /**
  * Compact model-outcome code for table rows: colored dot (or ⚑ for missed

--- a/frontend/src/components/sequences/outcomeDisplay.ts
+++ b/frontend/src/components/sequences/outcomeDisplay.ts
@@ -1,0 +1,35 @@
+import { SequenceOutcome } from '@/utils/modelAccuracy';
+
+/** A dot-less outcome (fn) renders the ⚑ glyph instead. */
+interface OutcomeDisplay {
+  code: string;
+  dotClass?: string;
+  title: string;
+}
+
+/**
+ * Code, dot color and tooltip per outcome. Shared by the OutcomeCode table
+ * cell and the Result filter, so a filter chip reads exactly like the column
+ * it filters.
+ */
+export const OUTCOMES: Record<SequenceOutcome, OutcomeDisplay> = {
+  tp: {
+    code: 'TP',
+    dotClass: 'bg-pine',
+    title: 'True positive — model correctly detected smoke',
+  },
+  fp: {
+    code: 'FP',
+    dotClass: 'bg-haze',
+    title: 'False positive — model flagged non-smoke',
+  },
+  fn: {
+    code: 'FN',
+    title: 'False negative — smoke was missed',
+  },
+  unsure: {
+    code: '?',
+    dotClass: 'bg-ember',
+    title: 'Unsure — needs review',
+  },
+};

--- a/frontend/src/utils/filterPills.ts
+++ b/frontend/src/utils/filterPills.ts
@@ -86,7 +86,7 @@ export function buildFilterPills(input: FilterPillInput): FilterPill[] {
   if (input.showModelAccuracy && input.selectedModelAccuracy !== 'all') {
     pills.push({
       id: 'accuracy',
-      label: `Accuracy: ${getModelAccuracyResult(input.selectedModelAccuracy).label}`,
+      label: `Result: ${getModelAccuracyResult(input.selectedModelAccuracy).label}`,
     });
   }
   if (input.showUnsureFilter && input.selectedUnsure !== 'all') {

--- a/frontend/tests/components/filters/FilterPopover.test.tsx
+++ b/frontend/tests/components/filters/FilterPopover.test.tsx
@@ -57,7 +57,7 @@ describe('FilterPopover', () => {
     fireEvent.click(screen.getByRole('button', { name: /more filters \(3\)/i }));
     expect(screen.getByLabelText('Source API')).toBeInTheDocument();
     expect(screen.getByLabelText('Alert API annotation')).toBeInTheDocument();
-    expect(screen.getByText('Model Accuracy')).toBeInTheDocument();
+    expect(screen.getByRole('radiogroup', { name: 'Result' })).toBeInTheDocument();
     // Not enabled for this page:
     expect(screen.queryByLabelText('Certainty')).not.toBeInTheDocument();
   });

--- a/frontend/tests/components/filters/ModelAccuracyFilter.test.tsx
+++ b/frontend/tests/components/filters/ModelAccuracyFilter.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ModelAccuracyFilter from '@/components/filters/ModelAccuracyFilter';
+
+describe('ModelAccuracyFilter', () => {
+  it('renders one chip per outcome, labelled like the Result column', () => {
+    render(<ModelAccuracyFilter selectedAccuracy="all" onSelectionChange={vi.fn()} />);
+    const chips = screen.getAllByRole('radio');
+    expect(chips.map(c => c.textContent)).toEqual([
+      'All',
+      'TPTrue positive',
+      'FPFalse positive',
+      '⚑FNFalse negative',
+    ]);
+  });
+
+  it('marks only the selected chip as checked', () => {
+    render(<ModelAccuracyFilter selectedAccuracy="false_positive" onSelectionChange={vi.fn()} />);
+    expect(screen.getByRole('radio', { name: /false positive/i })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /^all$/i })).not.toBeChecked();
+  });
+
+  it('reports the chosen accuracy on click', () => {
+    const onSelectionChange = vi.fn();
+    render(<ModelAccuracyFilter selectedAccuracy="all" onSelectionChange={onSelectionChange} />);
+    fireEvent.click(screen.getByRole('radio', { name: /false negative/i }));
+    expect(onSelectionChange).toHaveBeenCalledWith('false_negative');
+  });
+});

--- a/frontend/tests/components/filters/ModelAccuracyFilter.test.tsx
+++ b/frontend/tests/components/filters/ModelAccuracyFilter.test.tsx
@@ -1,19 +1,36 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import ModelAccuracyFilter from '@/components/filters/ModelAccuracyFilter';
 
+// The chip a radio labels — where its dot and code live.
+const chipOf = (radio: HTMLElement) => radio.closest('label') as HTMLLabelElement;
+
 describe('ModelAccuracyFilter', () => {
-  it('renders one chip per outcome, labelled like the Result column', () => {
+  it('renders one chip per outcome, named like the Result column', () => {
     render(<ModelAccuracyFilter selectedAccuracy="all" onSelectionChange={vi.fn()} />);
-    const chips = screen.getAllByRole('radio');
-    expect(chips.map(c => c.textContent)).toEqual([
+    expect(screen.getAllByRole('radio').map(r => chipOf(r).textContent)).toEqual([
       'All',
-      'TPTrue positive',
-      'FPFalse positive',
-      '⚑FNFalse negative',
+      'TPTrue Positive',
+      'FPFalse Positive',
+      '⚑FNFalse Negative',
     ]);
   });
 
-  it('marks only the selected chip as checked', () => {
+  it('marks each chip with the same dot the table row uses', () => {
+    render(<ModelAccuracyFilter selectedAccuracy="all" onSelectionChange={vi.fn()} />);
+    const chip = (name: RegExp) => chipOf(screen.getByRole('radio', { name }));
+    expect(chip(/true positive/i).querySelector('.bg-pine')).not.toBeNull();
+    expect(chip(/false positive/i).querySelector('.bg-haze')).not.toBeNull();
+    // False negative is the one outcome with a glyph instead of a dot.
+    expect(chip(/false negative/i)).toHaveTextContent('⚑');
+    expect(chip(/^all$/i).querySelector('[aria-hidden]')).toBeNull();
+  });
+
+  it('exposes the group under its visible label', () => {
+    render(<ModelAccuracyFilter selectedAccuracy="all" onSelectionChange={vi.fn()} />);
+    expect(screen.getByRole('radiogroup', { name: 'Result' })).toBeInTheDocument();
+  });
+
+  it('checks only the selected chip', () => {
     render(<ModelAccuracyFilter selectedAccuracy="false_positive" onSelectionChange={vi.fn()} />);
     expect(screen.getByRole('radio', { name: /false positive/i })).toBeChecked();
     expect(screen.getByRole('radio', { name: /^all$/i })).not.toBeChecked();

--- a/frontend/tests/utils/filterPills.test.ts
+++ b/frontend/tests/utils/filterPills.test.ts
@@ -55,7 +55,7 @@ describe('buildFilterPills', () => {
     expect(
       buildFilterPills({ ...active, showModelAccuracy: true, showUnsureFilter: true })
     ).toEqual([
-      { id: 'accuracy', label: 'Accuracy: False Positive' },
+      { id: 'accuracy', label: 'Result: False Positive' },
       { id: 'unsure', label: 'Only Unsure' },
     ]);
   });


### PR DESCRIPTION
## What

The Model Accuracy filter showed ✅ / ❌ / 🔍 while the table column it filters shows colored dots and `TP` / `FP` / `⚑ FN` codes. This makes the filter read like the column.

| | Before | After |
|---|---|---|
| Control | native `<select>` | chip radio group |
| Values | `✅ True Positive` | `● TP True Positive` |
| Label | Model Accuracy | Result |

`<option>` can't hold styled markup, so the dots required a different control. Chips are visually-hidden native radios inside `<label>`s — one tab stop, arrow-key selection and correct screen-reader announcement come for free, matching what the `<select>` did. Selection is a darker border plus a tinted fill rather than a solid one: a filled chip would swallow the dot.

The code/dot/title map moved out of `OutcomeCode.tsx` into `outcomeDisplay.ts`, so the table cell and the filter read one source and can't drift. It needs to be its own module — ESLint's `react-refresh/only-export-components` rejects a non-component export from a component file.

`Model Accuracy` → `Result` matches the `ColumnHeader label="Result"` on the classify-done and localize tables; the applied-filter pill follows (`Accuracy: …` → `Result: …`).

## Scope

The filter still only renders on `/classify/done`. `/localize/done` passes the accuracy state but not `showModelAccuracy`, and `/localize` has no FilterPopover at all — enabling them is #245. This restyle covers all three the moment they are.

Left alone: the `✅/❌/🔍` badge at `DetectionHeader.tsx:144` on the localize detail page, now the only consumer of `getModelAccuracyResult().icon`.

## Verification

- `npm run quality` clean; 917 tests pass (5 new for the filter, 2 updated expectations).
- Dot coverage checked by mutation: deleting the dot markup fails two tests.
- Driven in a browser against the dev server — chips match the Result column beside them, ArrowRight from `All` selects True Positive, focus ring renders on the chip.

## Noticed, not fixed

- On the **empty** Done list the Result filter disappears: `SequencesPage.tsx:304` gates it on `defaultProcessingStage === 'annotated'`, but `SequencesPageWrapper` passes `ALL_CLASSIFIED_STAGES` (an array), so the comparison is always false. The populated branch (`:452`) uses `isAnnotatedView` and works. Pre-existing — the `<select>` vanished the same way.
- Picking any filter closes the popover: the refetch drops `SequencesPage` into its loading branch, remounting it. Also pre-existing, and it affects the camera and org selects too.