### PR TITLE
Promote a false-positive object back into localization

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -16,7 +16,7 @@ from fastapi import (
 )
 from fastapi_pagination import Page, Params, create_page
 from fastapi_pagination.ext.sqlalchemy import apaginate
-from sqlalchemy import and_, asc, desc, func, select, text, or_
+from sqlalchemy import and_, asc, delete, desc, func, select, text, or_
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.dependencies import get_current_user, get_sequence_annotation_crud
@@ -56,6 +56,7 @@ from app.services.annotation_generation import (
     derive_group_label_from_annotation,
 )
 from app.services.localization_rule import needs_localization
+from app.worker import auto_annotate_sequence
 
 router = APIRouter()
 logger = logging.getLogger("uvicorn.error")
@@ -605,18 +606,23 @@ async def apply_annotation_update(
     user: User,
     *,
     commit: bool = True,
-) -> Tuple[SequenceAnnotation, bool]:
+) -> Tuple[SequenceAnnotation, bool, bool]:
     """Apply a single-lane sequence annotation update.
 
     Extracted from `update_sequence_annotation` (the PATCH endpoint) so a
     multi-lane classify-submit endpoint can apply several lane updates and
     commit once. Covers: get existing (strict) -> target computation -> exit
-    guard -> auto-generation trigger -> validate_detection_ids -> was/will-be
-    -annotated computation -> CRUD update.
+    guard -> FP-promotion demotion -> auto-generation trigger ->
+    validate_detection_ids -> was/will-be-annotated computation -> CRUD
+    update.
 
     Post-commit effects (`auto_create_detection_annotations`,
-    `_propagate_to_group_if_validated`) are NOT run here — the caller decides
-    whether to run them, using the returned `run_auto_create` flag.
+    `_propagate_to_group_if_validated`, deferring `auto_annotate_sequence`)
+    are NOT run here — the caller decides whether to run them, using the
+    returned `run_auto_create` and `run_promote_auto_annotate` flags. The
+    latter is True when an FP→smoke promotion was applied; the caller must
+    then defer `auto_annotate_sequence` for the lane's sequence after its
+    commit.
 
     With commit=False, the update is flushed but not committed; the caller
     owns the transaction (commit/rollback).
@@ -690,6 +696,61 @@ async def apply_annotation_update(
                 ),
             )
 
+    # FP→smoke promotion (issue #275, spec: fp-promote-relocalize): an
+    # annotated lane whose new flags need localization re-enters the
+    # pipeline at seq_annotation_done — but only when it carries no
+    # committed localization work. The FP exit auto-created empty
+    # annotated-stage detection annotations; left in place they would make
+    # every frame read as localized and let the exit guard above pass with
+    # zero boxes, so the promotion deletes them (contributions cascade) and
+    # re-arms the auto-annotate reference pass.
+    is_fp_promotion = (
+        existing.processing_stage == SequenceAnnotationProcessingStage.ANNOTATED
+        and target_processing_stage
+        == SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE
+        and needs_localization(
+            target_has_smoke, target_has_missed_smoke, target_is_unsure
+        )
+    )
+    if is_fp_promotion:
+        committed = (
+            await session.execute(
+                select(func.count(DetectionAnnotation.id))
+                .join(Detection, Detection.id == DetectionAnnotation.detection_id)
+                .where(
+                    Detection.sequence_id == existing.sequence_id,
+                    func.jsonb_array_length(
+                        DetectionAnnotation.annotation["annotation"]
+                    )
+                    > 0,
+                )
+            )
+        ).scalar_one()
+        if committed > 0:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"Cannot demote: sequence {existing.sequence_id} carries "
+                    f"{committed} committed detection annotation(s); "
+                    "re-localizing finished work is not supported"
+                ),
+            )
+        await session.execute(
+            delete(DetectionAnnotation)
+            .where(
+                DetectionAnnotation.detection_id.in_(
+                    select(Detection.id).where(
+                        Detection.sequence_id == existing.sequence_id
+                    )
+                )
+            )
+            .execution_options(synchronize_session=False)
+        )
+        sequence = await session.get(Sequence, existing.sequence_id)
+        if sequence is not None:
+            sequence.auto_annotate_enqueued_at = datetime.now(UTC)
+            session.add(sequence)
+
     # Check if we should auto-generate annotation content
     if should_trigger_auto_generation(target_processing_stage, target_annotation):
         logger.info(
@@ -748,7 +809,7 @@ async def apply_annotation_update(
         and not updated_annotation.is_unsure
     )
 
-    return updated_annotation, run_auto_create
+    return updated_annotation, run_auto_create, is_fp_promotion
 
 
 @router.patch("/{annotation_id}")
@@ -758,7 +819,11 @@ async def update_sequence_annotation(
     annotations: SequenceAnnotationCRUD = Depends(get_sequence_annotation_crud),
     current_user: User = Depends(get_current_user),
 ) -> SequenceAnnotationRead:
-    updated_annotation, run_auto_create = await apply_annotation_update(
+    (
+        updated_annotation,
+        run_auto_create,
+        run_promote_auto_annotate,
+    ) = await apply_annotation_update(
         annotation_id,
         payload,
         annotations,
@@ -780,6 +845,13 @@ async def update_sequence_annotation(
         )
         # Commit the detection annotations
         await annotations.session.commit()
+
+    if run_promote_auto_annotate:
+        # Post-commit so a lost defer can't strand the transaction; the
+        # periodic schedule_auto_annotate sweep re-enqueues stale lanes.
+        await auto_annotate_sequence.defer_async(
+            sequence_id=updated_annotation.sequence_id
+        )
 
     # Same propagation hook as create_sequence_annotation: when the
     # annotation has just reached SEQ_ANNOTATION_DONE and the seq is in a
@@ -1067,7 +1139,7 @@ async def classify_submit(
             ),
         )
 
-    lane_results: List[Tuple[SequenceAnnotation, bool]] = []
+    lane_results: List[Tuple[SequenceAnnotation, bool, bool]] = []
     try:
         for item in payload.items:
             update_payload = SequenceAnnotationUpdate(
@@ -1076,7 +1148,11 @@ async def classify_submit(
                 is_unsure=item.is_unsure,
                 processing_stage=item.processing_stage,
             )
-            updated_annotation, run_auto_create = await apply_annotation_update(
+            (
+                updated_annotation,
+                run_auto_create,
+                run_promote_auto_annotate,
+            ) = await apply_annotation_update(
                 item.annotation_id,
                 update_payload,
                 annotations,
@@ -1084,7 +1160,9 @@ async def classify_submit(
                 current_user,
                 commit=False,
             )
-            lane_results.append((updated_annotation, run_auto_create))
+            lane_results.append(
+                (updated_annotation, run_auto_create, run_promote_auto_annotate)
+            )
     except HTTPException:
         await session.rollback()
         raise
@@ -1093,7 +1171,7 @@ async def classify_submit(
     await session.commit()
 
     results: List[ClassifySubmitResult] = []
-    for updated_annotation, run_auto_create in lane_results:
+    for updated_annotation, run_auto_create, run_promote_auto_annotate in lane_results:
         if run_auto_create:
             await auto_create_detection_annotations(
                 sequence_id=updated_annotation.sequence_id,
@@ -1104,6 +1182,14 @@ async def classify_submit(
                 user_id=current_user.id,
             )
             await session.commit()
+
+        # Queue mode 409s annotated lanes before applying, so this flag is
+        # always False here today — handled anyway to stay symmetric with
+        # the PATCH path should the locked-stage rule ever change.
+        if run_promote_auto_annotate:
+            await auto_annotate_sequence.defer_async(
+                sequence_id=updated_annotation.sequence_id
+            )
 
         propagation_warning = await _propagate_to_group_if_validated(
             updated_annotation, annotations, session, current_user.id
@@ -1190,7 +1276,9 @@ async def localize_submit(
             update_payload = SequenceAnnotationUpdate(
                 processing_stage=SequenceAnnotationProcessingStage.ANNOTATED
             )
-            updated_annotation, run_auto_create = await apply_annotation_update(
+            # Third flag (FP promotion) ignored: every lane here targets
+            # ANNOTATED, so it can never be set.
+            updated_annotation, run_auto_create, _ = await apply_annotation_update(
                 annotation_id,
                 update_payload,
                 annotations,

--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -712,6 +712,38 @@ async def apply_annotation_update(
             target_has_smoke, target_has_missed_smoke, target_is_unsure
         )
     )
+
+    # Check if we should auto-generate annotation content
+    if should_trigger_auto_generation(target_processing_stage, target_annotation):
+        logger.info(
+            f"Auto-generating annotation for sequence {existing.sequence_id} during update"
+        )
+        generated_annotation = await auto_generate_annotation(
+            sequence_id=existing.sequence_id,
+            session=session,
+            confidence_threshold=payload.confidence_threshold or 0.0,
+            iou_threshold=payload.iou_threshold or 0.0,
+            min_cluster_size=payload.min_cluster_size or 1,
+        )
+
+        # Use generated annotation if successful
+        if generated_annotation:
+            payload.annotation = generated_annotation
+            logger.info(
+                f"Using auto-generated annotation with {len(generated_annotation.sequences_bbox)} sequences_bbox for sequence {existing.sequence_id}"
+            )
+        else:
+            logger.warning(
+                f"Auto-generation failed for sequence {existing.sequence_id}, proceeding with original annotation"
+            )
+
+    # Validate detection_ids if annotation is being updated
+    if payload.annotation is not None:
+        await validate_detection_ids(payload.annotation, session)
+
+    # The promotion's destructive step runs after every validation above, so
+    # nothing can raise between the delete and the row update — the pending
+    # delete must never be left behind by a later 422.
     if is_fp_promotion:
         committed = (
             await session.execute(
@@ -750,34 +782,6 @@ async def apply_annotation_update(
         if sequence is not None:
             sequence.auto_annotate_enqueued_at = datetime.now(UTC)
             session.add(sequence)
-
-    # Check if we should auto-generate annotation content
-    if should_trigger_auto_generation(target_processing_stage, target_annotation):
-        logger.info(
-            f"Auto-generating annotation for sequence {existing.sequence_id} during update"
-        )
-        generated_annotation = await auto_generate_annotation(
-            sequence_id=existing.sequence_id,
-            session=session,
-            confidence_threshold=payload.confidence_threshold or 0.0,
-            iou_threshold=payload.iou_threshold or 0.0,
-            min_cluster_size=payload.min_cluster_size or 1,
-        )
-
-        # Use generated annotation if successful
-        if generated_annotation:
-            payload.annotation = generated_annotation
-            logger.info(
-                f"Using auto-generated annotation with {len(generated_annotation.sequences_bbox)} sequences_bbox for sequence {existing.sequence_id}"
-            )
-        else:
-            logger.warning(
-                f"Auto-generation failed for sequence {existing.sequence_id}, proceeding with original annotation"
-            )
-
-    # Validate detection_ids if annotation is being updated
-    if payload.annotation is not None:
-        await validate_detection_ids(payload.annotation, session)
 
     # Check if processing_stage is being updated to "annotated" for auto-creation logic
     was_annotated_before = (

--- a/annotation_api/src/tests/endpoints/test_sequence_annotations.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_annotations.py
@@ -2833,3 +2833,80 @@ async def test_fp_promotion_rejected_when_lane_has_committed_boxes(
     survivor = await _get_detection_annotation(authenticated_client, detection_id)
     assert survivor["annotation"]["annotation"] != []
     assert not deferred
+
+
+@pytest.mark.asyncio
+async def test_fp_promotion_rolls_back_when_payload_fails_validation(
+    authenticated_client: AsyncClient, sequence_session, monkeypatch
+):
+    """The promotion's detection-annotation delete runs before
+    validate_detection_ids in apply_annotation_update; only the uncommitted
+    session protects the rows when validation then rejects the payload. Pin
+    that: a promotion carrying a bad detection_id must leave the stale
+    detection annotations in place, the stage untouched, and no job
+    deferred."""
+    deferred = False
+
+    async def fake_defer(**kwargs):
+        nonlocal deferred
+        deferred = True
+
+    monkeypatch.setattr(ep.auto_annotate_sequence, "defer_async", fake_defer)
+
+    detection_id = await _create_detection(authenticated_client, "3103")
+
+    fp_payload = {
+        "sequence_id": 1,
+        "has_missed_smoke": False,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": False,
+                    "false_positive_types": ["high_cloud"],
+                    "bboxes": [
+                        {"detection_id": detection_id, "xyxyn": [0.1, 0.1, 0.2, 0.2]}
+                    ],
+                }
+            ]
+        },
+        "processing_stage": "annotated",
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+    response = await authenticated_client.post(
+        "/annotations/sequences/", json=fp_payload
+    )
+    assert response.status_code == 201
+    annotation_id = response.json()["id"]
+
+    promote_payload = {
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": True,
+                    "smoke_type": "wildfire",
+                    "false_positive_types": [],
+                    # Nonexistent detection: validate_detection_ids rejects
+                    # the payload after the promotion block already ran.
+                    "bboxes": [{"detection_id": 999999, "xyxyn": [0.1, 0.1, 0.2, 0.2]}],
+                }
+            ]
+        },
+        "has_missed_smoke": False,
+        "is_unsure": False,
+        "processing_stage": "seq_annotation_done",
+    }
+    response = await authenticated_client.patch(
+        f"/annotations/sequences/{annotation_id}", json=promote_payload
+    )
+    assert response.status_code == 422
+
+    # The delete was rolled back with everything else: the stale empty
+    # detection annotation is still there, the lane still annotated.
+    response = await authenticated_client.get(f"/annotations/sequences/{annotation_id}")
+    assert response.json()["processing_stage"] == "annotated"
+    stale = await _get_detection_annotation(authenticated_client, detection_id)
+    assert stale["annotation"] == {"annotation": []}
+    sequence = await sequence_session.get(models.Sequence, 1)
+    await sequence_session.refresh(sequence)
+    assert sequence.auto_annotate_enqueued_at is None
+    assert not deferred

--- a/annotation_api/src/tests/endpoints/test_sequence_annotations.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_annotations.py
@@ -7,6 +7,7 @@ from httpx import AsyncClient
 from PIL import Image
 
 from app import models
+from app.api.api_v1.endpoints import sequence_annotations as ep
 
 now = datetime.now(UTC)
 
@@ -1666,7 +1667,7 @@ async def _get_detection_annotation(
 ) -> dict:
     """Fetch the auto-created detection annotation for a detection."""
     response = await authenticated_client.get("/annotations/detections/?sequence_id=1")
-    assert response.status_code == 200
+    assert response.status_code == 200, response.text
     for ann in response.json()["items"]:
         if ann["detection_id"] == detection_id:
             return ann
@@ -2665,3 +2666,170 @@ async def test_sequence_annotation_update_edge_cases(
     assert "lens_flare" in fp_types
     assert "other" in fp_types
     assert len(fp_types) == 3  # No duplicates
+
+
+@pytest.mark.asyncio
+async def test_fp_promotion_demotes_and_resets_localization(
+    authenticated_client: AsyncClient, sequence_session, monkeypatch
+):
+    """Promoting an FP lane back to smoke (issue #275) demotes it to
+    seq_annotation_done, deletes the empty auto-created detection
+    annotations, stamps auto_annotate_enqueued_at, and defers the
+    auto-annotate job."""
+    deferred = {}
+
+    async def fake_defer(**kwargs):
+        deferred.update(kwargs)
+
+    monkeypatch.setattr(ep.auto_annotate_sequence, "defer_async", fake_defer)
+
+    detection_id = await _create_detection(authenticated_client, "3101")
+
+    fp_payload = {
+        "sequence_id": 1,
+        "has_missed_smoke": False,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": False,
+                    "false_positive_types": ["high_cloud"],
+                    "bboxes": [
+                        {"detection_id": detection_id, "xyxyn": [0.1, 0.1, 0.2, 0.2]}
+                    ],
+                }
+            ]
+        },
+        "processing_stage": "annotated",
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+    response = await authenticated_client.post(
+        "/annotations/sequences/", json=fp_payload
+    )
+    assert response.status_code == 201
+    annotation_id = response.json()["id"]
+    # The FP exit auto-created an empty annotated-stage detection annotation.
+    stale = await _get_detection_annotation(authenticated_client, detection_id)
+    assert stale["processing_stage"] == "annotated"
+    assert stale["annotation"] == {"annotation": []}
+
+    promote_payload = {
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": True,
+                    "smoke_type": "wildfire",
+                    "false_positive_types": [],
+                    "bboxes": [
+                        {"detection_id": detection_id, "xyxyn": [0.1, 0.1, 0.2, 0.2]}
+                    ],
+                }
+            ]
+        },
+        "has_missed_smoke": False,
+        "is_unsure": False,
+        "processing_stage": "seq_annotation_done",
+    }
+    response = await authenticated_client.patch(
+        f"/annotations/sequences/{annotation_id}", json=promote_payload
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["processing_stage"] == "seq_annotation_done"
+    assert body["has_smoke"] is True
+
+    # Stale detection annotations are gone — the lane must not read as
+    # already-localized on the localize screens.
+    response = await authenticated_client.get("/annotations/detections/?sequence_id=1")
+    assert response.json()["items"] == []
+
+    # The auto-annotate reference pass was re-armed and deferred.
+    sequence = await sequence_session.get(models.Sequence, 1)
+    await sequence_session.refresh(sequence)
+    assert sequence.auto_annotate_enqueued_at is not None
+    assert deferred == {"sequence_id": 1}
+
+
+@pytest.mark.asyncio
+async def test_fp_promotion_rejected_when_lane_has_committed_boxes(
+    authenticated_client: AsyncClient, sequence_session, monkeypatch
+):
+    """A lane carrying committed localization work never demotes: 422, stage
+    untouched, detection annotations untouched, no job deferred."""
+    deferred = False
+
+    async def fake_defer(**kwargs):
+        nonlocal deferred
+        deferred = True
+
+    monkeypatch.setattr(ep.auto_annotate_sequence, "defer_async", fake_defer)
+
+    detection_id = await _create_detection(authenticated_client, "3102")
+
+    fp_payload = {
+        "sequence_id": 1,
+        "has_missed_smoke": False,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": False,
+                    "false_positive_types": ["high_cloud"],
+                    "bboxes": [
+                        {"detection_id": detection_id, "xyxyn": [0.1, 0.1, 0.2, 0.2]}
+                    ],
+                }
+            ]
+        },
+        "processing_stage": "annotated",
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+    response = await authenticated_client.post(
+        "/annotations/sequences/", json=fp_payload
+    )
+    assert response.status_code == 201
+    annotation_id = response.json()["id"]
+
+    # Give the auto-created detection annotation committed content, as a
+    # finished localization would have (written directly — the endpoint
+    # layer is not what's under test here).
+    da = await _get_detection_annotation(authenticated_client, detection_id)
+    da_row = await sequence_session.get(models.DetectionAnnotation, da["id"])
+    da_row.annotation = {
+        "annotation": [
+            {
+                "xyxyn": [0.1, 0.1, 0.2, 0.2],
+                "class_name": "smoke",
+                "smoke_type": "wildfire",
+            }
+        ]
+    }
+    sequence_session.add(da_row)
+    await sequence_session.commit()
+
+    promote_payload = {
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": True,
+                    "smoke_type": "wildfire",
+                    "false_positive_types": [],
+                    "bboxes": [
+                        {"detection_id": detection_id, "xyxyn": [0.1, 0.1, 0.2, 0.2]}
+                    ],
+                }
+            ]
+        },
+        "has_missed_smoke": False,
+        "is_unsure": False,
+        "processing_stage": "seq_annotation_done",
+    }
+    response = await authenticated_client.patch(
+        f"/annotations/sequences/{annotation_id}", json=promote_payload
+    )
+    assert response.status_code == 422
+
+    # Nothing moved: stage, detection annotation, and no deferred job.
+    response = await authenticated_client.get(f"/annotations/sequences/{annotation_id}")
+    assert response.json()["processing_stage"] == "annotated"
+    survivor = await _get_detection_annotation(authenticated_client, detection_id)
+    assert survivor["annotation"]["annotation"] != []
+    assert not deferred

--- a/docs/specs/2026-08-05-fp-promote-relocalize-design.md
+++ b/docs/specs/2026-08-05-fp-promote-relocalize-design.md
@@ -1,0 +1,134 @@
+# Promoting a false-positive object back into localization
+
+**Date**: 2026-08-05
+**Status**: Approved
+**Issue**: #275
+
+## Problem
+
+An object classify settled as a false positive exits the pipeline at
+`processing_stage = 'annotated'`. If an annotator later corrects that call —
+the "reflection" was real smoke — the correction never puts the object back
+into localization:
+
+- `determineClassifySubmitStage`
+  (`frontend/src/utils/annotation/localizeUtils.ts`) returns `annotated`
+  unchanged for anything already annotated, so the lane keeps `annotated`
+  while gaining `has_smoke = true`.
+- The Localize queue selects lanes at `seq_annotation_done`, so the lane
+  never reappears there.
+- On `/localize/:id` it renders as a non-workable Context row with no way to
+  box it, and the alert ships with a smoke object that has no localization.
+
+Two backend facts make this more than a one-line stage fix:
+
+1. **Stale detection annotations.** The FP exit's
+   `auto_create_detection_annotations` created a detection annotation at
+   `annotated` stage with empty content for every frame. If the lane were
+   demoted without touching them, `getCellState` would read every frame as
+   `done` (the lane looks fully localized with zero boxes) and the
+   localization exit guard in `apply_annotation_update` would pass trivially.
+2. **No auto-review reference.** The per-alert auto-annotate pass (which
+   writes `detection.auto_predictions` and stamps
+   `sequence.auto_annotated_at`) never ran for a lane that exited as FP, and
+   the Localize queue's `_ready_smoke_lane` requires `auto_annotated_at`.
+
+There is no explicit never-demote guard on the backend PATCH path — the
+frontend simply never sends a demotion — so "relaxing the backend rule" means
+adding demotion handling and its side effects, not loosening an existing
+check.
+
+## Decisions
+
+- **Only lanes with no committed localization work demote.** A lane that was
+  smoke, got fully localized (real boxes), was demoted to FP, and is now
+  promoted back stays at `annotated` — its old localization is still valid.
+  The discriminator is the lane's previous flags on the frontend and the
+  absence of non-empty detection annotations on the backend.
+- **The auto-annotate pass is triggered immediately** at promotion (not left
+  to the 5-minute periodic sweep), so the lane surfaces in the Localize
+  queue within seconds. The sweep's existing stale-retry logic remains the
+  safety net for a lost defer.
+- **FP → unsure stays `annotated`** (an unsure lane does not need
+  localization). Out of scope.
+
+## Design
+
+### 1. Stage rule — frontend
+
+`determineClassifySubmitStage` gains one argument,
+`previouslyNeededLocalization`, computed by the caller as
+`laneNeedsLocalization(lane.annotation)` from the lane's pre-edit flags. The
+`annotated` branch becomes:
+
+```ts
+if (currentStage === 'annotated') {
+  const nowNeedsLocalization = (hasSmoke || hasMissedSmoke) && !isUnsure;
+  return nowNeedsLocalization && !previouslyNeededLocalization
+    ? 'seq_annotation_done' // promoted FP lane re-enters localization
+    : 'annotated';          // never-demote for everything else
+}
+```
+
+The non-`annotated` branches are untouched. Both `ClassifyAlertPage` call
+sites pass the new argument; queue-mode lanes are never at `annotated`, so it
+only bites in done mode.
+
+### 2. Backend — demotion handling in `apply_annotation_update`
+
+When `existing.processing_stage == ANNOTATED`, the target stage is
+`SEQ_ANNOTATION_DONE`, and the target flags need localization
+(`needs_localization`):
+
+- **Guard**: if any of the lane's detection annotations carries non-empty
+  content (`annotation -> 'annotation'` array length > 0 — committed boxes),
+  reject 422. The frontend never sends this; the guard protects
+  genuinely-localized lanes from other clients.
+- **On accept**: delete the lane's detection-annotation rows (the empty
+  `annotated`-stage rows created at the FP exit) and stamp
+  `sequence.auto_annotate_enqueued_at = now`.
+- **Post-commit**: defer `auto_annotate_sequence` for the lane (same
+  mechanism as the `/auto-annotate` endpoint). `apply_annotation_update`
+  returns this as a flag alongside `run_auto_create`; both callers (the PATCH
+  endpoint and `classify-submit`) defer after their commit.
+
+Every other stage write on the PATCH path stays exactly as it is — the new
+handling is scoped to the promote case.
+
+### 3. Reclassify enablement and round trip
+
+- `LocalizeAlertPage.objectActionProps` drops the false-positive withholding
+  so `onReclassify` is offered on FP rows too; `LocalizeObjectRow` drops any
+  corresponding guard. The round trip from the reclassify spec
+  (`docs/specs/2026-08-04-localize-reclassify-object-design.md`) —
+  `/classify/done/:id?return=/localize/:id`, save, navigate back — needs no
+  change.
+- **Freshness**: done-mode submit invalidates `alert-detail` but not the
+  detection-annotation queries, so the localize page could redraw the
+  promoted lane against cached (now-deleted) detection annotations and show
+  every frame confirmed. Done-mode submit's `onSuccess` additionally
+  invalidates `QUERY_KEYS.DETECTION_ANNOTATIONS`.
+- On return, the promoted lane is immediately workable on `/localize/:id`
+  (reference layer falls back to engine boxes until the auto pass lands —
+  existing behavior for fresh smoke lanes); it appears in the Localize queue
+  once the deferred job stamps `auto_annotated_at`.
+
+## Testing
+
+- `determineClassifySubmitStage`: FP-annotated → smoke demotes;
+  FP-annotated → still-FP stays; smoke-annotated (flip-flop) stays;
+  FP-annotated → unsure stays.
+- Backend: PATCH promoting an FP lane returns 200 with stage
+  `seq_annotation_done`, deletes the empty detection annotations, stamps
+  `auto_annotate_enqueued_at`, and defers the job; a lane with committed
+  boxes gets 422; `classify-submit` handles the defer flag the same way.
+- `LocalizeAlertPage`: FP rows render `Reclassify`, with the same
+  destination/return behavior as smoke rows.
+
+## Files
+
+- `frontend/src/utils/annotation/localizeUtils.ts`
+- `frontend/src/pages/ClassifyAlertPage.tsx`
+- `frontend/src/pages/LocalizeAlertPage.tsx`
+- `frontend/src/components/localize/LocalizeObjectRow.tsx`
+- `annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py`

--- a/frontend/src/pages/AnnotationInterface.tsx
+++ b/frontend/src/pages/AnnotationInterface.tsx
@@ -7,7 +7,10 @@ import { QUERY_KEYS } from '@/utils/constants';
 import { SequenceAnnotation, SequenceBbox } from '@/types/api';
 import { useSequenceStore } from '@/store/useSequenceStore';
 import { getAnnotationProgress, isAnnotationComplete } from '@/utils/annotation/progressUtils';
-import { determineClassifySubmitStage } from '@/utils/annotation/localizeUtils';
+import {
+  determineClassifySubmitStage,
+  laneNeedsLocalization,
+} from '@/utils/annotation/localizeUtils';
 import {
   createBboxChangeHandler,
   createMissedSmokeHandler,
@@ -215,12 +218,14 @@ export default function AnnotationInterface({ mode }: AnnotationInterfaceProps =
           sequences_bbox: updatedBboxes, // Always preserve the actual bbox data
         },
         // FP-only lanes exit the pipeline at classify submit; smoke lanes park
-        // at seq_annotation_done for localization. Never demotes 'annotated'.
+        // at seq_annotation_done for localization. Never demotes 'annotated',
+        // except a promoted FP lane, which re-enters localization (#275).
         processing_stage: determineClassifySubmitStage({
           currentStage: annotation?.processing_stage,
           isUnsure,
           hasSmoke: hasSmokeNow,
           hasMissedSmoke: hasMissedSmokeNow,
+          previouslyNeededLocalization: annotation ? laneNeedsLocalization(annotation) : false,
         }),
         // Update derived fields - all false for unsure sequences
         has_smoke: hasSmokeNow,

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -34,7 +34,10 @@ import {
 } from '@/types/api';
 import { useSequenceStore } from '@/store/useSequenceStore';
 import { hasUserAnnotations, getInitialMissedSmokeReview } from '@/utils/annotation/sequenceUtils';
-import { determineClassifySubmitStage } from '@/utils/annotation/localizeUtils';
+import {
+  determineClassifySubmitStage,
+  laneNeedsLocalization,
+} from '@/utils/annotation/localizeUtils';
 import { createKeyboardHandler } from '@/utils/annotation/keyboardUtils';
 import { getObjectColor, ObjectOverlay } from '@/utils/annotation/objectColors';
 import { getProcessingStageLabel } from '@/utils/processingStage';
@@ -679,6 +682,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
               isUnsure: unsure,
               hasSmoke: hasSmokeNow,
               hasMissedSmoke: hasMissedSmokeForLane,
+              previouslyNeededLocalization: laneNeedsLocalization(lane.annotation!),
             }),
             has_smoke: hasSmokeNow,
             has_false_positives: unsure
@@ -720,6 +724,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
             isUnsure: unsure,
             hasSmoke,
             hasMissedSmoke: hasMissedSmokeForLane,
+            previouslyNeededLocalization: laneNeedsLocalization(lane.annotation),
           }),
         });
       });

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -736,6 +736,10 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.SEQUENCE_ANNOTATIONS });
       queryClient.invalidateQueries({ queryKey: ['annotation-counts'] });
       queryClient.invalidateQueries({ queryKey: ['pipeline-stats'] });
+      // A promoted FP lane's stale detection annotations were deleted
+      // server-side (#275); without this the localize page redraws the lane
+      // against the cached ones and shows every frame as already confirmed.
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.DETECTION_ANNOTATIONS });
 
       const warnings = response.results
         .filter(r => r.group_propagation_warning)

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -741,12 +741,10 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
         ? () => quickAcceptLane.mutate(object.laneSequenceId)
         : undefined,
     isAccepting: quickAcceptLane.isPending && quickAcceptLane.variables === object.laneSequenceId,
-    // Withheld on false-positive rows: promoting one back to smoke needs an
-    // auto-review pass first (issue #275), so offering the action would ship
-    // a path that silently does nothing for localize.
-    onReclassify: object.isFalsePositive
-      ? undefined
-      : () => handleReclassify(object.laneSequenceId),
+    // Offered on false-positive rows too: promoting one back to smoke
+    // demotes the lane server-side and re-runs its auto-review pass
+    // (spec: fp-promote-relocalize, issue #275).
+    onReclassify: () => handleReclassify(object.laneSequenceId),
   });
 
   const renderObjectRow = (object: AlertObjectStatus) => {

--- a/frontend/src/utils/annotation/localizeUtils.ts
+++ b/frontend/src/utils/annotation/localizeUtils.ts
@@ -4,15 +4,25 @@ import { LocalizationQueueLane } from '@/types/api';
  * Stage to write at classify submit (spec: smoke-localization entry point).
  * FP-only lanes (no smoke, no missed smoke, not unsure) exit the pipeline
  * immediately; smoke / missed-smoke / unsure lanes park at
- * seq_annotation_done. An already-annotated lane is never demoted.
+ * seq_annotation_done. An already-annotated lane is never demoted, with one
+ * exception (spec: fp-promote-relocalize, issue #275): a lane that did NOT
+ * need localization before this edit (an FP exit) but does now re-enters at
+ * seq_annotation_done — it never had any localization work to protect.
  */
 export function determineClassifySubmitStage(args: {
   currentStage: string | undefined;
   isUnsure: boolean;
   hasSmoke: boolean;
   hasMissedSmoke: boolean;
+  /** `laneNeedsLocalization()` over the lane's pre-edit flags. */
+  previouslyNeededLocalization: boolean;
 }): 'annotated' | 'seq_annotation_done' {
-  if (args.currentStage === 'annotated') return 'annotated';
+  const nowNeedsLocalization = (args.hasSmoke || args.hasMissedSmoke) && !args.isUnsure;
+  if (args.currentStage === 'annotated') {
+    return nowNeedsLocalization && !args.previouslyNeededLocalization
+      ? 'seq_annotation_done'
+      : 'annotated';
+  }
   if (!args.isUnsure && !args.hasSmoke && !args.hasMissedSmoke) return 'annotated';
   return 'seq_annotation_done';
 }

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -1372,6 +1372,31 @@ describe('ClassifyAlertPage done mode', () => {
     await waitFor(() => expect(navigateMock).toHaveBeenCalled(), { timeout: 2000 });
   });
 
+  it('demotes a promoted FP lane to seq_annotation_done in its PATCH (issue #275)', async () => {
+    await renderAndSettle(<ClassifyAlertPage mode="done" />, { wrapper: makeDoneWrapper(101) });
+
+    // Flip the FP lane (102 / annotation 202) to smoke + a smoke type.
+    const cardB = openRow('102:0');
+    fireEvent.click(cardB.getByRole('radio', { name: 'Smoke' }));
+    fireEvent.click(cardB.getByRole('radio', { name: 'Wildfire' }));
+
+    const submitButton = screen.getAllByRole('button', { name: /Save changes/ })[0];
+    expect(submitButton).not.toBeDisabled();
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(apiClient.updateSequenceAnnotation).toHaveBeenCalledTimes(1));
+    expect(apiClient.updateSequenceAnnotation).toHaveBeenCalledWith(
+      202,
+      expect.objectContaining({
+        processing_stage: 'seq_annotation_done',
+        has_smoke: true,
+      })
+    );
+
+    // Drain the success path's deferred navigate (see the sibling PATCH test).
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled(), { timeout: 2000 });
+  });
+
   it('an alert-level missed-smoke-only change makes the primary lane "changed" and is saved on its PATCH', async () => {
     await renderAndSettle(<ClassifyAlertPage mode="done" />, { wrapper: makeDoneWrapper(101) });
 

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2367,7 +2367,7 @@ describe('LocalizeAlertPage', () => {
       expect(contextRow.getByRole('button', { name: 'Reclassify Object 2' })).toBeInTheDocument();
     });
 
-    it('withholds Reclassify from false-positive context rows (FP -> smoke is issue #275)', async () => {
+    it('offers Reclassify on a false-positive context row (FP -> smoke, issue #275)', async () => {
       vi.mocked(apiClient.getAlertDetail).mockResolvedValue({
         ...makeTwoLaneAlertDetail(),
         lanes: [
@@ -2392,19 +2392,16 @@ describe('LocalizeAlertPage', () => {
 
       fireEvent.click(screen.getByRole('button', { name: /False positives/ }));
 
-      // Selected, where every other row shows its actions, the false
-      // positive still shows none.
+      // Still no localization action — but the classification is correctable.
       fireEvent.click(await screen.findByTestId('localize-object-row-object-2'));
       const fpRow = within(screen.getByTestId('localize-object-row-object-2'));
-      expect(fpRow.queryByRole('button', { name: /Reclassify/ })).not.toBeInTheDocument();
+      expect(fpRow.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
+      fireEvent.click(fpRow.getByRole('button', { name: 'Reclassify Object 2' }));
 
-      // The smoke row above it still has one.
-      fireEvent.click(screen.getByTestId('localize-object-row-object-1'));
-      expect(
-        within(screen.getByTestId('localize-object-row-object-1')).getByRole('button', {
-          name: 'Reclassify Object 1',
-        })
-      ).toBeInTheDocument();
+      // Same destination contract as smoke rows: the row's OWN lane.
+      const destination = await screen.findByTestId('classify-destination');
+      expect(destination.getAttribute('data-lane-id')).toBe('102');
+      expect(destination.getAttribute('data-return')).toBe('/localize/101');
     });
   });
 

--- a/frontend/tests/utils/localizeUtils.test.ts
+++ b/frontend/tests/utils/localizeUtils.test.ts
@@ -20,13 +20,14 @@ const lane = (id: number, over: Partial<LocalizationQueueLane> = {}): Localizati
 });
 
 describe('determineClassifySubmitStage', () => {
-  it('already-finalised stays annotated', () =>
+  it('already-finalised stays annotated (localized smoke lane edited while still smoke)', () =>
     expect(
       determineClassifySubmitStage({
         currentStage: 'annotated',
         isUnsure: false,
         hasSmoke: true,
         hasMissedSmoke: false,
+        previouslyNeededLocalization: true,
       })
     ).toBe('annotated'));
 
@@ -37,6 +38,7 @@ describe('determineClassifySubmitStage', () => {
         isUnsure: false,
         hasSmoke: false,
         hasMissedSmoke: false,
+        previouslyNeededLocalization: false,
       })
     ).toBe('annotated'));
 
@@ -47,6 +49,7 @@ describe('determineClassifySubmitStage', () => {
         isUnsure: false,
         hasSmoke: true,
         hasMissedSmoke: false,
+        previouslyNeededLocalization: false,
       })
     ).toBe('seq_annotation_done'));
 
@@ -57,6 +60,7 @@ describe('determineClassifySubmitStage', () => {
         isUnsure: false,
         hasSmoke: false,
         hasMissedSmoke: true,
+        previouslyNeededLocalization: false,
       })
     ).toBe('seq_annotation_done'));
 
@@ -67,8 +71,53 @@ describe('determineClassifySubmitStage', () => {
         isUnsure: true,
         hasSmoke: false,
         hasMissedSmoke: false,
+        previouslyNeededLocalization: false,
       })
     ).toBe('seq_annotation_done'));
+
+  it('promoted FP lane (annotated, now needs localization) demotes to seq_annotation_done', () =>
+    expect(
+      determineClassifySubmitStage({
+        currentStage: 'annotated',
+        isUnsure: false,
+        hasSmoke: true,
+        hasMissedSmoke: false,
+        previouslyNeededLocalization: false,
+      })
+    ).toBe('seq_annotation_done'));
+
+  it('FP lane corrected to missed smoke also demotes', () =>
+    expect(
+      determineClassifySubmitStage({
+        currentStage: 'annotated',
+        isUnsure: false,
+        hasSmoke: false,
+        hasMissedSmoke: true,
+        previouslyNeededLocalization: false,
+      })
+    ).toBe('seq_annotation_done'));
+
+  it('FP lane staying FP keeps annotated', () =>
+    expect(
+      determineClassifySubmitStage({
+        currentStage: 'annotated',
+        isUnsure: false,
+        hasSmoke: false,
+        hasMissedSmoke: false,
+        previouslyNeededLocalization: false,
+      })
+    ).toBe('annotated'));
+
+  it('FP lane flipped to unsure keeps annotated (unsure does not need localization)', () =>
+    expect(
+      determineClassifySubmitStage({
+        currentStage: 'annotated',
+        isUnsure: true,
+        hasSmoke: false,
+        hasMissedSmoke: false,
+        previouslyNeededLocalization: false,
+      })
+    ).toBe('annotated'));
 });
 
 describe('pickNextLocalizeLane', () => {


### PR DESCRIPTION
Closes #275.

Spec: `docs/specs/2026-08-05-fp-promote-relocalize-design.md` (committed here).

## What

An object classify settled as a false positive and later corrected to smoke now re-enters the localization pipeline instead of staying stranded at `annotated` with no boxes.

- **Frontend stage rule** — `determineClassifySubmitStage` gains a `previouslyNeededLocalization` argument (the lane's pre-edit flags). An `annotated` lane that did not need localization before the edit but does now returns to `seq_annotation_done`; every other annotated lane keeps the never-demote behavior. All three call sites (classify queue/done modes, single-sequence annotate) pass it.
- **Backend demotion handling** — `apply_annotation_update` recognizes the `annotated → seq_annotation_done` promotion: rejects it with 422 if the lane carries committed detection-annotation content (a genuinely localized lane never re-enters the queue), otherwise deletes the empty `annotated`-stage detection annotations the FP exit auto-created (they would make every frame read as already localized and let the exit guard pass with zero boxes), stamps `auto_annotate_enqueued_at`, and defers the `auto_annotate_sequence` job post-commit so the lane surfaces in the Localize queue within seconds. The periodic sweep remains the safety net for a lost defer.
- **Localize rail** — false-positive rows now offer `Reclassify` (the withholding referenced this issue); the existing `/classify/done/:id?return=/localize/:id` round trip covers the rest. Classify submit additionally invalidates the detection-annotation queries so the localize page doesn't redraw a promoted lane against cached (deleted) detection annotations.

## Tests

- `determineClassifySubmitStage` unit tests: promotion demotes (smoke and missed-smoke), FP→FP and FP→unsure stay, localized smoke lane stays.
- `ClassifyAlertPage` done mode: promoted FP lane's PATCH carries `seq_annotation_done`.
- Backend: promotion PATCH demotes, deletes the stale empty detection annotations, stamps `auto_annotate_enqueued_at`, defers the job; a lane with committed boxes gets 422 and nothing moves.
- `LocalizeAlertPage`: FP context row offers `Reclassify` with the same own-lane destination/return contract as smoke rows.

Frontend: 978 tests green. Backend: 572 tests green (isolated compose stack).