### PR TITLE
feat(frontend): draw winner boxes on the localize cropped loop

### DIFF
--- a/docs/specs/2026-08-05-localize-crop-winner-boxes-design.md
+++ b/docs/specs/2026-08-05-localize-crop-winner-boxes-design.md
@@ -1,0 +1,87 @@
+# Winner boxes on the localize cropped loop
+
+**Date:** 2026-08-05
+**Status:** Approved
+
+## Problem
+
+On `/localize/:sequenceId`, the cropped loop (the play-circle toggle above the
+frame grid) animates the active object's crops across its frames, but never
+shows *where* the current boxes are inside the crop. The annotator sees the
+plume loop but not the boxes that will be (or were) submitted for it, so
+judging whether the boxes actually track the smoke means leaving the loop for
+the per-frame editor.
+
+## Feature
+
+Draw the current winner boxes for the active object on top of the animated
+cropped view, in the object's color.
+
+"Winner" is exactly what `collectLaneBoxes` already computes per frame — no
+new data or semantics:
+
+- committed annotation boxes for done frames,
+- `getWinningBoxes` (auto layer if it has ≥1 box, else engine) for
+  un-annotated frames,
+- engine context boxes for false-positive lanes.
+
+Those boxes are already the `bboxes` prop of `CroppedImageSequence`; today
+they only steer the averaged crop window.
+
+## Design
+
+### Component API
+
+`CroppedImageSequence` gains one optional prop:
+
+```ts
+/** Draw each frame's boxes on the crop, in the accent color. */
+showBoxes?: boolean; // default false
+```
+
+`LocalizeAlertPage` passes `showBoxes` at its single call site. The other
+consumers (`ClassifyMediaPanel`, `ObjectCard`) are untouched and keep today's
+box-free rendering.
+
+The overlay is always on when the loop is open — no per-viewport toggle. The
+loop itself already sits behind the play-circle toggle.
+
+### Drawing
+
+In `drawToCanvas`, after the existing `drawImage`, when `showBoxes` is set:
+
+1. Collect **all** boxes sharing the current frame's detection:
+   `bboxes.filter(b => b.detection_id === bboxes[currentIndex].detection_id)`.
+   The loop makes one image entry per box, so a 2-box detection appears as two
+   consecutive identical frames; drawing only `bboxes[currentIndex]` would
+   flicker between the two boxes. Drawing the detection's full set renders
+   both frames identically.
+2. Map each normalized `xyxyn` into canvas space through the already-computed
+   crop rect — the exact inverse of the image transform:
+   `cx = (x * naturalWidth - crop.x) / crop.size * CANVAS_RES` (same for y
+   with `naturalHeight`).
+3. `strokeRect` with `strokeStyle = accentColor ?? '#f97316'` and
+   `lineWidth = 4` (≈2 CSS px at the 420 px display ceiling, matching the
+   `border-2` weight used by box overlays elsewhere).
+
+Boxes partially outside the crop window (possible at high zoom) clip
+naturally at the canvas edge. No new state; fetching, animation, and zoom are
+unchanged. Canvas stroking (not the DOM-div overlay convention of
+`ImageOverlays.tsx`) because this component is already fully canvas-based:
+reusing the same crop rect in the same draw call makes box/image drift
+impossible, and zoom comes for free.
+
+### Testing
+
+Extend the `CroppedImageSequence` tests with a mocked canvas 2D context:
+
+- with `showBoxes` and a known bbox + zoom, `strokeRect` receives the exact
+  transformed rect;
+- without `showBoxes`, no `strokeRect` call;
+- two boxes on one detection: both stroked on that frame.
+
+## Out of scope
+
+- Box overlays in the classify cockpit or `ObjectCard`.
+- A show/hide control inside the crop viewport.
+- Labels, confidence scores, or per-layer line styles on the overlay.

--- a/frontend/src/components/annotation/CroppedImageSequence.tsx
+++ b/frontend/src/components/annotation/CroppedImageSequence.tsx
@@ -19,6 +19,8 @@ interface CroppedImageSequenceProps {
   sequenceId: number;
   /** Ties the crop to its object: a thin viewport frame in the object's overlay color. */
   accentColor?: string;
+  /** Draw each frame's winner boxes on the crop, in the accent color. */
+  showBoxes?: boolean;
   /**
    * CSS max-width for the square viewport, e.g. `min(100%, 22vh)`. The
    * viewport is always square and always centred; only its ceiling changes.
@@ -43,6 +45,7 @@ export default function CroppedImageSequence({
   bboxes,
   sequenceId,
   accentColor,
+  showBoxes = false,
   maxSize,
   className = '',
 }: CroppedImageSequenceProps) {
@@ -225,7 +228,27 @@ export default function CroppedImageSequence({
     }
     ctx.clearRect(0, 0, CANVAS_RES, CANVAS_RES);
     ctx.drawImage(img, crop.x, crop.y, crop.size, crop.size, 0, 0, CANVAS_RES, CANVAS_RES);
-  }, [bboxes, currentIndex, images, zoomLevel]);
+
+    if (showBoxes) {
+      // ALL of the current detection's boxes, not just bboxes[currentIndex]:
+      // a multi-box detection appears as consecutive identical loop entries
+      // (one image per box), and drawing one box per entry would flicker
+      // between them. 4px at the 840 backing res ≈ 2 CSS px on screen.
+      const detectionId = bboxes[currentIndex]?.detection_id;
+      ctx.strokeStyle = accentColor ?? '#f97316';
+      ctx.lineWidth = 4;
+      for (const box of bboxes) {
+        if (box.detection_id !== detectionId) continue;
+        const [x1, y1, x2, y2] = box.xyxyn;
+        ctx.strokeRect(
+          ((x1 * img.naturalWidth - crop.x) / crop.size) * CANVAS_RES,
+          ((y1 * img.naturalHeight - crop.y) / crop.size) * CANVAS_RES,
+          (((x2 - x1) * img.naturalWidth) / crop.size) * CANVAS_RES,
+          (((y2 - y1) * img.naturalHeight) / crop.size) * CANVAS_RES
+        );
+      }
+    }
+  }, [bboxes, currentIndex, images, zoomLevel, showBoxes, accentColor]);
 
   // Mirrors `zoomLevel` for the wheel handler, which is bound once (see below)
   // and so can't close over the state value.

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1238,6 +1238,7 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
                 sequenceId={activeLaneId}
                 accentColor={activeObject?.color}
                 maxSize="min(420px, 40vh)"
+                showBoxes
               />
             </div>
           )}

--- a/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
+++ b/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
@@ -37,8 +37,13 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+  ctx2d.clearRect.mockClear();
   ctx2d.drawImage.mockClear();
   ctx2d.strokeRect.mockClear();
+  // Plain mutable properties, not mocks — clear them too, or a test that
+  // asserts an absent/default stroke would read the previous test's values.
+  ctx2d.strokeStyle = '';
+  ctx2d.lineWidth = 0;
 });
 
 // 128px-wide bbox in a 1280x720 frame, centered — maxSquareZoom is 2.5.
@@ -184,6 +189,29 @@ describe('CroppedImageSequence', () => {
       );
       // No accentColor passed: the overlay falls back to the fixed orange.
       expect(ctx2d.strokeStyle).toBe('#f97316');
+    });
+
+    // Pins that the overlay rides the SAME crop rect as the image under zoom
+    // — a refactor that computed the overlay's rect separately would slip
+    // past the 1x tests, where both derivations coincide.
+    it('keeps the boxes glued to the crop when zoomed', async () => {
+      render(<CroppedImageSequence bboxes={BBOXES} sequenceId={9} showBoxes />);
+      await waitFor(() => expect(ctx2d.strokeRect).toHaveBeenCalled());
+
+      ctx2d.strokeRect.mockClear();
+      fireEvent.click(screen.getByLabelText('Zoom in'));
+
+      // 1.5x shrinks the crop side to 384/1.5=256 → crop x=512, y=232. The
+      // box now maps to x=(576-512)/256*840=210, y=(324-232)/256*840=301.875,
+      // w=128/256*840=420, h=72/256*840=236.25.
+      await waitFor(() =>
+        expect(ctx2d.strokeRect).toHaveBeenCalledWith(
+          expect.closeTo(210, 3),
+          expect.closeTo(301.875, 3),
+          expect.closeTo(420, 3),
+          expect.closeTo(236.25, 3)
+        )
+      );
     });
   });
 });

--- a/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
+++ b/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
@@ -8,12 +8,20 @@ vi.mock('@/services/api', () => ({
   },
 }));
 
-// jsdom has no canvas 2D context — stub what drawToCanvas touches.
+// jsdom has no canvas 2D context — stub what drawToCanvas touches, at module
+// scope so tests can assert on stroke calls.
+const ctx2d = {
+  clearRect: vi.fn(),
+  drawImage: vi.fn(),
+  strokeRect: vi.fn(),
+  strokeStyle: '',
+  lineWidth: 0,
+};
+
 beforeAll(() => {
-  HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue({
-    clearRect: vi.fn(),
-    drawImage: vi.fn(),
-  }) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = vi
+    .fn()
+    .mockReturnValue(ctx2d) as unknown as typeof HTMLCanvasElement.prototype.getContext;
 
   // Images "load" instantly with fixed dimensions.
   class InstantImage {
@@ -26,6 +34,11 @@ beforeAll(() => {
     }
   }
   vi.stubGlobal('Image', InstantImage as unknown as typeof Image);
+});
+
+beforeEach(() => {
+  ctx2d.drawImage.mockClear();
+  ctx2d.strokeRect.mockClear();
 });
 
 // 128px-wide bbox in a 1280x720 frame, centered — maxSquareZoom is 2.5.
@@ -117,5 +130,60 @@ describe('CroppedImageSequence', () => {
     // A wheel that DOES move the zoom is still consumed.
     expect(fireEvent.wheel(viewport, { deltaY: -100, cancelable: true })).toBe(false);
     expect(screen.getByText('1.1x')).toBeInTheDocument();
+  });
+
+  describe('winner box overlay', () => {
+    // Geometry pinned by hand: bbox 0.45–0.55 of 1280x720 → 576,324–704,396
+    // in image px (side 128). Default crop side = 128 * CONTEXT_FACTOR(3) =
+    // 384, centred at (640,360) → crop x=448, y=168. On the 840px canvas the
+    // box lands at x=(576-448)/384*840=280, y=(324-168)/384*840=341.25,
+    // w=128/384*840=280, h=72/384*840=157.5.
+    it('strokes the frame boxes on the crop in the accent color when showBoxes is set', async () => {
+      render(
+        <CroppedImageSequence bboxes={BBOXES} sequenceId={9} accentColor="#E4572E" showBoxes />
+      );
+      await waitFor(() => expect(ctx2d.strokeRect).toHaveBeenCalled());
+      expect(ctx2d.strokeRect).toHaveBeenCalledWith(
+        expect.closeTo(280, 3),
+        expect.closeTo(341.25, 3),
+        expect.closeTo(280, 3),
+        expect.closeTo(157.5, 3)
+      );
+      expect(ctx2d.strokeStyle).toBe('#E4572E');
+      expect(ctx2d.lineWidth).toBe(4);
+    });
+
+    it('draws no boxes without showBoxes', async () => {
+      await renderLoaded();
+      await waitFor(() => expect(ctx2d.drawImage).toHaveBeenCalled());
+      expect(ctx2d.strokeRect).not.toHaveBeenCalled();
+    });
+
+    // A multi-box detection appears as consecutive identical loop entries
+    // (one image per box); each frame must draw the detection's FULL set or
+    // the loop flickers between boxes on identical images.
+    it('draws every box of the current detection, not just the entry being looped', async () => {
+      const twoBoxes: BoundingBox[] = [
+        { detection_id: 1, xyxyn: [0.45, 0.45, 0.55, 0.55] },
+        { detection_id: 1, xyxyn: [0.45, 0.45, 0.5, 0.5] },
+      ];
+      render(<CroppedImageSequence bboxes={twoBoxes} sequenceId={9} showBoxes />);
+      await waitFor(() => expect(ctx2d.strokeRect).toHaveBeenCalled());
+      // Averaged bbox [0.45,0.45,0.525,0.525] → crop x=480, y=207, size=288.
+      expect(ctx2d.strokeRect).toHaveBeenCalledWith(
+        expect.closeTo(280, 2),
+        expect.closeTo(341.25, 2),
+        expect.closeTo(373.333, 2),
+        expect.closeTo(210, 2)
+      );
+      expect(ctx2d.strokeRect).toHaveBeenCalledWith(
+        expect.closeTo(280, 2),
+        expect.closeTo(341.25, 2),
+        expect.closeTo(186.667, 2),
+        expect.closeTo(105, 2)
+      );
+      // No accentColor passed: the overlay falls back to the fixed orange.
+      expect(ctx2d.strokeStyle).toBe('#f97316');
+    });
   });
 });

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -49,11 +49,12 @@ vi.mock('@/services/api', () => ({
 vi.mock('@/components/annotation/CroppedImageSequence', () => ({
   // Exposes sequenceId so tests can assert WHICH lane's strip is showing, and
   // accentColor so they can assert it's tied to that object's identity.
-  default: (props: { sequenceId: number; accentColor?: string }) => (
+  default: (props: { sequenceId: number; accentColor?: string; showBoxes?: boolean }) => (
     <div
       data-testid="cropped-image-sequence"
       data-sequence-id={props.sequenceId}
       data-accent-color={props.accentColor}
+      data-show-boxes={props.showBoxes ? 'true' : undefined}
     />
   ),
 }));
@@ -1002,6 +1003,11 @@ describe('LocalizeAlertPage', () => {
       expect(screen.getByTestId('cropped-image-sequence')).toHaveAttribute(
         'data-sequence-id',
         '101'
+      );
+      // Localize opts in to the winner-box overlay on the loop.
+      expect(screen.getByTestId('cropped-image-sequence')).toHaveAttribute(
+        'data-show-boxes',
+        'true'
       );
     });
 


### PR DESCRIPTION
## Summary

On `/localize/:sequenceId`, the cropped loop (play-circle toggle) now draws the active object's current winner boxes on top of the animated crop, in the object's color.

- `CroppedImageSequence` gains an opt-in `showBoxes` prop (default off): after `drawImage`, the current frame's boxes are stroked on the same canvas, mapped through the already-computed `computeSquareCrop` rect — the exact inverse of the image transform, so box and image cannot drift, and zoom/clipping work unchanged.
- All boxes sharing the current frame's `detection_id` are drawn (a multi-box detection loops as consecutive identical entries; drawing one box per entry would flicker).
- Only `LocalizeAlertPage` opts in — classify cockpit and `ObjectCard` keep today's box-free rendering.
- "Winner" is exactly what `collectLaneBoxes` already feeds the loop: committed annotation boxes for done frames, winning model layer for pending ones, engine context boxes for FP lanes.

Spec: `docs/specs/2026-08-05-localize-crop-winner-boxes-design.md`

## Test plan

- [x] New unit tests: stroke geometry pinned by hand-computed crop math, no-stroke without `showBoxes`, full-detection box set, accent color + orange fallback
- [x] Page test asserts localize opts in
- [x] `npm run type-check`, `npm run lint`, full suite 976/976, prettier clean on touched src