### PR TITLE
fix(localize): make the false-positive context view actually show its object

### DIFF
--- a/frontend/src/components/detection-sequence/AlertFrameGrid.tsx
+++ b/frontend/src/components/detection-sequence/AlertFrameGrid.tsx
@@ -178,7 +178,12 @@ function AlertFrameCellView({
   // clicking used to open the fallback lane's detection, silently switching
   // which object you were editing.
   const isContextFrame = activeLaneId !== null && !isActiveLaneCell;
-  const isAccented = activeLaneId !== null && isActiveLaneCell;
+  // The full-cell accent outline says "this object is here — work on it".
+  // A false positive is settled and its cells are read-only, so the outline
+  // would be claiming work that doesn't exist; its dashed box already marks
+  // where the object is.
+  const isAccented =
+    activeLaneId !== null && isActiveLaneCell && activeCell.isFalsePositive !== true;
   // A false-positive object is settled; its frames are here to be LOOKED at
   // (including via the cropped-view strip), never edited. Opening the editor
   // on one would offer to re-box something classify already rejected.

--- a/frontend/src/components/detection-sequence/AlertFrameGrid.tsx
+++ b/frontend/src/components/detection-sequence/AlertFrameGrid.tsx
@@ -4,7 +4,9 @@
  * cell shows the frame image (of the active object's detection when it has
  * one there, else the first present lane's), a mini box per object present
  * on that frame in its own accent color (solid for a committed box, dashed
- * for a winning-but-not-yet-committed one), and a small status chip.
+ * for anything not committed — a winning model box awaiting acceptance, or
+ * a false-positive lane's engine track, which is read-only context and
+ * never gets committed at all), and a small status chip.
  *
  * Clicking a cell reports the frame's timestamp plus the shown (active, or
  * first-present-fallback) object's lane and detection id via `onCellClick`
@@ -235,7 +237,14 @@ function AlertFrameCellView({
                   top: `${top}px`,
                   width: `${width}px`,
                   height: `${height}px`,
-                  border: `2px ${cell.cellState === 'done' ? 'solid' : 'dashed'} ${box.color}`,
+                  // Solid means committed. A false-positive cell's state is
+                  // genuinely 'done' (its lane is annotated), but the boxes
+                  // shown are the engine track, not anything a human
+                  // committed — so it stays dashed like any other
+                  // not-yet-committed box.
+                  border: `2px ${
+                    cell.cellState === 'done' && !cell.isFalsePositive ? 'solid' : 'dashed'
+                  } ${box.color}`,
                 }}
               />
             );

--- a/frontend/src/components/localize/LocalizeObjectRow.tsx
+++ b/frontend/src/components/localize/LocalizeObjectRow.tsx
@@ -72,10 +72,17 @@ export const LocalizeObjectRow: React.FC<LocalizeObjectRowProps> = ({
     ? (falsePositiveTypes ?? []).map(t => t.replace(/_/g, ' ')).join(', ') || null
     : (smokeType ?? null);
 
-  const frame = !workable
-    ? 'border border-line bg-paper opacity-60'
-    : isActive
-      ? 'border border-line border-l-[3px] border-l-pine bg-paper'
+  // Selection is checked BEFORE workability. A non-workable row (a false
+  // positive, or an already-localized context lane) is still clickable and
+  // still drives the media column, so it needs the same "this is what
+  // you're looking at" feedback — and leaving it dimmed while it is the
+  // active object contradicts the selection. Its accent is neutral rather
+  // than pine, which on this page means workable / positive / in progress —
+  // a claim a settled object shouldn't make.
+  const frame = isActive
+    ? `border border-line border-l-[3px] bg-paper ${workable ? 'border-l-pine' : 'border-l-char'}`
+    : !workable
+      ? 'border border-line bg-paper opacity-60'
       : 'border border-line bg-paper hover:bg-ash';
 
   return (

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -827,6 +827,20 @@ export default function LocalizeAlertPage() {
     if (isFocused) setSizeOverrideCleared(true);
   };
 
+  // Hiding false positives again while one is the ACTIVE object would strand
+  // `activeLaneId` on a lane the frame model no longer contains: every
+  // remaining cell then reads as "not this object's frame", dimming the whole
+  // grid and making it unclickable with no way back except clicking a row.
+  // Deselect first. `exitFocus` is a no-op when not focused, so the explicit
+  // `setActiveLaneId(null)` covers that path too.
+  const handleToggleFalsePositives = () => {
+    if (showFalsePositives && activeLaneIsFalsePositive) {
+      exitFocus();
+      setActiveLaneId(null);
+    }
+    setShowFalsePositives(prev => !prev);
+  };
+
   // The cropped-view toolbar toggle while focused: the strip is already
   // forced visible by focus mode, so a plain on/off toggle would either do
   // nothing (if disabled) or fight focus mode (if it toggled the underlying
@@ -1051,7 +1065,7 @@ export default function LocalizeAlertPage() {
                 type="button"
                 aria-pressed={showFalsePositives}
                 disabled={falsePositiveLaneCount === 0}
-                onClick={() => setShowFalsePositives(prev => !prev)}
+                onClick={handleToggleFalsePositives}
                 title={
                   falsePositiveLaneCount === 0
                     ? 'This alert has no false-positive objects'

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -760,13 +760,19 @@ export default function LocalizeAlertPage() {
   // (`showCroppedView`, works standalone) and object-focus mode (`isFocused`
   // — shows it automatically while an object is focused, per the render
   // condition below).
+  // A false-positive lane's committed annotation is empty by construction,
+  // so the flipbook has to read its engine track instead — otherwise
+  // activating an FP object shows no strip at all, and looking closely at
+  // the rejected plume is the whole reason the row is on screen.
+  const activeLaneIsFalsePositive = activeObject?.isFalsePositive === true;
   const activeLaneBoxes = useMemo(() => {
     if (activeLaneId == null) return [];
     return collectLaneBoxes(
       detectionsByLaneId[activeLaneId] ?? [],
-      new Map((annotationsByLaneId[activeLaneId] ?? []).map(a => [a.detection_id, a]))
+      new Map((annotationsByLaneId[activeLaneId] ?? []).map(a => [a.detection_id, a])),
+      { falsePositive: activeLaneIsFalsePositive }
     );
-  }, [activeLaneId, detectionsByLaneId, annotationsByLaneId]);
+  }, [activeLaneId, detectionsByLaneId, annotationsByLaneId, activeLaneIsFalsePositive]);
 
   // Enters (or switches) object-focus mode: crop-on + small cards, a lens
   // for looking closely at just this object, plus the cropped-view strip

--- a/frontend/src/utils/annotation/alertLocalizeUtils.ts
+++ b/frontend/src/utils/annotation/alertLocalizeUtils.ts
@@ -31,7 +31,12 @@ import {
   SequenceAnnotation,
   SmokeType,
 } from '@/types/api';
-import { CellState, getCellState, getWinningBoxes } from './quickSubmitUtils';
+import {
+  CellState,
+  falsePositiveContextBoxes,
+  getCellState,
+  getWinningBoxes,
+} from './quickSubmitUtils';
 import { focusOnMainObject } from './gridCropUtils';
 import { laneNeedsLocalization } from './localizeUtils';
 import { getObjectColor } from './objectColors';
@@ -130,8 +135,14 @@ export function buildAlertFrameModel(
     for (const detection of detections) {
       const annotation = annotationByDetectionId.get(detection.id);
       const cellState = getCellState(detection, annotation);
-      const rawBoxes =
-        cellState === 'done'
+      // An FP lane's committed annotation is empty by construction (see
+      // `falsePositiveContextBoxes`), so reading it would leave this lane
+      // with nothing to draw — no mini-boxes, no crop-mode zoom, and a
+      // timeline row stuck at 'empty'. Its engine track is what the
+      // read-only context view is for.
+      const rawBoxes = falsePositive
+        ? falsePositiveContextBoxes(detection)
+        : cellState === 'done'
           ? (annotation?.annotation?.annotation ?? [])
               .filter(item => item.false_positive_type == null)
               .map(item => ({ xyxyn: item.xyxyn }))

--- a/frontend/src/utils/annotation/index.ts
+++ b/frontend/src/utils/annotation/index.ts
@@ -57,6 +57,7 @@ export {
   buildQuickSubmitPlan,
   getIsAnnotated,
   collectLaneBoxes,
+  falsePositiveContextBoxes,
 } from './quickSubmitUtils';
 export type { CellState, QuickSubmitPlan, QuickSubmitPayload } from './quickSubmitUtils';
 export { computeCellCrop, focusOnMainObject } from './gridCropUtils';

--- a/frontend/src/utils/annotation/quickSubmitUtils.ts
+++ b/frontend/src/utils/annotation/quickSubmitUtils.ts
@@ -79,17 +79,24 @@ export function getCellState(
  * The lane's committal boxes across all frames, in CroppedImageSequence's
  * input shape: committed smoke boxes for done frames, winning-layer boxes
  * for pending frames, nothing for no-box frames.
+ *
+ * `options.falsePositive` switches the whole lane to its engine track
+ * instead: an FP lane's committed annotation is empty by construction, so
+ * the default path would give the flipbook nothing to show. See
+ * `falsePositiveContextBoxes`.
  */
 export function collectLaneBoxes(
   detections: Detection[],
-  annotations: Map<number, DetectionAnnotation>
+  annotations: Map<number, DetectionAnnotation>,
+  options: { falsePositive?: boolean } = {}
 ): BoundingBox[] {
   const out: BoundingBox[] = [];
   for (const detection of detections) {
     const existing = annotations.get(detection.id);
     const state = getCellState(detection, existing);
-    const boxes =
-      state === 'done'
+    const boxes: { xyxyn: number[] }[] = options.falsePositive
+      ? falsePositiveContextBoxes(detection)
+      : state === 'done'
         ? (existing?.annotation?.annotation ?? []).filter(item => item.false_positive_type == null)
         : state === 'auto'
           ? getWinningBoxes(detection).boxes

--- a/frontend/src/utils/annotation/quickSubmitUtils.ts
+++ b/frontend/src/utils/annotation/quickSubmitUtils.ts
@@ -49,6 +49,24 @@ export function getWinningBoxes(detection: Detection) {
   return { layer, boxes };
 }
 
+/**
+ * The boxes to SHOW for a false-positive lane. Its committed annotation is
+ * deliberately empty — the backend writes `{"annotation": []}` at ANNOTATED
+ * for FP-only lanes, since the human's answer was "no smoke here" — so the
+ * engine track the lane was object-split on is the only record of where the
+ * object actually is. Deliberately `algo_predictions` rather than
+ * `getWinningBoxes`: the split ran on the engine track, so that track is the
+ * lane's identity, and a later auto-model box is not.
+ *
+ * Read-only context only — these are never committed, offered for
+ * acceptance, or submitted.
+ */
+export function falsePositiveContextBoxes(
+  detection: Detection
+): { xyxyn: [number, number, number, number] }[] {
+  return (detection.algo_predictions?.predictions ?? []).map(p => ({ xyxyn: p.xyxyn }));
+}
+
 export function getCellState(
   detection: Detection,
   annotation: DetectionAnnotation | undefined

--- a/frontend/tests/components/localize/LocalizeObjectRow.test.tsx
+++ b/frontend/tests/components/localize/LocalizeObjectRow.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Tests for LocalizeObjectRow's selection treatment. The row's frame styling
+ * used to branch on `!workable` FIRST, so a non-workable row (a false
+ * positive, or an already-localized context lane) could never reach the
+ * active branch: clicking it drove the media column but the row itself gave
+ * no feedback and stayed dimmed while it was the thing being looked at.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { LocalizeObjectRow } from '@/components/localize';
+import { getObjectColor } from '@/utils/annotation/objectColors';
+
+const baseProps = {
+  label: 'Object 2',
+  color: getObjectColor(1),
+  confirmedCount: 0,
+  presentCount: 3,
+  isActive: false,
+  onActivate: () => {},
+};
+
+const row = () => screen.getByTestId('localize-object-row-object-2');
+
+describe('LocalizeObjectRow selection treatment', () => {
+  it('leaves an unselected false-positive row dimmed and unaccented', () => {
+    render(<LocalizeObjectRow {...baseProps} workable={false} isFalsePositive />);
+
+    expect(row()).toHaveClass('opacity-60');
+    expect(row()).not.toHaveClass('border-l-char');
+  });
+
+  it('accents a selected false-positive row and lifts the dim', () => {
+    render(<LocalizeObjectRow {...baseProps} workable={false} isFalsePositive isActive />);
+
+    // Neutral rather than pine: pine means workable / positive / in progress
+    // on this page, which a settled false positive contradicts.
+    expect(row()).toHaveClass('border-l-[3px]');
+    expect(row()).toHaveClass('border-l-char');
+    expect(row()).not.toHaveClass('border-l-pine');
+    // Dimming what you are actively looking at contradicts the selection.
+    expect(row()).not.toHaveClass('opacity-60');
+    expect(row()).toHaveAttribute('data-active', 'true');
+  });
+
+  it('accents a selected already-localized context row the same way', () => {
+    render(<LocalizeObjectRow {...baseProps} workable={false} isActive />);
+
+    expect(row()).toHaveClass('border-l-char');
+    expect(row()).not.toHaveClass('opacity-60');
+  });
+
+  it('keeps pine for a selected workable row', () => {
+    render(<LocalizeObjectRow {...baseProps} workable isActive />);
+
+    expect(row()).toHaveClass('border-l-pine');
+    expect(row()).not.toHaveClass('border-l-char');
+  });
+});

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -1294,6 +1294,28 @@ describe('LocalizeAlertPage', () => {
       );
     });
 
+    it('shows the cropped flipbook for an activated false-positive object', async () => {
+      realisticFalsePositiveAlert();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: /False positives/ }));
+      await waitFor(() => {
+        expect(screen.getByTestId('localize-object-row-object-2')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Go to Object 2' }));
+
+      // Looking closely at the rejected plume is the entire point of the
+      // read-only FP view — the flipbook is gated on the lane having boxes,
+      // which its empty committed annotation never provided.
+      await waitFor(() => {
+        expect(screen.getByTestId('cropped-image-sequence')).toHaveAttribute(
+          'data-sequence-id',
+          '102'
+        );
+      });
+    });
+
     it('disables the toggle when the alert has no false-positive objects', async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
@@ -1313,7 +1335,7 @@ describe('LocalizeAlertPage', () => {
     });
 
     it('keeps false-positive frames read-only — visible, never openable in the editor', async () => {
-      alertWithFalsePositive();
+      realisticFalsePositiveAlert();
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
       fireEvent.click(screen.getByRole('button', { name: /False positives/ }));

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -1353,6 +1353,38 @@ describe('LocalizeAlertPage', () => {
       });
     });
 
+    it('deselects a false-positive object when the toggle hides it again', async () => {
+      realisticFalsePositiveAlert();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: /False positives/ }));
+      await waitFor(() => {
+        expect(screen.getByTestId('localize-object-row-object-2')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Go to Object 2' }));
+      await waitFor(() => {
+        expect(screen.getByTestId('cropped-image-sequence')).toBeInTheDocument();
+      });
+
+      // Hiding false positives again while one is the active object used to
+      // strand `activeLaneId` on a lane the model no longer contains: every
+      // remaining cell then read as "not this object's frame", so the whole
+      // grid went dimmed and unclickable with no way back except clicking a
+      // row.
+      fireEvent.click(screen.getByRole('button', { name: /False positives/ }));
+      await waitFor(() => {
+        expect(screen.queryByTestId('localize-object-row-object-2')).not.toBeInTheDocument();
+      });
+
+      const cell = screen.getByTestId(`alert-frame-cell-${T1}`);
+      expect(cell).not.toHaveAttribute('data-context');
+      expect(cell).not.toHaveAttribute('data-readonly');
+      fireEvent.click(cell);
+      await waitFor(() => {
+        expect(screen.getByTestId('image-modal')).toBeInTheDocument();
+      });
+    });
+
     it('disables the toggle when the alert has no false-positive objects', async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -1211,6 +1211,89 @@ describe('LocalizeAlertPage', () => {
       });
     }
 
+    /**
+     * Production-shaped false-positive lane, which `alertWithFalsePositive`
+     * above is NOT: a real FP lane carries an `annotated` detection
+     * annotation with an EMPTY box list (the backend writes
+     * `{"annotation": []}` when the human answers "no smoke here") and keeps
+     * the object's real location in `algo_predictions`. The default
+     * `makeDetection` fixture has an empty engine track and a populated
+     * `auto_predictions`, which is the reverse — so tests about what an FP
+     * lane displays must build their own detections.
+     */
+    function realisticFalsePositiveAlert() {
+      alertWithFalsePositive();
+      vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
+        if (id === 101) return [makeDetection(1001, T1)];
+        if (id === 102) {
+          return [makeDetection(1002, T1), makeDetection(1003, T2)].map(d => ({
+            ...d,
+            algo_predictions: {
+              predictions: [
+                {
+                  xyxyn: [0.5, 0.5, 0.7, 0.7] as [number, number, number, number],
+                  confidence: 0.8,
+                  class_name: 'smoke',
+                },
+              ],
+            },
+            auto_predictions: null,
+          }));
+        }
+        return [];
+      });
+      vi.mocked(apiClient.getDetectionAnnotations).mockImplementation(async filters => {
+        if (filters?.sequence_id !== 102) return emptyAnnotationsPage;
+        const items = [1002, 1003].map(detectionId => ({
+          ...makeDetectionAnnotation(detectionId),
+          annotation: { annotation: [] },
+        }));
+        return { ...emptyAnnotationsPage, items, total: items.length };
+      });
+    }
+
+    it('draws the engine track for a false-positive object, dashed as uncommitted context', async () => {
+      realisticFalsePositiveAlert();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: /False positives/ }));
+      await waitFor(() => {
+        expect(screen.getByTestId('localize-object-row-object-2')).toBeInTheDocument();
+      });
+
+      // The grid only paints box overlays once it has measured the rendered
+      // image, and jsdom never fires `load` on its own — so drive it here.
+      const frameImage = await within(screen.getByTestId(`alert-frame-cell-${T2}`)).findByRole(
+        'img'
+      );
+      fireEvent.load(frameImage);
+
+      const fpBox = await screen.findByTestId(`alert-frame-box-${T2}-102`);
+      // Dashed, not solid: nothing here is committed — it's where the engine
+      // thought the object was, kept for "is that plume already accounted
+      // for?" context.
+      expect(fpBox.getAttribute('style')).toContain('dashed');
+    });
+
+    it('gives a false-positive object a present timeline, not an empty one', async () => {
+      realisticFalsePositiveAlert();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: /False positives/ }));
+      await waitFor(() => {
+        expect(screen.getByTestId('localize-object-row-object-2')).toBeInTheDocument();
+      });
+
+      // Object 2 is the second row (`orderedObjectRows` puts FP rows last);
+      // its first segment covers T1, where the engine track puts a box.
+      // `ObjectStatusStrip` exposes a segment's status only through its
+      // aria-label.
+      expect(screen.getByTestId('status-segment-1-0')).toHaveAttribute(
+        'aria-label',
+        'Object 2, frame 1: confirmed'
+      );
+    });
+
     it('disables the toggle when the alert has no false-positive objects', async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -1316,6 +1316,43 @@ describe('LocalizeAlertPage', () => {
       });
     });
 
+    it("does not outline an activated false-positive object's frames", async () => {
+      realisticFalsePositiveAlert();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: /False positives/ }));
+      await waitFor(() => {
+        expect(screen.getByTestId('localize-object-row-object-2')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Go to Object 2' }));
+
+      // The full-cell accent outline says "this object is here, work on it".
+      // A false positive is settled and its cells are read-only — the dashed
+      // box already marks where it is.
+      await waitFor(() => {
+        expect(screen.getByTestId(`alert-frame-cell-${T2}`)).toHaveAttribute(
+          'data-readonly',
+          'true'
+        );
+      });
+      expect(screen.getByTestId(`alert-frame-cell-${T2}`).getAttribute('style') ?? '').not.toContain(
+        'outline'
+      );
+    });
+
+    it("still outlines an activated workable object's frames", async () => {
+      realisticFalsePositiveAlert();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Go to Object 1' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId(`alert-frame-cell-${T1}`).getAttribute('style') ?? '').toContain(
+          'outline'
+        );
+      });
+    });
+
     it('disables the toggle when the alert has no false-positive objects', async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 

--- a/frontend/tests/utils/annotation/alertLocalizeUtils.test.ts
+++ b/frontend/tests/utils/annotation/alertLocalizeUtils.test.ts
@@ -236,4 +236,86 @@ describe('buildAlertFrameModel', () => {
     expect(objectStatus[0].label).toBe('Object 2');
     expect(objectStatus[0].color).toBe(getObjectColor(1));
   });
+
+  describe('false-positive context lanes (includeFalsePositives)', () => {
+    /**
+     * The real shape of an FP-only lane: the backend writes its detection
+     * annotations as `{"annotation": []}` at stage `annotated` (the human
+     * said "no smoke here"), leaving the object's actual location in
+     * `algo_predictions`. Reading the committed boxes gives the lane
+     * nothing to draw, which is the bug this suite pins down.
+     */
+    const fpLane = () => makeLane(1, { has_smoke: false, has_missed_smoke: false });
+
+    it('shows the engine track for an FP lane whose committed annotation is empty', () => {
+      const t1 = '2026-01-01T10:00:00Z';
+      const engineBox = box(0.4, 0.4, 0.5, 0.5);
+
+      const { frames, objectStatus } = buildAlertFrameModel(
+        [fpLane()],
+        { 1: [makeDetection(1, t1, { engine: [engineBox], auto: [] })] },
+        { 1: [makeDetAnnotation(1, 'annotated', [])] },
+        { includeFalsePositives: true }
+      );
+
+      const cell = frames[0].cells[0];
+      expect(cell.isFalsePositive).toBe(true);
+      expect(cell.boxes).toEqual([{ xyxyn: [0.4, 0.4, 0.5, 0.5], color: getObjectColor(0) }]);
+      // The timeline row can only read 'confirmed' once boxes exist.
+      expect(objectStatus[0].statusByTimestamp[t1]).toBe('confirmed');
+    });
+
+    it('prefers the engine track over auto_predictions for an FP lane', () => {
+      const t1 = '2026-01-01T10:00:00Z';
+
+      const { frames } = buildAlertFrameModel(
+        [fpLane()],
+        {
+          1: [
+            makeDetection(1, t1, {
+              engine: [box(0.4, 0.4, 0.5, 0.5)],
+              auto: [box(0.7, 0.7, 0.8, 0.8)],
+            }),
+          ],
+        },
+        { 1: [makeDetAnnotation(1, 'annotated', [])] },
+        { includeFalsePositives: true }
+      );
+
+      expect(frames[0].cells[0].boxes.map(b => b.xyxyn)).toEqual([[0.4, 0.4, 0.5, 0.5]]);
+    });
+
+    it('reads empty for an FP frame with no engine box at all', () => {
+      const t1 = '2026-01-01T10:00:00Z';
+
+      const { frames, objectStatus } = buildAlertFrameModel(
+        [fpLane()],
+        { 1: [makeDetection(1, t1, { engine: [], auto: [] })] },
+        { 1: [makeDetAnnotation(1, 'annotated', [])] },
+        { includeFalsePositives: true }
+      );
+
+      expect(frames[0].cells[0].boxes).toEqual([]);
+      expect(objectStatus[0].statusByTimestamp[t1]).toBe('empty');
+    });
+
+    it('leaves a smoke lane reading its committed boxes, not the engine track', () => {
+      const t1 = '2026-01-01T10:00:00Z';
+
+      const { frames } = buildAlertFrameModel(
+        [makeLane(1)],
+        { 1: [makeDetection(1, t1, { engine: [box(0.4, 0.4, 0.5, 0.5)], auto: [] })] },
+        {
+          1: [
+            makeDetAnnotation(1, 'annotated', [
+              { xyxyn: [0.2, 0.2, 0.3, 0.3], class_name: 'smoke', smoke_type: 'wildfire' },
+            ]),
+          ],
+        },
+        { includeFalsePositives: true }
+      );
+
+      expect(frames[0].cells[0].boxes.map(b => b.xyxyn)).toEqual([[0.2, 0.2, 0.3, 0.3]]);
+    });
+  });
 });

--- a/frontend/tests/utils/annotation/quickSubmitUtils.test.ts
+++ b/frontend/tests/utils/annotation/quickSubmitUtils.test.ts
@@ -116,6 +116,26 @@ describe('collectLaneBoxes', () => {
 
     expect(result).toEqual([{ detection_id: 1, xyxyn: [0.25, 0.25, 0.35, 0.35] }]);
   });
+
+  it('reads the engine track for a false-positive lane, whose committed annotation is empty', () => {
+    // The production shape: an `annotated` detection annotation with an
+    // empty box list, and the object's real location in the engine track.
+    const detection = makeDetection(1, {
+      engine: [box(0.5, 0.5, 0.7, 0.7)],
+      auto: [box(0.1, 0.1, 0.2, 0.2)],
+    });
+    const annotations = new Map([[1, makeAnnotation(1, 'annotated', [])]]);
+
+    // Without the flag, the empty committed annotation wins and the lane
+    // contributes nothing — the bug this fixes.
+    expect(collectLaneBoxes([detection], annotations)).toEqual([]);
+
+    // With it, the engine track shows through — and beats auto_predictions,
+    // because the lane was object-split on the engine track.
+    expect(collectLaneBoxes([detection], annotations, { falsePositive: true })).toEqual([
+      { detection_id: 1, xyxyn: [0.5, 0.5, 0.7, 0.7] },
+    ]);
+  });
 });
 
 describe('buildQuickSubmitPlan', () => {


### PR DESCRIPTION
## Problem

On `/localize/:sequenceId`, turning on the **False positives** toggle revealed the FP object's row — and nothing else. No boxes on the frames, no crop-mode zoom, an all-empty timeline row, and no cropped flipbook when you activated it. The read-only context view exists to answer "is that plume already accounted for?" before someone adds a duplicate object, and it could not answer it.

## Root cause

An FP-only lane's detection annotations are written **empty** at stage `ANNOTATED`:

```python
# annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py:257
# Reworked model: detection annotations are created empty; the human ground truth
# is seeded at submit, not pre-filled from algo_predictions
annotation_data: dict = {"annotation": []}
```

That is correct — the human's answer was "no smoke here", so nothing is committed. But every box-reading path on the localize screen keys off `getCellState`, which sees `annotated` and returns `'done'`, then reads the committed boxes. For an FP lane that is always `[]`. The object's actual location survives only in `detection.algo_predictions`.

Verified across the whole local DB — every FP lane row, no exceptions:

```
 processing_stage | n_boxes | count
 ANNOTATED        |       0 |    77
```

while the detections themselves carry engine boxes on every frame (13/13 for the FP lane of alert 55664).

## Changes

| Commit | Change |
| --- | --- |
| `6e99cea` | New `falsePositiveContextBoxes(detection)` reads `algo_predictions`; `buildAlertFrameModel` routes FP lanes through it. Fixes mini-boxes, crop zoom, and the timeline row together — `AlertFrameGrid` derives all three from `cell.boxes`. |
| `707a976` | Border keys on `cellState === 'done' && !cell.isFalsePositive`, so FP context boxes render dashed. |
| `18be6c9` | `collectLaneBoxes(…, { falsePositive })` + wired from the page, so the cropped flipbook works for an activated FP object. |
| `edbfb58` | Non-workable rail rows get a selection state; FP cells lose the accent outline. |

### Why `algo_predictions` and not `getWinningBoxes`

The lane was object-split on the engine track, so that track is its identity — a later auto-model box is not. `getWinningBoxes` prefers `auto_predictions`, which would show a different object's box for a lane defined by the engine one.

### Why `cellState` is left alone

Overriding it to `'auto'` for FP lanes would have fixed both the boxes and the dashed border in one line, but `cellState` is a factual claim about the lane's annotation stage and is also consumed by `DetectionImageCard`. The border now keys on `isFalsePositive` instead.

### Row selection (`edbfb58`)

`LocalizeObjectRow` branched on `!workable` **before** `isActive`, so a false-positive or already-localized row could never reach the active branch: clicking it drove the media column while the row stayed dimmed and unaccented. Selection is now checked first, with a neutral `char` accent rather than pine — pine means workable / positive / in progress on this page, which a settled object shouldn't claim. This also fixes "Context" rows (already-localized lanes), which had the identical bug from the identical line; carving out an FP-only path would have needed extra code to preserve the bug next door.

The frame grid's full-cell accent outline is likewise a work signal (`outline: 2px solid <object color>` — the orange border visible on FP frames once they started activating), so FP cells no longer get it. Their dashed box already marks where the object is. Tests pin both directions so it can't quietly disappear for real work.

## Test coverage

954 → 968 tests, 85 → 86 files. New:

- `tests/utils/annotation/alertLocalizeUtils.test.ts` — 4 cases: engine track shown for an empty-committed FP lane, engine preferred over `auto_predictions`, `'empty'` when the engine track is empty, and a guard that smoke lanes still read their committed boxes.
- `tests/utils/annotation/quickSubmitUtils.test.ts` — `collectLaneBoxes` with and without the flag on the same fixture.
- `tests/components/localize/LocalizeObjectRow.test.tsx` (new file) — 4 cases covering the selection matrix.
- `tests/pages/LocalizeAlertPage.test.tsx` — dashed rendering, timeline presence, flipbook, and both outline directions.

### One existing test changed

`keeps false-positive frames read-only` gave its FP lane **no** detection annotations at all, so it exercised the `'auto'` path and read `auto_predictions` — not the production shape. It now uses a new `realisticFalsePositiveAlert()` fixture (empty `annotated` annotation + populated engine track). The assertions are unchanged; only the fixture got more honest.

## Verified manually

Against the local stack on alert 55664 (`/localize/57`), whose lane 58 is a real false positive with 13 engine-boxed frames: toggle reveals the row, timeline fills, activating it draws dashed boxes with crop zoom and shows the flipbook, and the cells remain non-openable.

## Not in scope

- **Intended side effect:** with the toggle on, opening a smoke frame now also renders the FP object as a labeled overlay in `ImageModal`, since `objectOverlays` sources from the same per-cell boxes the grid draws. That is what the existing comment there says the overlays are for.
- **An FP lane with an empty engine track still shows nothing.** Of 95 FP-lane frames in the local DB, 77 carry exactly one engine box and 18 carry none. Those 18 are 5 entire lanes (258, 271, 188, 134, 41) that have no boxes in **any** prediction layer — `auto_predictions` is empty for them too — so falling back to `getWinningBoxes` would achieve nothing. They render as an empty timeline row, which the `reads empty for an FP frame with no engine box at all` unit test pins. Why those lanes are boxless is an import-side question, out of scope here.
- `ObjectRow` on the classify screen has the identical `locked`-beats-`isActive` bug. Different page — flagged, not touched.
- Investigating this surfaced #276 (one `platform_alert_id` grouping temporally disjoint episodes). Unrelated to this fix.
