### PR TITLE
feat(frontend): put a localize row's actions behind its selection

### DIFF
--- a/frontend/src/components/detection-sequence/ViewToolbar.tsx
+++ b/frontend/src/components/detection-sequence/ViewToolbar.tsx
@@ -4,6 +4,12 @@
  * One shared button style — the header and flipbook speak the same visual
  * language.
  *
+ * The pressed state is pine-on-pine-soft rather than the old white pill: the
+ * toolbar moved onto a white control panel, where "white pill on a pale ash
+ * track" was two near-identical neutrals and you could no longer tell which
+ * size was selected. Soft rather than a solid fill, so a view preference
+ * doesn't shout as loudly as the actions beside it.
+ *
  * It used to carry a predictions toggle and an `isLocalize` switch, both for
  * the legacy per-lane page's `DetectionGrid`. That page is gone, and
  * `AlertFrameGrid` never read `showPredictions` (only `ImageModal` does, and
@@ -49,7 +55,7 @@ function IconToggle({
       aria-pressed={pressed}
       onClick={onClick}
       className={`rounded p-1.5 transition-colors ${
-        pressed ? 'bg-paper text-char' : 'text-haze hover:text-char'
+        pressed ? 'bg-pine-soft text-pine' : 'text-haze hover:text-char'
       }`}
     >
       {children}
@@ -75,7 +81,7 @@ export function ViewToolbar({
           aria-pressed={cardSize === s.value}
           onClick={() => onCardSizeChange(s.value)}
           className={`rounded px-2 py-0.5 font-body text-xs font-semibold transition-colors ${
-            cardSize === s.value ? 'bg-paper text-char' : 'text-haze hover:text-char'
+            cardSize === s.value ? 'bg-pine-soft text-pine' : 'text-haze hover:text-char'
           }`}
         >
           {s.label}

--- a/frontend/src/components/localize/LocalizeActionPanel.tsx
+++ b/frontend/src/components/localize/LocalizeActionPanel.tsx
@@ -1,0 +1,64 @@
+/**
+ * The media column's control bar, lifted out of the frames card into a panel
+ * of its own: what you're looking at (left), what to do about it (centre),
+ * and how to render it (right).
+ *
+ * The actions used to sit inside the frames card's header, competing with the
+ * column's name, the frame count and the view controls — where they read as
+ * chrome. On their own line, centred and full-size, they read as the step to
+ * take, and the card below goes back to being only the frames.
+ *
+ * Three flex tracks rather than a grid: `.grid` is a class the page's tests
+ * use to find the frame grid itself, and a second grid above it would answer
+ * to that name first. Equal `flex-1` ends keep the centre track centred on
+ * the panel regardless of how wide the label or the toolbar are.
+ */
+
+import React from 'react';
+
+export interface LocalizeActionPanelProps {
+  /** Names what the frames below show, e.g. "Frames — Object 2". */
+  title: string;
+  /** Stable per-object color (hex) for the active object — omitted when nothing is active. */
+  color?: string;
+  /** The active object's buttons. Absent when no object is active. */
+  actions?: React.ReactNode;
+  /** Frame count and the view controls — always present, they belong to the grid, not the object. */
+  controls: React.ReactNode;
+}
+
+export const LocalizeActionPanel: React.FC<LocalizeActionPanelProps> = ({
+  title,
+  color,
+  actions,
+  controls,
+}) => (
+  // Same card surface as the Objects rail beside it — paper on a hairline,
+  // per DESIGN.md. A tinted bar would have made the controls read as a
+  // toolbar bolted onto the page rather than one of its cards.
+  <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-card border border-line bg-paper px-[22px] py-3">
+    <span className="flex min-w-0 flex-1 items-center gap-2">
+      {color && (
+        <span
+          className="inline-block h-2.5 w-2.5 shrink-0 rounded-full ring-1 ring-char/10"
+          style={{ backgroundColor: color }}
+          aria-hidden="true"
+        />
+      )}
+      <span className="truncate font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
+        {title}
+      </span>
+    </span>
+
+    {actions && (
+      <span
+        data-testid="localize-active-object-actions"
+        className="flex shrink-0 flex-wrap items-center justify-center gap-2"
+      >
+        {actions}
+      </span>
+    )}
+
+    <span className="flex flex-1 shrink-0 items-center justify-end gap-2.5">{controls}</span>
+  </div>
+);

--- a/frontend/src/components/localize/LocalizeActionPanel.tsx
+++ b/frontend/src/components/localize/LocalizeActionPanel.tsx
@@ -36,7 +36,7 @@ export const LocalizeActionPanel: React.FC<LocalizeActionPanelProps> = ({
   // Same card surface as the Objects rail beside it — paper on a hairline,
   // per DESIGN.md. A tinted bar would have made the controls read as a
   // toolbar bolted onto the page rather than one of its cards.
-  <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-card border border-line bg-paper px-[22px] py-3">
+  <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-card border border-line bg-paper px-[22px] py-3">
     <span className="flex min-w-0 flex-1 items-center gap-2">
       {color && (
         <span

--- a/frontend/src/components/localize/LocalizeObjectActions.tsx
+++ b/frontend/src/components/localize/LocalizeObjectActions.tsx
@@ -23,10 +23,25 @@ export interface LocalizeObjectActionsProps {
   onReclassify?: () => void;
   /** Passed through to the tooltips — `above` where the panel edge is below the buttons. */
   tooltipPlacement?: 'below' | 'above';
+  /**
+   * `compact` fits the rail row's line, where these are one of several things
+   * competing for a narrow strip. `prominent` is the media column's call to
+   * action, where they ARE the point of the screen: full-size buttons, and
+   * Accept in the primary fill, since it is the one that moves the work on.
+   */
+  size?: 'compact' | 'prominent';
 }
 
-const BUTTON_CLASSES =
+const COMPACT =
   'whitespace-nowrap rounded-lg border border-line bg-paper px-2 py-1 font-body text-xs font-medium text-char hover:bg-ash disabled:cursor-not-allowed disabled:opacity-50';
+// Pine rather than ember: on this page pine is the colour of work moving
+// forward — it is what Submit wears — and accepting an object's boxes is the
+// same motion, one object at a time. Ember would read as the alert's headline
+// action and compete with Submit for it.
+const PROMINENT_PRIMARY =
+  'inline-flex items-center whitespace-nowrap rounded-lg bg-pine px-4 py-2 font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50';
+const PROMINENT_SECONDARY =
+  'inline-flex items-center whitespace-nowrap rounded-lg border border-line bg-paper px-3 py-2 font-body text-sm font-medium text-char hover:bg-ash';
 
 export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
   label,
@@ -34,6 +49,7 @@ export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
   isAccepting = false,
   onReclassify,
   tooltipPlacement = 'below',
+  size = 'compact',
 }) => (
   <>
     {onAcceptBoxes && (
@@ -55,7 +71,7 @@ export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
             onAcceptBoxes();
           }}
           disabled={isAccepting}
-          className={BUTTON_CLASSES}
+          className={size === 'prominent' ? PROMINENT_PRIMARY : COMPACT}
         >
           {isAccepting ? 'Accepting…' : 'Accept boxes'}
         </button>
@@ -75,7 +91,7 @@ export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
             e.stopPropagation();
             onReclassify();
           }}
-          className={BUTTON_CLASSES}
+          className={size === 'prominent' ? PROMINENT_SECONDARY : COMPACT}
         >
           Reclassify
         </button>

--- a/frontend/src/components/localize/LocalizeObjectActions.tsx
+++ b/frontend/src/components/localize/LocalizeObjectActions.tsx
@@ -1,0 +1,85 @@
+/**
+ * The two things you can do to one localize object: bulk-accept the model's
+ * boxes, or send it back to classify. Shared, because they appear in two
+ * places at once — the object's rail row and the media column's CTA bar —
+ * and a second copy of the buttons would mean a second copy of the tooltip
+ * copy, which is where the explanation of what each one does actually lives.
+ *
+ * Either action can be withheld by omitting its handler: false positives get
+ * neither, and a lane past localization (or one with nothing left pending)
+ * keeps only Reclassify.
+ */
+
+import React from 'react';
+import { Tooltip } from '@/components/ui/Tooltip';
+
+export interface LocalizeObjectActionsProps {
+  /** e.g. "Object 2" — names both buttons, so a screen reader hears which object it acts on. */
+  label: string;
+  /** Bulk-accepts the winning model boxes for this lane's pending frames. */
+  onAcceptBoxes?: () => void;
+  isAccepting?: boolean;
+  /** Opens this object's classification for correction (classify's done mode). */
+  onReclassify?: () => void;
+  /** Passed through to the tooltips — `above` where the panel edge is below the buttons. */
+  tooltipPlacement?: 'below' | 'above';
+}
+
+const BUTTON_CLASSES =
+  'whitespace-nowrap rounded-lg border border-line bg-paper px-2 py-1 font-body text-xs font-medium text-char hover:bg-ash disabled:cursor-not-allowed disabled:opacity-50';
+
+export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
+  label,
+  onAcceptBoxes,
+  isAccepting = false,
+  onReclassify,
+  tooltipPlacement = 'below',
+}) => (
+  <>
+    {onAcceptBoxes && (
+      // Says what it commits and what it leaves alone: the action is bulk,
+      // and the object it belongs to is the only thing it touches.
+      <Tooltip
+        placement={tooltipPlacement}
+        tip={`Commits the model's predicted box on every frame of ${label} that still needs one. No other object is affected.`}
+      >
+        <button
+          type="button"
+          // The visible label stays short for the rail's width; the accessible
+          // name keeps naming the object, so "accept THIS object's boxes" is
+          // unambiguous to a screen reader (and to the page tests, which
+          // address rows by object).
+          aria-label={`Accept ${label}'s boxes`}
+          onClick={e => {
+            e.stopPropagation();
+            onAcceptBoxes();
+          }}
+          disabled={isAccepting}
+          className={BUTTON_CLASSES}
+        >
+          {isAccepting ? 'Accepting…' : 'Accept boxes'}
+        </button>
+      </Tooltip>
+    )}
+    {onReclassify && (
+      // Warns that it leaves the page — and that you come back, which is the
+      // part that makes clicking it feel safe.
+      <Tooltip
+        placement={tooltipPlacement}
+        tip={`Opens ${label} in classify to correct its smoke type or mark it a false positive, then returns you here.`}
+      >
+        <button
+          type="button"
+          aria-label={`Reclassify ${label}`}
+          onClick={e => {
+            e.stopPropagation();
+            onReclassify();
+          }}
+          className={BUTTON_CLASSES}
+        >
+          Reclassify
+        </button>
+      </Tooltip>
+    )}
+  </>
+);

--- a/frontend/src/components/localize/LocalizeObjectActions.tsx
+++ b/frontend/src/components/localize/LocalizeObjectActions.tsx
@@ -26,22 +26,29 @@ export interface LocalizeObjectActionsProps {
   /**
    * `compact` fits the rail row's line, where these are one of several things
    * competing for a narrow strip. `prominent` is the media column's call to
-   * action, where they ARE the point of the screen: full-size buttons, and
-   * Accept in the primary fill, since it is the one that moves the work on.
+   * action: the same height, so the control panel doesn't grow when an object
+   * is selected, but Accept carries the primary fill since it is the one that
+   * moves the work on.
    */
   size?: 'compact' | 'prominent';
 }
 
 const COMPACT =
   'whitespace-nowrap rounded-lg border border-line bg-paper px-2 py-1 font-body text-xs font-medium text-char hover:bg-ash disabled:cursor-not-allowed disabled:opacity-50';
+// Prominence comes from fill and placement, not from size: these sit on the
+// control panel's line, and anything taller than the view toolbar beside them
+// would grow the panel the moment an object is selected — the page would
+// twitch on every selection. So they match the toolbar's height and earn
+// their weight from colour.
+//
 // Pine rather than ember: on this page pine is the colour of work moving
 // forward — it is what Submit wears — and accepting an object's boxes is the
 // same motion, one object at a time. Ember would read as the alert's headline
 // action and compete with Submit for it.
 const PROMINENT_PRIMARY =
-  'inline-flex items-center whitespace-nowrap rounded-lg bg-pine px-4 py-2 font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50';
+  'inline-flex items-center whitespace-nowrap rounded-lg bg-pine px-3 py-1 font-body text-xs font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50';
 const PROMINENT_SECONDARY =
-  'inline-flex items-center whitespace-nowrap rounded-lg border border-line bg-paper px-3 py-2 font-body text-sm font-medium text-char hover:bg-ash';
+  'inline-flex items-center whitespace-nowrap rounded-lg border border-line bg-paper px-3 py-1 font-body text-xs font-medium text-char hover:bg-ash';
 
 export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
   label,

--- a/frontend/src/components/localize/LocalizeObjectRow.tsx
+++ b/frontend/src/components/localize/LocalizeObjectRow.tsx
@@ -8,11 +8,13 @@
  * on the header line's right rather than expanding the row, taking the place
  * of the progress count and status chip. The selected row is the one being
  * worked, so its right side turns into what you can DO to it; every other row
- * keeps saying where it stands. Both halves are the same width class, so the
- * swap doesn't reflow the rail, and the trade is deliberate: reaching Accept
- * boxes costs the click that selects the row (which also points the media
- * column at the object), and in exchange the rail stops showing a wall of
- * buttons for lanes nobody is looking at.
+ * keeps saying where it stands. The buttons are wider than the metadata they
+ * replace, so the name and subtitle truncate to absorb the difference. The
+ * trade is deliberate: reaching Accept boxes costs the click that selects the
+ * row (which also points the media column at the object), and in exchange the
+ * rail stops showing a wall of buttons for lanes nobody is looking at. The
+ * same pair of actions also sits above the media column, where the object's
+ * frames are — see `LocalizeActiveObjectBar`.
  *
  * Rows past localization lose Accept boxes but keep Reclassify — a finished
  * lane can still have been classified wrong — and stay clickable: activating
@@ -23,7 +25,7 @@
  */
 
 import React from 'react';
-import { Tooltip } from '@/components/ui/Tooltip';
+import { LocalizeObjectActions } from './LocalizeObjectActions';
 
 export interface LocalizeObjectRowProps {
   /** e.g. "Object 2" — the object's own label, shared with the timeline and grid overlays. */
@@ -122,9 +124,23 @@ export const LocalizeObjectRow: React.FC<LocalizeObjectRowProps> = ({
       data-dimmed={dimmed ? 'true' : undefined}
       // role="group" rather than a button: workable rows contain their own
       // action buttons, and nesting interactive controls is invalid HTML.
+      // It still has to be reachable and operable from the keyboard, because
+      // selecting the row is now the ONLY way to reach those buttons — a
+      // mouse-only affordance in front of them would put the actions out of
+      // keyboard reach entirely. Enter/Space rather than activate-on-focus:
+      // tabbing across the rail shouldn't drag the media column (and
+      // crop-mode) along with it.
       role="group"
       aria-label={label}
-      className={`cursor-pointer rounded-lg px-3.5 py-2.5 transition-colors ${frame}`}
+      tabIndex={0}
+      onKeyDown={e => {
+        if (e.target !== e.currentTarget) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onActivate();
+        }
+      }}
+      className={`cursor-pointer rounded-lg px-3.5 py-2.5 transition-colors focus:outline-none focus:ring-2 focus:ring-pine ${frame}`}
       onClick={onActivate}
     >
       <div className="flex items-center justify-between gap-2">
@@ -135,12 +151,13 @@ export const LocalizeObjectRow: React.FC<LocalizeObjectRowProps> = ({
             aria-hidden="true"
           />
           {/* Name and what-it-is on one line: the row is a one-line summary,
-              and stacking them made it two lines tall for a word. The name
-              never shrinks (it's short and it's the row's identity); the
-              subtitle truncates, since a long false-positive list is the only
-              thing here that can outgrow the rail. */}
+              and stacking them made it two lines tall for a word. Both
+              truncate rather than push: the selected row's buttons are wider
+              than the metadata they replace, and at the narrow end of the
+              rail something has to give — better a clipped word than a row
+              that overflows into a horizontal scrollbar. */}
           <span className="flex min-w-0 items-baseline gap-1.5">
-            <span className="shrink-0 font-body text-sm font-semibold text-char">{label}</span>
+            <span className="truncate font-body text-sm font-semibold text-char">{label}</span>
             {subtitle && (
               <>
                 {/* Same separator the alert header uses between organisation
@@ -158,51 +175,12 @@ export const LocalizeObjectRow: React.FC<LocalizeObjectRowProps> = ({
         </span>
         <span className="flex shrink-0 items-center gap-1.5">
           {showActions ? (
-            <>
-              {onAcceptBoxes && (
-                // Says what it commits and what it leaves alone: the action is
-                // bulk, and the row it sits on is the only thing it touches.
-                <Tooltip
-                  tip={`Commits the model's predicted box on every frame of ${label} that still needs one. No other object is affected.`}
-                >
-                  <button
-                    type="button"
-                    // The visible label stays short for the rail's width; the
-                    // accessible name keeps naming the object, so "accept THIS
-                    // object's boxes" is unambiguous to a screen reader (and to
-                    // the page tests, which address rows by object).
-                    aria-label={`Accept ${label}'s boxes`}
-                    onClick={e => {
-                      e.stopPropagation();
-                      onAcceptBoxes();
-                    }}
-                    disabled={isAccepting}
-                    className="whitespace-nowrap rounded-lg border border-line bg-paper px-2 py-1 font-body text-xs font-medium text-char hover:bg-ash disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {isAccepting ? 'Accepting…' : 'Accept boxes'}
-                  </button>
-                </Tooltip>
-              )}
-              {onReclassify && (
-                // Warns that it leaves the page — and that you come back,
-                // which is the part that makes clicking it feel safe.
-                <Tooltip
-                  tip={`Opens ${label} in classify to correct its smoke type or mark it a false positive, then returns you here.`}
-                >
-                  <button
-                    type="button"
-                    aria-label={`Reclassify ${label}`}
-                    onClick={e => {
-                      e.stopPropagation();
-                      onReclassify();
-                    }}
-                    className="whitespace-nowrap rounded-lg border border-line bg-paper px-2 py-1 font-body text-xs font-medium text-char hover:bg-ash"
-                  >
-                    Reclassify
-                  </button>
-                </Tooltip>
-              )}
-            </>
+            <LocalizeObjectActions
+              label={label}
+              onAcceptBoxes={onAcceptBoxes}
+              isAccepting={isAccepting}
+              onReclassify={onReclassify}
+            />
           ) : (
             <>
               {/* A false positive has no localization work, so a progress

--- a/frontend/src/components/localize/LocalizeObjectRow.tsx
+++ b/frontend/src/components/localize/LocalizeObjectRow.tsx
@@ -4,11 +4,15 @@
  * *classification*, this one carries a per-object *localization progress*:
  * how many of the frames the object appears on already have a committed box.
  *
- * Unlike classify's row, the actions don't hide behind activation: Accept
- * boxes is a one-click bulk action on the row's own lane, so it stays visible
- * on every workable row (matching the pre-cockpit strip's behavior).
- * Activation therefore shows up purely as the accent treatment — the media
- * column follows the active object, so the row doesn't need to expand.
+ * Like classify's row, the actions hide behind activation — but they appear
+ * on the header line's right rather than expanding the row, taking the place
+ * of the progress count and status chip. The selected row is the one being
+ * worked, so its right side turns into what you can DO to it; every other row
+ * keeps saying where it stands. Both halves are the same width class, so the
+ * swap doesn't reflow the rail, and the trade is deliberate: reaching Accept
+ * boxes costs the click that selects the row (which also points the media
+ * column at the object), and in exchange the rail stops showing a wall of
+ * buttons for lanes nobody is looking at.
  *
  * Rows past localization lose Accept boxes but keep Reclassify — a finished
  * lane can still have been classified wrong — and stay clickable: activating
@@ -19,7 +23,7 @@
  */
 
 import React from 'react';
-import { Pencil } from 'lucide-react';
+import { Tooltip } from '@/components/ui/Tooltip';
 
 export interface LocalizeObjectRowProps {
   /** e.g. "Object 2" — the object's own label, shared with the timeline and grid overlays. */
@@ -76,6 +80,11 @@ export const LocalizeObjectRow: React.FC<LocalizeObjectRowProps> = ({
   onReclassify,
 }) => {
   const pendingCount = presentCount - confirmedCount;
+
+  // The right-hand swap. A row the page gave no actions (a false positive)
+  // has nothing to swap in, so selecting it must not blank the one thing it
+  // says about itself.
+  const showActions = isActive && !!(onAcceptBoxes || onReclassify);
 
   const status = isFalsePositive
     ? { label: 'False positive', tone: 'bg-ash text-haze' }
@@ -137,58 +146,70 @@ export const LocalizeObjectRow: React.FC<LocalizeObjectRowProps> = ({
           </span>
         </span>
         <span className="flex shrink-0 items-center gap-1.5">
-          {/* A false positive has no localization work, so a progress
-              fraction over its frames would be meaningless. */}
-          {!isFalsePositive && (
-            <span className="font-data text-detail text-haze">
-              {confirmedCount}/{presentCount}
-            </span>
+          {showActions ? (
+            <>
+              {onAcceptBoxes && (
+                // Says what it commits and what it leaves alone: the action is
+                // bulk, and the row it sits on is the only thing it touches.
+                <Tooltip
+                  tip={`Commits the model's predicted box on every frame of ${label} that still needs one. No other object is affected.`}
+                >
+                  <button
+                    type="button"
+                    // The visible label stays short for the rail's width; the
+                    // accessible name keeps naming the object, so "accept THIS
+                    // object's boxes" is unambiguous to a screen reader (and to
+                    // the page tests, which address rows by object).
+                    aria-label={`Accept ${label}'s boxes`}
+                    onClick={e => {
+                      e.stopPropagation();
+                      onAcceptBoxes();
+                    }}
+                    disabled={isAccepting}
+                    className="whitespace-nowrap rounded-lg border border-line bg-paper px-2 py-1 font-body text-xs font-medium text-char hover:bg-ash disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isAccepting ? 'Accepting…' : 'Accept boxes'}
+                  </button>
+                </Tooltip>
+              )}
+              {onReclassify && (
+                // Warns that it leaves the page — and that you come back,
+                // which is the part that makes clicking it feel safe.
+                <Tooltip
+                  tip={`Opens ${label} in classify to correct its smoke type or mark it a false positive, then returns you here.`}
+                >
+                  <button
+                    type="button"
+                    aria-label={`Reclassify ${label}`}
+                    onClick={e => {
+                      e.stopPropagation();
+                      onReclassify();
+                    }}
+                    className="whitespace-nowrap rounded-lg border border-line bg-paper px-2 py-1 font-body text-xs font-medium text-char hover:bg-ash"
+                  >
+                    Reclassify
+                  </button>
+                </Tooltip>
+              )}
+            </>
+          ) : (
+            <>
+              {/* A false positive has no localization work, so a progress
+                  fraction over its frames would be meaningless. */}
+              {!isFalsePositive && (
+                <span className="font-data text-detail text-haze">
+                  {confirmedCount}/{presentCount}
+                </span>
+              )}
+              <span
+                className={`whitespace-nowrap rounded-full px-2 py-0.5 font-body text-xs font-semibold ${status.tone}`}
+              >
+                {status.label}
+              </span>
+            </>
           )}
-          <span
-            className={`whitespace-nowrap rounded-full px-2 py-0.5 font-body text-xs font-semibold ${status.tone}`}
-          >
-            {status.label}
-          </span>
         </span>
       </div>
-
-      {(onAcceptBoxes || onReclassify) && (
-        <div className="mt-2 flex items-center gap-1.5">
-          {onAcceptBoxes && (
-            <button
-              type="button"
-              // The visible label stays short for the rail's width; the
-              // accessible name keeps naming the object, so "accept THIS
-              // object's boxes" is unambiguous to a screen reader (and to the
-              // page tests, which address rows by object).
-              aria-label={`Accept ${label}'s boxes`}
-              onClick={e => {
-                e.stopPropagation();
-                onAcceptBoxes();
-              }}
-              disabled={isAccepting}
-              title={`Accept ${label}'s predicted boxes for all pending frames`}
-              className="rounded-lg border border-line bg-paper px-2 py-1 font-body text-xs font-medium text-char hover:bg-ash disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {isAccepting ? 'Accepting…' : 'Accept boxes'}
-            </button>
-          )}
-          {onReclassify && (
-            <button
-              type="button"
-              aria-label={`Reclassify ${label}`}
-              onClick={e => {
-                e.stopPropagation();
-                onReclassify();
-              }}
-              title={`Correct ${label}'s classification`}
-              className="inline-flex items-center gap-1 rounded-lg border border-line bg-paper px-2 py-1 font-body text-xs font-medium text-char hover:bg-ash"
-            >
-              <Pencil className="h-3 w-3" aria-hidden="true" /> Reclassify
-            </button>
-          )}
-        </div>
-      )}
     </div>
   );
 };

--- a/frontend/src/components/localize/LocalizeObjectRow.tsx
+++ b/frontend/src/components/localize/LocalizeObjectRow.tsx
@@ -134,14 +134,25 @@ export const LocalizeObjectRow: React.FC<LocalizeObjectRowProps> = ({
             style={{ backgroundColor: color }}
             aria-hidden="true"
           />
-          <span className="min-w-0">
-            <span className="block truncate font-body text-sm font-semibold text-char">
-              {label}
-            </span>
+          {/* Name and what-it-is on one line: the row is a one-line summary,
+              and stacking them made it two lines tall for a word. The name
+              never shrinks (it's short and it's the row's identity); the
+              subtitle truncates, since a long false-positive list is the only
+              thing here that can outgrow the rail. */}
+          <span className="flex min-w-0 items-baseline gap-1.5">
+            <span className="shrink-0 font-body text-sm font-semibold text-char">{label}</span>
             {subtitle && (
-              <span className="block truncate font-body text-detail capitalize text-haze">
-                {subtitle}
-              </span>
+              <>
+                {/* Same separator the alert header uses between organisation
+                    and camera. Hidden from screen readers, which get the two
+                    spans as separate phrases already. */}
+                <span className="shrink-0 font-body text-detail text-haze" aria-hidden="true">
+                  ·
+                </span>
+                <span className="truncate font-body text-detail capitalize text-haze">
+                  {subtitle}
+                </span>
+              </>
             )}
           </span>
         </span>

--- a/frontend/src/components/localize/index.ts
+++ b/frontend/src/components/localize/index.ts
@@ -2,5 +2,7 @@ export { LocalizeObjectRow } from './LocalizeObjectRow';
 export type { LocalizeObjectRowProps } from './LocalizeObjectRow';
 export { LocalizeRail } from './LocalizeRail';
 export type { LocalizeRailProps } from './LocalizeRail';
+export { LocalizeObjectActions } from './LocalizeObjectActions';
+export type { LocalizeObjectActionsProps } from './LocalizeObjectActions';
 export { LocalizeMissedSmokeRow } from './LocalizeMissedSmokeRow';
 export type { LocalizeMissedSmokeRowProps } from './LocalizeMissedSmokeRow';

--- a/frontend/src/components/localize/index.ts
+++ b/frontend/src/components/localize/index.ts
@@ -2,6 +2,8 @@ export { LocalizeObjectRow } from './LocalizeObjectRow';
 export type { LocalizeObjectRowProps } from './LocalizeObjectRow';
 export { LocalizeRail } from './LocalizeRail';
 export type { LocalizeRailProps } from './LocalizeRail';
+export { LocalizeActionPanel } from './LocalizeActionPanel';
+export type { LocalizeActionPanelProps } from './LocalizeActionPanel';
 export { LocalizeObjectActions } from './LocalizeObjectActions';
 export type { LocalizeObjectActionsProps } from './LocalizeObjectActions';
 export { LocalizeMissedSmokeRow } from './LocalizeMissedSmokeRow';

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -10,10 +10,9 @@
  * accessible name) gives screen readers the same sentence sighted users hover
  * for.
  *
- * The bubble hangs below the trigger and grows leftward from its right edge:
- * both current callers sit at the right edge of a narrow rail, where a
- * centered bubble would overhang the panel. Flat and dark per DESIGN.md —
- * hairlines and ink, no drop shadow.
+ * The bubble grows leftward from the trigger's right edge: its callers sit in
+ * a narrow rail, where a centered bubble would overhang the panel. Flat and
+ * dark per DESIGN.md — hairlines and ink, no drop shadow.
  */
 
 import React from 'react';
@@ -21,11 +20,17 @@ import React from 'react';
 export interface TooltipProps {
   /** The sentence to show. Plain text — this is a description, not a layout slot. */
   tip: string;
+  /**
+   * Which side of the trigger the bubble hangs off. The caller decides
+   * because the panel edge decides: a control at the bottom of the rail
+   * needs `above`, or its bubble is clipped by the rail's own scroll box.
+   */
+  placement?: 'below' | 'above';
   /** The control being described. Receives `aria-describedby`. */
   children: React.ReactElement<{ 'aria-describedby'?: string }>;
 }
 
-export const Tooltip: React.FC<TooltipProps> = ({ tip, children }) => {
+export const Tooltip: React.FC<TooltipProps> = ({ tip, placement = 'below', children }) => {
   const id = React.useId();
 
   return (
@@ -34,7 +39,9 @@ export const Tooltip: React.FC<TooltipProps> = ({ tip, children }) => {
       <span
         id={id}
         role="tooltip"
-        className="pointer-events-none absolute right-0 top-full z-20 mt-1.5 hidden w-max max-w-[15rem] whitespace-normal rounded-lg bg-char px-2.5 py-1.5 font-body text-xs font-normal normal-case leading-snug tracking-normal text-white group-hover:block group-focus-within:block"
+        className={`pointer-events-none absolute right-0 z-20 hidden w-max max-w-[15rem] whitespace-normal rounded-lg bg-char px-2.5 py-1.5 font-body text-xs font-normal normal-case leading-snug tracking-normal text-white group-hover:block group-focus-within:block ${
+          placement === 'above' ? 'bottom-full mb-1.5' : 'top-full mt-1.5'
+        }`}
       >
         {tip}
       </span>

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -3,8 +3,10 @@
  * browser's `title`, which arrives after a delay, can't be themed, and never
  * shows up for keyboard users at all.
  *
- * CSS-only, like the table headers' bubble it generalizes
- * (`sequences/ColumnHeader`): no timers, no positioning library, no state.
+ * CSS-only, like the hand-rolled bubble in `sequences/ColumnHeader` it takes
+ * its look from: no timers, no positioning library, no state. That one (and
+ * the two in the sequence-group pages) still carries its own copy — this is
+ * the version worth migrating them onto, not a migration that happened.
  * `group-focus-within` earns the tooltip its keyboard path, and
  * `aria-describedby` (wired onto the trigger, so the trigger keeps its own
  * accessible name) gives screen readers the same sentence sighted users hover
@@ -35,7 +37,11 @@ export const Tooltip: React.FC<TooltipProps> = ({ tip, placement = 'below', chil
 
   return (
     <span className="group relative inline-flex">
-      {React.cloneElement(children, { 'aria-describedby': id })}
+      {React.cloneElement(children, {
+        // Appended, not assigned: a trigger that already points at its own
+        // description keeps it, and gains this one.
+        'aria-describedby': [children.props['aria-describedby'], id].filter(Boolean).join(' '),
+      })}
       <span
         id={id}
         role="tooltip"

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -1,0 +1,43 @@
+/**
+ * A hover/focus tooltip for a single control — the styled counterpart of the
+ * browser's `title`, which arrives after a delay, can't be themed, and never
+ * shows up for keyboard users at all.
+ *
+ * CSS-only, like the table headers' bubble it generalizes
+ * (`sequences/ColumnHeader`): no timers, no positioning library, no state.
+ * `group-focus-within` earns the tooltip its keyboard path, and
+ * `aria-describedby` (wired onto the trigger, so the trigger keeps its own
+ * accessible name) gives screen readers the same sentence sighted users hover
+ * for.
+ *
+ * The bubble hangs below the trigger and grows leftward from its right edge:
+ * both current callers sit at the right edge of a narrow rail, where a
+ * centered bubble would overhang the panel. Flat and dark per DESIGN.md —
+ * hairlines and ink, no drop shadow.
+ */
+
+import React from 'react';
+
+export interface TooltipProps {
+  /** The sentence to show. Plain text — this is a description, not a layout slot. */
+  tip: string;
+  /** The control being described. Receives `aria-describedby`. */
+  children: React.ReactElement<{ 'aria-describedby'?: string }>;
+}
+
+export const Tooltip: React.FC<TooltipProps> = ({ tip, children }) => {
+  const id = React.useId();
+
+  return (
+    <span className="group relative inline-flex">
+      {React.cloneElement(children, { 'aria-describedby': id })}
+      <span
+        id={id}
+        role="tooltip"
+        className="pointer-events-none absolute right-0 top-full z-20 mt-1.5 hidden w-max max-w-[15rem] whitespace-normal rounded-lg bg-char px-2.5 py-1.5 font-body text-xs font-normal normal-case leading-snug tracking-normal text-white group-hover:block group-focus-within:block"
+      >
+        {tip}
+      </span>
+    </span>
+  );
+};

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -123,6 +123,7 @@ import CroppedImageSequence from '@/components/annotation/CroppedImageSequence';
 import { usePersistedTabState } from '@/hooks/usePersistedTabState';
 import { useToastNotifications } from '@/utils/notification/toastUtils';
 import { NotificationSystem } from '@/components/ui/NotificationSystem';
+import { Tooltip } from '@/components/ui/Tooltip';
 import {
   ROUTES,
   classifyDetailWithReturn,
@@ -763,6 +764,17 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // already-annotated objects must not satisfy (or block) the gate.
   const allObjectsAccepted = workableObjects.length > 0 && workableObjects.every(isObjectLocalized);
 
+  // What the submit button's tooltip says. The blocked case counts the
+  // objects rather than restating the rule: "2 objects still have frames
+  // without a box" tells you how much is left, where "accept every object's
+  // boxes" only tells you what you already tried to do.
+  const objectsAwaitingBoxes = workableObjects.filter(o => !isObjectLocalized(o)).length;
+  const submitTooltip = allObjectsAccepted
+    ? 'Submits every object still awaiting localization, then returns you to the list.'
+    : `${objectsAwaitingBoxes} object${objectsAwaitingBoxes === 1 ? '' : 's'} still ${
+        objectsAwaitingBoxes === 1 ? 'has' : 'have'
+      } frames without a box. Accept or draw them to enable submit.`;
+
   // Every workable lane's sequence-annotation id — the payload
   // `localizeSubmit` takes, and the set both bulk actions iterate.
   const workableLanes: { laneSequenceId: number; annotationId: number }[] = useMemo(
@@ -1244,36 +1256,33 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
                   All objects localized
                 </p>
               ) : (
-                <div className="space-y-1.5">
-                  <button
-                    type="button"
-                    onClick={e => {
-                      e.stopPropagation();
-                      handleSubmitClick();
-                    }}
-                    disabled={!allObjectsAccepted || submitAlert.isPending}
-                    title={
-                      allObjectsAccepted
-                        ? 'Submit every object still awaiting localization'
-                        : "Accept every object's boxes first"
-                    }
-                    className="mx-auto flex items-center justify-center rounded-lg bg-pine px-5 py-2.5 text-center font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {submitAlert.isPending ? (
-                      <div className="w-3.5 h-3.5 mr-1.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                    ) : (
-                      <Upload className="w-3.5 h-3.5 mr-1.5 shrink-0" />
-                    )}
-                    Submit
-                  </button>
-                  {/* Says WHY it's disabled — otherwise the gate reads as a
-                    bug once every row looks handled but one still has a
-                    pending frame. */}
-                  {!allObjectsAccepted && (
-                    <p className="text-center font-body text-detail text-haze">
-                      Accept every object&rsquo;s boxes to enable
-                    </p>
-                  )}
+                <div className="flex justify-center">
+                  {/* The tooltip carries the gate's explanation, which used to
+                      be a line of copy under the button. Hovering the thing
+                      you can't click is where the question gets asked, and it
+                      names HOW MANY objects are holding submit back rather
+                      than restating the rule — otherwise the gate reads as a
+                      bug once every row looks handled but one still has a
+                      pending frame. Above, because the footer is the last
+                      thing in a rail that scrolls. */}
+                  <Tooltip placement="above" tip={submitTooltip}>
+                    <button
+                      type="button"
+                      onClick={e => {
+                        e.stopPropagation();
+                        handleSubmitClick();
+                      }}
+                      disabled={!allObjectsAccepted || submitAlert.isPending}
+                      className="flex items-center justify-center rounded-lg bg-pine px-5 py-2.5 text-center font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {submitAlert.isPending ? (
+                        <div className="w-3.5 h-3.5 mr-1.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                      ) : (
+                        <Upload className="w-3.5 h-3.5 mr-1.5 shrink-0" />
+                      )}
+                      Submit
+                    </button>
+                  </Tooltip>
                 </div>
               )
             }

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -117,6 +117,7 @@ import {
 } from '@/utils/annotation';
 import { ObjectStatusStrip } from '@/components/sequence-annotation';
 import {
+  LocalizeActionPanel,
   LocalizeMissedSmokeRow,
   LocalizeObjectActions,
   LocalizeObjectRow,
@@ -769,14 +770,6 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // The color also outlines the frames it actually appears on.
   const activeObject = objectStatusRows.find(o => o.laneSequenceId === activeLaneId);
   const activeObjectLabel = activeObject?.label ?? null;
-  // Frames of the active object still without a box — the media column's
-  // header states it, since the selected rail row gave up its own count.
-  const activeObjectPending = activeObject
-    ? (() => {
-        const progress = objectProgress.get(activeObject.laneSequenceId);
-        return progress ? progress.presentCount - progress.confirmedCount : null;
-      })()
-    : null;
 
   // Submit gate: every workable object must already have a committed box on
   // every frame it appears on. An object is "accepted" either via its row's
@@ -1146,51 +1139,30 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
           viewport. Below lg they stack. */}
       <div className="flex flex-col gap-4 pt-20 lg:flex-row lg:items-start">
         <div className="lg:flex-[1.5] lg:min-w-0">
-          <div className="rounded-card border border-line bg-paper px-[22px] py-5">
-            {/* The view controls sit with the grid they drive, not in the
-                alert header — S/M/L, crop and the flipbook are all about
-                how these cells render. */}
-            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-              <div className="flex min-w-0 items-baseline gap-1.5">
-                <span className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
-                  {/* Which object's images the cells are showing — invisible
-                      before the cockpit split, and the grid's cells only make
-                      sense once you know whose frames they are. */}
-                  Frames{activeObjectLabel ? ` — ${activeObjectLabel}` : ''}
-                </span>
-                {/* What is left on the active object. The selected rail row
-                    trades its progress for its buttons, so this is where an
-                    accept becomes visible on the object it acted on. */}
-                {activeObjectPending !== null && (
-                  <span className="truncate font-body text-detail text-haze">
-                    ·{' '}
-                    {activeObjectPending === 0
-                      ? 'every frame has a box'
-                      : `${activeObjectPending} frame${
-                          activeObjectPending === 1 ? '' : 's'
-                        } still need${activeObjectPending === 1 ? 's' : ''} a box`}
-                  </span>
-                )}
-              </div>
-              <div className="flex shrink-0 items-center gap-2.5">
-                {/* The active object's actions ride the same line as the view
-                    controls, where the eye already is once an object is
-                    selected — the rail's copy is across the page. Driven by
-                    `activeLaneId` alone, not by focus mode: closing the frame
-                    editor leaves an object active without re-entering focus,
-                    and that is exactly when the annotator is most obviously
-                    working one object. */}
-                {activeObject && (
-                  <span
-                    data-testid="localize-active-object-actions"
-                    className="flex items-center gap-1.5"
-                  >
-                    <LocalizeObjectActions
-                      label={activeObject.label}
-                      {...objectActionProps(activeObject)}
-                    />
-                  </span>
-                )}
+          {/* Everything that acts on the frames, in one bar above the card
+              that holds them: which object they belong to, what to do about
+              it, and how to render them. The actions are driven by
+              `activeLaneId` alone, not by focus mode — closing the frame
+              editor leaves an object active without re-entering focus, and
+              that is exactly when the annotator is most obviously working one
+              object. */}
+          <LocalizeActionPanel
+            // Which object's images the cells are showing — invisible before
+            // the cockpit split, and the grid's cells only make sense once
+            // you know whose frames they are.
+            title={`Frames${activeObjectLabel ? ` — ${activeObjectLabel}` : ''}`}
+            color={activeObject?.color}
+            actions={
+              activeObject && (
+                <LocalizeObjectActions
+                  label={activeObject.label}
+                  size="prominent"
+                  {...objectActionProps(activeObject)}
+                />
+              )
+            }
+            controls={
+              <>
                 <span className="font-data text-detail text-haze">
                   {frameModel.frames.length} frame{frameModel.frames.length === 1 ? '' : 's'}
                 </span>
@@ -1202,9 +1174,11 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
                   showCroppedView={isFocused || showCroppedView}
                   onToggleCroppedView={handleToggleCroppedView}
                 />
-              </div>
-            </div>
+              </>
+            }
+          />
 
+          <div className="rounded-card border border-line bg-paper px-[22px] py-5">
             {(isFocused || showCroppedView) &&
               activeLaneId != null &&
               activeLaneBoxes.length > 0 && (

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -116,7 +116,12 @@ import {
   sequenceSmokeType,
 } from '@/utils/annotation';
 import { ObjectStatusStrip } from '@/components/sequence-annotation';
-import { LocalizeMissedSmokeRow, LocalizeObjectRow, LocalizeRail } from '@/components/localize';
+import {
+  LocalizeMissedSmokeRow,
+  LocalizeObjectActions,
+  LocalizeObjectRow,
+  LocalizeRail,
+} from '@/components/localize';
 import { AlertFrameGrid, ImageModal, ViewToolbar } from '@/components/detection-sequence';
 import type { CardSize } from '@/components/detection-sequence/ViewToolbar';
 import CroppedImageSequence from '@/components/annotation/CroppedImageSequence';
@@ -653,8 +658,8 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
 
   // The timeline's rows: identity + per-frame statuses + the "selected"
   // accent for whichever object is currently focused. The quick-accept
-  // action no longer rides along here — it moved to the rail's own row,
-  // where an object's progress and its actions sit together.
+  // action no longer rides along here — it lives on the selected object's
+  // rail row and above the media column, on the active object.
   const objectStatusRows: AlertObjectStatus[] = frameModel.objectStatus.map(object => ({
     ...object,
     selected: isFocused && activeLaneId === object.laneSequenceId,
@@ -712,6 +717,26 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
         !!lane.annotation && !laneNeedsLocalization(lane.annotation) && !lane.annotation.is_unsure
     ).length ?? 0;
 
+  // Which actions an object gets, and what they do — shared by the rail row
+  // and the media column's CTA bar so the two can't disagree about whether an
+  // object is acceptable or correctable.
+  const objectActionProps = (object: AlertObjectStatus) => ({
+    // Withheld once the lane has nothing pending: re-accepting would fire a
+    // mutation with an empty payload and toast success for a no-op. It is
+    // also the only way the selected row/bar can show that the accept landed.
+    onAcceptBoxes:
+      object.workable && !isObjectLocalized(object)
+        ? () => quickAcceptLane.mutate(object.laneSequenceId)
+        : undefined,
+    isAccepting: quickAcceptLane.isPending && quickAcceptLane.variables === object.laneSequenceId,
+    // Withheld on false-positive rows: promoting one back to smoke needs an
+    // auto-review pass first (issue #275), so offering the action would ship
+    // a path that silently does nothing for localize.
+    onReclassify: object.isFalsePositive
+      ? undefined
+      : () => handleReclassify(object.laneSequenceId),
+  });
+
   const renderObjectRow = (object: AlertObjectStatus) => {
     const progress = objectProgress.get(object.laneSequenceId) ?? {
       presentCount: 0,
@@ -734,18 +759,7 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
         dimmed={object.isFalsePositive || (!object.workable && workableObjects.length > 0)}
         isActive={isFocused && activeLaneId === object.laneSequenceId}
         onActivate={() => handleObjectClick(object.laneSequenceId)}
-        onAcceptBoxes={
-          object.workable ? () => quickAcceptLane.mutate(object.laneSequenceId) : undefined
-        }
-        isAccepting={
-          quickAcceptLane.isPending && quickAcceptLane.variables === object.laneSequenceId
-        }
-        onReclassify={
-          // Withheld on false-positive rows: promoting one back to smoke
-          // needs an auto-review pass first (issue #275), so offering the
-          // action would ship a path that silently does nothing for localize.
-          object.isFalsePositive ? undefined : () => handleReclassify(object.laneSequenceId)
-        }
+        {...objectActionProps(object)}
       />
     );
   };
@@ -755,6 +769,14 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // The color also outlines the frames it actually appears on.
   const activeObject = objectStatusRows.find(o => o.laneSequenceId === activeLaneId);
   const activeObjectLabel = activeObject?.label ?? null;
+  // Frames of the active object still without a box — the media column's
+  // header states it, since the selected rail row gave up its own count.
+  const activeObjectPending = activeObject
+    ? (() => {
+        const progress = objectProgress.get(activeObject.laneSequenceId);
+        return progress ? progress.presentCount - progress.confirmedCount : null;
+      })()
+    : null;
 
   // Submit gate: every workable object must already have a committed box on
   // every frame it appears on. An object is "accepted" either via its row's
@@ -1129,13 +1151,46 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
                 alert header — S/M/L, crop and the flipbook are all about
                 how these cells render. */}
             <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-              <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
-                {/* Which object's images the cells are showing — invisible
-                    before the cockpit split, and the grid's cells only make
-                    sense once you know whose frames they are. */}
-                Frames{activeObjectLabel ? ` — ${activeObjectLabel}` : ''}
+              <div className="flex min-w-0 items-baseline gap-1.5">
+                <span className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
+                  {/* Which object's images the cells are showing — invisible
+                      before the cockpit split, and the grid's cells only make
+                      sense once you know whose frames they are. */}
+                  Frames{activeObjectLabel ? ` — ${activeObjectLabel}` : ''}
+                </span>
+                {/* What is left on the active object. The selected rail row
+                    trades its progress for its buttons, so this is where an
+                    accept becomes visible on the object it acted on. */}
+                {activeObjectPending !== null && (
+                  <span className="truncate font-body text-detail text-haze">
+                    ·{' '}
+                    {activeObjectPending === 0
+                      ? 'every frame has a box'
+                      : `${activeObjectPending} frame${
+                          activeObjectPending === 1 ? '' : 's'
+                        } still need${activeObjectPending === 1 ? 's' : ''} a box`}
+                  </span>
+                )}
               </div>
               <div className="flex shrink-0 items-center gap-2.5">
+                {/* The active object's actions ride the same line as the view
+                    controls, where the eye already is once an object is
+                    selected — the rail's copy is across the page. Driven by
+                    `activeLaneId` alone, not by focus mode: closing the frame
+                    editor leaves an object active without re-entering focus,
+                    and that is exactly when the annotator is most obviously
+                    working one object. */}
+                {activeObject && (
+                  <span
+                    data-testid="localize-active-object-actions"
+                    className="flex items-center gap-1.5"
+                  >
+                    <LocalizeObjectActions
+                      label={activeObject.label}
+                      {...objectActionProps(activeObject)}
+                    />
+                  </span>
+                )}
                 <span className="font-data text-detail text-haze">
                   {frameModel.frames.length} frame{frameModel.frames.length === 1 ? '' : 's'}
                 </span>

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1178,25 +1178,26 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
             }
           />
 
-          <div className="rounded-card border border-line bg-paper px-[22px] py-5">
-            {(isFocused || showCroppedView) &&
-              activeLaneId != null &&
-              activeLaneBoxes.length > 0 && (
-                <div className="mb-4 flex justify-center">
-                  <CroppedImageSequence bboxes={activeLaneBoxes} sequenceId={activeLaneId} />
-                </div>
-              )}
+          {/* The cells sit straight on the page, with no card of their own:
+              everything that frames them — the object, the actions, the view
+              controls — moved up into the panel above, so a second border
+              around the images was drawing a box around a box. The images
+              carry their own edges. */}
+          {(isFocused || showCroppedView) && activeLaneId != null && activeLaneBoxes.length > 0 && (
+            <div className="mb-4 flex justify-center">
+              <CroppedImageSequence bboxes={activeLaneBoxes} sequenceId={activeLaneId} />
+            </div>
+          )}
 
-            <AlertFrameGrid
-              frames={frameModel.frames}
-              activeLaneId={activeLaneId}
-              onCellClick={handleCellClick}
-              cellRef={handleCellRef}
-              cardMinWidth={cardMinWidth}
-              cropMode={cropMode}
-              highlightedFrame={highlightedFrame}
-            />
-          </div>
+          <AlertFrameGrid
+            frames={frameModel.frames}
+            activeLaneId={activeLaneId}
+            onCellClick={handleCellClick}
+            cellRef={handleCellRef}
+            cardMinWidth={cardMinWidth}
+            cropMode={cropMode}
+            highlightedFrame={highlightedFrame}
+          />
         </div>
 
         <div className="lg:sticky lg:top-20 lg:max-h-[calc(100vh-6rem)] lg:flex-1 lg:min-w-0 lg:overflow-y-auto">

--- a/frontend/tests/components/detection-sequence/ViewToolbar.test.tsx
+++ b/frontend/tests/components/detection-sequence/ViewToolbar.test.tsx
@@ -22,6 +22,17 @@ describe('ViewToolbar', () => {
     expect(screen.getByRole('button', { name: 'S' })).toHaveAttribute('aria-pressed', 'false');
   });
 
+  it('tints the pressed controls, which a white pill on the panel could not do', () => {
+    // The toolbar sits on a white control panel now: the old `bg-paper`
+    // pressed state was white on pale ash, near-invisible.
+    render(<ViewToolbar {...baseProps} cropMode />);
+
+    expect(screen.getByRole('button', { name: 'M' })).toHaveClass('bg-pine-soft');
+    expect(screen.getByRole('button', { name: 'S' })).not.toHaveClass('bg-pine-soft');
+    expect(screen.getByTitle('Crop cells (C)')).toHaveClass('bg-pine-soft');
+    expect(screen.getByTitle('Cropped view')).not.toHaveClass('bg-pine-soft');
+  });
+
   // The crop and flipbook toggles used to hide behind an `isLocalize` flag,
   // for the legacy per-lane page that also used this toolbar. That page is
   // gone and the collocated localize screen is the only consumer, so they

--- a/frontend/tests/components/localize/LocalizeObjectRow.test.tsx
+++ b/frontend/tests/components/localize/LocalizeObjectRow.test.tsx
@@ -117,22 +117,25 @@ describe('LocalizeObjectRow reclassify action', () => {
     expect(screen.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
   });
 
-  it('renders no action strip at all when the page withholds both actions', () => {
-    renderRow({
-      isFalsePositive: true,
-      workable: false,
-      smokeType: undefined,
-      falsePositiveTypes: ['cloud'],
-      onAcceptBoxes: undefined,
-      onReclassify: undefined,
-    });
-
-    expect(screen.queryByRole('button', { name: /Reclassify/ })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
-  });
 });
 
 describe('LocalizeObjectRow action visibility', () => {
+  it('is selectable from the keyboard, since selection now gates the actions', () => {
+    // Without this the row is a mouse-only affordance in front of the only
+    // copy of these buttons in the rail — the actions would be unreachable
+    // by keyboard entirely.
+    const { onActivate } = renderRow({ isActive: false, onAcceptBoxes: vi.fn() });
+    const row = screen.getByTestId('localize-object-row-object-1');
+
+    expect(row).toHaveAttribute('tabindex', '0');
+
+    fireEvent.keyDown(row, { key: 'Enter' });
+    expect(onActivate).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(row, { key: ' ' });
+    expect(onActivate).toHaveBeenCalledTimes(2);
+  });
+
   it('withholds both actions until the row is selected', () => {
     renderRow({ isActive: false, onAcceptBoxes: vi.fn() });
 
@@ -152,6 +155,40 @@ describe('LocalizeObjectRow action visibility', () => {
     // the rail is too narrow to carry both.
     expect(screen.queryByText('0/2')).not.toBeInTheDocument();
     expect(screen.queryByText('2 left')).not.toBeInTheDocument();
+  });
+
+  it('swaps a context row’s Localized chip for its one action when selected', () => {
+    // The rule is the same past localization: the chip is what the row says
+    // at rest, Reclassify is what it offers when you turn to it.
+    const { rerender } = render(
+      <LocalizeObjectRow
+        label="Object 1"
+        color="#E4572E"
+        confirmedCount={2}
+        presentCount={2}
+        workable={false}
+        isActive={false}
+        onActivate={() => {}}
+        onReclassify={() => {}}
+      />
+    );
+    expect(screen.getByText('Localized')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Reclassify/ })).not.toBeInTheDocument();
+
+    rerender(
+      <LocalizeObjectRow
+        label="Object 1"
+        color="#E4572E"
+        confirmedCount={2}
+        presentCount={2}
+        workable={false}
+        isActive
+        onActivate={() => {}}
+        onReclassify={() => {}}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Reclassify Object 1' })).toBeInTheDocument();
+    expect(screen.queryByText('Localized')).not.toBeInTheDocument();
   });
 
   it('keeps the status chip on a selected row that has no actions to show', () => {

--- a/frontend/tests/components/localize/LocalizeObjectRow.test.tsx
+++ b/frontend/tests/components/localize/LocalizeObjectRow.test.tsx
@@ -10,6 +10,10 @@
  * Actions: `Accept boxes` is covered through the page; `Reclassify` is
  * covered here — which rows get it, and that it doesn't double as a row
  * activation.
+ *
+ * Action visibility: the actions live behind selection, and they take the
+ * right-hand metadata's place rather than adding a line — so the rail reads
+ * as one column of quiet rows plus whichever one you're working on.
  */
 
 import React from 'react';
@@ -67,6 +71,8 @@ describe('LocalizeObjectRow selection treatment', () => {
   });
 });
 
+// Selected by default: the actions only exist on the selected row, so a
+// suite about the actions has to start there.
 function renderRow(overrides: Partial<React.ComponentProps<typeof LocalizeObjectRow>> = {}) {
   const onActivate = vi.fn();
   const onReclassify = vi.fn();
@@ -78,7 +84,7 @@ function renderRow(overrides: Partial<React.ComponentProps<typeof LocalizeObject
       presentCount={2}
       workable
       smokeType="wildfire"
-      isActive={false}
+      isActive
       onActivate={onActivate}
       onReclassify={onReclassify}
       {...overrides}
@@ -123,5 +129,44 @@ describe('LocalizeObjectRow reclassify action', () => {
 
     expect(screen.queryByRole('button', { name: /Reclassify/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
+  });
+});
+
+describe('LocalizeObjectRow action visibility', () => {
+  it('withholds both actions until the row is selected', () => {
+    renderRow({ isActive: false, onAcceptBoxes: vi.fn() });
+
+    expect(screen.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Reclassify/ })).not.toBeInTheDocument();
+    // What an unselected row says instead: how far along it is.
+    expect(screen.getByText('0/2')).toBeInTheDocument();
+    expect(screen.getByText('2 left')).toBeInTheDocument();
+  });
+
+  it('reveals them in the metadata’s place once selected', () => {
+    renderRow({ onAcceptBoxes: vi.fn() });
+
+    expect(screen.getByRole('button', { name: "Accept Object 1's boxes" })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reclassify Object 1' })).toBeInTheDocument();
+    // The count and status chip step aside rather than sharing the line —
+    // the rail is too narrow to carry both.
+    expect(screen.queryByText('0/2')).not.toBeInTheDocument();
+    expect(screen.queryByText('2 left')).not.toBeInTheDocument();
+  });
+
+  it('keeps the status chip on a selected row that has no actions to show', () => {
+    // A false positive gets neither action, so there is nothing to swap in —
+    // blanking its right side would lose the only thing it says.
+    renderRow({
+      isActive: true,
+      isFalsePositive: true,
+      workable: false,
+      smokeType: undefined,
+      falsePositiveTypes: ['cloud'],
+      onAcceptBoxes: undefined,
+      onReclassify: undefined,
+    });
+
+    expect(screen.getByText('False positive')).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/ui/Tooltip.test.tsx
+++ b/frontend/tests/components/ui/Tooltip.test.tsx
@@ -38,4 +38,23 @@ describe('Tooltip', () => {
     expect(tip).toHaveClass('group-hover:block');
     expect(tip).toHaveClass('group-focus-within:block');
   });
+
+  it('hangs below the trigger by default and above it on request', () => {
+    // Placement is the caller's call because the panel edge decides it: a
+    // control at the bottom of a scrolling rail would have its bubble clipped
+    // if it always dropped downward.
+    const { rerender } = render(
+      <Tooltip tip="Below.">
+        <button type="button">Down</button>
+      </Tooltip>
+    );
+    expect(screen.getByRole('tooltip')).toHaveClass('top-full');
+
+    rerender(
+      <Tooltip tip="Above." placement="above">
+        <button type="button">Up</button>
+      </Tooltip>
+    );
+    expect(screen.getByRole('tooltip')).toHaveClass('bottom-full');
+  });
 });

--- a/frontend/tests/components/ui/Tooltip.test.tsx
+++ b/frontend/tests/components/ui/Tooltip.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * The shared hover tooltip. CSS-only, so what a test can actually pin down is
+ * the wiring: the tip reaches assistive tech through `aria-describedby`
+ * (rather than being an unannounced decoration), it never steals the
+ * trigger's accessible name, and it starts hidden.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Tooltip } from '@/components/ui/Tooltip';
+
+describe('Tooltip', () => {
+  it('describes its trigger without renaming it', () => {
+    render(
+      <Tooltip tip="Commits every pending box.">
+        <button type="button" aria-label="Accept boxes">
+          Accept
+        </button>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Accept boxes' });
+    const tip = screen.getByRole('tooltip');
+
+    expect(trigger).toHaveAttribute('aria-describedby', tip.id);
+    expect(tip).toHaveTextContent('Commits every pending box.');
+  });
+
+  it('keeps the bubble hidden until the trigger is hovered or focused', () => {
+    render(
+      <Tooltip tip="Explains the action.">
+        <button type="button">Do it</button>
+      </Tooltip>
+    );
+
+    const tip = screen.getByRole('tooltip');
+    expect(tip).toHaveClass('hidden');
+    expect(tip).toHaveClass('group-hover:block');
+    expect(tip).toHaveClass('group-focus-within:block');
+  });
+});

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -733,9 +733,14 @@ describe('LocalizeAlertPage', () => {
     await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
     // The action lives on the selected row, so reaching it goes through
-    // selecting the object it belongs to.
+    // selecting the object it belongs to. Scoped to the row because the media
+    // column's CTA bar offers the same action for the same object.
     fireEvent.click(screen.getByTestId('localize-object-row-object-1'));
-    fireEvent.click(screen.getByRole('button', { name: "Accept Object 1's boxes" }));
+    fireEvent.click(
+      within(screen.getByTestId('localize-object-row-object-1')).getByRole('button', {
+        name: "Accept Object 1's boxes",
+      })
+    );
 
     await waitFor(() => {
       expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
@@ -1836,7 +1841,10 @@ describe('LocalizeAlertPage', () => {
       expect(within(fpRow).getByText('cloud')).toBeInTheDocument();
       // No localization work, so no progress fraction.
       expect(within(fpRow).queryByText(/^\d+\/\d+$/)).not.toBeInTheDocument();
-      // Read-only: no accept action, and it never becomes work to do.
+      // Read-only: no accept action, and it never becomes work to do. Asserted
+      // with the row SELECTED — unselected rows show no actions at all now, so
+      // checking a resting row would pass no matter what this row is.
+      fireEvent.click(fpRow);
       expect(within(fpRow).queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
       expect(screen.getByText('0 of 1 object localized')).toBeInTheDocument();
     });
@@ -1847,6 +1855,73 @@ describe('LocalizeAlertPage', () => {
       expect(
         within(screen.getByTestId('localize-object-row-object-1')).getByText('wildfire')
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('active object CTA, on the media column header', () => {
+    it('appears with the view controls only once an object is active, naming the work left', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      expect(screen.queryByTestId('localize-active-object-actions')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('localize-object-row-object-1'));
+
+      const cta = within(screen.getByTestId('localize-active-object-actions'));
+      expect(cta.getByRole('button', { name: "Accept Object 1's boxes" })).toBeInTheDocument();
+      expect(cta.getByRole('button', { name: 'Reclassify Object 1' })).toBeInTheDocument();
+      // The header names the object and what is left on it.
+      expect(screen.getByText(/Frames — Object 1/)).toBeInTheDocument();
+      expect(screen.getByText(/1 frame still needs a box/)).toBeInTheDocument();
+    });
+
+    it("accepts the active object's boxes from the header, then reports nothing left and drops the action", async () => {
+      vi.mocked(apiClient.createDetectionAnnotation).mockImplementation(async payload => ({
+        id: 9100 + payload.detection_id,
+        detection_id: payload.detection_id,
+        annotation: payload.annotation,
+        processing_stage: payload.processing_stage,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: null,
+      }));
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByTestId('localize-object-row-object-1'));
+      fireEvent.click(
+        within(screen.getByTestId('localize-active-object-actions')).getByRole('button', {
+          name: "Accept Object 1's boxes",
+        })
+      );
+
+      // Object 1's lane is detection 1001 only — the CTA acts on the active
+      // object, not on the alert.
+      await waitFor(() => {
+        expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
+          expect.objectContaining({ detection_id: 1001 })
+        );
+      });
+      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalledWith(
+        expect.objectContaining({ detection_id: 1002 })
+      );
+
+      expect(apiClient.updateDetectionAnnotation).not.toHaveBeenCalled();
+    });
+
+    it('reports nothing left and drops Accept once the object has every box', async () => {
+      // The header is where a finished object becomes legible: the selected
+      // rail row traded its progress for its buttons, so this is the only
+      // place that can say the accept landed — and re-accepting is withheld
+      // rather than firing a mutation with nothing in it.
+      mockAllFramesAccepted();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByTestId('localize-object-row-object-1'));
+
+      await waitFor(() => {
+        expect(screen.getByText(/every frame has a box/)).toBeInTheDocument();
+      });
+      const cta = within(screen.getByTestId('localize-active-object-actions'));
+      expect(cta.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
+      expect(cta.getByRole('button', { name: 'Reclassify Object 1' })).toBeInTheDocument();
     });
   });
 

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -1858,8 +1858,8 @@ describe('LocalizeAlertPage', () => {
     });
   });
 
-  describe('active object CTA, on the media column header', () => {
-    it('appears with the view controls only once an object is active, naming the work left', async () => {
+  describe('active object CTA, over the media column', () => {
+    it('appears above the frames only once an object is active', async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
       expect(screen.queryByTestId('localize-active-object-actions')).not.toBeInTheDocument();
@@ -1869,9 +1869,8 @@ describe('LocalizeAlertPage', () => {
       const cta = within(screen.getByTestId('localize-active-object-actions'));
       expect(cta.getByRole('button', { name: "Accept Object 1's boxes" })).toBeInTheDocument();
       expect(cta.getByRole('button', { name: 'Reclassify Object 1' })).toBeInTheDocument();
-      // The header names the object and what is left on it.
+      // The column header still names whose frames these are.
       expect(screen.getByText(/Frames — Object 1/)).toBeInTheDocument();
-      expect(screen.getByText(/1 frame still needs a box/)).toBeInTheDocument();
     });
 
     it("accepts the active object's boxes from the header, then reports nothing left and drops the action", async () => {
@@ -1906,22 +1905,19 @@ describe('LocalizeAlertPage', () => {
       expect(apiClient.updateDetectionAnnotation).not.toHaveBeenCalled();
     });
 
-    it('reports nothing left and drops Accept once the object has every box', async () => {
-      // The header is where a finished object becomes legible: the selected
-      // rail row traded its progress for its buttons, so this is the only
-      // place that can say the accept landed — and re-accepting is withheld
-      // rather than firing a mutation with nothing in it.
+    it('drops Accept once the object has every box, keeping Reclassify', async () => {
+      // Withheld rather than firing a mutation with nothing in it — and the
+      // button disappearing is what tells you the accept landed.
       mockAllFramesAccepted();
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
       fireEvent.click(screen.getByTestId('localize-object-row-object-1'));
 
       await waitFor(() => {
-        expect(screen.getByText(/every frame has a box/)).toBeInTheDocument();
+        const cta = within(screen.getByTestId('localize-active-object-actions'));
+        expect(cta.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
+        expect(cta.getByRole('button', { name: 'Reclassify Object 1' })).toBeInTheDocument();
       });
-      const cta = within(screen.getByTestId('localize-active-object-actions'));
-      expect(cta.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
-      expect(cta.getByRole('button', { name: 'Reclassify Object 1' })).toBeInTheDocument();
     });
   });
 

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -600,6 +600,9 @@ describe('LocalizeAlertPage', () => {
 
     await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
+    // The action lives on the selected row, so reaching it goes through
+    // selecting the object it belongs to.
+    fireEvent.click(screen.getByTestId('localize-object-row-object-1'));
     fireEvent.click(screen.getByRole('button', { name: "Accept Object 1's boxes" }));
 
     await waitFor(() => {
@@ -1168,6 +1171,9 @@ describe('LocalizeAlertPage', () => {
       );
 
       // And its rail row says 0 of 2 done rather than implying progress.
+      // Adding an object activates it, and a selected row shows its actions
+      // in the fraction's place — so deselect to read the progress off it.
+      fireEvent.click(screen.getByTestId('localize-object-row-object-3'));
       expect(
         within(screen.getByTestId('localize-object-row-object-3')).getByText('0/2')
       ).toBeInTheDocument();
@@ -1933,6 +1939,8 @@ describe('LocalizeAlertPage', () => {
     it("navigates to the row's OWN lane in classify done mode, carrying a return to this page", async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
+      // Reclassify is on the selected row only, so select Object 2 first.
+      fireEvent.click(screen.getByTestId('localize-object-row-object-2'));
       fireEvent.click(
         within(screen.getByTestId('localize-object-row-object-2')).getByRole('button', {
           name: 'Reclassify Object 2',
@@ -1952,6 +1960,7 @@ describe('LocalizeAlertPage', () => {
       // from.
       await renderAndSettle(<LocalizeAlertPage mode="done" />, { wrapper: doneWrapper });
 
+      fireEvent.click(screen.getByTestId('localize-object-row-object-2'));
       fireEvent.click(
         within(screen.getByTestId('localize-object-row-object-2')).getByRole('button', {
           name: 'Reclassify Object 2',
@@ -1983,6 +1992,7 @@ describe('LocalizeAlertPage', () => {
       });
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
+      fireEvent.click(screen.getByTestId('localize-object-row-object-2'));
       const contextRow = within(screen.getByTestId('localize-object-row-object-2'));
       // Context rows carry no Accept boxes action, but stay correctable.
       expect(contextRow.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
@@ -2014,9 +2024,14 @@ describe('LocalizeAlertPage', () => {
 
       fireEvent.click(screen.getByRole('button', { name: /False positives/ }));
 
-      const fpRow = within(await screen.findByTestId('localize-object-row-object-2'));
+      // Selected, where every other row shows its actions, the false
+      // positive still shows none.
+      fireEvent.click(await screen.findByTestId('localize-object-row-object-2'));
+      const fpRow = within(screen.getByTestId('localize-object-row-object-2'));
       expect(fpRow.queryByRole('button', { name: /Reclassify/ })).not.toBeInTheDocument();
+
       // The smoke row above it still has one.
+      fireEvent.click(screen.getByTestId('localize-object-row-object-1'));
       expect(
         within(screen.getByTestId('localize-object-row-object-1')).getByRole('button', {
           name: 'Reclassify Object 1',

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -1033,9 +1033,26 @@ describe('LocalizeAlertPage', () => {
     it('stays disabled, with an explanation, while any object still has a pending frame', async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
-      expect(screen.getByRole('button', { name: /Submit/ })).toBeDisabled();
-      expect(screen.getByText(/Accept every object’s boxes to enable/)).toBeInTheDocument();
+      const submit = screen.getByRole('button', { name: /Submit/ });
+      expect(submit).toBeDisabled();
+
+      // The explanation lives in the button's tooltip now, and counts the
+      // objects holding submit back rather than restating the rule.
+      const tip = screen.getByRole('tooltip');
+      expect(submit).toHaveAttribute('aria-describedby', tip.id);
+      expect(tip).toHaveTextContent('2 objects still have frames without a box');
+
       expect(screen.getByText('0 of 2 objects localized')).toBeInTheDocument();
+    });
+
+    it('switches the tooltip to what submit will do once every object is accepted', async () => {
+      mockAllFramesAccepted();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      await waitFor(() => expect(screen.getByRole('button', { name: /Submit/ })).toBeEnabled());
+      expect(screen.getByRole('tooltip')).toHaveTextContent(
+        'Submits every object still awaiting localization'
+      );
     });
 
     it('enables once every object is accepted, submits exactly the workable annotation ids, and navigates back to the queue', async () => {


### PR DESCRIPTION
## What

On the localize cockpit rail, `Accept boxes` and `Reclassify` used to sit on every row — a five-object alert showed ten buttons for lanes nobody was looking at. They now appear only on the **selected** row, and on the header line's **right**, in the place of the progress count and status chip (matching how `LocalizeMissedSmokeRow` puts its Yes/No controls on the right of its own header line).

Unselected rows are unchanged: `3/5` + status chip, no buttons.

A row the page gives no actions — a false positive gets neither — keeps its chip when selected. There is nothing to swap in, and blanking its right side would lose the only thing it says about itself.

Rows past localization follow the same rule: their `Reclassify` shows once they're selected.

**Trade:** reaching `Accept boxes` now costs the click that selects the row, which also points the media column at that object.

## Tooltips

The explanatory text moves from native `title` to a new shared `ui/Tooltip`:

- instant, instead of the browser's ~1s delay
- reachable by keyboard via `group-focus-within` — a native `title` never shows for keyboard users
- wired to the button with `aria-describedby`, without touching its accessible name
- flat dark bubble per DESIGN.md (hairlines and ink, no `shadow-*`)

It generalizes the bubble `sequences/ColumnHeader` already used, so the app has one tooltip look rather than two. CSS-only — no timers, no positioning library, no state.

Known limit: the rail scrolls, so a tooltip on the very last row can clip at the panel's bottom edge — same as the existing table-header tooltips. Fixing it properly needs portal-based positioning.

## Tests

- `LocalizeObjectRow.test.tsx` — 3 new: hidden until selected, revealed in the metadata's place, chip retained when a selected row has no actions.
- `Tooltip.test.tsx` — new: describes its trigger without renaming it, hidden until hover/focus.
- `LocalizeAlertPage.test.tsx` — six tests now select a row before reaching an action. That's the intended two-click cost, not a workaround.

Full suite: 959 passed / 84 files. `npm run quality` clean.