### PR TITLE
feat(frontend): cockpit-ify /localize/:id, gate submit on accepted objects

### DIFF
--- a/frontend/src/components/detection-sequence/AlertFrameGrid.tsx
+++ b/frontend/src/components/detection-sequence/AlertFrameGrid.tsx
@@ -34,6 +34,8 @@ interface AlertFrameGridProps {
   onCellClick: (recordedAt: string, laneSequenceId: number, detectionId: number) => void;
   /** Registers the cell's DOM node for the page's scroll-to-frame behavior (segment click). */
   cellRef?: (recordedAt: string, el: HTMLDivElement | null) => void;
+  /** The active object's accent color — outlines the frames it actually appears on. */
+  activeColor?: string;
   /** Minimum cell width driving the auto-fill column count — matches DetectionGrid's card-size knob. */
   cardMinWidth?: number;
   /** Zoom each cell around the active object's boxes for that frame; no-op with no active object. */
@@ -47,6 +49,7 @@ export function AlertFrameGrid({
   activeLaneId,
   onCellClick,
   cellRef,
+  activeColor,
   cardMinWidth = 220,
   cropMode = false,
   highlightedFrame = null,
@@ -65,6 +68,7 @@ export function AlertFrameGrid({
           key={frame.recordedAt}
           frame={frame}
           activeLaneId={activeLaneId}
+          activeColor={activeColor}
           cropMode={cropMode}
           highlighted={highlightedFrame === frame.recordedAt}
           onClick={activeCell =>
@@ -80,6 +84,7 @@ export function AlertFrameGrid({
 interface AlertFrameCellViewProps {
   frame: AlertFrame;
   activeLaneId: number | null;
+  activeColor?: string;
   cropMode: boolean;
   highlighted: boolean;
   onClick: (activeCell: AlertFrameCell) => void;
@@ -89,13 +94,19 @@ interface AlertFrameCellViewProps {
 function AlertFrameCellView({
   frame,
   activeLaneId,
+  activeColor,
   cropMode,
   highlighted,
   onClick,
   cellRef,
 }: AlertFrameCellViewProps) {
+  // Fallback (no active object) prefers a lane that can actually be worked:
+  // landing on a false-positive cell would make the whole frame read-only,
+  // hiding the smoke object that shares it behind an un-clickable cell.
   const activeCell: AlertFrameCell =
-    frame.cells.find(c => c.laneSequenceId === activeLaneId) ?? frame.cells[0];
+    frame.cells.find(c => c.laneSequenceId === activeLaneId) ??
+    frame.cells.find(c => !c.isFalsePositive) ??
+    frame.cells[0];
   // Crop only applies when the active lane is actually present on this
   // frame — a fallback cell (active lane absent here) has no "the object"
   // box to focus on, so it stays full-frame.
@@ -118,12 +129,27 @@ function AlertFrameCellView({
     if (imgRef.current && containerRef.current) {
       const containerRect = containerRef.current.getBoundingClientRect();
       const imgRect = imgRef.current.getBoundingClientRect();
-      setImageInfo({
+      const next: ImageInfo = {
         width: imgRect.width,
         height: imgRect.height,
         offsetX: imgRect.left - containerRect.left,
         offsetY: imgRect.top - containerRect.top,
-      });
+      };
+      // Bail out when the measurement is unchanged. This runs from a
+      // ResizeObserver callback, and an unconditional setState there is a
+      // feedback loop waiting to happen: re-render -> layout -> observer
+      // fires -> setState -> ... Activating an object used to trip it —
+      // focus mode flips crop on AND forces small cards, so the grid
+      // re-columns and every cell re-measures at once.
+      setImageInfo(prev =>
+        prev &&
+        prev.width === next.width &&
+        prev.height === next.height &&
+        prev.offsetX === next.offsetX &&
+        prev.offsetY === next.offsetY
+          ? prev
+          : next
+      );
     }
   }, []);
 
@@ -143,9 +169,17 @@ function AlertFrameCellView({
     return () => observer.disconnect();
   }, [handleImageLoad, isLoading, imageData?.url]);
 
-  const doneCount = frame.cells.filter(c => c.cellState === 'done').length;
-  const total = frame.cells.length;
-  const allDone = doneCount === total;
+  // With an object active, a frame it doesn't appear on is context only:
+  // there is nothing of THIS object to annotate there. It fades back so the
+  // object's own span reads at a glance, and it stops being a click target —
+  // clicking used to open the fallback lane's detection, silently switching
+  // which object you were editing.
+  const isContextFrame = activeLaneId !== null && !isActiveLaneCell;
+  const isAccented = activeLaneId !== null && isActiveLaneCell;
+  // A false-positive object is settled; its frames are here to be LOOKED at
+  // (including via the cropped-view strip), never edited. Opening the editor
+  // on one would offer to re-box something classify already rejected.
+  const isReadOnly = isContextFrame || activeCell.isFalsePositive === true;
 
   return (
     <div
@@ -155,10 +189,22 @@ function AlertFrameCellView({
       }}
       data-testid={`alert-frame-cell-${frame.recordedAt}`}
       data-highlighted={highlighted ? 'true' : undefined}
-      className={`group aspect-video relative overflow-hidden bg-ash cursor-pointer transition-shadow duration-700 ${
+      data-context={isContextFrame ? 'true' : undefined}
+      data-readonly={isReadOnly ? 'true' : undefined}
+      className={`group aspect-video relative overflow-hidden bg-ash transition-shadow duration-700 ${
+        isContextFrame ? 'opacity-40 saturate-50' : ''
+      } ${isReadOnly ? 'cursor-default' : 'cursor-pointer'} ${
         highlighted ? 'ring-2 ring-pine ring-offset-2' : ''
       }`}
-      onClick={() => onClick(activeCell)}
+      // `outline` rather than a Tailwind ring: the arrival highlight above
+      // already owns the ring (box-shadow), and the two would clobber each
+      // other on a cell that is both accented and highlighted.
+      style={
+        isAccented && activeColor
+          ? { outline: `2px solid ${activeColor}`, outlineOffset: '-2px' }
+          : undefined
+      }
+      onClick={isReadOnly ? undefined : () => onClick(activeCell)}
     >
       {isLoading && <div className="absolute inset-0 animate-pulse bg-ash" />}
 
@@ -194,15 +240,6 @@ function AlertFrameCellView({
             );
           })
         )}
-
-      <span
-        data-testid={`alert-frame-status-${frame.recordedAt}`}
-        className={`absolute top-1 right-1 rounded-full px-1.5 py-0.5 font-data text-[10px] font-semibold ${
-          allDone ? 'bg-pine-soft text-pine' : 'bg-ember-soft text-ember'
-        }`}
-      >
-        {doneCount}/{total}
-      </span>
 
       <div className="absolute bottom-0 left-0 bg-char/60 text-white text-[10px] px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
         {new Date(frame.recordedAt).toLocaleString()}

--- a/frontend/src/components/detection-sequence/ViewToolbar.tsx
+++ b/frontend/src/components/detection-sequence/ViewToolbar.tsx
@@ -2,6 +2,12 @@
  * Compact view controls for the detection grid: S/M/L card size plus icon
  * toggles for predictions, crop mode, and the cropped flipbook. One shared
  * button style — the header and flipbook speak the same visual language.
+ *
+ * The predictions toggle is opt-in (`onTogglePredictions`): it drives
+ * `DetectionGrid`'s overlays on the legacy per-lane page, but `AlertFrameGrid`
+ * on the collocated localize screen never reads `showPredictions`, so the
+ * cockpit omits it rather than showing a control that moves nothing on
+ * screen.
  */
 
 import { Crop, Eye, Film } from 'lucide-react';
@@ -17,8 +23,9 @@ const CARD_SIZES: { value: CardSize; label: string; title: string }[] = [
 interface ViewToolbarProps {
   cardSize: CardSize;
   onCardSizeChange: (size: CardSize) => void;
-  showPredictions: boolean;
-  onTogglePredictions: (show: boolean) => void;
+  showPredictions?: boolean;
+  /** Omit to hide the predictions toggle entirely (see the note above). */
+  onTogglePredictions?: (show: boolean) => void;
   isLocalize?: boolean;
   cropMode?: boolean;
   onToggleCropMode?: (crop: boolean) => void;
@@ -44,8 +51,8 @@ function IconToggle({
       aria-label={title}
       aria-pressed={pressed}
       onClick={onClick}
-      className={`p-1.5 rounded ${
-        pressed ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-900'
+      className={`rounded p-1.5 transition-colors ${
+        pressed ? 'bg-paper text-char' : 'text-haze hover:text-char'
       }`}
     >
       {children}
@@ -65,7 +72,7 @@ export function ViewToolbar({
   onToggleCroppedView,
 }: ViewToolbarProps) {
   return (
-    <div className="inline-flex items-center rounded-md bg-gray-200 p-0.5 gap-0.5">
+    <div className="inline-flex items-center gap-0.5 rounded-lg bg-ash p-0.5">
       {CARD_SIZES.map(s => (
         <button
           key={s.value}
@@ -73,23 +80,23 @@ export function ViewToolbar({
           title={s.title}
           aria-pressed={cardSize === s.value}
           onClick={() => onCardSizeChange(s.value)}
-          className={`px-2 py-0.5 rounded text-xs font-semibold ${
-            cardSize === s.value
-              ? 'bg-white text-gray-900 shadow-sm'
-              : 'text-gray-500 hover:text-gray-900'
+          className={`rounded px-2 py-0.5 font-body text-xs font-semibold transition-colors ${
+            cardSize === s.value ? 'bg-paper text-char' : 'text-haze hover:text-char'
           }`}
         >
           {s.label}
         </button>
       ))}
-      <div className="w-px self-stretch bg-gray-300 mx-0.5" />
-      <IconToggle
-        title="Show predictions (P)"
-        pressed={showPredictions}
-        onClick={() => onTogglePredictions(!showPredictions)}
-      >
-        <Eye className="w-3.5 h-3.5" />
-      </IconToggle>
+      <div className="mx-0.5 w-px self-stretch bg-line" />
+      {onTogglePredictions && (
+        <IconToggle
+          title="Show predictions (P)"
+          pressed={showPredictions ?? false}
+          onClick={() => onTogglePredictions(!showPredictions)}
+        >
+          <Eye className="w-3.5 h-3.5" />
+        </IconToggle>
+      )}
       {isLocalize && (
         <>
           <IconToggle

--- a/frontend/src/components/localize/LocalizeMissedSmokeRow.tsx
+++ b/frontend/src/components/localize/LocalizeMissedSmokeRow.tsx
@@ -1,0 +1,87 @@
+/**
+ * The localize rail's missed-smoke question — the counterpart of classify's
+ * `DecisionRail` row, and the context for "+ Add object" sitting directly
+ * below it.
+ *
+ * Localize used to READ `has_missed_smoke` without ever showing it: the flag
+ * classify set only surfaced at submit time, in the "you flagged missed smoke
+ * but added no object" dialog. Here it is visible up front and answerable in
+ * place, so the reason to add an object is on screen before you need it.
+ *
+ * Binary rather than classify's tri-state: classify's own submit already
+ * requires the question to be answered, so by the time an alert reaches
+ * localize `has_missed_smoke` is a real answer, not "not asked yet".
+ *
+ * The answer gates adding an object, and the control lives INSIDE this row
+ * rather than beside it: "+ Add object" only exists once the answer is Yes,
+ * so the question and the only action it authorizes read as one unit instead
+ * of a button that is mysteriously dead until something above it is answered.
+ */
+
+import React from 'react';
+
+export interface LocalizeMissedSmokeRowProps {
+  /** Current answer for this alert. */
+  hasMissedSmoke: boolean;
+  onChange: (hasMissedSmoke: boolean) => void;
+  /** True while the PATCH is in flight. */
+  isSaving?: boolean;
+  /** No lane can carry the flag (nothing annotated yet) — render read-only. */
+  disabled?: boolean;
+  /** The "+ Add object" control, rendered inside the row and only while the answer is Yes. */
+  addObject?: React.ReactNode;
+}
+
+const chip = (selected: boolean, selectedClasses: string, disabled: boolean) =>
+  `inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 font-body text-xs font-medium transition-colors ${
+    selected ? selectedClasses : 'border-line bg-paper text-char hover:bg-ash'
+  } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`;
+
+export const LocalizeMissedSmokeRow: React.FC<LocalizeMissedSmokeRowProps> = ({
+  hasMissedSmoke,
+  onChange,
+  isSaving = false,
+  disabled = false,
+  addObject,
+}) => (
+  <div
+    data-testid="localize-missed-smoke-row"
+    className="rounded-lg border border-line px-3.5 py-2.5"
+  >
+    <div className="flex items-center justify-between gap-2">
+      <span className="font-body text-sm font-semibold text-char">Missed smoke?</span>
+      <span role="radiogroup" aria-label="Missed smoke" className="flex items-center gap-1.5">
+        <button
+          type="button"
+          role="radio"
+          aria-checked={hasMissedSmoke}
+          aria-label="Yes"
+          disabled={disabled || isSaving}
+          onClick={() => onChange(true)}
+          className={chip(hasMissedSmoke, 'border-ember bg-ember-soft text-ember', disabled)}
+        >
+          Yes
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={!hasMissedSmoke}
+          aria-label="No"
+          disabled={disabled || isSaving}
+          onClick={() => onChange(false)}
+          className={chip(!hasMissedSmoke, 'border-pine bg-pine text-white', disabled)}
+        >
+          No
+        </button>
+      </span>
+    </div>
+    {hasMissedSmoke && (
+      <>
+        <p className="mt-1.5 font-body text-detail text-haze">
+          Add the object the AI missed, so it gets its own row to localize.
+        </p>
+        {addObject && <div className="mt-2 flex flex-wrap items-center gap-2">{addObject}</div>}
+      </>
+    )}
+  </div>
+);

--- a/frontend/src/components/localize/LocalizeObjectRow.tsx
+++ b/frontend/src/components/localize/LocalizeObjectRow.tsx
@@ -1,0 +1,149 @@
+/**
+ * One object's row in the localize cockpit's rail — the localize counterpart
+ * of classify's `ObjectRow`. Where classify's row carries a per-object
+ * *classification*, this one carries a per-object *localization progress*:
+ * how many of the frames the object appears on already have a committed box.
+ *
+ * Unlike classify's row, the action doesn't hide behind activation: Accept
+ * boxes is a one-click bulk action on the row's own lane, so it stays visible
+ * on every workable row (matching the pre-cockpit strip's behavior).
+ * Activation therefore shows up purely as the accent treatment — the media
+ * column follows the active object, so the row doesn't need to expand.
+ *
+ * Context rows (lanes already localized) render dimmed and action-less, but
+ * stay clickable: activating one points the media column at its frames,
+ * which is the whole reason they're on screen.
+ */
+
+import React from 'react';
+
+export interface LocalizeObjectRowProps {
+  /** e.g. "Object 2" — the object's own label, shared with the timeline and grid overlays. */
+  label: string;
+  /** Stable per-object color (hex) — matches the timeline swatch and the grid's box color. */
+  color: string;
+  /** Frames this object appears on that already carry a committed box. */
+  confirmedCount: number;
+  /** Frames this object appears on at all (confirmed + pending). */
+  presentCount: number;
+  /** False for lanes already past localization — read-only context. */
+  workable: boolean;
+  /** What classify decided this is (wildfire / industrial / other) — omitted on false-positive rows. */
+  smokeType?: string;
+  /** Read-only false-positive context, surfaced by the opt-in toggle. */
+  isFalsePositive?: boolean;
+  /** The false-positive types classify recorded, shown in place of a smoke type. */
+  falsePositiveTypes?: string[];
+  /** True when this object drives the media column (focus mode). */
+  isActive: boolean;
+  onActivate: () => void;
+  /** Bulk-accepts the winning model boxes for this lane's pending frames. Omit on context rows. */
+  onAcceptBoxes?: () => void;
+  isAccepting?: boolean;
+}
+
+export const LocalizeObjectRow: React.FC<LocalizeObjectRowProps> = ({
+  label,
+  color,
+  confirmedCount,
+  presentCount,
+  workable,
+  smokeType,
+  isFalsePositive = false,
+  falsePositiveTypes,
+  isActive,
+  onActivate,
+  onAcceptBoxes,
+  isAccepting = false,
+}) => {
+  const pendingCount = presentCount - confirmedCount;
+
+  const status = isFalsePositive
+    ? { label: 'False positive', tone: 'bg-ash text-haze' }
+    : !workable
+      ? { label: 'Context', tone: 'bg-ash text-haze' }
+      : pendingCount === 0
+        ? { label: 'Done', tone: 'bg-pine-soft text-pine' }
+        : { label: `${pendingCount} left`, tone: 'bg-ember-soft text-ember' };
+
+  // What this object is, under its name: the smoke type classify chose, or
+  // the false-positive types it was rejected as.
+  const subtitle = isFalsePositive
+    ? (falsePositiveTypes ?? []).map(t => t.replace(/_/g, ' ')).join(', ') || null
+    : (smokeType ?? null);
+
+  const frame = !workable
+    ? 'border border-line bg-paper opacity-60'
+    : isActive
+      ? 'border border-line border-l-[3px] border-l-pine bg-paper'
+      : 'border border-line bg-paper hover:bg-ash';
+
+  return (
+    <div
+      data-testid={`localize-object-row-${label.replace(/\s+/g, '-').toLowerCase()}`}
+      data-active={isActive ? 'true' : undefined}
+      // role="group" rather than a button: workable rows contain their own
+      // action buttons, and nesting interactive controls is invalid HTML.
+      role="group"
+      aria-label={label}
+      className={`cursor-pointer rounded-lg px-3.5 py-2.5 transition-colors ${frame}`}
+      onClick={onActivate}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="flex min-w-0 items-center gap-2">
+          <span
+            className="inline-block h-2.5 w-2.5 shrink-0 rounded-full ring-1 ring-char/10"
+            style={{ backgroundColor: color }}
+            aria-hidden="true"
+          />
+          <span className="min-w-0">
+            <span className="block truncate font-body text-sm font-semibold text-char">
+              {label}
+            </span>
+            {subtitle && (
+              <span className="block truncate font-body text-detail capitalize text-haze">
+                {subtitle}
+              </span>
+            )}
+          </span>
+        </span>
+        <span className="flex shrink-0 items-center gap-1.5">
+          {/* A false positive has no localization work, so a progress
+              fraction over its frames would be meaningless. */}
+          {!isFalsePositive && (
+            <span className="font-data text-detail text-haze">
+              {confirmedCount}/{presentCount}
+            </span>
+          )}
+          <span
+            className={`whitespace-nowrap rounded-full px-2 py-0.5 font-body text-xs font-semibold ${status.tone}`}
+          >
+            {status.label}
+          </span>
+        </span>
+      </div>
+
+      {onAcceptBoxes && (
+        <div className="mt-2">
+          <button
+            type="button"
+            // The visible label stays short for the rail's width; the
+            // accessible name keeps naming the object, so "accept THIS
+            // object's boxes" is unambiguous to a screen reader (and to the
+            // page tests, which address rows by object).
+            aria-label={`Accept ${label}'s boxes`}
+            onClick={e => {
+              e.stopPropagation();
+              onAcceptBoxes();
+            }}
+            disabled={isAccepting}
+            title={`Accept ${label}'s predicted boxes for all pending frames`}
+            className="rounded-lg border border-line bg-paper px-2 py-1 font-body text-xs font-medium text-char hover:bg-ash disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isAccepting ? 'Accepting…' : 'Accept boxes'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/localize/LocalizeRail.tsx
+++ b/frontend/src/components/localize/LocalizeRail.tsx
@@ -1,0 +1,50 @@
+/**
+ * The localize cockpit's right-hand column: the whole alert's localization
+ * state, mirroring classify's `DecisionRail`. Object rows come in as
+ * children (the page owns their ordering and wiring); the rail owns only the
+ * frame, the "+ Add object" slot below the rows, and the submit footer.
+ *
+ * Its own slot is `addObject` rather than classify's fixed missed-smoke row:
+ * on the localize side, "the AI missed a plume entirely" is answered by
+ * spawning a real sibling lane, not by ticking an alert-level flag.
+ */
+
+import React from 'react';
+
+export interface LocalizeRailProps {
+  /** Rendered top-right of the Objects header. */
+  headerAction?: React.ReactNode;
+  /** The missed-smoke question, which carries "+ Add object" inside it — rendered below the rows. */
+  missedSmoke?: React.ReactNode;
+  /** The page's submit button. */
+  footer?: React.ReactNode;
+  /** Object rows, already ordered. */
+  children: React.ReactNode;
+}
+
+export const LocalizeRail: React.FC<LocalizeRailProps> = ({
+  headerAction,
+  missedSmoke,
+  footer,
+  children,
+}) => (
+  <div className="rounded-card border border-line bg-paper px-[22px] py-5">
+    <div className="mb-3 flex items-center justify-between">
+      <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
+        Objects
+      </div>
+      {headerAction}
+    </div>
+
+    <div className="space-y-2">{children}</div>
+
+    {missedSmoke && (
+      <>
+        <hr className="my-4 border-0 border-t border-line" />
+        {missedSmoke}
+      </>
+    )}
+
+    {footer && <div className="mt-4">{footer}</div>}
+  </div>
+);

--- a/frontend/src/components/localize/index.ts
+++ b/frontend/src/components/localize/index.ts
@@ -1,0 +1,6 @@
+export { LocalizeObjectRow } from './LocalizeObjectRow';
+export type { LocalizeObjectRowProps } from './LocalizeObjectRow';
+export { LocalizeRail } from './LocalizeRail';
+export type { LocalizeRailProps } from './LocalizeRail';
+export { LocalizeMissedSmokeRow } from './LocalizeMissedSmokeRow';
+export type { LocalizeMissedSmokeRowProps } from './LocalizeMissedSmokeRow';

--- a/frontend/src/components/sequence-annotation/ObjectStatusStrip.tsx
+++ b/frontend/src/components/sequence-annotation/ObjectStatusStrip.tsx
@@ -1,10 +1,16 @@
 /**
- * Tri-state, clickable-segment object timeline for the collocated localize
- * screens. One row per object — a color swatch + label button ("Go to
- * Object N") plus a per-frame status bar across the union of the alert's
- * frame timestamps, where each frame is its own button reporting that
- * object's status at that timestamp: `confirmed` (solid fill), `pending`
- * (reduced-opacity fill), or `absent` (neutral track, no fill).
+ * Clickable-segment object timeline for the collocated localize screens. One
+ * row per object — a color swatch + label button ("Go to Object N") plus a
+ * per-frame status bar across the union of the alert's frame timestamps,
+ * where each frame is its own button reporting that object's status at that
+ * timestamp: `confirmed` (solid fill), `pending` (reduced-opacity fill — a
+ * model box waiting to be accepted), `empty` (outline only — on this frame
+ * but with nothing on it yet), or `absent` (neutral track, no fill — not on
+ * this frame at all).
+ *
+ * `empty` is deliberately distinct from `pending`: collapsing the two made a
+ * frame with nothing on it look identical to one with a box to accept, which
+ * painted a just-added object's whole timeline as if it were already full.
  *
  * Renders for `objects.length >= 1` — unlike ObjectPresenceStrip's ≥2 gate,
  * a single-object alert still benefits from seeing its own frame statuses.
@@ -30,7 +36,7 @@
 
 import React from 'react';
 
-export type ObjectStatusStripStatus = 'confirmed' | 'pending' | 'absent';
+export type ObjectStatusStripStatus = 'confirmed' | 'pending' | 'empty' | 'absent';
 
 export interface ObjectStatusStripObject {
   /** e.g. "Object 2" — same numbering as the object's card. */
@@ -39,8 +45,6 @@ export interface ObjectStatusStripObject {
   color: string;
   /** This object's status per frame timestamp (ISO string); frames absent from the map render as `absent`. */
   statusByTimestamp: Record<string, ObjectStatusStripStatus>;
-  /** Optional action (e.g. a quick-accept button) rendered at the row's trailing edge. */
-  action?: React.ReactNode;
   /** Renders the row with an accent fill + left border — this object's current "focused" state. */
   selected?: boolean;
 }
@@ -94,6 +98,16 @@ function segmentAppearance(
   }
   if (status === 'pending') {
     return { className: `${SEGMENT_BASE_CLASS} opacity-40`, style: { backgroundColor: color } };
+  }
+  if (status === 'empty') {
+    // Present on this frame, but nothing to show yet — no committed box and
+    // no model prediction to accept. An outline in the object's own color
+    // keeps it legible as "this object's frame" without the fill that would
+    // imply content (a just-added object's whole timeline is this state).
+    return {
+      className: `${SEGMENT_BASE_CLASS} opacity-50`,
+      style: { boxShadow: `inset 0 0 0 1px ${color}` },
+    };
   }
   // absent — neutral track, no fill; the row's track background shows through.
   return { className: SEGMENT_BASE_CLASS };
@@ -155,7 +169,6 @@ export const ObjectStatusStrip: React.FC<ObjectStatusStripProps> = ({
                 );
               })}
             </div>
-            {object.action}
           </div>
         );
       })}

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -9,9 +9,8 @@
  * detection in `ImageModal` (URL-driven via the optional `:detectionId`, so
  * the back button closes the editor), a per-object "Accept boxes" quick
  * action on each workable strip row, and the S/M/L card-size + crop-zoom
- * view controls. Task 5 wires the header's submit button: "Accept all &
- * submit alert" runs every workable lane's quick-accept plan, then submits
- * the whole alert atomically via the bulk `localize-submit` endpoint.
+ * view controls. Task 5 wires submitting the whole alert atomically via the
+ * bulk `localize-submit` endpoint.
  *
  * Post-Task-5 feedback round: a segment click gives its target cell a fading
  * ring highlight and encodes the shown detection in a `?frame=` query param
@@ -27,9 +26,43 @@
  * popover (dropped — the inline cropped-view strip replaces it).
  *
  * Task 9 retires the earlier ⚑ pseudo-object row (a carrier-lane box that
- * stood in for missed smoke) in favor of "+ Add object": a timeline footer
- * action that spawns a brand-new sibling lane for a plume the AI missed
- * entirely, so it gets its own real object row like any other.
+ * stood in for missed smoke) in favor of "+ Add object": a footer action
+ * that spawns a brand-new sibling lane for a plume the AI missed entirely,
+ * so it gets its own real object row like any other.
+ *
+ * Cockpit round: the page adopts ClassifyAlertPage's two-column shape —
+ * a media column (the active object's frame grid, plus its cropped-view
+ * flipbook) beside a sticky `LocalizeRail` carrying the whole alert's
+ * localization state. That collapses the three blocks the body used to
+ * stack (workable timeline -> standalone "+ Add object" card -> a separate
+ * dimmed "Already localized" timeline) into one rail: every object gets a
+ * row in lane order, with already-localized lanes dimmed in place rather
+ * than exiled to their own strip, and the timeline moves below the rail
+ * into the slot classify gives `ObjectPresenceStrip`. Submit moves out of
+ * the header into the rail footer and turns pine per DESIGN.md's
+ * "primary is pine in Localize contexts"; the header keeps identity, the
+ * view toolbar, and a progress badge that now reports how many objects are
+ * fully localized rather than a bare object count.
+ *
+ * Submit is also gated now: it enables only once every workable object
+ * already carries a committed box on every frame it appears on, accepted
+ * per object from its own rail row. Submit therefore no longer accepts
+ * anything itself, and the old per-frame "N frames with no box — submit
+ * anyway?" two-step went with that: under the gate there is never a pending
+ * no-box frame left at submit time. The missed-smoke soft-confirm is the
+ * only gate left in front of it.
+ *
+ * The rail also owns the missed-smoke question, which guards "+ Add object":
+ * it starts at No on every alert — deliberately NOT seeded from the lanes'
+ * inherited `has_missed_smoke`, so arriving on an alert classify already
+ * flagged never pre-authorizes adding — and answering writes the flag
+ * through to the carrying lane.
+ *
+ * False-positive objects are hidden by default (the queue's own rule, via
+ * `laneNeedsLocalization`) behind a rail toggle that surfaces them as a
+ * separated, read-only group — enough to answer "is that plume already
+ * accounted for?" before someone adds a duplicate object for it. Unsure
+ * lanes stay excluded either way.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -44,15 +77,16 @@ import {
   findFrameByDetectionId,
   AlertObjectStatus,
 } from '@/utils/annotation/alertLocalizeUtils';
+import { laneNeedsLocalization } from '@/utils/annotation/localizeUtils';
 import {
   buildQuickSubmitPlan,
   collectLaneBoxes,
   getIsAnnotated,
   saveDetectionReview,
   sequenceSmokeType,
-  type QuickSubmitPlan,
 } from '@/utils/annotation';
 import { ObjectStatusStrip } from '@/components/sequence-annotation';
+import { LocalizeMissedSmokeRow, LocalizeObjectRow, LocalizeRail } from '@/components/localize';
 import { AlertFrameGrid, ImageModal, ViewToolbar } from '@/components/detection-sequence';
 import type { CardSize } from '@/components/detection-sequence/ViewToolbar';
 import CroppedImageSequence from '@/components/annotation/CroppedImageSequence';
@@ -80,22 +114,33 @@ export default function LocalizeAlertPage() {
   const [cardSize, setCardSize] = usePersistedTabState<CardSize>('detectionAnnotateCardSize', 'md');
   const [cropMode, setCropMode] = useState(false);
   const [showCroppedView, setShowCroppedView] = useState(false);
+  // Opt-in read-only context: objects classify settled as false positives.
+  // Off by default so the default view matches the queue's own rule; on, it
+  // answers "is that plume already accounted for?" before someone adds a
+  // duplicate object for something already rejected.
+  const [showFalsePositives, setShowFalsePositives] = useState(false);
   const [showPredictions, setShowPredictions] = useState(true);
   const [persistentDrawMode, setPersistentDrawMode] = useState(false);
   const [selectedSmokeType, setSelectedSmokeType] = useState<SmokeType>('wildfire');
   const smokeTypeInitFor = useRef<number | null>(null);
-  const [submitConfirming, setSubmitConfirming] = useState(false);
 
   // The three-way "you flagged missed smoke but added no object" dialog and
   // whether it's already been answered this submit round (so re-clicking
-  // "Accept all & submit" after "Submit anyway" falls through to the
-  // ordinary no-box confirm instead of re-asking the same question).
+  // Submit after "Submit anyway" goes straight through instead of re-asking
+  // the same question).
   const [missedSmokeConfirm, setMissedSmokeConfirm] = useState(false);
   const [softConfirmResolved, setSoftConfirmResolved] = useState(false);
   // "+ Add object": lane ids spawned via the picker this session (feeds the
   // soft-confirm gate below) and whether the picker is currently open.
   const [sessionAddedObjects, setSessionAddedObjects] = useState<number[]>([]);
   const [addObjectPickerOpen, setAddObjectPickerOpen] = useState(false);
+
+  // The rail's missed-smoke answer, and the gate in front of "+ Add object".
+  // Deliberately NOT seeded from the lanes' inherited `has_missed_smoke`:
+  // adding an object has to be a decision made here, so arriving on an alert
+  // classify already flagged must not pre-authorize it. Answering writes the
+  // flag through to the carrier lane.
+  const [missedSmoke, setMissedSmoke] = useState(false);
 
   // Object-focus mode: entering it (row/segment click activating an object)
   // stashes the pre-focus crop-mode so the selected row's second click can
@@ -164,6 +209,7 @@ export default function LocalizeAlertPage() {
     setSoftConfirmResolved(false);
     setSessionAddedObjects([]);
     setAddObjectPickerOpen(false);
+    setMissedSmoke(false);
     frameRefs.current = {};
   }, [sequenceIdNum]);
 
@@ -253,7 +299,9 @@ export default function LocalizeAlertPage() {
   }, [laneSequenceIds, laneAnnotationsQueries]);
 
   const frameModel = alertDetail
-    ? buildAlertFrameModel(alertDetail.lanes, detectionsByLaneId, annotationsByLaneId)
+    ? buildAlertFrameModel(alertDetail.lanes, detectionsByLaneId, annotationsByLaneId, {
+        includeFalsePositives: showFalsePositives,
+      })
     : { frames: [], objectStatus: [] };
 
   // Soft-confirm gate for submit: `has_missed_smoke` is set on some lane,
@@ -263,6 +311,17 @@ export default function LocalizeAlertPage() {
   const anyLaneFlagged = alertDetail?.lanes.some(l => l.annotation?.has_missed_smoke) ?? false;
   const softConfirmNeeded =
     anyLaneFlagged && sessionAddedObjects.length === 0 && !softConfirmResolved;
+
+  // The alert-level missed-smoke flag lives on ONE lane's annotation.
+  // Whichever lane
+  // already carries it stays the carrier (so toggling edits that row rather
+  // than stranding a stale flag on another lane); otherwise it goes on the
+  // first lane that has an annotation at all. Undefined only when no lane is
+  // annotated yet, which renders the row read-only.
+  const missedSmokeAnnotationId = (
+    alertDetail?.lanes.find(l => l.annotation?.has_missed_smoke) ??
+    alertDetail?.lanes.find(l => !!l.annotation)
+  )?.annotation?.id;
 
   // Reproduces a shared/reloaded `?frame=<detectionId>` link: resolves the
   // detection id against every lane's frames (independent of the editor's
@@ -304,6 +363,10 @@ export default function LocalizeAlertPage() {
       const laneId = lane.sequence.id;
       const detection = (detectionsByLaneId[laneId] ?? []).find(d => d.id === detectionIdNum);
       if (detection) {
+        // Lanes that don't need localization (false positives, unsure) are
+        // never editable here — the grid already refuses to open them, and
+        // this closes the pasted/back-button URL route in as well.
+        if (!lane.annotation || !laneNeedsLocalization(lane.annotation)) return null;
         const existingAnnotation =
           (annotationsByLaneId[laneId] ?? []).find(a => a.detection_id === detectionIdNum) ?? null;
         return {
@@ -417,15 +480,27 @@ export default function LocalizeAlertPage() {
     },
   });
 
-  // Soft-confirm's "Submit & clear flag" path: PATCHes the flag off the
-  // lane currently carrying it before the submit proceeds.
-  const clearMissedSmokeFlag = useMutation({
-    mutationFn: (annotationId: number) =>
-      apiClient.updateSequenceAnnotation(annotationId, { has_missed_smoke: false }),
+  // The alert-level missed-smoke flag. Written from two places: the rail's
+  // own Yes/No row, and the soft-confirm's "Submit & clear flag" path.
+  const setMissedSmokeFlag = useMutation({
+    mutationFn: ({ annotationId, value }: { annotationId: number; value: boolean }) =>
+      apiClient.updateSequenceAnnotation(annotationId, { has_missed_smoke: value }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: alertDetailQueryKey });
     },
+    onError: () => {
+      showToastNotification('Failed to update missed smoke — try again', 'error');
+    },
   });
+
+  const handleMissedSmokeChange = (value: boolean) => {
+    setMissedSmoke(value);
+    // Answering No also closes a picker opened under a previous Yes, so the
+    // gate can't be walked around by leaving it open.
+    if (!value) setAddObjectPickerOpen(false);
+    if (missedSmokeAnnotationId == null) return;
+    setMissedSmokeFlag.mutate({ annotationId: missedSmokeAnnotationId, value });
+  };
 
   const handleModalSubmit = (
     detection: Detection,
@@ -503,72 +578,119 @@ export default function LocalizeAlertPage() {
     },
   });
 
-  // Workable lanes get a trailing quick-accept action; every row gets the
-  // "selected" accent treatment when it's the currently focused object (see
-  // object-focus mode below — its cropped-view strip renders separately,
-  // not per-row here).
-  const objectStatusRows: AlertObjectStatus[] = frameModel.objectStatus.map(object => {
-    const isAccepting =
-      quickAcceptLane.isPending && quickAcceptLane.variables === object.laneSequenceId;
-    return {
-      ...object,
-      action: object.workable ? (
-        <button
-          type="button"
-          onClick={e => {
-            e.stopPropagation();
-            quickAcceptLane.mutate(object.laneSequenceId);
-          }}
-          disabled={isAccepting}
-          title={`Accept ${object.label}'s predicted boxes for all pending frames`}
-          className="shrink-0 rounded-lg border border-line bg-paper px-2 py-1 font-body text-xs font-medium text-char hover:bg-ash disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {isAccepting ? 'Accepting…' : `Accept ${object.label}'s boxes`}
-        </button>
-      ) : undefined,
-      selected: isFocused && activeLaneId === object.laneSequenceId,
-    };
-  });
+  // The timeline's rows: identity + per-frame statuses + the "selected"
+  // accent for whichever object is currently focused. The quick-accept
+  // action no longer rides along here — it moved to the rail's own row,
+  // where an object's progress and its actions sit together.
+  const objectStatusRows: AlertObjectStatus[] = frameModel.objectStatus.map(object => ({
+    ...object,
+    selected: isFocused && activeLaneId === object.laneSequenceId,
+  }));
 
   const workableObjects = objectStatusRows.filter(o => o.workable);
-  const contextObjects = objectStatusRows.filter(o => !o.workable);
 
-  // Every workable lane's quick-accept plan plus its sequence-annotation id
-  // (the id `localizeSubmit` needs) — feeds both the two-step confirm's
-  // no-box count and the accept-all mutation's submit payload.
-  const workableLanePlans: {
-    laneSequenceId: number;
-    annotationId: number;
-    plan: QuickSubmitPlan;
-  }[] = useMemo(
+  // Per-object localization progress, derived from the same
+  // `statusByTimestamp` the timeline segments render. Keyed by lane rather
+  // than positional, so grouping the rail's rows (smoke first, false
+  // positives last) can't desynchronize a row from its numbers.
+  // 'absent' frames count toward neither total — an object isn't behind on a
+  // frame it never appeared on.
+  const objectProgress = new Map(
+    objectStatusRows.map(object => {
+      const present = Object.entries(object.statusByTimestamp).filter(
+        ([, status]) => status !== 'absent'
+      );
+      // Anything not yet confirmed still needs handling — both a frame with
+      // a model box waiting ('pending') and one with nothing on it at all
+      // ('empty', e.g. every frame of a just-added object).
+      const outstanding = present.filter(([, status]) => status !== 'confirmed');
+      return [
+        object.laneSequenceId,
+        { presentCount: present.length, confirmedCount: present.length - outstanding.length },
+      ] as const;
+    })
+  );
+
+  // Header progress badge: workable objects with no pending frame left.
+  const localizedObjectCount = workableObjects.filter(object => {
+    const progress = objectProgress.get(object.laneSequenceId);
+    return !!progress && progress.confirmedCount === progress.presentCount;
+  }).length;
+
+  // The rail (and the timeline below it) group false positives after the
+  // real objects, so the read-only context can't be mistaken for work.
+  // Both consume this same order, keeping their row indices aligned.
+  const smokeObjectRows = objectStatusRows.filter(o => !o.isFalsePositive);
+  const falsePositiveRows = objectStatusRows.filter(o => o.isFalsePositive);
+  const orderedObjectRows = [...smokeObjectRows, ...falsePositiveRows];
+
+  // Counted straight off the lanes, not off `frameModel` — the model only
+  // materializes false-positive lanes while the toggle is ON, so the toggle
+  // needs its own source to know whether it has anything to reveal.
+  const falsePositiveLaneCount =
+    alertDetail?.lanes.filter(
+      lane =>
+        !!lane.annotation && !laneNeedsLocalization(lane.annotation) && !lane.annotation.is_unsure
+    ).length ?? 0;
+
+  const renderObjectRow = (object: AlertObjectStatus) => {
+    const progress = objectProgress.get(object.laneSequenceId) ?? {
+      presentCount: 0,
+      confirmedCount: 0,
+    };
+    return (
+      <LocalizeObjectRow
+        key={object.laneSequenceId}
+        label={object.label}
+        color={object.color}
+        confirmedCount={progress.confirmedCount}
+        presentCount={progress.presentCount}
+        workable={object.workable}
+        smokeType={object.smokeType}
+        isFalsePositive={object.isFalsePositive}
+        falsePositiveTypes={object.falsePositiveTypes}
+        isActive={isFocused && activeLaneId === object.laneSequenceId}
+        onActivate={() => handleObjectClick(object.laneSequenceId)}
+        onAcceptBoxes={
+          object.workable ? () => quickAcceptLane.mutate(object.laneSequenceId) : undefined
+        }
+        isAccepting={
+          quickAcceptLane.isPending && quickAcceptLane.variables === object.laneSequenceId
+        }
+      />
+    );
+  };
+
+  // Names the media column: with an object active the grid shows that
+  // object's detections, so the column header should say whose they are.
+  // The color also outlines the frames it actually appears on.
+  const activeObject = objectStatusRows.find(o => o.laneSequenceId === activeLaneId);
+  const activeObjectLabel = activeObject?.label ?? null;
+
+  // Submit gate: every workable object must already have a committed box on
+  // every frame it appears on. An object is "accepted" either via its row's
+  // Accept-boxes action or by drawing its frames in the editor — submitting
+  // is the last step, not a shortcut past the per-object review.
+  const allObjectsAccepted =
+    workableObjects.length > 0 && localizedObjectCount === workableObjects.length;
+
+  // Every workable lane's sequence-annotation id — the payload
+  // `localizeSubmit` takes, and the set both bulk actions iterate.
+  const workableLanes: { laneSequenceId: number; annotationId: number }[] = useMemo(
     () =>
       workableObjects.flatMap(object => {
         const lane = alertDetail?.lanes.find(l => l.sequence.id === object.laneSequenceId);
         if (!lane?.annotation) return [];
-        const detections = detectionsByLaneId[object.laneSequenceId] ?? [];
-        const annotations = new Map(
-          (annotationsByLaneId[object.laneSequenceId] ?? []).map(a => [a.detection_id, a])
-        );
-        const plan = buildQuickSubmitPlan(
-          detections,
-          annotations,
-          sequenceSmokeType(lane.annotation)
-        );
-        return [{ laneSequenceId: object.laneSequenceId, annotationId: lane.annotation.id, plan }];
+        return [{ laneSequenceId: object.laneSequenceId, annotationId: lane.annotation.id }];
       }),
-    [workableObjects, alertDetail, detectionsByLaneId, annotationsByLaneId]
+    [workableObjects, alertDetail]
   );
-  const totalNoBoxCount = workableLanePlans.reduce((sum, { plan }) => sum + plan.noBoxCount, 0);
 
-  // Accept-all & submit: runs every workable lane's quick-accept plan in
-  // order (sequential, fail-fast), then atomically submits the whole alert.
-  const acceptAllAndSubmit = useMutation({
-    mutationFn: async () => {
-      for (const { laneSequenceId } of workableLanePlans) {
-        await runLaneQuickAccept(laneSequenceId);
-      }
-      return apiClient.localizeSubmit(workableLanePlans.map(p => p.annotationId));
-    },
+  // Submit: atomically ships the whole alert. No accept step of its own —
+  // `allObjectsAccepted` gates the button, so every frame already carries a
+  // committed box by the time this can fire.
+  const submitAlert = useMutation({
+    mutationFn: async () => apiClient.localizeSubmit(workableLanes.map(l => l.annotationId)),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['localization-queue'] });
       queryClient.invalidateQueries({ queryKey: ['annotation-counts'] });
@@ -579,14 +701,10 @@ export default function LocalizeAlertPage() {
     },
     onError: err => {
       const detail = (err as { detail?: string })?.detail || (err as Error)?.message || '';
-      // Any failure here — a mid-loop accept save (server truth may already
-      // include some of this attempt's writes) or a rejected localize-submit
-      // — can leave the page's cache stale relative to the server. Always
-      // invalidate every workable lane's detection-annotations query so a
-      // retry re-derives its plan from server truth instead of re-POSTing
-      // creates for detections the server already has annotated (constraint
-      // errors).
-      workableLanePlans.forEach(({ laneSequenceId }) => {
+      // A rejected submit means the page's view of "everything is accepted"
+      // disagreed with the server — refetch each lane so the rows redraw
+      // with their true pending counts rather than staying falsely complete.
+      workableLanes.forEach(({ laneSequenceId }) => {
         queryClient.invalidateQueries({
           queryKey: [...QUERY_KEYS.DETECTION_ANNOTATIONS, 'by-sequence', laneSequenceId],
         });
@@ -599,40 +717,26 @@ export default function LocalizeAlertPage() {
     },
   });
 
-  // Same two-step confirm pattern as the legacy page's quick-submit: a
-  // lane with pending frames that have no box at all needs an explicit
-  // "submit anyway?" before the button's second click actually submits.
-  //
-  // Composes with the missed-smoke soft-confirm below: the soft-confirm (an
-  // alert-wide "did you forget to add the missed object" question) is
-  // resolved FIRST, since it's the more meaningful of the two; only once
-  // it's answered does this fall through to the routine per-frame no-box
-  // warning.
+  // The missed-smoke soft-confirm ("you flagged missed smoke but added no
+  // object") is the only gate left in front of submit — the old two-step
+  // no-box warning went away with the bulk-accept-on-submit it guarded:
+  // submit now requires every frame to already carry a committed box, so
+  // there is never a pending no-box frame left to warn about.
   const handleSubmitClick = () => {
-    if (workableObjects.length === 0 || acceptAllAndSubmit.isPending) return;
+    if (!allObjectsAccepted || submitAlert.isPending) return;
     if (softConfirmNeeded) {
       setMissedSmokeConfirm(true);
       return;
     }
-    if (totalNoBoxCount > 0 && !submitConfirming) {
-      setSubmitConfirming(true);
-      return;
-    }
-    setSubmitConfirming(false);
-    acceptAllAndSubmit.mutate();
+    submitAlert.mutate();
   };
 
-  // Continues past the soft-confirm dialog into the ordinary submit flow
-  // (still subject to the no-box two-step) — shared by both of its
-  // "proceed" options ("Submit anyway" and "Submit & clear flag").
+  // Continues past the soft-confirm dialog into the submit — shared by both
+  // of its "proceed" options ("Submit anyway" and "Submit & clear flag").
   const proceedPastSoftConfirm = () => {
     setMissedSmokeConfirm(false);
     setSoftConfirmResolved(true);
-    if (totalNoBoxCount > 0) {
-      setSubmitConfirming(true);
-      return;
-    }
-    acceptAllAndSubmit.mutate();
+    submitAlert.mutate();
   };
 
   const handleSubmitAnyway = () => proceedPastSoftConfirm();
@@ -640,19 +744,13 @@ export default function LocalizeAlertPage() {
   const handleSubmitAndClearFlag = async () => {
     const flaggedLane = alertDetail?.lanes.find(l => l.annotation?.has_missed_smoke);
     if (flaggedLane?.annotation) {
-      await clearMissedSmokeFlag.mutateAsync(flaggedLane.annotation.id);
+      await setMissedSmokeFlag.mutateAsync({
+        annotationId: flaggedLane.annotation.id,
+        value: false,
+      });
     }
     proceedPastSoftConfirm();
   };
-
-  // A click anywhere else cancels the pending confirm (the header button
-  // stops propagation, so its own click never lands here).
-  useEffect(() => {
-    if (!submitConfirming) return;
-    const cancel = () => setSubmitConfirming(false);
-    window.addEventListener('click', cancel);
-    return () => window.removeEventListener('click', cancel);
-  }, [submitConfirming]);
 
   // Cropped flipbook: the active object's boxes across all its frames —
   // mirrors the legacy grid's cropped-view block, scoped to whichever
@@ -793,33 +891,6 @@ export default function LocalizeAlertPage() {
     },
   });
 
-  // "Open Object N ✎" header shortcut: the first workable object that still
-  // has a pending frame, and that frame's own (chronologically earliest)
-  // timestamp — activating + scrolling reuses the exact segment-click path.
-  const firstPendingObject = workableObjects
-    .map(object => {
-      const pendingTimestamps = Object.entries(object.statusByTimestamp)
-        .filter(([, status]) => status === 'pending')
-        .map(([timestamp]) => timestamp)
-        .sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
-      return pendingTimestamps.length > 0
-        ? {
-            laneSequenceId: object.laneSequenceId,
-            label: object.label,
-            timestamp: pendingTimestamps[0],
-          }
-        : null;
-    })
-    .find(
-      (entry): entry is { laneSequenceId: number; label: string; timestamp: string } =>
-        entry !== null
-    );
-
-  const handleOpenPendingObject = () => {
-    if (!firstPendingObject) return;
-    handleSegmentClick(firstPendingObject.laneSequenceId, firstPendingObject.timestamp);
-  };
-
   const handleCellRef = (recordedAt: string, el: HTMLDivElement | null) => {
     frameRefs.current[recordedAt] = el;
   };
@@ -893,133 +964,218 @@ export default function LocalizeAlertPage() {
             <span className="font-data text-detail text-haze">
               {new Date(alertDetail.recorded_at).toLocaleString()}
             </span>
-            <span className="flex-none rounded-full px-2.5 py-0.5 font-data text-xs font-semibold bg-ember-soft text-ember">
-              {workableObjects.length} object{workableObjects.length === 1 ? '' : 's'}
-            </span>
-          </div>
-
-          <div className="flex flex-none items-center gap-2">
-            <ViewToolbar
-              cardSize={effectiveCardSize}
-              onCardSizeChange={handleCardSizeChange}
-              showPredictions={showPredictions}
-              onTogglePredictions={setShowPredictions}
-              isLocalize
-              cropMode={cropMode}
-              onToggleCropMode={setCropMode}
-              showCroppedView={isFocused || showCroppedView}
-              onToggleCroppedView={handleToggleCroppedView}
-            />
-
-            {firstPendingObject && (
-              <button
-                type="button"
-                onClick={handleOpenPendingObject}
-                title={`Jump to ${firstPendingObject.label}'s first pending frame`}
-                className="inline-flex items-center rounded-lg border border-line bg-paper px-3 py-2 font-body text-sm font-medium text-char hover:bg-ash"
-              >
-                Open {firstPendingObject.label} ✎
-              </button>
-            )}
-
-            <button
-              type="button"
-              onClick={e => {
-                e.stopPropagation();
-                handleSubmitClick();
-              }}
-              disabled={workableObjects.length === 0 || acceptAllAndSubmit.isPending}
-              title="Accept predicted boxes for every pending frame and submit the whole alert"
-              className={`inline-flex items-center rounded-lg px-4 py-2 font-body text-sm font-semibold text-white focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
-                submitConfirming ? 'bg-signal hover:brightness-95' : 'bg-ember hover:brightness-95'
+            <span
+              className={`flex-none rounded-full px-2.5 py-0.5 font-data text-xs font-semibold ${
+                workableObjects.length > 0 && localizedObjectCount === workableObjects.length
+                  ? 'bg-pine-soft text-pine'
+                  : 'bg-ember-soft text-ember'
               }`}
             >
-              {acceptAllAndSubmit.isPending ? (
-                <div className="w-3.5 h-3.5 mr-1.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
-              ) : (
-                <Upload className="w-3.5 h-3.5 mr-1.5" />
-              )}
-              {submitConfirming
-                ? `${totalNoBoxCount} frame${totalNoBoxCount === 1 ? '' : 's'} with no box — submit anyway?`
-                : 'Accept all & submit alert'}
-            </button>
+              {localizedObjectCount} of {workableObjects.length} object
+              {workableObjects.length === 1 ? '' : 's'} localized
+            </span>
           </div>
         </div>
       </div>
 
-      <div className="space-y-6 pt-20">
-        <ObjectStatusStrip
-          objects={workableObjects}
-          onObjectClick={i => handleObjectClick(workableObjects[i].laneSequenceId)}
-          onSegmentClick={(i, ts) => handleSegmentClick(workableObjects[i].laneSequenceId, ts)}
-          title="Objects to localize"
-        />
+      {/* Cockpit: media column (the active object's frames) + the rail (the
+          whole alert's localization state), mirroring ClassifyAlertPage. The
+          media column flows with the page; the rail sticks below the fixed
+          header on desktop, scrolling internally only if it outgrows the
+          viewport. Below lg they stack. */}
+      <div className="flex flex-col gap-4 pt-20 lg:flex-row lg:items-start">
+        <div className="lg:flex-[1.5] lg:min-w-0">
+          <div className="rounded-card border border-line bg-paper px-[22px] py-5">
+            {/* The view controls sit with the grid they drive, not in the
+                alert header — S/M/L, crop and the flipbook are all about
+                how these cells render. The predictions toggle is omitted:
+                AlertFrameGrid never reads `showPredictions` (only ImageModal
+                does, and it carries its own toggle). */}
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
+                {/* Which object's images the cells are showing — invisible
+                    before the cockpit split, and the grid's cells only make
+                    sense once you know whose frames they are. */}
+                Frames{activeObjectLabel ? ` — ${activeObjectLabel}` : ''}
+              </div>
+              <div className="flex shrink-0 items-center gap-2.5">
+                <span className="font-data text-detail text-haze">
+                  {frameModel.frames.length} frame{frameModel.frames.length === 1 ? '' : 's'}
+                </span>
+                <ViewToolbar
+                  cardSize={effectiveCardSize}
+                  onCardSizeChange={handleCardSizeChange}
+                  isLocalize
+                  cropMode={cropMode}
+                  onToggleCropMode={setCropMode}
+                  showCroppedView={isFocused || showCroppedView}
+                  onToggleCroppedView={handleToggleCroppedView}
+                />
+              </div>
+            </div>
 
-        {/* "+ Add object": spawns a brand-new sibling lane for smoke the
-            classify pass missed entirely — the timeline's own footer
-            action, replacing the retired ⚑ row. */}
-        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-line bg-paper px-4 py-3">
-          {addObjectPickerOpen ? (
-            <>
-              <span className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
-                Smoke type
-              </span>
-              {(['wildfire', 'industrial', 'other'] as SmokeType[]).map(type => (
-                <button
-                  key={type}
-                  type="button"
-                  onClick={() => addObject.mutate(type)}
-                  disabled={addObject.isPending}
-                  className="inline-flex items-center rounded-full bg-ash px-3 py-1 font-body text-xs font-medium capitalize text-haze transition-colors hover:bg-pine-soft hover:text-pine disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {type}
-                </button>
-              ))}
-              <button
-                type="button"
-                onClick={() => setAddObjectPickerOpen(false)}
-                className="font-body text-detail text-haze hover:text-char"
-              >
-                Cancel
-              </button>
-            </>
-          ) : (
-            <button
-              type="button"
-              onClick={() => setAddObjectPickerOpen(true)}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-line bg-paper px-3 py-2 font-body text-sm font-medium text-char hover:bg-ash"
-            >
-              <Plus className="w-3.5 h-3.5" /> Add object
-            </button>
-          )}
-        </div>
+            {(isFocused || showCroppedView) &&
+              activeLaneId != null &&
+              activeLaneBoxes.length > 0 && (
+                <div className="mb-4 flex justify-center">
+                  <CroppedImageSequence bboxes={activeLaneBoxes} sequenceId={activeLaneId} />
+                </div>
+              )}
 
-        {contextObjects.length > 0 && (
-          <div className="opacity-60" data-testid="context-object-strip">
-            <ObjectStatusStrip
-              objects={contextObjects}
-              onObjectClick={i => handleObjectClick(contextObjects[i].laneSequenceId)}
-              onSegmentClick={(i, ts) => handleSegmentClick(contextObjects[i].laneSequenceId, ts)}
-              title="Already localized"
+            <AlertFrameGrid
+              frames={frameModel.frames}
+              activeLaneId={activeLaneId}
+              activeColor={activeObject?.color}
+              onCellClick={handleCellClick}
+              cellRef={handleCellRef}
+              cardMinWidth={cardMinWidth}
+              cropMode={cropMode}
+              highlightedFrame={highlightedFrame}
             />
           </div>
-        )}
+        </div>
 
-        {(isFocused || showCroppedView) && activeLaneId != null && activeLaneBoxes.length > 0 && (
-          <div className="flex justify-center">
-            <CroppedImageSequence bboxes={activeLaneBoxes} sequenceId={activeLaneId} />
+        <div className="lg:sticky lg:top-20 lg:max-h-[calc(100vh-6rem)] lg:flex-1 lg:min-w-0 lg:overflow-y-auto">
+          <LocalizeRail
+            // The toggle governs which object ROWS exist, so it belongs with
+            // Objects rather than with the frame grid's view controls.
+            headerAction={
+              <button
+                type="button"
+                aria-pressed={showFalsePositives}
+                disabled={falsePositiveLaneCount === 0}
+                onClick={() => setShowFalsePositives(prev => !prev)}
+                title={
+                  falsePositiveLaneCount === 0
+                    ? 'This alert has no false-positive objects'
+                    : 'Show objects classify settled as false positives, as read-only context'
+                }
+                className={`inline-flex items-center gap-1.5 rounded-lg border px-2 py-1 font-body text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                  showFalsePositives
+                    ? 'border-char bg-ash text-char'
+                    : 'border-line bg-paper text-haze hover:text-char'
+                }`}
+              >
+                False positives
+                {falsePositiveLaneCount > 0 && (
+                  <span className="font-data text-[10px] font-semibold">
+                    {falsePositiveLaneCount}
+                  </span>
+                )}
+              </button>
+            }
+            missedSmoke={
+              <LocalizeMissedSmokeRow
+                hasMissedSmoke={missedSmoke}
+                onChange={handleMissedSmokeChange}
+                isSaving={setMissedSmokeFlag.isPending}
+                disabled={missedSmokeAnnotationId == null}
+                addObject={
+                  /* "+ Add object" lives inside the question it answers, and
+                     only exists once that answer is Yes — a control that
+                     appears with the reason for it, rather than a dead button
+                     waiting on something above it. */
+                  addObjectPickerOpen ? (
+                    <>
+                      <span className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
+                        Smoke type
+                      </span>
+                      {(['wildfire', 'industrial', 'other'] as SmokeType[]).map(type => (
+                        <button
+                          key={type}
+                          type="button"
+                          onClick={() => addObject.mutate(type)}
+                          disabled={addObject.isPending}
+                          className="inline-flex items-center rounded-full bg-ash px-3 py-1 font-body text-xs font-medium capitalize text-haze transition-colors hover:bg-pine-soft hover:text-pine disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {type}
+                        </button>
+                      ))}
+                      <button
+                        type="button"
+                        onClick={() => setAddObjectPickerOpen(false)}
+                        className="font-body text-detail text-haze hover:text-char"
+                      >
+                        Cancel
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setAddObjectPickerOpen(true)}
+                      title="Add an object the AI missed entirely"
+                      className="inline-flex items-center gap-1.5 rounded-lg border border-line bg-paper px-3 py-2 font-body text-sm font-medium text-char hover:bg-ash"
+                    >
+                      <Plus className="w-3.5 h-3.5" /> Add object
+                    </button>
+                  )
+                }
+              />
+            }
+            footer={
+              <div className="space-y-1.5">
+                <button
+                  type="button"
+                  onClick={e => {
+                    e.stopPropagation();
+                    handleSubmitClick();
+                  }}
+                  disabled={!allObjectsAccepted || submitAlert.isPending}
+                  title={
+                    allObjectsAccepted
+                      ? 'Submit the whole alert'
+                      : "Accept every object's boxes first"
+                  }
+                  className="mx-auto flex items-center justify-center rounded-lg bg-pine px-5 py-2.5 text-center font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {submitAlert.isPending ? (
+                    <div className="w-3.5 h-3.5 mr-1.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                  ) : (
+                    <Upload className="w-3.5 h-3.5 mr-1.5 shrink-0" />
+                  )}
+                  Submit alert
+                </button>
+                {/* Says WHY it's disabled — otherwise the gate reads as a
+                    bug once every row looks handled but one still has a
+                    pending frame. */}
+                {!allObjectsAccepted && workableObjects.length > 0 && (
+                  <p className="text-center font-body text-detail text-haze">
+                    Accept every object&rsquo;s boxes to enable
+                  </p>
+                )}
+              </div>
+            }
+          >
+            {smokeObjectRows.map(renderObjectRow)}
+
+            {/* False positives are read-only context, not work — a labeled
+                break keeps them from reading as more objects to localize. */}
+            {falsePositiveRows.length > 0 && (
+              <div data-testid="false-positive-divider" className="flex items-center gap-2 pt-2.5">
+                <span className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
+                  False positives
+                </span>
+                <span className="h-px flex-1 bg-line" />
+              </div>
+            )}
+            {falsePositiveRows.map(renderObjectRow)}
+          </LocalizeRail>
+
+          {/* Per-frame temporal context + color legend for the rail's
+              objects, in the same slot classify gives ObjectPresenceStrip.
+              Context (already-localized) objects render here too, so the
+              row indices line up 1:1 with the rail above. */}
+          <div className="mt-4">
+            <ObjectStatusStrip
+              objects={orderedObjectRows}
+              onObjectClick={i => handleObjectClick(orderedObjectRows[i].laneSequenceId)}
+              onSegmentClick={(i, ts) =>
+                handleSegmentClick(orderedObjectRows[i].laneSequenceId, ts)
+              }
+              title="Timeline"
+            />
           </div>
-        )}
-
-        <AlertFrameGrid
-          frames={frameModel.frames}
-          activeLaneId={activeLaneId}
-          onCellClick={handleCellClick}
-          cellRef={handleCellRef}
-          cardMinWidth={cardMinWidth}
-          cropMode={cropMode}
-          highlightedFrame={highlightedFrame}
-        />
+        </div>
       </div>
 
       {modalContext && (

--- a/frontend/src/utils/annotation/alertLocalizeUtils.ts
+++ b/frontend/src/utils/annotation/alertLocalizeUtils.ts
@@ -11,19 +11,32 @@
  *    shape — feeds the page's status strip(s).
  *
  * A lane "contributes" (renders at all, in either the grid or the strip)
- * only when it has an annotation AND `laneNeedsLocalization` is true —
- * unsure lanes and FP-only lanes are excluded entirely, mirroring the
- * queue's own filter (`LocalizeQueueTable`). Among contributing lanes,
- * `workable` distinguishes the ones still open for localization
- * (`processing_stage === 'seq_annotation_done'`) from already-annotated
- * lanes, which still render as read-only context.
+ * only when it has an annotation AND `laneNeedsLocalization` is true,
+ * mirroring the queue's own filter (`LocalizeQueueTable`). Among
+ * contributing lanes, `workable` distinguishes the ones still open for
+ * localization (`processing_stage === 'seq_annotation_done'`) from
+ * already-annotated lanes, which still render as read-only context.
+ *
+ * Two kinds of lane fall outside that rule. Unsure lanes are excluded
+ * unconditionally. False-positive lanes are excluded by default too, but
+ * `options.includeFalsePositives` opts them in as read-only context
+ * (`isFalsePositive`, never `workable`) — enough to answer "is that plume
+ * already accounted for?" without offering to re-box it.
  */
 
-import { AlertLane, Detection, DetectionAnnotation } from '@/types/api';
+import {
+  AlertLane,
+  Detection,
+  DetectionAnnotation,
+  SequenceAnnotation,
+  SmokeType,
+} from '@/types/api';
 import { CellState, getCellState, getWinningBoxes } from './quickSubmitUtils';
 import { focusOnMainObject } from './gridCropUtils';
 import { laneNeedsLocalization } from './localizeUtils';
 import { getObjectColor } from './objectColors';
+import { sequenceSmokeType } from './reviewUtils';
+import { parseFalsePositiveTypes } from '@/utils/modelAccuracy';
 import type {
   ObjectStatusStripObject,
   ObjectStatusStripStatus,
@@ -40,6 +53,8 @@ export interface AlertFrameCell {
   detectionId: number;
   cellState: CellState;
   boxes: AlertFrameBox[];
+  /** Read-only false-positive context (opt-in) — visible, never openable in the editor. */
+  isFalsePositive?: boolean;
 }
 
 export interface AlertFrame {
@@ -52,6 +67,12 @@ export interface AlertObjectStatus extends ObjectStatusStripObject {
   laneSequenceId: number;
   /** True when the lane is still open for localization (`seq_annotation_done`); false for already-annotated context lanes. */
   workable: boolean;
+  /** What classify decided this object is — shown on its row so you know what you're boxing. */
+  smokeType?: SmokeType;
+  /** Set on opt-in false-positive context rows; they are never workable. */
+  isFalsePositive?: boolean;
+  /** The false-positive types classify recorded, for the row's label. */
+  falsePositiveTypes?: string[];
 }
 
 export interface AlertFrameModel {
@@ -59,10 +80,26 @@ export interface AlertFrameModel {
   objectStatus: AlertObjectStatus[];
 }
 
+/**
+ * A lane classify settled as a false positive: no smoke and no missed smoke,
+ * but a definite answer (an unsure lane is a different thing — "don't know",
+ * not "confirmed not smoke" — and stays excluded either way).
+ */
+function isFalsePositiveLane(annotation: SequenceAnnotation): boolean {
+  return !laneNeedsLocalization(annotation) && !annotation.is_unsure;
+}
+
 export function buildAlertFrameModel(
   lanes: AlertLane[],
   detectionsByLaneId: Record<number, Detection[]>,
-  annotationsByLaneId: Record<number, DetectionAnnotation[]>
+  annotationsByLaneId: Record<number, DetectionAnnotation[]>,
+  /**
+   * Opt in to rendering false-positive lanes as read-only context. Off by
+   * default, matching the queue's own rule. On, they answer "is that plume
+   * already accounted for?" before someone adds a duplicate object for
+   * something classify already rejected.
+   */
+  options: { includeFalsePositives?: boolean } = {}
 ): AlertFrameModel {
   const objectStatus: AlertObjectStatus[] = [];
   // recordedAt -> laneSequenceId -> cell, so each lane's later frame keeps
@@ -72,11 +109,17 @@ export function buildAlertFrameModel(
   const frameMap = new Map<string, Map<number, AlertFrameCell>>();
 
   lanes.forEach((lane, index) => {
-    if (!lane.annotation || !laneNeedsLocalization(lane.annotation)) return;
+    if (!lane.annotation) return;
+    const needsLocalization = laneNeedsLocalization(lane.annotation);
+    const falsePositive = isFalsePositiveLane(lane.annotation);
+    // Unsure lanes are neither, so they fall through and stay excluded.
+    if (!needsLocalization && !(falsePositive && options.includeFalsePositives)) return;
 
     const laneSequenceId = lane.sequence.id;
+    // Indexed over ALL lanes, so an object's color and number never shift
+    // when the false-positive toggle changes which lanes render.
     const color = getObjectColor(index);
-    const workable = lane.annotation.processing_stage === 'seq_annotation_done';
+    const workable = !falsePositive && lane.annotation.processing_stage === 'seq_annotation_done';
     const detections = detectionsByLaneId[laneSequenceId] ?? [];
     const annotationByDetectionId = new Map(
       (annotationsByLaneId[laneSequenceId] ?? []).map(a => [a.detection_id, a])
@@ -87,8 +130,6 @@ export function buildAlertFrameModel(
     for (const detection of detections) {
       const annotation = annotationByDetectionId.get(detection.id);
       const cellState = getCellState(detection, annotation);
-      statusByTimestamp[detection.recorded_at] = cellState === 'done' ? 'confirmed' : 'pending';
-
       const rawBoxes =
         cellState === 'done'
           ? (annotation?.annotation?.annotation ?? [])
@@ -97,6 +138,25 @@ export function buildAlertFrameModel(
           : cellState === 'auto'
             ? getWinningBoxes(detection).boxes.map(b => ({ xyxyn: b.xyxyn }))
             : [];
+
+      // All three cell states stay distinct on the strip. Collapsing 'auto'
+      // and 'no-box' into one "pending" fill made a frame with nothing on it
+      // look identical to one with a model box waiting to be accepted — most
+      // visibly on a just-added object, whose lane has no predictions at all
+      // yet still painted a full, colored timeline.
+      //
+      // A false-positive lane is settled — it needs no localization work, so
+      // its frames read as done-or-nothing rather than borrowing the
+      // pending/empty vocabulary of frames still awaiting a box.
+      statusByTimestamp[detection.recorded_at] = falsePositive
+        ? rawBoxes.length > 0
+          ? 'confirmed'
+          : 'empty'
+        : cellState === 'done'
+          ? 'confirmed'
+          : cellState === 'auto'
+            ? 'pending'
+            : 'empty';
       const boxes: AlertFrameBox[] = focusOnMainObject(detection, rawBoxes).map(b => ({
         xyxyn: b.xyxyn,
         color,
@@ -112,6 +172,7 @@ export function buildAlertFrameModel(
         detectionId: detection.id,
         cellState,
         boxes,
+        isFalsePositive: falsePositive || undefined,
       });
     }
 
@@ -120,6 +181,11 @@ export function buildAlertFrameModel(
       color,
       laneSequenceId,
       workable,
+      smokeType: falsePositive ? undefined : sequenceSmokeType(lane.annotation),
+      isFalsePositive: falsePositive || undefined,
+      falsePositiveTypes: falsePositive
+        ? parseFalsePositiveTypes(lane.annotation.false_positive_types)
+        : undefined,
       statusByTimestamp,
     });
   });

--- a/frontend/tests/components/sequence-annotation/ObjectStatusStrip.test.tsx
+++ b/frontend/tests/components/sequence-annotation/ObjectStatusStrip.test.tsx
@@ -3,7 +3,7 @@
  * used by the collocated localize screens. One row per object — color
  * swatch + label (as a button, "Go to Object N") plus a per-frame status
  * bar across the union of the alert's frame timestamps, where each frame
- * segment is itself a button (confirmed/pending/absent fill) firing
+ * segment is itself a button (confirmed/pending/empty/absent fill) firing
  * `onSegmentClick`. Unlike ObjectPresenceStrip, this renders from a single
  * object up.
  */
@@ -64,7 +64,30 @@ describe('ObjectStatusStrip', () => {
     expect(screen.queryByText('Object timeline')).not.toBeInTheDocument();
   });
 
-  it('renders tri-state fills: confirmed solid, pending reduced opacity, absent neutral (no inline fill)', () => {
+  it('renders empty distinctly from pending: outlined in the object color, never filled', () => {
+    render(
+      <ObjectStatusStrip
+        objects={[
+          {
+            label: 'Object 1',
+            color: '#3b82f6',
+            statusByTimestamp: { [t1]: 'pending', [t2]: 'empty' },
+          },
+        ]}
+      />
+    );
+
+    // pending = a model box waiting to be accepted -> filled.
+    expect(screen.getByTestId('status-segment-0-0')).toHaveStyle({ backgroundColor: '#3b82f6' });
+
+    // empty = on the frame, but nothing on it yet -> outline only, so a
+    // just-added object's timeline can't read as already full.
+    const empty = screen.getByTestId('status-segment-0-1');
+    expect(empty).toHaveStyle({ boxShadow: 'inset 0 0 0 1px #3b82f6' });
+    expect(empty).not.toHaveStyle({ backgroundColor: '#3b82f6' });
+  });
+
+  it('renders fills: confirmed solid, pending reduced opacity, absent neutral (no inline fill)', () => {
     render(
       <ObjectStatusStrip
         objects={[
@@ -295,22 +318,5 @@ describe('ObjectStatusStrip', () => {
     expect(selectedRow).toHaveAttribute('data-selected', 'true');
     expect(selectedRow).toHaveClass('bg-pine-soft');
     expect(selectedRow).toHaveClass('border-l-pine');
-  });
-
-  it('renders an optional trailing action for an object (e.g. a quick-accept button)', () => {
-    render(
-      <ObjectStatusStrip
-        objects={[
-          {
-            label: 'Object 1',
-            color: '#3b82f6',
-            statusByTimestamp: { [t1]: 'confirmed' },
-            action: <button data-testid="my-action">Accept</button>,
-          },
-        ]}
-      />
-    );
-
-    expect(screen.getByTestId('my-action')).toBeInTheDocument();
   });
 });

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -206,6 +206,55 @@ function makeTwoLaneAlertDetail(): AlertDetail {
 const emptyAnnotationsPage = { items: [], page: 1, pages: 1, size: 100, total: 0 };
 
 /**
+ * "+ Add object" is gated behind the rail's missed-smoke question, which
+ * starts at No on every alert (deliberately NOT seeded from the flag classify
+ * set — adding an object has to be a decision made on this screen). Any test
+ * that adds an object has to open that gate first.
+ */
+function answerMissedSmokeYes() {
+  fireEvent.click(
+    within(screen.getByTestId('localize-missed-smoke-row')).getByRole('radio', { name: 'Yes' })
+  );
+}
+
+function makeDetectionAnnotation(detectionId: number): DetectionAnnotation {
+  return {
+    id: 9200 + detectionId,
+    detection_id: detectionId,
+    annotation: {
+      annotation: [
+        {
+          xyxyn: [0.1, 0.1, 0.3, 0.3],
+          class_name: 'smoke',
+          smoke_type: 'wildfire',
+          origin: 'human',
+        },
+      ],
+    },
+    processing_stage: 'annotated',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: null,
+  };
+}
+
+/**
+ * Puts every frame of both default lanes into the `done` cell state (an
+ * annotated-stage detection annotation per detection). This is the state the
+ * submit gate demands: "Submit alert" only enables once every workable object
+ * already carries a committed box on every frame it appears on, so any test
+ * that needs to actually reach a submit has to start from here.
+ */
+function mockAllFramesAccepted() {
+  const detectionIdsByLane: Record<number, number[]> = { 101: [1001], 102: [1002, 1003] };
+  vi.mocked(apiClient.getDetectionAnnotations).mockImplementation(async filters => {
+    const items = (detectionIdsByLane[filters?.sequence_id ?? 0] ?? []).map(
+      makeDetectionAnnotation
+    );
+    return { ...emptyAnnotationsPage, items, total: items.length };
+  });
+}
+
+/**
  * Renders and waits for the async chain (sequence -> alert-detail ->
  * per-lane detections) to settle far enough for real frame data to have
  * landed — waiting for testid presence alone can catch the page mid-flight,
@@ -275,7 +324,13 @@ describe('LocalizeAlertPage', () => {
     // Both lanes are seq_annotation_done (workable) -> no context strip.
     expect(screen.queryByTestId('context-object-strip')).not.toBeInTheDocument();
 
-    expect(screen.getByText('2 objects')).toBeInTheDocument();
+    // Each object also gets a rail row carrying its localization progress.
+    expect(screen.getByTestId('localize-object-row-object-1')).toBeInTheDocument();
+    expect(screen.getByTestId('localize-object-row-object-2')).toBeInTheDocument();
+
+    // Header badge reports progress, not just a count: neither lane has any
+    // committed box yet, so nothing is localized.
+    expect(screen.getByText('0 of 2 objects localized')).toBeInTheDocument();
   });
 
   it('clicking a strip row activates that object (the shared frame now shows its detection)', async () => {
@@ -328,7 +383,8 @@ describe('LocalizeAlertPage', () => {
     await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
     expect(screen.getAllByTestId(/^object-status-row-/)).toHaveLength(1);
-    expect(screen.getByText('1 object')).toBeInTheDocument();
+    expect(screen.getAllByTestId(/^localize-object-row-/)).toHaveLength(1);
+    expect(screen.getByText('0 of 1 object localized')).toBeInTheDocument();
   });
 
   it('no ⚑ flag row renders (retired in favor of "+ Add object")', async () => {
@@ -374,6 +430,38 @@ describe('LocalizeAlertPage', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('image-modal-detection-id')).toHaveTextContent('1002');
+    });
+  });
+
+  // Object 1 (lane 101) is only on T1; T2 belongs to Object 2 alone. With
+  // Object 1 active, T2 is context: nothing of Object 1 to annotate there.
+  it('marks frames the active object is absent from as context, and makes them non-interactive', async () => {
+    await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go to Object 1' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`alert-frame-cell-${T2}`)).toHaveAttribute('data-context', 'true');
+    });
+    // The object's own frame stays full-strength and outlined in its color.
+    const ownCell = screen.getByTestId(`alert-frame-cell-${T1}`);
+    expect(ownCell).not.toHaveAttribute('data-context');
+    expect(ownCell.style.outline).toContain('solid');
+
+    // Clicking the context frame must NOT open the fallback lane's editor —
+    // that used to silently switch which object you were annotating.
+    fireEvent.click(screen.getByTestId(`alert-frame-cell-${T2}`));
+    expect(screen.queryByTestId('image-modal')).not.toBeInTheDocument();
+  });
+
+  it('leaves every frame interactive when no object is active', async () => {
+    await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+    expect(screen.getByTestId(`alert-frame-cell-${T2}`)).not.toHaveAttribute('data-context');
+
+    fireEvent.click(screen.getByTestId(`alert-frame-cell-${T2}`));
+    await waitFor(() => {
+      expect(screen.getByTestId('image-modal-detection-id')).toHaveTextContent('1003');
     });
   });
 
@@ -430,7 +518,10 @@ describe('LocalizeAlertPage', () => {
     await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
     // No active object: T1 falls back to the first present lane (Object 1 / detection 1001, no existing annotation).
-    expect(screen.getByTestId(`alert-frame-status-${T1}`)).toHaveTextContent('0/2');
+    expect(screen.getByTestId('status-segment-0-0')).toHaveAttribute(
+      'aria-label',
+      'Object 1, frame 1: pending'
+    );
     fireEvent.click(screen.getByTestId(`alert-frame-cell-${T1}`));
     await waitFor(() => {
       expect(screen.getByTestId('image-modal-detection-id')).toHaveTextContent('1001');
@@ -451,10 +542,18 @@ describe('LocalizeAlertPage', () => {
     });
 
     // Only lane 101's detection-annotations query was invalidated/refetched
-    // — the grid status for T1 now reflects one committed box of two.
+    // — Object 1's T1 frame now reads as confirmed on the timeline, while
+    // Object 2's own T1 frame is untouched.
     await waitFor(() => {
-      expect(screen.getByTestId(`alert-frame-status-${T1}`)).toHaveTextContent('1/2');
+      expect(screen.getByTestId('status-segment-0-0')).toHaveAttribute(
+        'aria-label',
+        'Object 1, frame 1: confirmed'
+      );
     });
+    expect(screen.getByTestId('status-segment-1-0')).toHaveAttribute(
+      'aria-label',
+      'Object 2, frame 1: pending'
+    );
 
     expect(screen.getByText('Frame saved')).toBeInTheDocument();
   });
@@ -765,52 +864,56 @@ describe('LocalizeAlertPage', () => {
     });
   });
 
-  describe('Accept all & submit alert', () => {
-    it("runs each workable lane's quick-accept plan, then submits exactly the workable annotation ids, and navigates back to the queue", async () => {
+  describe('Submit alert', () => {
+    it('stays disabled, with an explanation, while any object still has a pending frame', async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
-      fireEvent.click(screen.getByRole('button', { name: 'Accept all & submit alert' }));
+      expect(screen.getByRole('button', { name: /Submit alert/ })).toBeDisabled();
+      expect(screen.getByText(/Accept every object’s boxes to enable/)).toBeInTheDocument();
+      expect(screen.getByText('0 of 2 objects localized')).toBeInTheDocument();
+    });
 
-      // Every pending frame across both lanes is accepted before submit.
-      await waitFor(() => {
-        expect(apiClient.createDetectionAnnotation).toHaveBeenCalledTimes(3);
-      });
-      expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
-        expect.objectContaining({ detection_id: 1001 })
-      );
-      expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
-        expect.objectContaining({ detection_id: 1002 })
-      );
-      expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
-        expect.objectContaining({ detection_id: 1003 })
-      );
+    it('enables once every object is accepted, submits exactly the workable annotation ids, and navigates back to the queue', async () => {
+      mockAllFramesAccepted();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
-      // Exactly one bulk submit call, with both lanes' sequence-annotation ids.
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Submit alert/ })).toBeEnabled()
+      );
+      expect(screen.getByText('2 of 2 objects localized')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: /Submit alert/ }));
+
+      // Exactly one bulk submit, with both lanes' sequence-annotation ids —
+      // and no accepting of its own: submit no longer writes boxes.
       await waitFor(() => {
         expect(apiClient.localizeSubmit).toHaveBeenCalledWith([201, 202]);
       });
       expect(apiClient.localizeSubmit).toHaveBeenCalledTimes(1);
+      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
 
       expect(screen.getByText('Alert submitted')).toBeInTheDocument();
       await waitFor(
         () => expect(screen.getByTestId('localize-queue-landing')).toBeInTheDocument(),
-        {
-          timeout: 2000,
-        }
+        { timeout: 2000 }
       );
     });
 
     it('toasts and refetches statuses without navigating when the backend rejects an incomplete lane (422)', async () => {
+      mockAllFramesAccepted();
       vi.mocked(apiClient.localizeSubmit).mockRejectedValue({
         detail:
           'Cannot submit: 1 detection(s) lack an annotated-stage detection annotation (localization incomplete)',
       });
 
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Submit alert/ })).toBeEnabled()
+      );
 
       const callsBefore = vi.mocked(apiClient.getDetectionAnnotations).mock.calls.length;
 
-      fireEvent.click(screen.getByRole('button', { name: 'Accept all & submit alert' }));
+      fireEvent.click(screen.getByRole('button', { name: /Submit alert/ }));
 
       await waitFor(() => {
         expect(
@@ -828,93 +931,7 @@ describe('LocalizeAlertPage', () => {
       });
     });
 
-    it("a save that fails mid-loop across lanes never submits, toasts the failure, and invalidates every workable lane's cache (not just the failed one) so a retry re-derives from server truth", async () => {
-      // Lane 1 (Object 1 / detection 1001) saves fine; lane 2's first
-      // pending frame (1002) rejects with a generic (non-"incomplete")
-      // error — a mid-loop network blip, not a 422 from localize-submit
-      // itself (localizeSubmit is never even reached).
-      vi.mocked(apiClient.createDetectionAnnotation).mockImplementation(async payload => {
-        if (payload.detection_id === 1002) {
-          throw { detail: 'Network error' };
-        }
-        return {
-          id: 9100 + payload.detection_id,
-          detection_id: payload.detection_id,
-          annotation: payload.annotation,
-          processing_stage: payload.processing_stage,
-          created_at: '2026-01-01T00:00:00Z',
-          updated_at: null,
-        };
-      });
-
-      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-
-      const callsForLane = (id: number) =>
-        vi
-          .mocked(apiClient.getDetectionAnnotations)
-          .mock.calls.filter(([filters]) => filters?.sequence_id === id).length;
-      const lane101Before = callsForLane(101);
-      const lane102Before = callsForLane(102);
-
-      fireEvent.click(screen.getByRole('button', { name: 'Accept all & submit alert' }));
-
-      // Lane 1 saved successfully before lane 2 failed.
-      await waitFor(() => {
-        expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
-          expect.objectContaining({ detection_id: 1001 })
-        );
-      });
-      // Fail-fast within lane 2 too: its second frame (1003) is never attempted.
-      await waitFor(() => {
-        expect(screen.getByText('Submit failed: Network error')).toBeInTheDocument();
-      });
-      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalledWith(
-        expect.objectContaining({ detection_id: 1003 })
-      );
-      expect(apiClient.localizeSubmit).not.toHaveBeenCalled();
-
-      // Both workable lanes' detection-annotation caches are invalidated —
-      // including lane 1's, whose saves actually landed server-side — so a
-      // retry re-derives its plan from server truth instead of re-POSTing
-      // creates for already-annotated detections.
-      await waitFor(() => {
-        expect(callsForLane(101)).toBeGreaterThan(lane101Before);
-        expect(callsForLane(102)).toBeGreaterThan(lane102Before);
-      });
-    });
-
-    it('warns with a two-step confirm when some pending frames have no box, then proceeds on the second click', async () => {
-      // Detection 1002 has no predictions at all (no auto, no algo) -> a
-      // pending frame with zero boxes, contributing to the no-box count.
-      vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
-        if (id === 101) return [makeDetection(1001, T1)];
-        if (id === 102) {
-          return [
-            { ...makeDetection(1002, T1), auto_predictions: { predictions: [] } },
-            makeDetection(1003, T2),
-          ];
-        }
-        return [];
-      });
-
-      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-
-      fireEvent.click(screen.getByRole('button', { name: 'Accept all & submit alert' }));
-
-      await waitFor(() => {
-        expect(screen.getByText('1 frame with no box — submit anyway?')).toBeInTheDocument();
-      });
-      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
-      expect(apiClient.localizeSubmit).not.toHaveBeenCalled();
-
-      fireEvent.click(screen.getByRole('button', { name: '1 frame with no box — submit anyway?' }));
-
-      await waitFor(() => {
-        expect(apiClient.localizeSubmit).toHaveBeenCalledWith([201, 202]);
-      });
-    });
-
-    it('disables the submit button when no lane is workable (both lanes already annotated)', async () => {
+    it('is disabled when no lane is workable (both lanes already annotated)', async () => {
       vi.mocked(apiClient.getAlertDetail).mockResolvedValue({
         ...makeTwoLaneAlertDetail(),
         lanes: [
@@ -939,20 +956,8 @@ describe('LocalizeAlertPage', () => {
 
       render(<LocalizeAlertPage />, { wrapper });
       await waitFor(() =>
-        expect(screen.getByRole('button', { name: 'Accept all & submit alert' })).toBeDisabled()
+        expect(screen.getByRole('button', { name: /Submit alert/ })).toBeDisabled()
       );
-    });
-  });
-
-  it('the "Open Object N" shortcut activates the first workable object with a pending frame and scrolls to it', async () => {
-    await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-
-    fireEvent.click(screen.getByRole('button', { name: 'Open Object 1 ✎' }));
-
-    await waitFor(() => expect(Element.prototype.scrollIntoView).toHaveBeenCalled());
-    await waitFor(() => {
-      const img = within(screen.getByTestId(`alert-frame-cell-${T1}`)).getByRole('img');
-      expect(img).toHaveAttribute('src', 'https://img.example/1001.jpg');
     });
   });
 
@@ -976,21 +981,24 @@ describe('LocalizeAlertPage', () => {
         return [];
       });
       let nextId = 103;
-      vi.mocked(apiClient.addObject).mockImplementation(async (_sourceApi, _platformAlertId, smokeType) => {
-        const id = nextId;
-        nextId += 1;
-        const newLane: AlertLane = {
-          sequence: makeSequence({ id, alert_api_id: 9000 + id }),
-          annotation: makeAnnotation({ id: id * 10, sequence_id: id, smoke_types: [smokeType] }),
-        };
-        alertLanes = [...alertLanes, newLane];
-        return newLane;
-      });
+      vi.mocked(apiClient.addObject).mockImplementation(
+        async (_sourceApi, _platformAlertId, smokeType) => {
+          const id = nextId;
+          nextId += 1;
+          const newLane: AlertLane = {
+            sequence: makeSequence({ id, alert_api_id: 9000 + id }),
+            annotation: makeAnnotation({ id: id * 10, sequence_id: id, smoke_types: [smokeType] }),
+          };
+          alertLanes = [...alertLanes, newLane];
+          return newLane;
+        }
+      );
     }
 
     it('opens a smoke-type picker, and Cancel closes it without adding anything', async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
+      answerMissedSmokeYes();
       fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
       expect(screen.getByRole('button', { name: 'wildfire' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'industrial' })).toBeInTheDocument();
@@ -1006,6 +1014,7 @@ describe('LocalizeAlertPage', () => {
       mockAddObjectFlow();
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
+      answerMissedSmokeYes();
       fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
       fireEvent.click(screen.getByRole('button', { name: 'industrial' }));
 
@@ -1036,10 +1045,12 @@ describe('LocalizeAlertPage', () => {
       mockAddObjectFlow();
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
+      answerMissedSmokeYes();
       fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
       fireEvent.click(screen.getByRole('button', { name: 'wildfire' }));
       await waitFor(() => expect(screen.getByTestId('object-status-row-2')).toBeInTheDocument());
 
+      answerMissedSmokeYes();
       fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
       fireEvent.click(screen.getByRole('button', { name: 'other' }));
       await waitFor(() => expect(screen.getByTestId('object-status-row-3')).toBeInTheDocument());
@@ -1053,11 +1064,118 @@ describe('LocalizeAlertPage', () => {
       ).toBeInTheDocument();
     });
 
+    /**
+     * Faithful to the backend's `/alert/add-object`: the spawned lane's
+     * detections are cloned with `algo_predictions: []` and no
+     * auto_predictions (the AI never saw this object), and every frame gets
+     * a DetectionAnnotation at `bbox_annotation` stage — so every cell is
+     * `no-box`, with nothing to accept until the annotator draws.
+     * `mockAddObjectFlow` above is deliberately looser (its lanes carry
+     * model boxes); this is the shape the real endpoint produces.
+     */
+    function mockRealisticAddObjectFlow() {
+      let alertLanes: AlertLane[] = makeTwoLaneAlertDetail().lanes;
+      vi.mocked(apiClient.getAlertDetail).mockImplementation(async () => ({
+        ...makeTwoLaneAlertDetail(),
+        lanes: alertLanes,
+      }));
+      vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
+        if (id === 101) return [makeDetection(1001, T1)];
+        if (id === 102) return [makeDetection(1002, T1), makeDetection(1003, T2)];
+        if (id === 103) {
+          // Cloned frames: no predictions of any kind.
+          return [
+            {
+              ...makeDetection(1004, T1),
+              algo_predictions: { predictions: [] },
+              auto_predictions: undefined,
+            },
+            {
+              ...makeDetection(1005, T2),
+              algo_predictions: { predictions: [] },
+              auto_predictions: undefined,
+            },
+          ];
+        }
+        return [];
+      });
+      vi.mocked(apiClient.getDetectionAnnotations).mockImplementation(async filters => {
+        if (filters?.sequence_id !== 103) return emptyAnnotationsPage;
+        const items = [1004, 1005].map(detectionId => ({
+          ...makeDetectionAnnotation(detectionId),
+          annotation: { annotation: [] },
+          processing_stage: 'bbox_annotation' as const,
+        }));
+        return { ...emptyAnnotationsPage, items, total: items.length };
+      });
+      vi.mocked(apiClient.addObject).mockImplementation(async () => {
+        const newLane: AlertLane = {
+          sequence: makeSequence({ id: 103, alert_api_id: 9003 }),
+          annotation: makeAnnotation({ id: 203, sequence_id: 103 }),
+        };
+        alertLanes = [...alertLanes, newLane];
+        return newLane;
+      });
+    }
+
+    it('a just-added object reads as empty across its timeline — no fill implying boxes it does not have', async () => {
+      mockRealisticAddObjectFlow();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      answerMissedSmokeYes();
+      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
+      fireEvent.click(screen.getByRole('button', { name: 'wildfire' }));
+      await waitFor(() => expect(screen.getByTestId('object-status-row-2')).toBeInTheDocument());
+
+      // Both of its frames are 'empty' (present, nothing on them), NOT
+      // 'pending' — which used to paint a filled bar across the whole row.
+      await waitFor(() => {
+        expect(screen.getByTestId('status-segment-2-0')).toHaveAttribute(
+          'aria-label',
+          'Object 3, frame 1: empty'
+        );
+      });
+      expect(screen.getByTestId('status-segment-2-1')).toHaveAttribute(
+        'aria-label',
+        'Object 3, frame 2: empty'
+      );
+
+      // And its rail row says 0 of 2 done rather than implying progress.
+      expect(
+        within(screen.getByTestId('localize-object-row-object-3')).getByText('0/2')
+      ).toBeInTheDocument();
+    });
+
+    it('clicking a just-added object activates it without hanging (no boxes to focus on)', async () => {
+      mockRealisticAddObjectFlow();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      answerMissedSmokeYes();
+      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
+      fireEvent.click(screen.getByRole('button', { name: 'wildfire' }));
+      await waitFor(() => expect(screen.getByTestId('object-status-row-2')).toBeInTheDocument());
+
+      // Row click toggles focus off (add already focused it), then on again.
+      fireEvent.click(screen.getByTestId('localize-object-row-object-3'));
+      fireEvent.click(screen.getByTestId('localize-object-row-object-3'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('localize-object-row-object-3')).toHaveAttribute(
+          'data-active',
+          'true'
+        );
+      });
+      // Focus mode forces the cropped-view strip, but the lane has no boxes
+      // to crop — it must simply not render rather than spin.
+      expect(screen.queryByTestId('cropped-image-sequence')).not.toBeInTheDocument();
+    });
+
     it('toasts on a failed add and keeps the picker usable for a retry', async () => {
       vi.mocked(apiClient.addObject).mockRejectedValueOnce(new Error('Network error'));
 
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
+      answerMissedSmokeYes();
       fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
       fireEvent.click(screen.getByRole('button', { name: 'wildfire' }));
 
@@ -1068,7 +1186,269 @@ describe('LocalizeAlertPage', () => {
     });
   });
 
+  describe('false-positive context toggle', () => {
+    /** Lane 102 classified as a false positive rather than smoke. */
+    function alertWithFalsePositive() {
+      vi.mocked(apiClient.getAlertDetail).mockResolvedValue({
+        ...makeTwoLaneAlertDetail(),
+        lanes: [
+          {
+            sequence: makeSequence({ id: 101, alert_api_id: 9001 }),
+            annotation: makeAnnotation({ id: 201, sequence_id: 101 }),
+          },
+          {
+            sequence: makeSequence({ id: 102, alert_api_id: 9002 }),
+            annotation: makeAnnotation({
+              id: 202,
+              sequence_id: 102,
+              has_smoke: false,
+              has_missed_smoke: false,
+              smoke_types: [],
+              false_positive_types: '["cloud"]',
+            }),
+          },
+        ],
+      });
+    }
+
+    it('disables the toggle when the alert has no false-positive objects', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      const toggle = screen.getByRole('button', { name: /False positives/ });
+      expect(toggle).toBeDisabled();
+      // No count badge when there is nothing to reveal.
+      expect(toggle).toHaveTextContent(/^False positives$/);
+    });
+
+    it('shows how many false-positive objects the alert has', async () => {
+      alertWithFalsePositive();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      const toggle = screen.getByRole('button', { name: /False positives/ });
+      expect(toggle).toBeEnabled();
+      expect(toggle).toHaveTextContent('False positives1');
+    });
+
+    it('keeps false-positive frames read-only — visible, never openable in the editor', async () => {
+      alertWithFalsePositive();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: /False positives/ }));
+      await waitFor(() => {
+        expect(screen.getByTestId('localize-object-row-object-2')).toBeInTheDocument();
+      });
+
+      // Activate the false-positive object: its cropped view is the point.
+      fireEvent.click(screen.getByRole('button', { name: 'Go to Object 2' }));
+      await waitFor(() => {
+        expect(screen.getByTestId('cropped-image-sequence')).toHaveAttribute(
+          'data-sequence-id',
+          '102'
+        );
+      });
+
+      // But its frames never open the editable modal.
+      expect(screen.getByTestId(`alert-frame-cell-${T2}`)).toHaveAttribute('data-readonly', 'true');
+      fireEvent.click(screen.getByTestId(`alert-frame-cell-${T2}`));
+      expect(screen.queryByTestId('image-modal')).not.toBeInTheDocument();
+    });
+
+    it('keeps a shared frame workable when the FIRST lane on it is the false positive', async () => {
+      // Primary lane is the false positive; the smoke object is the sibling.
+      // With no object active the grid falls back to a cell — it must pick
+      // the workable one, or the whole frame would go read-only and hide the
+      // smoke object behind an un-clickable cell.
+      vi.mocked(apiClient.getAlertDetail).mockResolvedValue({
+        ...makeTwoLaneAlertDetail(),
+        lanes: [
+          {
+            sequence: makeSequence({ id: 101, alert_api_id: 9001 }),
+            annotation: makeAnnotation({
+              id: 201,
+              sequence_id: 101,
+              has_smoke: false,
+              has_missed_smoke: false,
+              smoke_types: [],
+              false_positive_types: '["cloud"]',
+            }),
+          },
+          {
+            sequence: makeSequence({ id: 102, alert_api_id: 9002 }),
+            annotation: makeAnnotation({ id: 202, sequence_id: 102 }),
+          },
+        ],
+      });
+
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      fireEvent.click(screen.getByRole('button', { name: /False positives/ }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('localize-object-row-object-1')).toBeInTheDocument();
+      });
+
+      // T1 carries both lanes; it stays openable, on the smoke lane.
+      expect(screen.getByTestId(`alert-frame-cell-${T1}`)).not.toHaveAttribute('data-readonly');
+      fireEvent.click(screen.getByTestId(`alert-frame-cell-${T1}`));
+      await waitFor(() => {
+        expect(screen.getByTestId('image-modal-detection-id')).toHaveTextContent('1002');
+      });
+    });
+
+    it('hides false-positive objects by default, matching the queue rule', async () => {
+      alertWithFalsePositive();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      expect(screen.getByTestId('localize-object-row-object-1')).toBeInTheDocument();
+      expect(screen.queryByTestId('localize-object-row-object-2')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('false-positive-divider')).not.toBeInTheDocument();
+    });
+
+    it('surfaces them as a separated, read-only group when toggled on', async () => {
+      alertWithFalsePositive();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: /False positives/ }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('localize-object-row-object-2')).toBeInTheDocument();
+      });
+      // Visually separated from the objects that still need work.
+      expect(screen.getByTestId('false-positive-divider')).toBeInTheDocument();
+
+      const fpRow = screen.getByTestId('localize-object-row-object-2');
+      expect(within(fpRow).getByText('False positive')).toBeInTheDocument();
+      expect(within(fpRow).getByText('cloud')).toBeInTheDocument();
+      // No localization work, so no progress fraction.
+      expect(within(fpRow).queryByText(/^\d+\/\d+$/)).not.toBeInTheDocument();
+      // Read-only: no accept action, and it never becomes work to do.
+      expect(within(fpRow).queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
+      expect(screen.getByText('0 of 1 object localized')).toBeInTheDocument();
+    });
+
+    it("shows each smoke object's type on its row", async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      expect(
+        within(screen.getByTestId('localize-object-row-object-1')).getByText('wildfire')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('missed-smoke row', () => {
+    function flaggedAlert() {
+      vi.mocked(apiClient.getAlertDetail).mockResolvedValue({
+        ...makeTwoLaneAlertDetail(),
+        lanes: [
+          {
+            sequence: makeSequence({ id: 101, alert_api_id: 9001 }),
+            annotation: makeAnnotation({ id: 201, sequence_id: 101, has_missed_smoke: true }),
+          },
+          {
+            sequence: makeSequence({ id: 102, alert_api_id: 9002 }),
+            annotation: makeAnnotation({ id: 202, sequence_id: 102 }),
+          },
+        ],
+      });
+    }
+
+    it('starts at No even on an alert classify already flagged — adding an object is a decision made here', async () => {
+      flaggedAlert();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      const row = screen.getByTestId('localize-missed-smoke-row');
+      expect(within(row).getByRole('radio', { name: 'No' })).toHaveAttribute(
+        'aria-checked',
+        'true'
+      );
+      // And so the inherited flag alone never pre-authorizes adding.
+      expect(screen.queryByRole('button', { name: 'Add object' })).not.toBeInTheDocument();
+    });
+
+    it('gates "+ Add object" until answered Yes, and re-locks it on No', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      // The control does not exist at all until the question is answered Yes.
+      expect(screen.queryByRole('button', { name: 'Add object' })).not.toBeInTheDocument();
+
+      answerMissedSmokeYes();
+      expect(screen.getByRole('button', { name: 'Add object' })).toBeEnabled();
+      // It lives inside the question it answers, not beside it.
+      expect(
+        within(screen.getByTestId('localize-missed-smoke-row')).getByRole('button', {
+          name: 'Add object',
+        })
+      ).toBeInTheDocument();
+      expect(
+        within(screen.getByTestId('localize-missed-smoke-row')).getByText(
+          /Add the object the AI missed/
+        )
+      ).toBeInTheDocument();
+
+      // Both radios disable while the PATCH is in flight (no double-writes),
+      // so wait for it to settle before answering the other way.
+      const noRadio = within(screen.getByTestId('localize-missed-smoke-row')).getByRole('radio', {
+        name: 'No',
+      });
+      await waitFor(() => expect(noRadio).toBeEnabled());
+      fireEvent.click(noRadio);
+      expect(screen.queryByRole('button', { name: 'Add object' })).not.toBeInTheDocument();
+    });
+
+    it('answering Yes PATCHes the flag onto the first annotated lane', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(
+        within(screen.getByTestId('localize-missed-smoke-row')).getByRole('radio', { name: 'Yes' })
+      );
+
+      await waitFor(() => {
+        expect(apiClient.updateSequenceAnnotation).toHaveBeenCalledWith(201, {
+          has_missed_smoke: true,
+        });
+      });
+    });
+
+    it('answering No clears it from whichever lane already carries it', async () => {
+      flaggedAlert();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(
+        within(screen.getByTestId('localize-missed-smoke-row')).getByRole('radio', { name: 'No' })
+      );
+
+      await waitFor(() => {
+        expect(apiClient.updateSequenceAnnotation).toHaveBeenCalledWith(201, {
+          has_missed_smoke: false,
+        });
+      });
+    });
+
+    it('answering Yes is what records the flag — the add itself no longer needs to', async () => {
+      vi.mocked(apiClient.addObject).mockResolvedValue({
+        sequence: makeSequence({ id: 103, alert_api_id: 9003 }),
+        annotation: makeAnnotation({ id: 203, sequence_id: 103 }),
+      });
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      answerMissedSmokeYes();
+      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
+      fireEvent.click(screen.getByRole('button', { name: 'wildfire' }));
+
+      await waitFor(() => {
+        expect(apiClient.updateSequenceAnnotation).toHaveBeenCalledWith(201, {
+          has_missed_smoke: true,
+        });
+      });
+    });
+  });
+
   describe('soft-confirm on submit (flagged, no object added this session)', () => {
+    // Every case here has to actually reach submit, which is gated on all
+    // objects already being accepted.
+    beforeEach(() => {
+      mockAllFramesAccepted();
+    });
+
     function mockFlaggedAlert() {
       vi.mocked(apiClient.getAlertDetail).mockResolvedValue({
         ...makeTwoLaneAlertDetail(),
@@ -1089,7 +1469,7 @@ describe('LocalizeAlertPage', () => {
       mockFlaggedAlert();
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
-      fireEvent.click(screen.getByRole('button', { name: 'Accept all & submit alert' }));
+      fireEvent.click(screen.getByRole('button', { name: /Submit alert/ }));
 
       await waitFor(() => {
         expect(
@@ -1120,6 +1500,13 @@ describe('LocalizeAlertPage', () => {
         if (id === 103) return [makeDetection(1004, T1)];
         return [];
       });
+      // The spawned lane's own frame must be accepted too, or the submit
+      // gate (not the soft-confirm) would be what blocks the click.
+      vi.mocked(apiClient.getDetectionAnnotations).mockImplementation(async filters => {
+        const byLane: Record<number, number[]> = { 101: [1001], 102: [1002, 1003], 103: [1004] };
+        const items = (byLane[filters?.sequence_id ?? 0] ?? []).map(makeDetectionAnnotation);
+        return { ...emptyAnnotationsPage, items, total: items.length };
+      });
       vi.mocked(apiClient.addObject).mockImplementation(async () => {
         const newLane: AlertLane = {
           sequence: makeSequence({ id: 103, alert_api_id: 9003 }),
@@ -1131,11 +1518,12 @@ describe('LocalizeAlertPage', () => {
 
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
+      answerMissedSmokeYes();
       fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
       fireEvent.click(screen.getByRole('button', { name: 'wildfire' }));
       await waitFor(() => expect(screen.getByTestId('object-status-row-2')).toBeInTheDocument());
 
-      fireEvent.click(screen.getByRole('button', { name: 'Accept all & submit alert' }));
+      fireEvent.click(screen.getByRole('button', { name: /Submit alert/ }));
 
       expect(
         screen.queryByText('You flagged missed smoke but added no object — submit anyway?')
@@ -1146,7 +1534,7 @@ describe('LocalizeAlertPage', () => {
       mockFlaggedAlert();
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
-      fireEvent.click(screen.getByRole('button', { name: 'Accept all & submit alert' }));
+      fireEvent.click(screen.getByRole('button', { name: /Submit alert/ }));
 
       await waitFor(() => {
         expect(
@@ -1167,7 +1555,7 @@ describe('LocalizeAlertPage', () => {
       mockFlaggedAlert();
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
-      fireEvent.click(screen.getByRole('button', { name: 'Accept all & submit alert' }));
+      fireEvent.click(screen.getByRole('button', { name: /Submit alert/ }));
       await waitFor(() => {
         expect(screen.getByTestId('missed-smoke-confirm')).toBeInTheDocument();
       });
@@ -1184,7 +1572,7 @@ describe('LocalizeAlertPage', () => {
       mockFlaggedAlert();
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
-      fireEvent.click(screen.getByRole('button', { name: 'Accept all & submit alert' }));
+      fireEvent.click(screen.getByRole('button', { name: /Submit alert/ }));
       await waitFor(() => {
         expect(screen.getByTestId('missed-smoke-confirm')).toBeInTheDocument();
       });
@@ -1201,41 +1589,20 @@ describe('LocalizeAlertPage', () => {
       });
     });
 
-    it('composes with the no-box two-step confirm: soft-confirm resolves first, then the routine no-box warning', async () => {
+    it('is the only gate left in front of submit — resolving it submits straight away', async () => {
       mockFlaggedAlert();
-      // Detection 1002 has no predictions -> a pending frame with zero
-      // boxes, same setup as the plain no-box confirm test.
-      vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
-        if (id === 101) return [makeDetection(1001, T1)];
-        if (id === 102) {
-          return [
-            { ...makeDetection(1002, T1), auto_predictions: { predictions: [] } },
-            makeDetection(1003, T2),
-          ];
-        }
-        return [];
-      });
-
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
-      fireEvent.click(screen.getByRole('button', { name: 'Accept all & submit alert' }));
+      fireEvent.click(screen.getByRole('button', { name: /Submit alert/ }));
       await waitFor(() => {
         expect(screen.getByTestId('missed-smoke-confirm')).toBeInTheDocument();
       });
       expect(apiClient.localizeSubmit).not.toHaveBeenCalled();
 
+      // The old per-frame "N frames with no box — submit anyway?" two-step
+      // went away with the bulk-accept-on-submit it guarded: submit now
+      // requires every frame to already carry a committed box.
       fireEvent.click(screen.getByRole('button', { name: 'Submit anyway' }));
-
-      // Soft-confirm resolved -> falls through to the ordinary per-frame
-      // no-box two-step, not straight to submit.
-      await waitFor(() => {
-        expect(screen.getByText('1 frame with no box — submit anyway?')).toBeInTheDocument();
-      });
-      expect(apiClient.localizeSubmit).not.toHaveBeenCalled();
-
-      fireEvent.click(
-        screen.getByRole('button', { name: '1 frame with no box — submit anyway?' })
-      );
 
       await waitFor(() => {
         expect(apiClient.localizeSubmit).toHaveBeenCalledWith([201, 202]);

--- a/frontend/tests/utils/annotation/alertLocalizeUtils.test.ts
+++ b/frontend/tests/utils/annotation/alertLocalizeUtils.test.ts
@@ -68,7 +68,11 @@ describe('buildAlertFrameModel', () => {
     };
     const annotationsByLaneId = { 1: [], 2: [] };
 
-    const { frames } = buildAlertFrameModel([laneA, laneB], detectionsByLaneId, annotationsByLaneId);
+    const { frames } = buildAlertFrameModel(
+      [laneA, laneB],
+      detectionsByLaneId,
+      annotationsByLaneId
+    );
 
     expect(frames.map(f => f.recordedAt)).toEqual([t1, t3, t2]);
     // t2 is shared by both lanes -> two cells there.
@@ -78,7 +82,7 @@ describe('buildAlertFrameModel', () => {
     expect(frames.find(f => f.recordedAt === t3)?.cells).toHaveLength(1);
   });
 
-  it('maps per-frame status: annotated -> confirmed, auto winning boxes -> pending, no-box -> pending', () => {
+  it('maps per-frame status: annotated -> confirmed, auto winning boxes -> pending, no-box -> empty', () => {
     const tDone = '2026-01-01T10:00:00Z';
     const tAuto = '2026-01-01T10:00:10Z';
     const tNoBox = '2026-01-01T10:00:20Z';
@@ -109,7 +113,9 @@ describe('buildAlertFrameModel', () => {
     expect(objectStatus[0].statusByTimestamp).toEqual({
       [tDone]: 'confirmed',
       [tAuto]: 'pending',
-      [tNoBox]: 'pending',
+      // Distinct from 'pending': nothing committed AND no model box to
+      // accept, so the strip must not paint it as if it had content.
+      [tNoBox]: 'empty',
     });
 
     const doneCell = frames.find(f => f.recordedAt === tDone)!.cells[0];
@@ -145,7 +151,8 @@ describe('buildAlertFrameModel', () => {
     );
 
     const objectA = objectStatus.find(o => o.laneSequenceId === 1)!;
-    expect(objectA.statusByTimestamp[t1]).toBe('pending');
+    // Present at t1 but with no boxes at all -> 'empty', not 'pending'.
+    expect(objectA.statusByTimestamp[t1]).toBe('empty');
     expect(objectA.statusByTimestamp[t2]).toBeUndefined();
 
     // Frame t2's only cell belongs to lane B; lane A contributes nothing there.
@@ -158,7 +165,9 @@ describe('buildAlertFrameModel', () => {
     const lane = makeLane(1, { processing_stage: 'annotated' });
     const detectionsByLaneId = { 1: [makeDetection(1, t1, { engine: [] })] };
     const annotationsByLaneId = {
-      1: [makeDetAnnotation(1, 'annotated', [{ xyxyn: [0.1, 0.1, 0.2, 0.2], class_name: 'smoke' }])],
+      1: [
+        makeDetAnnotation(1, 'annotated', [{ xyxyn: [0.1, 0.1, 0.2, 0.2], class_name: 'smoke' }]),
+      ],
     };
 
     const { objectStatus, frames } = buildAlertFrameModel(


### PR DESCRIPTION
Restructures the collocated localize screen into `ClassifyAlertPage`'s two-column cockpit, and tightens the decisions it asks for. Built iteratively against a live dev server, so most of this came from eyeballing the real screen rather than from a spec.

## Layout

Media column (frame grid + cropped-view flipbook) beside a sticky `LocalizeRail`, replacing the vertical stack of *workable timeline → standalone "+ Add object" card → separate "Already localized" strip*. Every object is now one rail row in lane order, with already-localized lanes dimmed in place; the timeline moves below the rail into the slot classify gives `ObjectPresenceStrip`.

- Header badge reports progress (`2 of 5 objects localized`) rather than a bare count.
- Submit moves into the rail footer and turns **pine**, per DESIGN.md's "primary is `pine` in Localize contexts".
- View controls move out of the alert header into the media column header, beside the grid they actually drive. The 👁 predictions toggle is dropped there — `AlertFrameGrid` never read `showPredictions` (only `ImageModal` does, and it carries its own toggle, and it covers the header when open). `ViewToolbar` keeps the prop optional for `DetectionHeader`, and migrates off the deprecated `gray-*` palette.
- Object rows show the smoke type classify chose.

## Decisions

- **Submit is gated** on every workable object already carrying a committed box on every frame it appears on, and no longer accepts anything itself. The per-frame *"N frames with no box — submit anyway?"* two-step went with it: `confirmed` ⟺ the exact predicate `buildQuickSubmitPlan` skips on, so under the gate that state is unreachable.
- **The rail owns the missed-smoke question**, which guards "+ Add object" and carries it inside. It starts at **No** on every alert — deliberately *not* seeded from the lanes' inherited `has_missed_smoke` — so arriving on an alert classify already flagged never pre-authorizes adding.
- **False positives** stay hidden by default (the queue's own `laneNeedsLocalization` rule) behind a rail toggle that surfaces them as a separated, read-only group: labeled divider, FP types, no accept action, no progress fraction, and frames that are visible — including the cropped view — but never openable in the editor. Also closed off at `modalContext`, so a pasted URL can't re-box something classify already rejected. Unsure lanes stay excluded either way.

## Fixes found while building

- **A just-added object's timeline rendered as if it were already full.** `getCellState` has three states but the strip collapsed `auto` and `no-box` into one `pending` fill; `add-object` clones detections with empty `algo_predictions` and no `auto_predictions`, so every frame is `no-box`. Adds a distinct `empty` status (outline, no fill). This also corrected progress arithmetic that would otherwise have counted those frames as *confirmed*.
- **A browser freeze when activating an object.** `AlertFrameGrid` called `setImageInfo` unconditionally from inside a `ResizeObserver` callback — a textbook feedback loop. Activating an object is what trips it: focus mode flips crop on *and* forces small cards, so `cardMinWidth` goes 340→240, the grid re-columns, and every cell re-measures at once. Now bails when the measurement is unchanged. ⚠️ **Not reproducible in jsdom** (no layout, so `ResizeObserver`/`getBoundingClientRect` are inert) — verified by reasoning, wants a browser check.
- **Silent object switching.** Frames the active object is absent from now render dimmed and non-interactive; clicking one used to open the fallback lane's detection and switch which object you were editing.
- The no-active-object fallback cell prefers a workable lane, so a shared frame whose first lane is a false positive stays openable.
- Drops the per-cell `done/total` chip and the now-orphaned `ObjectStatusStrip.action` prop.

## Verification

All four CI jobs run clean locally: `build`, `quality:ci`, `test`, `test:coverage` — **939 tests, 82 files**.

`LocalizeAlertPage.test.tsx` grew from 38 to 52 tests. Notable rewrites: the 11 tests built around submit's implicit bulk-accept were reworked around the gate, and a new `mockRealisticAddObjectFlow` fixture matches what the backend actually produces (the existing one gave spawned lanes model predictions, which `/alert/add-object` never does).

## Not in scope

- `/localize/done/:id` — still the legacy per-lane `DetectionSequenceAnnotatePage`.
- Auto-advance to the next alert on submit.
- Removing an added object — blocked on a real marker: `_object_index` shows importer-split sibling lanes and `add-object` lanes share the same `alert_api_id` scheme, so nothing currently distinguishes a human-added lane from an imported one. Needs an `is_manual`-style column before a DELETE can be safe.
- Annotating an object on a frame it has no `Detection` for (the 30-vs-4-frames case) — needs a backend way to extend a lane onto a frame.
