### PR TITLE
Pin the localize cockpit's panes, scroll only the frame grid

### DIFF
--- a/docs/specs/2026-08-04-localize-fixed-panes-scrolling-grid-design.md
+++ b/docs/specs/2026-08-04-localize-fixed-panes-scrolling-grid-design.md
@@ -1,0 +1,110 @@
+# Localize cockpit: fixed panes, scrolling grid
+
+**Date:** 2026-08-04
+**Scope:** `/localize/:sequenceId` and `/localize/done/:sequenceId` (`LocalizeAlertPage`)
+
+## Problem
+
+Everything on the localize cockpit scrolls together. Scrolling down to reach a
+later frame carries away the "Frames" control panel — the object's name, its
+accept/reject actions, the view toolbar — and the whole page header. The
+Objects rail is `lg:sticky`, so it survives, but it is the only thing that
+does. An annotator working the bottom of a long grid loses the controls that
+act on what they are looking at.
+
+## Goal
+
+Everything except the frame cells stays put. The grid is the only thing that
+scrolls.
+
+## Design
+
+### 1. Header compacted to one row
+
+`LocalizeAlertPage`'s fixed header currently stacks a back link over a row of
+title / recorded-at / progress badge, costing ~80px. It becomes a single
+48px row: `← Alerts`, `org · camera`, recorded-at, progress badge. No
+information is dropped.
+
+`h-12` fixed rather than derived from padding, so the reserve below it is an
+exact number rather than a guess. The root's reserve drops from `pt-20` to
+`pt-8`: `AppLayout`'s `p-6` already contributes 24px, so content starts 8px
+under the bar.
+
+This diverges from `ClassifyAlertPage`, which keeps the two-row header. The
+two pages mirror each other, but only localize was asked for; classify can
+follow later if the compaction reads well.
+
+### 2. Cockpit becomes a viewport-height shell at `lg:`
+
+Below `lg` nothing changes — the columns stack and the page scrolls normally,
+which is the only sensible behavior on a narrow viewport. At `lg` and up:
+
+```
+root      flex gap-4 pt-8  lg:h-[calc(100vh-3rem)] lg:flex-row lg:overflow-hidden
+                            └─ 3rem = AppLayout's p-6 top + bottom
+├ left    lg:flex-[1.5] lg:min-w-0 lg:flex lg:min-h-0 lg:flex-col
+│  ├ LocalizeActionPanel ("Frames")   lg:shrink-0   ← pinned
+│  ├ CroppedImageSequence (when disclosed)  shrink-0  ← pinned
+│  └ <div lg:flex-1 lg:min-h-0 lg:overflow-y-auto>  ← the only scroller
+│       └ AlertFrameGrid
+└ right   lg:flex-1 lg:min-w-0 lg:flex lg:min-h-0 lg:flex-col lg:overflow-y-auto
+   ├ LocalizeRail (Objects)                         ← pinned column,
+   └ ObjectStatusStrip (Timeline)                     scrolls internally if tall
+```
+
+Notes on the mechanics:
+
+- `lg:items-start` comes off the root so both columns stretch to full height.
+- Every flex-column ancestor of a scroller needs `min-h-0`; without it the
+  default `min-height: auto` lets the content push the column past the
+  viewport and the page scrolls instead of the grid.
+- The right column loses `lg:sticky lg:top-20 lg:max-h-[calc(100vh-6rem)]`.
+  It is now a real fixed-height flex child, so the max-height is structural.
+  Objects and Timeline scroll together inside it when they outgrow the column.
+- `scrollIntoView({ block: 'center' })` on `frameRefs` — used by the `?frame=`
+  deep link and by timeline segment clicks — keeps working. It resolves
+  against the nearest scrollable ancestor, which becomes the grid wrapper.
+
+### 3. The cropped loop stays, pinned above the grid
+
+`CroppedImageSequence` renders in the media column between the Frames panel
+and the cells, disclosed by the `PlayCircle` button in the panel's controls
+(PR #283). It stays exactly there and keeps that trigger — this change only
+places it in the pinned region rather than the scrolling one, so the loop and
+the grid it is cropped from are on screen together, and adds `shrink-0` so
+the loop keeps its full height while the grid takes what is left.
+
+An earlier draft of this spec deleted the loop outright. PR #283 landed
+first and re-homed it out of the way of the Frames panel, which is what the
+deletion was for; deleting it as well would have reverted a shipped feature
+for no remaining reason.
+
+## Testing
+
+The full frontend suite is green before the change and must be green after.
+
+- No cropped-loop test changes: the loop's behavior is unchanged, so PR
+  #283's cases carry over as they are.
+- Add a case asserting the grid sits in its own `overflow-y-auto` container
+  while the Frames panel and the rail do not, so a later refactor cannot
+  silently return the page to a single page-level scroll.
+
+Layout itself is verified visually in the browser at `lg` and below `lg`,
+per the project's frontend visual-check recipe — jsdom does not lay out, so
+the class assertions above are a regression guard, not proof.
+
+Also pinned: a cell click activates a lane WITHOUT entering focus mode.
+That distinction is deliberate — opening the editor should not flip the grid
+behind the modal into crop-on and small cards — and no test covered it for
+the click path.
+
+The header compacts to one row, so nothing wraps; the recorded-at timestamp
+hides below `sm` rather than squeezing the title to zero width and pushing
+the progress badge off a bar that cannot scroll.
+
+## Out of scope
+
+- `ClassifyAlertPage`'s header and cockpit.
+- Any change to `AppLayout`'s scroll container.
+- `CroppedImageSequence` itself, its trigger, or its other consumers.

--- a/docs/specs/2026-08-04-localize-fixed-panes-scrolling-grid-design.md
+++ b/docs/specs/2026-08-04-localize-fixed-panes-scrolling-grid-design.md
@@ -31,9 +31,14 @@ exact number rather than a guess. The root's reserve drops from `pt-20` to
 `pt-8`: `AppLayout`'s `p-6` already contributes 24px, so content starts 8px
 under the bar.
 
-This diverges from `ClassifyAlertPage`, which keeps the two-row header. The
-two pages mirror each other, but only localize was asked for; classify can
-follow later if the compaction reads well.
+`ClassifyAlertPage` takes the same treatment, so the two mirrored pages keep
+matching. Its header carries one extra element — the prev/next alert nav —
+which becomes the last item on the row via `ml-auto`. Three anchors
+downstream follow the new bar height: the root's reserve (`pt-20` -> `pt-8`),
+the group-conflict banner (`sticky top-20` -> `top-12`), and the decision
+rail (`lg:top-20` / `max-h-[calc(100vh-6rem)]` -> `lg:top-12` /
+`max-h-[calc(100vh-4rem)]`). Classify does NOT get the viewport-height shell;
+only the header changes there.
 
 ### 2. Cockpit becomes a viewport-height shell at `lg:`
 
@@ -105,6 +110,6 @@ the progress badge off a bar that cannot scroll.
 
 ## Out of scope
 
-- `ClassifyAlertPage`'s header and cockpit.
+- `ClassifyAlertPage`'s cockpit layout — only its header is touched.
 - Any change to `AppLayout`'s scroll container.
 - `CroppedImageSequence` itself, its trigger, or its other consumers.

--- a/frontend/src/components/localize/LocalizeActionPanel.tsx
+++ b/frontend/src/components/localize/LocalizeActionPanel.tsx
@@ -36,7 +36,11 @@ export const LocalizeActionPanel: React.FC<LocalizeActionPanelProps> = ({
   // Same card surface as the Objects rail beside it — paper on a hairline,
   // per DESIGN.md. A tinted bar would have made the controls read as a
   // toolbar bolted onto the page rather than one of its cards.
-  <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-card border border-line bg-paper px-[22px] py-3">
+  // Padding is tighter than the rail's card beside it: this one is a control
+  // bar that never scrolls away, so every row of it is a row the grid below
+  // doesn't get. The buttons keep the view toolbar's height — shrinking them
+  // instead would make the panel twitch as objects are selected.
+  <div className="mb-2 flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1.5 rounded-card border border-line bg-paper px-4 py-1.5">
     <span className="flex min-w-0 flex-1 items-center gap-2">
       {color && (
         <span

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -973,68 +973,72 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
 
   return (
     <>
-      {/* Pinned toolbar-scale header — same idiom as SequenceGroupAnnotatePage:
-          fixed to the viewport past the sidebar so alert identity, progress,
-          and Submit stay reachable while scrolling the object cards below.
-          The root's pt-20 reserves its space. */}
-      <div className="fixed top-0 left-0 md:left-64 right-0 z-30 px-6 pt-3 pb-2.5 bg-paper/85 border-b border-line backdrop-blur-sm">
+      {/* Pinned header, one row deep — same idiom as LocalizeAlertPage: fixed
+          to the viewport past the sidebar so alert identity, progress and the
+          alert-to-alert nav stay reachable while the object cards scroll
+          below. The back link used to sit on a line of its own above the
+          identity row; folding it in gives the cards 32px of viewport back.
+          `h-12` is a fixed height rather than one derived from padding,
+          because everything anchored to the bar below — the root's reserve,
+          the conflict banner, the sticky rail — has to know the number. */}
+      <div className="fixed top-0 left-0 md:left-64 right-0 z-30 flex h-12 items-center gap-3 px-6 bg-paper/85 border-b border-line backdrop-blur-sm">
         <button
           onClick={() => {
             clearAnnotationWorkflow();
             navigate(backUrl);
           }}
-          className="font-body text-detail text-haze hover:text-char inline-flex items-center gap-1"
+          className="font-body text-detail text-haze hover:text-char inline-flex shrink-0 items-center gap-1"
         >
           <ArrowLeft className="w-3.5 h-3.5" /> Alerts
         </button>
+        <span className="h-4 w-px shrink-0 bg-line" />
+        <h1 className="font-display text-heading font-semibold text-char truncate">
+          {alertDetail.organisation_name} · {alertDetail.camera_name}
+        </h1>
+        {/* One row means nothing wraps, so the narrowest viewports have to
+            shed something rather than squeeze the title to nothing and push
+            the badge off a bar that cannot scroll. The timestamp goes first:
+            it is the least load-bearing thing here. */}
+        <span className="hidden sm:inline font-data text-detail text-haze shrink-0">
+          {formatDateTime(alertDetail.recorded_at)}
+        </span>
+        <span
+          className={`flex-none rounded-full px-2.5 py-0.5 font-data text-xs font-semibold ${
+            editableCards.length > 0 && classifiedCount === editableCards.length
+              ? 'bg-pine-soft text-pine'
+              : 'bg-ember-soft text-ember'
+          }`}
+        >
+          {classifiedCount} of {editableCards.length} objects classified
+        </span>
 
-        <div className="mt-1 flex items-center justify-between gap-4">
-          <div className="flex flex-wrap items-center gap-2.5 min-w-0">
-            <h1 className="font-display text-heading font-semibold text-char truncate">
-              {alertDetail.organisation_name} · {alertDetail.camera_name}
-            </h1>
-            <span className="font-data text-detail text-haze">
-              {formatDateTime(alertDetail.recorded_at)}
-            </span>
-            <span
-              className={`flex-none rounded-full px-2.5 py-0.5 font-data text-xs font-semibold ${
-                editableCards.length > 0 && classifiedCount === editableCards.length
-                  ? 'bg-pine-soft text-pine'
-                  : 'bg-ember-soft text-ember'
-              }`}
+        {annotationWorkflow && annotationWorkflow.isActive && (
+          // `ml-auto` rather than a `justify-between` wrapper: with one row
+          // the nav is simply the last thing on the line, pushed right.
+          <div className="ml-auto flex flex-none items-center gap-2">
+            <button
+              onClick={handlePreviousAlert}
+              disabled={!canNavigatePrevious()}
+              className="p-1.5 rounded-lg border border-line bg-paper text-haze hover:bg-ash disabled:opacity-40 disabled:cursor-not-allowed"
+              title={canNavigatePrevious() ? 'Previous alert' : 'Already at first alert'}
             >
-              {classifiedCount} of {editableCards.length} objects classified
-            </span>
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <button
+              onClick={handleNextAlert}
+              disabled={!canNavigateNext()}
+              className="p-1.5 rounded-lg border border-line bg-paper text-haze hover:bg-ash disabled:opacity-40 disabled:cursor-not-allowed"
+              title={canNavigateNext() ? 'Next alert' : 'Already at last alert'}
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
           </div>
-
-          <div className="flex flex-none items-center gap-2">
-            {annotationWorkflow && annotationWorkflow.isActive && (
-              <>
-                <button
-                  onClick={handlePreviousAlert}
-                  disabled={!canNavigatePrevious()}
-                  className="p-1.5 rounded-lg border border-line bg-paper text-haze hover:bg-ash disabled:opacity-40 disabled:cursor-not-allowed"
-                  title={canNavigatePrevious() ? 'Previous alert' : 'Already at first alert'}
-                >
-                  <ChevronLeft className="w-4 h-4" />
-                </button>
-                <button
-                  onClick={handleNextAlert}
-                  disabled={!canNavigateNext()}
-                  className="p-1.5 rounded-lg border border-line bg-paper text-haze hover:bg-ash disabled:opacity-40 disabled:cursor-not-allowed"
-                  title={canNavigateNext() ? 'Next alert' : 'Already at last alert'}
-                >
-                  <ChevronRight className="w-4 h-4" />
-                </button>
-              </>
-            )}
-          </div>
-        </div>
+        )}
       </div>
 
-      <div className="space-y-4 pt-20">
+      <div className="space-y-4 pt-8">
         {groupConflictWarnings.length > 0 && (
-          <div className="sticky top-20 z-30 bg-signal-soft border-b-2 border-signal px-4 py-3">
+          <div className="sticky top-12 z-30 bg-signal-soft border-b-2 border-signal px-4 py-3">
             <div className="max-w-7xl mx-auto space-y-2">
               {groupConflictWarnings.map((warning, i) => (
                 <div key={i} className="flex items-start gap-3">
@@ -1084,7 +1088,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
               objectOverlays={playerObjectOverlays}
             />
           </div>
-          <div className="lg:flex-1 lg:min-w-0 lg:sticky lg:top-20 lg:max-h-[calc(100vh-6rem)] lg:overflow-y-auto">
+          <div className="lg:flex-1 lg:min-w-0 lg:sticky lg:top-12 lg:max-h-[calc(100vh-4rem)] lg:overflow-y-auto">
             <DecisionRail
               missedSmokeReview={missedSmokeReview}
               onMissedSmokeReviewChange={handleMissedSmokeReviewChange}

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -58,6 +58,13 @@
  * view toolbar, and a progress badge that now reports how many objects are
  * fully localized rather than a bare object count.
  *
+ * Fixed-pane round: from lg up the cockpit is a viewport-height shell and
+ * the frame cells are the page's only scroller, so everything that acts on
+ * them — the Frames panel and the cropped loop above, the Objects rail and
+ * Timeline beside — never leaves the screen. The header compacted to a
+ * single 48px row to pay for it. See
+ * docs/specs/2026-08-04-localize-fixed-panes-scrolling-grid-design.md.
+ *
  * The per-frame editor is URL-driven from a CHILD route under whichever
  * provenance prefix the page is mounted at —
  * `<basePath>/object/:laneId/:detectionId` — which names the object
@@ -1095,46 +1102,57 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
 
   return (
     <>
-      {/* Pinned toolbar-scale header — same idiom as ClassifyAlertPage: fixed
-          to the viewport past the sidebar; the root's pt-20 reserves its
-          space. */}
-      <div className="fixed top-0 left-0 md:left-64 right-0 z-30 px-6 pt-3 pb-2.5 bg-paper/85 border-b border-line backdrop-blur-sm">
+      {/* Pinned header, one row deep: the back link used to sit on a line of
+          its own above the identity row, and that second line was 32px of
+          the viewport the frame grid below now keeps. `h-12` is a fixed
+          height rather than one derived from padding, because the root's
+          reserve below has to be an exact number, not a guess. */}
+      <div className="fixed top-0 left-0 md:left-64 right-0 z-30 flex h-12 items-center gap-3 px-6 bg-paper/85 border-b border-line backdrop-blur-sm">
         <button
           onClick={() => navigate(listPath)}
-          className="font-body text-detail text-haze hover:text-char inline-flex items-center gap-1"
+          className="font-body text-detail text-haze hover:text-char inline-flex shrink-0 items-center gap-1"
         >
           <ArrowLeft className="w-3.5 h-3.5" /> Alerts
         </button>
-
-        <div className="mt-1 flex items-center justify-between gap-4">
-          <div className="flex flex-wrap items-center gap-2.5 min-w-0">
-            <h1 className="font-display text-heading font-semibold text-char truncate">
-              {alertDetail.organisation_name} · {alertDetail.camera_name}
-            </h1>
-            <span className="font-data text-detail text-haze">
-              {formatDateTime(alertDetail.recorded_at)}
-            </span>
-            <span
-              className={`flex-none rounded-full px-2.5 py-0.5 font-data text-xs font-semibold ${
-                smokeObjectRows.length > 0 && localizedObjectCount === smokeObjectRows.length
-                  ? 'bg-pine-soft text-pine'
-                  : 'bg-ember-soft text-ember'
-              }`}
-            >
-              {localizedObjectCount} of {smokeObjectRows.length} object
-              {smokeObjectRows.length === 1 ? '' : 's'} localized
-            </span>
-          </div>
-        </div>
+        <span className="h-4 w-px shrink-0 bg-line" />
+        <h1 className="font-display text-heading font-semibold text-char truncate">
+          {alertDetail.organisation_name} · {alertDetail.camera_name}
+        </h1>
+        {/* One row means nothing wraps, so the narrowest viewports have to
+            shed something rather than squeeze the title to nothing and push
+            the badge off a bar that cannot scroll. The timestamp goes first:
+            every frame cell below carries its own. */}
+        <span className="hidden sm:inline font-data text-detail text-haze shrink-0">
+          {formatDateTime(alertDetail.recorded_at)}
+        </span>
+        <span
+          className={`flex-none rounded-full px-2.5 py-0.5 font-data text-xs font-semibold ${
+            smokeObjectRows.length > 0 && localizedObjectCount === smokeObjectRows.length
+              ? 'bg-pine-soft text-pine'
+              : 'bg-ember-soft text-ember'
+          }`}
+        >
+          {localizedObjectCount} of {smokeObjectRows.length} object
+          {smokeObjectRows.length === 1 ? '' : 's'} localized
+        </span>
       </div>
 
       {/* Cockpit: media column (the active object's frames) + the rail (the
-          whole alert's localization state), mirroring ClassifyAlertPage. The
-          media column flows with the page; the rail sticks below the fixed
-          header on desktop, scrolling internally only if it outgrows the
-          viewport. Below lg they stack. */}
-      <div className="flex flex-col gap-4 pt-20 lg:flex-row lg:items-start">
-        <div className="lg:flex-[1.5] lg:min-w-0">
+          whole alert's localization state), mirroring ClassifyAlertPage.
+          From lg up the whole thing is a viewport-height shell that never
+          scrolls: the frame cells are the only scroller on the page, so the
+          controls that act on them — the Frames panel and the cropped loop
+          above, the Objects rail and Timeline beside — stay on screen no
+          matter how deep into the grid you are. `calc(100vh-3rem)` is the
+          viewport less AppLayout's `p-6` top and bottom; `pt-8` clears the
+          48px header, 24px of which the same padding already covers. Below
+          lg the columns stack and the page scrolls normally, which is the
+          only thing that works on a narrow viewport. */}
+      <div className="flex flex-col gap-4 pt-8 lg:h-[calc(100vh-3rem)] lg:flex-row lg:overflow-hidden">
+        {/* min-h-0 on every flex-column ancestor of a scroller: the default
+            `min-height: auto` would let the cells push the column past the
+            viewport, and the page would scroll instead of the grid. */}
+        <div className="lg:flex lg:min-h-0 lg:flex-[1.5] lg:min-w-0 lg:flex-col">
           {/* Everything that acts on the frames, in one bar above the card
               that holds them: which object they belong to, what to do about
               it, and how to render them. The actions are driven by
@@ -1210,8 +1228,11 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
               resolves against ~zero and the square collapses to a few pixels.
               Centring is the component's job; the wrapper just gives it a
               width to fill. */}
+          {/* `shrink-0`, because it is pinned above the scroller: the loop
+              keeps its full height and the grid takes what is left, rather
+              than the loop squashing as the cells grow. */}
           {canShowCrop && cropExpanded && activeLaneId != null && (
-            <div className="mb-4">
+            <div className="mb-4 shrink-0">
               <CroppedImageSequence
                 bboxes={activeLaneBoxes}
                 sequenceId={activeLaneId}
@@ -1225,19 +1246,34 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
               everything that frames them — the object, the actions, the view
               controls — moved up into the panel above, so a second border
               around the images was drawing a box around a box. The images
-              carry their own edges. */}
-          <AlertFrameGrid
-            frames={frameModel.frames}
-            activeLaneId={activeLaneId}
-            onCellClick={handleCellClick}
-            cellRef={handleCellRef}
-            cardMinWidth={cardMinWidth}
-            cropMode={cropMode}
-            highlightedFrame={highlightedFrame}
-          />
+              carry their own edges.
+
+              This wrapper is the page's only scroller. `scrollIntoView` on
+              the cell refs (the `?frame=` deep link, timeline segment
+              clicks) resolves against the nearest scrollable ancestor, so it
+              now scrolls this container rather than the window — same
+              behavior, smaller box. */}
+          <div
+            data-testid="frame-grid-scroller"
+            className="lg:min-h-0 lg:flex-1 lg:overflow-y-auto"
+          >
+            <AlertFrameGrid
+              frames={frameModel.frames}
+              activeLaneId={activeLaneId}
+              onCellClick={handleCellClick}
+              cellRef={handleCellRef}
+              cardMinWidth={cardMinWidth}
+              cropMode={cropMode}
+              highlightedFrame={highlightedFrame}
+            />
+          </div>
         </div>
 
-        <div className="lg:sticky lg:top-20 lg:max-h-[calc(100vh-6rem)] lg:flex-1 lg:min-w-0 lg:overflow-y-auto">
+        {/* The rail no longer sticks: it is a full-height column of the
+            shell, so its ceiling is structural rather than a max-height
+            guess. Objects and Timeline scroll together inside it when the
+            alert has more objects than fit. */}
+        <div className="lg:flex lg:min-h-0 lg:flex-1 lg:min-w-0 lg:flex-col lg:overflow-y-auto">
           <LocalizeRail
             // The toggle governs which object ROWS exist, so it belongs with
             // Objects rather than with the frame grid's view controls.

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -414,6 +414,33 @@ describe('LocalizeAlertPage', () => {
     expect(screen.getByText('0 of 2 objects localized')).toBeInTheDocument();
   });
 
+  // jsdom does not lay anything out, so this is a structural guard rather
+  // than proof: it pins WHICH element owns the scroll, so a later refactor
+  // cannot quietly return the cockpit to one page-level scroller and carry
+  // the Frames panel, the cropped loop and the rail off screen with the
+  // cells.
+  it('scrolls the frame cells alone — the Frames panel and the rail are not inside the scroller', async () => {
+    await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+    const scroller = screen.getByTestId('frame-grid-scroller');
+    expect(scroller).toContainElement(screen.getByTestId(`alert-frame-cell-${T1}`));
+
+    // The controls that act on those cells sit outside it.
+    expect(scroller).not.toContainElement(screen.getByText('Frames'));
+    expect(scroller).not.toContainElement(screen.getByTestId('localize-object-row-object-1'));
+
+    // The scroller alone proves nothing: an overflow container inside an
+    // unbounded column just grows instead of scrolling. What makes the grid
+    // the ONLY scroller is the bounded ancestor chain — a fixed-height root,
+    // and `min-h-0` on every flex column between it and the cells, without
+    // which `min-height: auto` lets the cells push the whole page taller.
+    expect(scroller.className).toContain('lg:min-h-0');
+    const column = scroller.parentElement as HTMLElement;
+    expect(column.className).toContain('lg:min-h-0');
+    expect(column.className).toContain('lg:flex-col');
+    expect((column.parentElement as HTMLElement).className).toContain('lg:h-[calc(100vh-3rem)]');
+  });
+
   it('clicking a strip row activates that object (the shared frame now shows its detection)', async () => {
     await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
@@ -496,6 +523,17 @@ describe('LocalizeAlertPage', () => {
       const img = within(screen.getByTestId(`alert-frame-cell-${T1}`)).getByRole('img');
       expect(img).toHaveAttribute('src', 'https://img.example/1002.jpg');
     });
+
+    // Active, but NOT focused: `handleCellClick` uses a plain
+    // `setActiveLaneId` on purpose, because opening the editor shouldn't also
+    // flip the background grid into crop-on + small cards behind the modal.
+    // Nothing else pins that distinction for the click path — the pasted-URL
+    // path has its own test — so unifying the two activation helpers would
+    // otherwise pass CI.
+    expect(screen.getByTestId('object-status-row-1')).not.toHaveAttribute('data-selected');
+    expect(
+      within(screen.getByTestId(`alert-frame-cell-${T1}`)).getByRole('img').style.transform
+    ).toBe('');
   });
 
   it('clicking a grid cell navigates to the editor URL naming the object and the frame', async () => {


### PR DESCRIPTION
## What

On `/localize/:sequenceId`, everything scrolled together. Reaching a frame near the bottom of a long grid carried away the Frames panel — the object's name, its Accept/Reclassify actions, the view controls — and the page header with it. The Objects rail was `lg:sticky`, so it was the only thing that survived.

From `lg` up the cockpit is now a viewport-height shell that never scrolls. The frame cells are the page's only scroller, so everything that acts on them stays on screen: the Frames panel and the cropped loop above, the Objects rail and the Timeline beside.

```
root      flex gap-4 pt-8  lg:h-[calc(100vh-3rem)] lg:flex-row lg:overflow-hidden
                            └─ 3rem = AppLayout's p-6 top + bottom
├ left    lg:flex-[1.5] lg:flex lg:min-h-0 lg:flex-col
│  ├ LocalizeActionPanel ("Frames")        lg:shrink-0   ← pinned
│  ├ CroppedImageSequence (when disclosed)    shrink-0   ← pinned
│  └ <div lg:flex-1 lg:min-h-0 lg:overflow-y-auto>       ← the only scroller
│       └ AlertFrameGrid
└ right   lg:flex-1 lg:flex lg:min-h-0 lg:flex-col lg:overflow-y-auto
   ├ LocalizeRail (Objects)                              ← pinned column,
   └ ObjectStatusStrip (Timeline)                          scrolls internally if tall
```

The rail stops being `sticky` with a `max-h-[calc(100vh-6rem)]` guess and becomes a real full-height column, so its ceiling is structural.

Below `lg` nothing changes — the columns stack and the page scrolls normally, which is the only thing that works on a narrow viewport.

## Paying for it

- **Header compacts to one row.** 48px instead of ~80: back link, title, recorded-at, progress badge on a single line. `h-12` is fixed rather than derived from padding, because the reserve below has to be an exact number.
- **The timestamp hides below `sm`.** One row means nothing wraps; at phone widths the title was squeezing to zero width and the badge overflowed a bar that cannot scroll. Every frame cell carries its own timestamp.
- **The Frames panel sheds the padding** it carried from when it was a standalone card (`py-3`/`px-[22px]` → `py-1.5`/`px-4`). Every row of a pinned bar is a row the grid does not get.

## Relationship to #283

The cropped loop and its `PlayCircle` disclosure are untouched. This only moves the loop into the pinned region rather than the scrolling one, plus `shrink-0` so it keeps its full height while the grid takes what is left — the loop and the frames it is cropped from are now on screen together.

## Tests

973 passing. Two new guards:

- **The bounded ancestor chain**, not just the scroller's own class. An overflow container inside an unbounded column grows instead of scrolling, so asserting `lg:overflow-y-auto` alone would have proved nothing — drop the root's height or a `min-h-0` and the page reverts to one scroller with the test still green.
- **A cell click activates a lane without entering focus mode.** Deliberate (opening the editor should not flip the grid behind the modal into crop-on + small cards) but nothing covered it for the click path — mutation-checked: swapping in `activateFocus` now fails.

`scrollIntoView` for the `?frame=` deep link and timeline segment clicks resolves against the nearest scrollable ancestor, so it now scrolls the grid container instead of the window — same behavior, smaller box.

Spec: `docs/specs/2026-08-04-localize-fixed-panes-scrolling-grid-design.md`

## Classify gets the same header

`ClassifyAlertPage` mirrors this page, so its header takes the same one-row treatment — otherwise the two screens now disagree about how tall an alert header is. It carries one extra element, the prev/next alert nav, which becomes the last item on the line via `ml-auto` rather than a `justify-between` wrapper.

Three anchors follow the new 48px bar, all previously pinned to the old 80px one: the root's reserve (`pt-20` → `pt-8`), the group-conflict banner (`sticky top-20` → `top-12`), and the sticky decision rail (`lg:top-20` / `max-h-[calc(100vh-6rem)]` → `lg:top-12` / `max-h-[calc(100vh-4rem)]`). Left alone, the banner would have floated in a 32px gap and the rail would have tucked under the header.

Classify keeps its normal page scroll — only the header changes there.
