### PR TITLE
fix(api): stamp annotation updated_at server-side

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/import_annotations.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/import_annotations.py
@@ -23,7 +23,6 @@ import json
 import logging
 import os
 from copy import deepcopy
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 import requests
@@ -96,10 +95,6 @@ def setup_logging(level: str) -> None:
         level=getattr(logging, level.upper()),
         format="[%(levelname)s] %(message)s",
     )
-
-
-def iso_utc_now() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def get_token(
@@ -245,7 +240,6 @@ def build_payload_keep_bboxes_update_labels(
 
     ann_curr["sequences_bbox"] = curr_groups
     payload["annotation"] = ann_curr
-    payload["updated_at"] = iso_utc_now()
     return payload
 
 

--- a/annotation_api/src/app/models.py
+++ b/annotation_api/src/app/models.py
@@ -359,8 +359,10 @@ class SequenceAnnotation(SQLModel, table=True):
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True)),
     )
+    # Server-owned: stamped on every UPDATE, never supplied by clients (#216).
     updated_at: Optional[datetime] = Field(
-        default=None, sa_column=Column(DateTime(timezone=True))
+        default=None,
+        sa_column=Column(DateTime(timezone=True), onupdate=lambda: datetime.now(UTC)),
     )
     processing_stage: SequenceAnnotationProcessingStage
 
@@ -420,8 +422,10 @@ class DetectionAnnotation(SQLModel, table=True):
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True)),
     )
+    # Server-owned: stamped on every UPDATE, never supplied by clients (#216).
     updated_at: Optional[datetime] = Field(
-        default=None, sa_column=Column(DateTime(timezone=True))
+        default=None,
+        sa_column=Column(DateTime(timezone=True), onupdate=lambda: datetime.now(UTC)),
     )
 
 

--- a/annotation_api/src/app/schemas/sequence_annotations.py
+++ b/annotation_api/src/app/schemas/sequence_annotations.py
@@ -226,7 +226,6 @@ class SequenceAnnotationUpdate(BaseModel):
         description="Updated processing stage in the sequence annotation workflow. Use to advance or modify the current stage.",
         examples=["ready_to_annotate", "annotated"],
     )
-    updated_at: Optional[datetime] = None
 
     # Optional configuration parameters for automatic annotation generation
     confidence_threshold: Optional[float] = Field(

--- a/annotation_api/src/tests/endpoints/test_annotation_updated_at.py
+++ b/annotation_api/src/tests/endpoints/test_annotation_updated_at.py
@@ -1,0 +1,113 @@
+"""The server owns `updated_at` on annotation rows (#216).
+
+Clients never supply it; every mutation stamps it. Until this was fixed the
+column stayed NULL forever, so nothing could sort or report on last-modified.
+"""
+
+import json
+from datetime import datetime, UTC
+
+import pytest
+from httpx import AsyncClient
+
+from app import models
+
+
+def _parse(timestamp: str) -> datetime:
+    """Parse an API timestamp as UTC-aware, whatever the serializer emitted."""
+    parsed = datetime.fromisoformat(timestamp)
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+async def _create_sequence_annotation(client: AsyncClient) -> dict:
+    payload = {
+        "sequence_id": 1,
+        "has_missed_smoke": False,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": True,
+                    "false_positive_types": [],
+                    "bboxes": [{"detection_id": 1, "xyxyn": [0.1, 0.1, 0.2, 0.2]}],
+                }
+            ]
+        },
+        "processing_stage": models.SequenceAnnotationProcessingStage.IMPORTED.value,
+    }
+    response = await client.post("/annotations/sequences/", json=payload)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+@pytest.mark.asyncio
+async def test_patch_sequence_annotation_stamps_updated_at(
+    authenticated_client: AsyncClient, sequence_session, detection_session
+):
+    created = await _create_sequence_annotation(authenticated_client)
+    assert created["updated_at"] is None
+
+    response = await authenticated_client.patch(
+        f"/annotations/sequences/{created['id']}",
+        json={"has_missed_smoke": True},
+    )
+    assert response.status_code == 200, response.text
+
+    updated_at = response.json()["updated_at"]
+    assert updated_at is not None
+    assert _parse(updated_at) >= _parse(created["created_at"])
+
+
+@pytest.mark.asyncio
+async def test_patch_sequence_annotation_ignores_client_supplied_updated_at(
+    authenticated_client: AsyncClient, sequence_session, detection_session
+):
+    created = await _create_sequence_annotation(authenticated_client)
+
+    response = await authenticated_client.patch(
+        f"/annotations/sequences/{created['id']}",
+        json={"has_missed_smoke": True, "updated_at": "2000-01-01T00:00:00+00:00"},
+    )
+    assert response.status_code == 200, response.text
+
+    updated_at = _parse(response.json()["updated_at"])
+    assert updated_at.year != 2000
+    assert updated_at >= _parse(created["created_at"])
+
+
+@pytest.mark.asyncio
+async def test_patch_detection_annotation_stamps_updated_at(
+    authenticated_client: AsyncClient, sequence_session, detection_session
+):
+    create_payload = {
+        "detection_id": "1",
+        "annotation": json.dumps(
+            {
+                "annotation": [
+                    {
+                        "xyxyn": [0.1, 0.1, 0.2, 0.2],
+                        "class_name": "smoke",
+                        "smoke_type": "wildfire",
+                    }
+                ]
+            }
+        ),
+        "processing_stage": models.DetectionAnnotationProcessingStage.VISUAL_CHECK.value,
+    }
+    create_response = await authenticated_client.post(
+        "/annotations/detections/", data=create_payload
+    )
+    assert create_response.status_code == 201, create_response.text
+    created = create_response.json()
+    assert created["updated_at"] is None
+
+    response = await authenticated_client.patch(
+        f"/annotations/detections/{created['id']}",
+        json={
+            "processing_stage": models.DetectionAnnotationProcessingStage.ANNOTATED.value
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    updated_at = response.json()["updated_at"]
+    assert updated_at is not None
+    assert _parse(updated_at) >= _parse(created["created_at"])

--- a/annotation_api/src/tests/endpoints/test_classify_submit.py
+++ b/annotation_api/src/tests/endpoints/test_classify_submit.py
@@ -329,6 +329,48 @@ async def test_single_item_submit_degenerate_alert(
 
 
 @pytest.mark.asyncio
+async def test_submit_stamps_updated_at_on_every_lane(
+    authenticated_client: AsyncClient, async_session, mock_img
+):
+    """This path writes each lane with commit=False (flush, then one shared
+    commit), unlike the single-lane PATCH. The server-side updated_at stamp
+    (#216) has to survive that too, on every lane of the alert."""
+    seq_a = await _create_sequence(
+        async_session, alert_api_id=1601, platform_alert_id=950
+    )
+    seq_b = await _create_sequence(
+        async_session, alert_api_id=1602, platform_alert_id=950
+    )
+    det_a = await _create_detection(authenticated_client, mock_img, seq_a.id, 1601)
+    det_b = await _create_detection(authenticated_client, mock_img, seq_b.id, 1602)
+    ann_a = await _create_sequence_annotation(
+        authenticated_client, seq_a.id, det_a, is_smoke=False, stage="ready_to_annotate"
+    )
+    ann_b = await _create_sequence_annotation(
+        authenticated_client, seq_b.id, det_b, is_smoke=True, stage="ready_to_annotate"
+    )
+    assert ann_a["updated_at"] is None
+    assert ann_b["updated_at"] is None
+
+    resp = await authenticated_client.post(
+        "/annotations/sequences/classify-submit",
+        json={
+            "items": [
+                _item(ann_a, processing_stage="annotated"),
+                _item(ann_b, processing_stage="seq_annotation_done"),
+            ]
+        },
+    )
+    assert resp.status_code == 200
+
+    for annotation in (ann_a, ann_b):
+        stored = await authenticated_client.get(
+            f"/annotations/sequences/{annotation['id']}"
+        )
+        assert stored.json()["updated_at"] is not None, annotation["id"]
+
+
+@pytest.mark.asyncio
 async def test_unsure_lane_reaching_annotated_skips_auto_create(
     authenticated_client: AsyncClient, async_session, mock_img
 ):


### PR DESCRIPTION
Closes #216.

## Problem

`sequences_annotations.updated_at` and `detections_annotations.updated_at` were never written. After classifying sequences through the UI, every row still had `updated_at IS NULL`:

```
 sequence_id | updated_at |          created_at
-------------+------------+-------------------------------
          29 |            | 2026-07-28 12:13:42.583139+00
          23 |            | 2026-07-28 12:13:41.856097+00
```

The CRUD update path only persists what the payload carries, and `SequenceAnnotationUpdate` exposed `updated_at` as a client-supplied field that the frontend never sends. `DetectionAnnotationUpdate` had no such field at all, so that model could not be stamped either. Anything wanting to sort, filter or report on last-modified silently got NULLs.

## Fix

- **`models.py`** — `onupdate=lambda: datetime.now(UTC)` on the `updated_at` columns of `SequenceAnnotation` and `DetectionAnnotation`. It fires on every UPDATE regardless of which code path emits it, so future write paths can't miss it. Being a Python-side default, **no migration is needed**.
- **`schemas/sequence_annotations.py`** — dropped `updated_at` from `SequenceAnnotationUpdate`. This is what makes `onupdate` authoritative: SQLAlchemy skips `onupdate` for any column the client set explicitly, so leaving the field in would let a client keep overriding the server.
- **`scripts/.../import_annotations.py`** — removed `payload["updated_at"] = iso_utc_now()`, now a no-op, along with the `iso_utc_now` helper and `datetime` import it orphaned. The update schemas ignore extra keys, so any other client still sending the field keeps working — it just stops winning over the server.

No backfill: existing NULL rows are left meaning "last modified unknown" rather than given an invented modification time equal to `created_at`.

## Tests

`src/tests/endpoints/test_annotation_updated_at.py` covers three behaviours, each written first and watched fail:

- sequence annotation PATCH stamps `updated_at`
- a client-supplied `updated_at` in the PATCH body is ignored, and the server stamps its own
- detection annotation PATCH stamps `updated_at`

Full backend suite: 569 passed.

## Out of scope

`SequenceGroup.updated_at` is still stamped by hand at three call sites (`sequence_annotations.py:913,1400`, `sequence_groups.py:302`) — the same fragility this PR removes for annotations. Left alone to keep the diff to #216; happy to file a follow-up.