### PR TITLE
Withhold alerts with an undecided object from the localize queue

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/export.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/export.py
@@ -302,8 +302,16 @@ async def export_detections(
     if has_missed_smoke is not None:
         conditions.append(SequenceAnnotation.has_missed_smoke == has_missed_smoke)
 
+    # Unsure lanes are not training data. They used to be excluded
+    # incidentally, by the default `annotated` stage filter; settling one as
+    # undecidable now puts it at `annotated` (spec: 2026-08-05 unsure lanes
+    # gate the localize queue), so the exclusion has to be explicit.
+    # `is_not(True)` rather than `== False` so a NULL flag on a legacy row is
+    # exported rather than silently dropped.
     if is_unsure is not None:
         conditions.append(SequenceAnnotation.is_unsure == is_unsure)
+    else:
+        conditions.append(SequenceAnnotation.is_unsure.is_not(True))
 
     # default filter on processing stage annotated unless user overrides
     if sequence_processing_stage is not None:

--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -55,7 +55,10 @@ from app.services.annotation_generation import (
     apply_label_to_sequences_bbox,
     derive_group_label_from_annotation,
 )
-from app.services.localization_rule import needs_localization
+from app.services.localization_rule import (
+    needs_localization,
+    unsettled_unsure_clause,
+)
 
 router = APIRouter()
 logger = logging.getLogger("uvicorn.error")
@@ -1181,6 +1184,30 @@ async def localize_submit(
             detail=(
                 f"Annotation(s) {sorted(wrong_stage_ids)} are not at "
                 "seq_annotation_done; refresh the queue and retry"
+            ),
+        )
+
+    # An alert with an undecided object is not ready for localization (spec:
+    # 2026-08-05 unsure lanes gate the localize queue). The queue already
+    # hides it; this stops a deep link or a stale tab from completing it.
+    alert_source_api, alert_platform_id = next(iter(alert_keys))
+    undecided = (
+        await session.execute(
+            select(func.count(SequenceAnnotation.id))
+            .join(Sequence, Sequence.id == SequenceAnnotation.sequence_id)
+            .where(
+                Sequence.source_api == alert_source_api,
+                Sequence.platform_alert_id == alert_platform_id,
+                unsettled_unsure_clause(SequenceAnnotation),
+            )
+        )
+    ).scalar_one()
+    if undecided > 0:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Cannot submit: {undecided} object(s) of this alert are still "
+                "undecided (marked unsure). Settle them in Classify first."
             ),
         )
 

--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -37,7 +37,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.api.dependencies import get_current_user, get_sequence_crud
 from app.crud import SequenceCRUD
 from app.db import get_session
-from app.services.localization_rule import needs_localization_clause
+from app.services.localization_rule import (
+    needs_localization_clause,
+    unsettled_unsure_clause,
+)
 from app.models import (
     Detection,
     DetectionAnnotation,
@@ -882,6 +885,13 @@ async def localization_queue(
                         else_=0,
                     )
                 ),
+                # An undecided sibling withholds the whole alert (spec:
+                # 2026-08-05 unsure lanes gate the localize queue). The
+                # candidate pre-filter stays valid: this only removes alerts.
+                func.sum(
+                    case((unsettled_unsure_clause(SequenceAnnotation), 1), else_=0)
+                )
+                == 0,
                 func.sum(case((ready_smoke_lane, 1), else_=0)) > 0,
             )
         )

--- a/annotation_api/src/app/services/localization_rule.py
+++ b/annotation_api/src/app/services/localization_rule.py
@@ -15,9 +15,15 @@ Single source of truth for the auto-annotate sweep, the localization queue,
 the submit exit guard, and the GET /sequences needs_localization filter. The
 rule exists in two forms because SQL clauses and Python booleans cannot share
 code; keep them in lockstep.
+
+The module also owns the complementary question of whether a lane is SETTLED
+— see `unsettled_unsure_clause`. Needing localization is about one lane's own
+work; being unsettled is about what a lane does to its siblings.
 """
 
 from sqlalchemy import and_, or_
+
+from app.models import SequenceAnnotationProcessingStage
 
 
 def needs_localization(
@@ -32,4 +38,17 @@ def needs_localization_clause(ann):
     return and_(
         or_(ann.has_smoke.is_(True), ann.has_missed_smoke.is_(True)),
         ann.is_unsure.is_(False),
+    )
+
+
+def unsettled_unsure_clause(ann):
+    """A lane still marked unsure and parked awaiting a decision. Such a
+    lane withholds its whole alert from localization (spec: 2026-08-05
+    unsure lanes gate the localize queue) — an alert is not ready to be
+    boxed while one of its objects is undecided. Settling it as undecidable
+    moves it to annotated with is_unsure kept, which this clause excludes.
+    Parameterized over a (possibly aliased) SequenceAnnotation."""
+    return and_(
+        ann.is_unsure.is_(True),
+        ann.processing_stage == SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE,
     )

--- a/annotation_api/src/tests/endpoints/test_export.py
+++ b/annotation_api/src/tests/endpoints/test_export.py
@@ -945,3 +945,91 @@ async def test_export_detections_pagination(
     rec_times = [datetime.fromisoformat(r["recorded_at"]) for r in all_rows]
     assert rec_times == sorted(rec_times)
     assert len(all_rows) == 5
+
+
+async def _seed_unsure_annotated_lane(client: AsyncClient) -> int:
+    """One detection on fixture sequence 1 plus an annotated annotation
+    carrying is_unsure — the shape "Undecidable for now" produces."""
+    img = Image.new("RGB", (64, 64), color="blue")
+    img_bytes = io.BytesIO()
+    img.save(img_bytes, format="JPEG")
+    img_bytes.seek(0)
+    det_resp = await client.post(
+        "/detections",
+        data={
+            "sequence_id": "1",
+            "alert_api_id": "8301",
+            "recorded_at": now.isoformat(),
+            "algo_predictions": json.dumps(
+                {
+                    "predictions": [
+                        {
+                            "class_name": "smoke",
+                            "xyxyn": [0.1, 0.1, 0.3, 0.3],
+                            "confidence": 0.95,
+                        }
+                    ]
+                }
+            ),
+        },
+        files={"file": ("test.jpg", img_bytes, "image/jpeg")},
+    )
+    assert det_resp.status_code == 201
+    detection_id = det_resp.json()["id"]
+
+    seq_ann_resp = await client.post(
+        "/annotations/sequences/",
+        json={
+            "sequence_id": 1,
+            "has_missed_smoke": False,
+            "is_unsure": True,
+            "annotation": {"sequences_bbox": []},
+            "processing_stage": (
+                models.SequenceAnnotationProcessingStage.ANNOTATED.value
+            ),
+            "created_at": now.isoformat(),
+        },
+    )
+    assert seq_ann_resp.status_code == 201
+    return detection_id
+
+
+@pytest.mark.asyncio
+async def test_export_excludes_unsure_lanes_by_default(
+    authenticated_client: AsyncClient,
+    sequence_session,
+    detection_session,
+    monkeypatch,
+):
+    """An unsure lane closed as undecidable sits at `annotated`, the export
+    default stage — it must not reach training data unasked (spec:
+    2026-08-05 unsure lanes gate the localize queue)."""
+    monkeypatch.setattr(
+        storage_module.s3_service, "get_bucket", lambda _name: DummyBucket()
+    )
+    detection_id = await _seed_unsure_annotated_lane(authenticated_client)
+
+    resp = await authenticated_client.get("/export/detections")
+    assert resp.status_code == 200
+    assert all(row["detection_id"] != detection_id for row in resp.json())
+
+
+@pytest.mark.asyncio
+async def test_export_returns_unsure_lanes_when_asked(
+    authenticated_client: AsyncClient,
+    sequence_session,
+    detection_session,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        storage_module.s3_service, "get_bucket", lambda _name: DummyBucket()
+    )
+    detection_id = await _seed_unsure_annotated_lane(authenticated_client)
+
+    resp = await authenticated_client.get(
+        "/export/detections", params={"is_unsure": "true"}
+    )
+    assert resp.status_code == 200
+    rows = resp.json()
+    row = next(r for r in rows if r["detection_id"] == detection_id)
+    assert row["sequence_is_unsure"] is True

--- a/annotation_api/src/tests/endpoints/test_localization_queue.py
+++ b/annotation_api/src/tests/endpoints/test_localization_queue.py
@@ -282,6 +282,60 @@ async def test_missed_smoke_only_alert_surfaces(
 
 
 @pytest.mark.asyncio
+async def test_unsettled_unsure_sibling_blocks_alert(
+    authenticated_client: AsyncClient, async_session
+):
+    """A ready smoke lane does not pull its alert in while a sibling is
+    still undecided (spec: unsure lanes gate the localize queue)."""
+    await _lane(
+        async_session,
+        alert_api_id=500,
+        platform_alert_id=500,
+        stage=Stage.SEQ_ANNOTATION_DONE,
+        has_smoke=True,
+        auto_annotated=True,
+    )
+    await _lane(
+        async_session,
+        alert_api_id=1_000_500_001,
+        platform_alert_id=500,
+        stage=Stage.SEQ_ANNOTATION_DONE,
+        has_smoke=True,
+        is_unsure=True,
+    )
+    resp = await authenticated_client.get("/sequences/localization-queue")
+    assert resp.json()["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_settled_unsure_sibling_does_not_block(
+    authenticated_client: AsyncClient, async_session
+):
+    """An unsure lane closed as undecidable (annotated + is_unsure) is
+    settled, so its alert is available for localization."""
+    await _lane(
+        async_session,
+        alert_api_id=500,
+        platform_alert_id=500,
+        stage=Stage.SEQ_ANNOTATION_DONE,
+        has_smoke=True,
+        auto_annotated=True,
+    )
+    await _lane(
+        async_session,
+        alert_api_id=1_000_500_001,
+        platform_alert_id=500,
+        stage=Stage.ANNOTATED,
+        has_smoke=True,
+        is_unsure=True,
+    )
+    resp = await authenticated_client.get("/sequences/localization-queue")
+    data = resp.json()
+    assert data["total"] == 1
+    assert len(data["items"][0]["lanes"]) == 2
+
+
+@pytest.mark.asyncio
 async def test_requires_auth(async_client: AsyncClient):
     resp = await async_client.get("/sequences/localization-queue")
     assert resp.status_code in (401, 403)

--- a/annotation_api/src/tests/endpoints/test_localize_submit.py
+++ b/annotation_api/src/tests/endpoints/test_localize_submit.py
@@ -391,3 +391,46 @@ async def test_fp_tracked_lane_parity(
     )
     count_after = len(listing_after.json()["items"])
     assert count_after == count_before
+
+
+@pytest.mark.asyncio
+async def test_unsettled_unsure_sibling_blocks_submit(
+    authenticated_client: AsyncClient, async_session, mock_img
+):
+    """The queue is a listing, not access control — a deep link to a blocked
+    alert must not be completable (spec: 2026-08-05 unsure lanes gate the
+    localize queue)."""
+    seq_a = await _create_sequence(
+        async_session, alert_api_id=2201, platform_alert_id=3200
+    )
+    seq_b = await _create_sequence(
+        async_session, alert_api_id=2202, platform_alert_id=3200
+    )
+    det_a = await _create_detection(authenticated_client, mock_img, seq_a.id, 2201)
+    det_b = await _create_detection(authenticated_client, mock_img, seq_b.id, 2202)
+    ann_a = await _create_sequence_annotation(
+        authenticated_client,
+        seq_a.id,
+        det_a,
+        is_smoke=True,
+        stage="seq_annotation_done",
+    )
+    await _create_sequence_annotation(
+        authenticated_client,
+        seq_b.id,
+        det_b,
+        is_smoke=True,
+        stage="seq_annotation_done",
+        is_unsure=True,
+    )
+    await _annotate_detection(authenticated_client, det_a)
+
+    resp = await authenticated_client.post(
+        "/annotations/sequences/localize-submit",
+        json={"annotation_ids": [ann_a["id"]]},
+    )
+    assert resp.status_code == 422
+    assert "undecided" in resp.json()["detail"].lower()
+
+    get_a = await authenticated_client.get(f"/annotations/sequences/{ann_a['id']}")
+    assert get_a.json()["processing_stage"] == "seq_annotation_done"

--- a/annotation_api/src/tests/services/test_auto_annotate_scheduling.py
+++ b/annotation_api/src/tests/services/test_auto_annotate_scheduling.py
@@ -272,3 +272,28 @@ async def test_unsure_missed_smoke_lane_is_not_enqueued(async_session):
     )
     await schedule_pending_auto_annotate(async_session)
     assert await _enqueued_ids(async_session) == set()
+
+
+@pytest.mark.asyncio
+async def test_blocked_alert_still_enqueues_its_smoke_lane(async_session):
+    """The localize queue's gate does not reach into the sweep: a smoke lane
+    whose alert is blocked by an undecided sibling still gets its GPU pass,
+    so the alert is available the moment the sibling is settled (spec:
+    2026-08-05 unsure lanes gate the localize queue)."""
+    smoke = await _lane(
+        async_session,
+        alert_api_id=910,
+        platform_alert_id=910,
+        stage=Stage.SEQ_ANNOTATION_DONE,
+        has_smoke=True,
+    )
+    await _lane(
+        async_session,
+        alert_api_id=911,
+        platform_alert_id=910,
+        stage=Stage.SEQ_ANNOTATION_DONE,
+        has_smoke=True,
+        is_unsure=True,
+    )
+    await schedule_pending_auto_annotate(async_session)
+    assert await _enqueued_ids(async_session) == {smoke.id}

--- a/docs/specs/2026-08-05-unsure-lane-localize-gate-design.md
+++ b/docs/specs/2026-08-05-unsure-lane-localize-gate-design.md
@@ -1,0 +1,224 @@
+# Unsure lanes gate the localize queue
+
+Date: 2026-08-05
+Status: approved, not implemented
+
+## Problem
+
+An alert enters the localization queue when **every** sibling lane sits at a
+done stage and **at least one** lane matches the localization rule
+(`(has_smoke OR has_missed_smoke) AND NOT is_unsure`) at `seq_annotation_done`
+with its auto reference layer built
+(`annotation_api/src/app/api/api_v1/endpoints/sequences.py:838`).
+
+An unsure lane parks at `seq_annotation_done` at classify submit
+(`frontend/src/utils/annotation/localizeUtils.ts:16`), and `seq_annotation_done`
+counts as a done stage. So an unsure lane satisfies the completeness gate
+without ever being work. An alert with one smoke lane and one unsure lane
+enters the queue on the strength of the smoke lane, and the unsure lane is
+carried along invisibly.
+
+Verified against the local database: alert `55664` (`sampzon-ldd-01`) has three
+lanes — a wildfire smoke lane (seq 57, `seq_annotation_done`, auto-annotated), a
+false-positive lane (seq 58, `annotated`), and an unsure lane (seq 59,
+`seq_annotation_done`). It is in the queue today.
+
+Three consequences follow:
+
+- The unsure object is invisible on the localize screen.
+  `buildAlertFrameModel` (`frontend/src/utils/annotation/alertLocalizeUtils.ts:121`)
+  drops unsure lanes unconditionally — not even behind the false-positive
+  context toggle.
+- Submitting the alert ships only workable lanes, so the alert leaves
+  `/localize` with the unsure lane still parked. It is then reachable only
+  through the "Only Unsure" filter on `/classify/done`.
+- The queue row advertises the wrong thing: `rollupOutcomes` precedence
+  (`fn > unsure > tp > fp`) makes 55664 display `? +2` for an object you cannot
+  act on, rather than `tp` for the wildfire you are about to box.
+
+The behaviour was deliberate — the smoke-localization spec
+(`docs/specs/2026-07-28-smoke-localization-entry-point-design.md:92-97`) states
+that unsure lanes "park at `seq_annotation_done` and are resolved through
+sequence review, without blocking siblings". This spec revises that decision:
+an unsure lane is an *undecided* object, and an alert should not be presented as
+ready for localization while one of its objects is undecided.
+
+## Scope
+
+**In:** the queue gate, the action that settles an unsure lane, the server-side
+submit guard, the export default, the localize queue row's outcome rollup, the
+stage label, and tests for all of it.
+
+**Out:** any dedicated unsure triage queue or dashboard counter — the unsure
+backlog stays on `/classify/done` behind its existing filter. No change to how
+unsure lanes render in the localize frame grid or object status strip — they
+stay invisible there, including behind the false-positive context toggle. No
+change to the auto-annotate sweep's gating. No schema migration.
+
+## Settled vs. unsettled
+
+A lane is **unsettled** when:
+
+    is_unsure = true AND processing_stage = seq_annotation_done
+
+Every other lane at a done stage (`seq_annotation_done`, `annotated`) is
+**settled**. An unsure lane at `annotated` is settled-as-undecidable: someone
+looked at it and recorded that it cannot be decided for now.
+
+The rule lives in `annotation_api/src/app/services/localization_rule.py`
+alongside `needs_localization`, in both SQL and Python form, for the same reason
+that rule does: SQL clauses and Python booleans cannot share code, and every
+caller must agree.
+
+```python
+def is_unsettled_unsure(is_unsure: bool, processing_stage) -> bool: ...
+def unsettled_unsure_clause(ann): ...
+```
+
+## Queue gate
+
+`localization_queue` gains one condition in its `HAVING` aggregate:
+
+```
+count(*) == sum(done_stage)          # unchanged: every sibling classified
+AND sum(unsettled_unsure) == 0       # new: no sibling left undecided
+AND sum(ready_smoke_lane) > 0        # unchanged: there is work to do
+```
+
+The existing candidate pre-filter (#215) is unchanged: it selects alerts having
+at least one ready smoke lane, which still contains every alert the gate can
+admit. The new condition only removes alerts, so the pre-filter stays a valid
+cost bound.
+
+`GET /sequences?needs_localization=true` filters per-sequence, not per-alert, and
+already excludes unsure lanes through `needs_localization`. It needs no change.
+
+Effect on current data: 55664 leaves `/localize` until seq 59 is settled. The
+other four alerts carrying an unsure lane have no smoke lane at all and were
+never in the queue.
+
+## Auto-annotate sweep: unchanged
+
+`schedule_pending_auto_annotate` keeps gating on the existing completeness rule.
+A blocked alert's smoke lane still gets its GPU pass in the background, so when
+the unsure lane is settled the alert appears in `/localize` immediately rather
+than waiting for the next sweep plus a GPU run.
+
+This spends GPU on alerts that may stay blocked. With five unsure lanes in the
+whole database that cost is negligible, and it buys instant availability on
+unblock. Revisit only if unsure usage grows by orders of magnitude.
+
+## Settling a lane: "Undecidable for now"
+
+On `/classify/done/<alert>`, an unsure object gets one new per-lane control:
+**"Undecidable for now"**. It joins the existing pending-changes set and lands on
+*Save changes* — the done-mode PATCH path
+(`frontend/src/pages/ClassifyAlertPage.tsx:655`). No new endpoint, no new submit
+path, no schema change.
+
+It targets `processing_stage: annotated` while keeping `is_unsure: true`.
+`determineClassifySubmitStage` gains a `deferred` input: an unsure lane returns
+`annotated` when deferred and `seq_annotation_done` otherwise. The existing
+`currentStage === 'annotated'` short-circuit is unaffected.
+
+The backend needs no guard change for this transition. The localization exit
+guard (`sequence_annotations.py:658`) only fires when `needs_localization` holds,
+which is false for an unsure lane, so no detection annotations are demanded.
+`auto_create_detection_annotations` likewise skips unsure lanes
+(`sequence_annotations.py:749`).
+
+The lane stays re-editable from done mode afterwards — done mode unlocks any lane
+carrying an annotation regardless of stage
+(`ClassifyAlertPage.tsx:65`) — and stays findable under the "Only Unsure" filter.
+Re-deciding it as smoke returns it to `seq_annotation_done`, where the sweep
+picks it up and the alert re-enters `/localize` through the normal path.
+
+The first-pass classify queue is untouched: marking an object unsure there still
+parks it at `seq_annotation_done`, which is now precisely the signal that
+someone must come back to it.
+
+## Submit guard
+
+The queue is a listing, not access control — `/localize/57` keeps resolving when
+its alert is blocked, so a bookmark or a back-button lands on a screen the
+annotator can complete. Enforcement therefore belongs on the server:
+
+`localize-submit` rejects with 422 when any sibling lane of the alert is
+unsettled-unsure, in the style of the existing localization exit guard. The
+check runs once per request against the alert's siblings, before the per-lane
+loop, since every item already belongs to one alert.
+
+`LocalizeAlertPage` shows a banner — *"1 object still undecided — settle it in
+Classify"* — linking to `/classify/done/<alert>`, and disables Submit. Boxes stay
+drawable, so work in progress is not thrown away; it just cannot be committed
+until the alert is settled.
+
+## Export default
+
+`/export` defaults to `processing_stage = annotated` and applies no unsure
+filter unless one is passed (`export.py:305-314`). Unsure lanes are excluded
+today only incidentally, by their stage. Moving settled-undecidable lanes to
+`annotated` would newly pull them into default exports.
+
+Fix: when the caller passes no `is_unsure` value, exclude unsure lanes. Callers
+that want them ask for them explicitly with `is_unsure=true`.
+
+## Outcome rollup on the localize queue
+
+Once seq 59 is settled, 55664 re-enters `/localize` and its row again shows `?`
+dominant for an object that is invisible on the screen the row leads to.
+
+`LocalizeQueueTable` rolls up only lanes matching the localization rule, so the
+row shows `tp` — the wildfire about to be boxed. `alertOutcome`
+(`LocalizeQueueTable.tsx:44`) switches from `item.lanes` to `smokeLanes(item)`,
+which the file already computes for its Objects and Frames columns.
+
+`ClassifyDoneTable` and `LocalizeDoneQueueTable` keep rolling up every lane, and
+`rollupOutcomes` itself is unchanged. On those screens the unsure object
+genuinely is part of what is being summarised.
+
+## Stage label
+
+`getProcessingStageLabel` renders `seq_annotation_done` as "Awaiting
+localization" (`frontend/src/utils/processingStage.ts:172`). For an unsettled
+unsure lane that is wrong: it awaits a *decision*, and that stage is now what
+gates the queue.
+
+Callers that know the lane's `is_unsure` flag render "Awaiting decision"
+instead. The label function takes an optional second argument rather than a new
+status value, so the `ProcessingStage` union and every exhaustive switch over it
+stay untouched.
+
+## Testing
+
+Backend, extending `src/tests/endpoints/test_localization_queue.py` and
+siblings:
+
+- an unsettled unsure sibling blocks an otherwise-ready alert (the 55664 shape —
+  currently untested in either direction)
+- a settled unsure sibling (`annotated` + `is_unsure`) does not block
+- an all-unsure alert still yields nothing (existing test, unchanged)
+- `localize-submit` returns 422 when a sibling is unsettled-unsure, and the
+  batch rolls back
+- `schedule_pending_auto_annotate` still enqueues the smoke lane of a blocked
+  alert
+- `/export` excludes unsure lanes by default and returns them for
+  `is_unsure=true`
+
+Frontend, unit tests only — no new harness:
+
+- `determineClassifySubmitStage` returns `annotated` for a deferred unsure lane
+  and `seq_annotation_done` otherwise
+- `LocalizeQueueTable`'s outcome rollup ignores non-localizable lanes
+- the blocked-alert banner renders and Submit is disabled
+
+## Consequences
+
+Marking an object unsure is free today. After this it withholds a wildfire from
+the localize queue until someone acts, which makes unsure a throughput lever.
+"Undecidable for now" is what keeps that from being a deadlock, so the control
+must be easy to find on `/classify/done`.
+
+Alerts carrying an unsure lane and no smoke lane are unaffected — they were never
+in the localize queue and remain reachable only through the "Only Unsure" filter.
+Four such alerts exist today.

--- a/frontend/src/components/classify/ClassificationChips.tsx
+++ b/frontend/src/components/classify/ClassificationChips.tsx
@@ -27,6 +27,10 @@ export interface ClassificationChipsProps {
   ) => void;
   /** Omit to hide the Unsure chip. */
   onUnsureChange?: (cardKey: string, unsure: boolean) => void;
+  /** Whether this unsure lane is currently settled as undecidable. */
+  deferred?: boolean;
+  /** Omit to hide the "Undecidable for now" chip (queue mode hides it). */
+  onDeferredChange?: (cardKey: string, deferred: boolean) => void;
 }
 
 // Keyboard letter per FP type — mirrors keyboardUtils' bindings (same map
@@ -84,6 +88,8 @@ export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
   onBboxChange,
   onClassificationChange,
   onUnsureChange,
+  deferred,
+  onDeferredChange,
 }) => {
   // Smoke / False positive / Unsure are mutually exclusive: picking either
   // classification clears unsure, and turning unsure on clears the
@@ -170,6 +176,32 @@ export const ClassificationChips: React.FC<ClassificationChipsProps> = ({
           </button>
         )}
       </div>
+
+      {/* An unsure lane holds its whole alert out of the localize queue
+          (spec: 2026-08-05 unsure lanes gate the localize queue). This
+          settles it — still unsure, but no longer blocking — so a wildfire
+          sibling can be boxed even when this object can't be decided. */}
+      {unsure && onDeferredChange && (
+        <div>
+          <button
+            type="button"
+            tabIndex={-1}
+            role="checkbox"
+            aria-checked={!!deferred}
+            aria-label="Undecidable for now"
+            data-testid={`undecidable-chip-${cardKey}`}
+            onClick={() => onDeferredChange(cardKey, !deferred)}
+            className={typeChip(!!deferred, 'bg-signal-soft text-signal')}
+          >
+            Undecidable for now
+          </button>
+          <p className="mt-1 font-body text-detail text-haze">
+            {deferred
+              ? 'Settled — this object no longer holds the alert back from localization.'
+              : 'This object is holding its alert out of the localize queue.'}
+          </p>
+        </div>
+      )}
 
       {smokeSelected && (
         <div>

--- a/frontend/src/components/classify/ObjectRow.tsx
+++ b/frontend/src/components/classify/ObjectRow.tsx
@@ -43,6 +43,8 @@ export interface ObjectRowProps {
     classification: 'smoke' | 'false_positive' | 'unselected'
   ) => void;
   onUnsureChange?: (cardKey: string, unsure: boolean) => void;
+  deferred?: boolean;
+  onDeferredChange?: (cardKey: string, deferred: boolean) => void;
 }
 
 export const ObjectRow: React.FC<ObjectRowProps> = ({
@@ -61,6 +63,8 @@ export const ObjectRow: React.FC<ObjectRowProps> = ({
   onBboxChange,
   onClassificationChange,
   onUnsureChange,
+  deferred,
+  onDeferredChange,
 }) => {
   const status = getObjectRowStatus({ bbox, classification, unsure });
   const expanded = isActive && !locked;
@@ -135,6 +139,8 @@ export const ObjectRow: React.FC<ObjectRowProps> = ({
             onBboxChange={onBboxChange}
             onClassificationChange={onClassificationChange}
             onUnsureChange={onUnsureChange}
+            deferred={deferred}
+            onDeferredChange={onDeferredChange}
           />
         </div>
       )}

--- a/frontend/src/components/sequences/LocalizeQueueTable.tsx
+++ b/frontend/src/components/sequences/LocalizeQueueTable.tsx
@@ -39,11 +39,15 @@ function smokeFrames(item: LocalizationQueueItem): number {
   return smokeLanes(item).reduce((sum, l) => sum + l.total_detections, 0);
 }
 
-// Alert-level rollup over every lane (not just smoke lanes): dominant
-// outcome + count of the other objects.
+// Outcome rollup over the lanes this screen is actually about — the ones
+// you'll box. Rolling up every lane made an alert advertise `?` for an unsure
+// object the localize screen never shows (spec: 2026-08-05 unsure lanes gate
+// the localize queue), and counted objects the Objects column doesn't.
+// ClassifyDoneTable and LocalizeDoneQueueTable still roll up every lane —
+// there, the other objects genuinely are part of the summary.
 function alertOutcome(item: LocalizationQueueItem) {
   return rollupOutcomes(
-    item.lanes.flatMap(lane => {
+    smokeLanes(item).flatMap(lane => {
       const outcome = deriveSequenceOutcome(lane);
       return outcome ? [outcome] : [];
     })

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -160,6 +160,10 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     Record<string, CardClassification>
   >({});
   const [laneUnsure, setLaneUnsure] = useState<Record<number, boolean>>({});
+  // "Undecidable for now": an unsure lane the annotator has settled, so it
+  // stops withholding its alert from localization (spec: 2026-08-05 unsure
+  // lanes gate the localize queue). Done mode only.
+  const [laneDeferred, setLaneDeferred] = useState<Record<number, boolean>>({});
   const [missedSmokeReview, setMissedSmokeReview] = useState<'yes' | 'no' | null>(null);
   const [hasMissedSmoke, setHasMissedSmoke] = useState<boolean>(false);
 
@@ -194,6 +198,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
   const initialSnapshotRef = useRef<{
     laneBboxes: Record<number, SequenceBbox[]>;
     laneUnsure: Record<number, boolean>;
+    laneDeferred: Record<number, boolean>;
     hasMissedSmoke: boolean;
   } | null>(null);
 
@@ -234,6 +239,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     setLaneBboxes({});
     setPrimaryClassification({});
     setLaneUnsure({});
+    setLaneDeferred({});
     setMissedSmokeReview(null);
     setHasMissedSmoke(false);
     setActiveCardKey(null);
@@ -247,6 +253,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     const newLaneBboxes: Record<number, SequenceBbox[]> = {};
     const newPrimaryClassification: Record<string, CardClassification> = {};
     const newLaneUnsure: Record<number, boolean> = {};
+    const newLaneDeferred: Record<number, boolean> = {};
     let newMissedSmokeReview: 'yes' | 'no' | null = null;
     let newHasMissedSmoke = false;
 
@@ -276,6 +283,11 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
       }));
       newLaneBboxes[lane.sequence.id] = bboxes;
       newLaneUnsure[lane.sequence.id] = lane.annotation.is_unsure || false;
+      // An unsure lane already at `annotated` was settled as undecidable —
+      // that pairing is the only thing that records the deferral.
+      newLaneDeferred[lane.sequence.id] =
+        (lane.annotation.is_unsure || false) &&
+        lane.annotation.processing_stage === 'annotated';
       bboxes.forEach((bbox, trackIndex) => {
         const cardKey = `${lane.sequence.id}:${trackIndex}`;
         // A track only counts as classified when it has a real smoke_type or
@@ -295,6 +307,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     setLaneBboxes(newLaneBboxes);
     setPrimaryClassification(newPrimaryClassification);
     setLaneUnsure(newLaneUnsure);
+    setLaneDeferred(newLaneDeferred);
     setMissedSmokeReview(newMissedSmokeReview);
     setHasMissedSmoke(newHasMissedSmoke);
 
@@ -303,6 +316,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     initialSnapshotRef.current = {
       laneBboxes: newLaneBboxes,
       laneUnsure: newLaneUnsure,
+      laneDeferred: newLaneDeferred,
       hasMissedSmoke: newHasMissedSmoke,
     };
   };
@@ -559,6 +573,15 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     const card = cards.find(c => c.cardKey === cardKey);
     if (!card || card.locked) return;
     setLaneUnsure(prev => ({ ...prev, [card.laneSequenceId]: unsure }));
+    // Deferral only means something on an unsure lane — clearing unsure must
+    // clear it too, or a stale deferral rides along into the PATCH.
+    if (!unsure) setLaneDeferred(prev => ({ ...prev, [card.laneSequenceId]: false }));
+  };
+
+  const handleDeferredChangeByCardKey = (cardKey: string, deferred: boolean) => {
+    const card = cards.find(c => c.cardKey === cardKey);
+    if (!card || card.locked) return;
+    setLaneDeferred(prev => ({ ...prev, [card.laneSequenceId]: deferred }));
   };
 
   const handleMissedSmokeReviewChange = (review: 'yes' | 'no') => {
@@ -628,8 +651,10 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     );
     const unsureChanged =
       (laneUnsure[laneSequenceId] ?? false) !== (snapshot.laneUnsure[laneSequenceId] ?? false);
+    const deferredChanged =
+      (laneDeferred[laneSequenceId] ?? false) !== (snapshot.laneDeferred[laneSequenceId] ?? false);
     const missedSmokeChanged = carriesMissedSmoke && hasMissedSmoke !== snapshot.hasMissedSmoke;
-    return bboxesChanged || unsureChanged || missedSmokeChanged;
+    return bboxesChanged || unsureChanged || missedSmokeChanged || deferredChanged;
   };
   const changedLaneCount =
     mode === 'done' && alertDetail
@@ -670,6 +695,9 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
           const isMissedSmokeCarrier = lane.sequence.id === missedSmokeCarrierLaneId;
           const bboxes = laneBboxes[lane.sequence.id] ?? [];
           const unsure = laneUnsure[lane.sequence.id] ?? false;
+          const deferred = laneDeferred[lane.sequence.id] ?? false;
+          const wasDeferredUnsure =
+            initialSnapshotRef.current?.laneDeferred[lane.sequence.id] ?? false;
           const hasSmokeNow = unsure ? false : bboxes.some(b => b.is_smoke);
           const hasMissedSmokeForLane = isMissedSmokeCarrier && !unsure ? hasMissedSmoke : false;
           const updates: Partial<SequenceAnnotation> = {
@@ -679,6 +707,8 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
               isUnsure: unsure,
               hasSmoke: hasSmokeNow,
               hasMissedSmoke: hasMissedSmokeForLane,
+              deferred,
+              wasDeferredUnsure,
             }),
             has_smoke: hasSmokeNow,
             has_false_positives: unsure
@@ -1186,6 +1216,10 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
                     onBboxChange={handleBboxChangeByCardKey}
                     onClassificationChange={handleClassificationChangeByCardKey}
                     onUnsureChange={card.locked ? undefined : handleUnsureChangeByCardKey}
+                    deferred={laneDeferred[card.laneSequenceId] ?? false}
+                    onDeferredChange={
+                      mode === 'done' && !card.locked ? handleDeferredChangeByCardKey : undefined
+                    }
                   />
                 );
               })}

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -286,8 +286,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
       // An unsure lane already at `annotated` was settled as undecidable —
       // that pairing is the only thing that records the deferral.
       newLaneDeferred[lane.sequence.id] =
-        (lane.annotation.is_unsure || false) &&
-        lane.annotation.processing_stage === 'annotated';
+        (lane.annotation.is_unsure || false) && lane.annotation.processing_stage === 'annotated';
       bboxes.forEach((bbox, trackIndex) => {
         const cardKey = `${lane.sequence.id}:${trackIndex}`;
         // A track only counts as classified when it has a real smoke_type or
@@ -1184,7 +1183,10 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
                 // (Awaiting localization / Fully annotated) is just noise.
                 const stageBadge =
                   card.locked && mode !== 'done'
-                    ? getProcessingStageLabel(lane.annotation!.processing_stage)
+                    ? getProcessingStageLabel(
+                        lane.annotation!.processing_stage,
+                        lane.annotation!.is_unsure ?? false
+                      )
                     : undefined;
                 const overlay = cardOverlayData.find(o => o.cardKey === card.cardKey);
 

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -791,16 +791,34 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // already-annotated objects must not satisfy (or block) the gate.
   const allObjectsAccepted = workableObjects.length > 0 && workableObjects.every(isObjectLocalized);
 
+  // An alert with an undecided object is not ready for localization (spec:
+  // 2026-08-05 unsure lanes gate the localize queue). The queue hides it;
+  // this covers deep links and stale tabs, and matches the server guard on
+  // localize-submit — better to say so up front than to let a 422 explain it
+  // after every box is drawn.
+  const undecidedLanes = (alertDetail?.lanes ?? []).filter(
+    lane => lane.annotation?.is_unsure && lane.annotation.processing_stage === 'seq_annotation_done'
+  );
+  const undecidedLaneCount = undecidedLanes.length;
+  const submitBlocked = !allObjectsAccepted || undecidedLaneCount > 0;
+
   // What the submit button's tooltip says. The blocked case counts the
   // objects rather than restating the rule: "2 objects still have frames
   // without a box" tells you how much is left, where "accept every object's
   // boxes" only tells you what you already tried to do.
   const objectsAwaitingBoxes = workableObjects.filter(o => !isObjectLocalized(o)).length;
-  const submitTooltip = allObjectsAccepted
-    ? 'Submits every object still awaiting localization, then returns you to the list.'
-    : `${objectsAwaitingBoxes} object${objectsAwaitingBoxes === 1 ? '' : 's'} still ${
-        objectsAwaitingBoxes === 1 ? 'has' : 'have'
-      } frames without a box. Accept or draw them to enable submit.`;
+  const submitTooltip =
+    undecidedLaneCount > 0
+      ? `${undecidedLaneCount} object${undecidedLaneCount === 1 ? '' : 's'} in this alert ${
+          undecidedLaneCount === 1 ? 'is' : 'are'
+        } still marked unsure. Settle ${
+          undecidedLaneCount === 1 ? 'it' : 'them'
+        } in Classify to unlock submit.`
+      : allObjectsAccepted
+        ? 'Submits every object still awaiting localization, then returns you to the list.'
+        : `${objectsAwaitingBoxes} object${objectsAwaitingBoxes === 1 ? '' : 's'} still ${
+            objectsAwaitingBoxes === 1 ? 'has' : 'have'
+          } frames without a box. Accept or draw them to enable submit.`;
 
   // Every workable lane's sequence-annotation id — the payload
   // `localizeSubmit` takes, and the set both bulk actions iterate.
@@ -851,7 +869,7 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // submit now requires every frame to already carry a committed box, so
   // there is never a pending no-box frame left to warn about.
   const handleSubmitClick = () => {
-    if (!allObjectsAccepted || submitAlert.isPending) return;
+    if (submitBlocked || submitAlert.isPending) return;
     if (softConfirmNeeded) {
       setMissedSmokeConfirm(true);
       return;
@@ -1359,8 +1377,35 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
                   All objects localized
                 </p>
               ) : (
-                <div className="flex justify-center">
-                  {/* The tooltip carries the gate's explanation, which used to
+                <div>
+                  {/* An undecided object holds the whole alert back. Say so
+                      here rather than letting the server's 422 explain it
+                      after every box is drawn — and offer the one action
+                      that clears it, which round-trips back to this page. */}
+                  {undecidedLaneCount > 0 && (
+                    <div
+                      data-testid="undecided-lanes-banner"
+                      className="mb-2.5 rounded-lg border border-signal bg-signal-soft px-3 py-2 font-body text-detail text-signal"
+                    >
+                      {undecidedLaneCount === 1
+                        ? '1 object is'
+                        : `${undecidedLaneCount} objects are`}{' '}
+                      still undecided.{' '}
+                      <button
+                        type="button"
+                        onClick={e => {
+                          e.stopPropagation();
+                          handleReclassify(undecidedLanes[0].sequence.id);
+                        }}
+                        className="font-semibold underline underline-offset-2 hover:no-underline"
+                      >
+                        Settle in Classify
+                      </button>{' '}
+                      to unlock submit.
+                    </div>
+                  )}
+                  <div className="flex justify-center">
+                    {/* The tooltip carries the gate's explanation, which used to
                       be a line of copy under the button. Hovering the thing
                       you can't click is where the question gets asked, and it
                       names HOW MANY objects are holding submit back rather
@@ -1368,24 +1413,25 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
                       bug once every row looks handled but one still has a
                       pending frame. Above, because the footer is the last
                       thing in a rail that scrolls. */}
-                  <Tooltip placement="above" tip={submitTooltip}>
-                    <button
-                      type="button"
-                      onClick={e => {
-                        e.stopPropagation();
-                        handleSubmitClick();
-                      }}
-                      disabled={!allObjectsAccepted || submitAlert.isPending}
-                      className="flex items-center justify-center rounded-lg bg-pine px-5 py-2.5 text-center font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      {submitAlert.isPending ? (
-                        <div className="w-3.5 h-3.5 mr-1.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                      ) : (
-                        <Upload className="w-3.5 h-3.5 mr-1.5 shrink-0" />
-                      )}
-                      Submit
-                    </button>
-                  </Tooltip>
+                    <Tooltip placement="above" tip={submitTooltip}>
+                      <button
+                        type="button"
+                        onClick={e => {
+                          e.stopPropagation();
+                          handleSubmitClick();
+                        }}
+                        disabled={submitBlocked || submitAlert.isPending}
+                        className="flex items-center justify-center rounded-lg bg-pine px-5 py-2.5 text-center font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {submitAlert.isPending ? (
+                          <div className="w-3.5 h-3.5 mr-1.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                        ) : (
+                          <Upload className="w-3.5 h-3.5 mr-1.5 shrink-0" />
+                        )}
+                        Submit
+                      </button>
+                    </Tooltip>
+                  </div>
                 </div>
               )
             }

--- a/frontend/src/utils/annotation/localizeUtils.ts
+++ b/frontend/src/utils/annotation/localizeUtils.ts
@@ -1,19 +1,32 @@
 import { LocalizationQueueLane } from '@/types/api';
 
 /**
- * Stage to write at classify submit (spec: smoke-localization entry point).
+ * Stage to write at classify submit (spec: smoke-localization entry point;
+ * amended by 2026-08-05 unsure lanes gate the localize queue).
+ *
  * FP-only lanes (no smoke, no missed smoke, not unsure) exit the pipeline
- * immediately; smoke / missed-smoke / unsure lanes park at
- * seq_annotation_done. An already-annotated lane is never demoted.
+ * immediately. Smoke / missed-smoke lanes park at seq_annotation_done.
+ *
+ * An unsure lane parks at seq_annotation_done — where it withholds its whole
+ * alert from localization — until it is explicitly deferred ("Undecidable for
+ * now"), which settles it at annotated with is_unsure kept true.
+ *
+ * An already-annotated lane is never demoted, with one exception: a lane that
+ * loaded as deferred-unsure may return to seq_annotation_done when it is
+ * re-decided as smoke, otherwise "for now" would be permanent and the object
+ * could never be localized.
  */
 export function determineClassifySubmitStage(args: {
   currentStage: string | undefined;
   isUnsure: boolean;
   hasSmoke: boolean;
   hasMissedSmoke: boolean;
+  deferred?: boolean;
+  wasDeferredUnsure?: boolean;
 }): 'annotated' | 'seq_annotation_done' {
-  if (args.currentStage === 'annotated') return 'annotated';
-  if (!args.isUnsure && !args.hasSmoke && !args.hasMissedSmoke) return 'annotated';
+  if (args.isUnsure) return args.deferred ? 'annotated' : 'seq_annotation_done';
+  if (args.currentStage === 'annotated' && !args.wasDeferredUnsure) return 'annotated';
+  if (!args.hasSmoke && !args.hasMissedSmoke) return 'annotated';
   return 'seq_annotation_done';
 }
 

--- a/frontend/src/utils/processingStage.ts
+++ b/frontend/src/utils/processingStage.ts
@@ -150,6 +150,8 @@ export function filterSequencesByProcessingStage(
  * across all components that show processing stage information.
  *
  * @param {ProcessingStageStatus | ProcessingStage} status - The status to get a label for
+ * @param {boolean} isUnsure - The lane's unsure flag, which changes what
+ *   `seq_annotation_done` means (see below). Omit when unknown.
  * @returns {string} Human-readable label for the processing stage
  *
  * @example
@@ -162,9 +164,21 @@ export function filterSequencesByProcessingStage(
  *
  * const label3 = getProcessingStageLabel('annotated');
  * // Returns: 'Fully annotated'
+ *
+ * const label4 = getProcessingStageLabel('seq_annotation_done', true);
+ * // Returns: 'Awaiting decision'
  * ```
  */
-export function getProcessingStageLabel(status: ProcessingStageStatus | ProcessingStage): string {
+export function getProcessingStageLabel(
+  status: ProcessingStageStatus | ProcessingStage,
+  isUnsure = false
+): string {
+  // An unsure lane parked at seq_annotation_done awaits a DECISION, not
+  // localization — and that stage is exactly what withholds its alert from
+  // the localize queue (spec: 2026-08-05 unsure lanes gate the localize
+  // queue), so calling it "Awaiting localization" points at the wrong queue.
+  if (isUnsure && status === 'seq_annotation_done') return 'Awaiting decision';
+
   const labels: Record<ProcessingStageStatus, string> = {
     no_annotation: 'No annotation',
     imported: 'Imported',

--- a/frontend/tests/components/sequences/LocalizeQueueTable.test.tsx
+++ b/frontend/tests/components/sequences/LocalizeQueueTable.test.tsx
@@ -85,7 +85,26 @@ describe('LocalizeQueueTable', () => {
     render(<LocalizeQueueTable items={[item]} onItemClick={onItemClick} />);
 
     expect(screen.getByTitle('False negative — smoke was missed')).toBeInTheDocument();
-    expect(screen.getByText('+2')).toBeInTheDocument();
+    // +1, not +2: the FP lane is not one of this screen's objects, so it is
+    // outside the rollup — the count now agrees with the Objects column,
+    // which has always counted localizable lanes only.
+    expect(screen.getByText('+1')).toBeInTheDocument();
+  });
+
+  it('an unsure sibling does not take over the row outcome', () => {
+    // Unsure outranks TP in rollupOutcomes' precedence, so before the
+    // localizable-only rollup this row advertised `?` for an object the
+    // localize screen never shows (spec: 2026-08-05 unsure lanes gate the
+    // localize queue).
+    const item = createItem({
+      lanes: [createLane(), createLane({ sequence_id: 12, is_unsure: true })],
+    });
+    render(<LocalizeQueueTable items={[item]} onItemClick={onItemClick} />);
+
+    expect(
+      screen.getByTitle('True positive — model correctly detected smoke')
+    ).toBeInTheDocument();
+    expect(screen.queryByTitle('Unsure — needs review')).not.toBeInTheDocument();
   });
 
   it('renders column tooltips', () => {

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -1372,6 +1372,42 @@ describe('ClassifyAlertPage done mode', () => {
     await waitFor(() => expect(navigateMock).toHaveBeenCalled(), { timeout: 2000 });
   });
 
+  it('marking a lane unsure without settling it still parks at seq_annotation_done', async () => {
+    await renderAndSettle(<ClassifyAlertPage mode="done" />, { wrapper: makeDoneWrapper(101) });
+
+    const cardA = within(screen.getByTestId('object-card-101:0'));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Unsure' }));
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Save changes/ })[0]);
+
+    await waitFor(() => expect(apiClient.updateSequenceAnnotation).toHaveBeenCalledTimes(1));
+    expect(apiClient.updateSequenceAnnotation).toHaveBeenCalledWith(
+      201,
+      expect.objectContaining({ processing_stage: 'seq_annotation_done', is_unsure: true })
+    );
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled(), { timeout: 2000 });
+  });
+
+  it('settling an unsure lane as undecidable sends it to annotated, unblocking its alert', async () => {
+    await renderAndSettle(<ClassifyAlertPage mode="done" />, { wrapper: makeDoneWrapper(101) });
+
+    const cardA = within(screen.getByTestId('object-card-101:0'));
+    fireEvent.click(cardA.getByRole('radio', { name: 'Unsure' }));
+    fireEvent.click(cardA.getByRole('checkbox', { name: 'Undecidable for now' }));
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Save changes/ })[0]);
+
+    await waitFor(() => expect(apiClient.updateSequenceAnnotation).toHaveBeenCalledTimes(1));
+    // is_unsure stays true — the object is settled, not decided.
+    expect(apiClient.updateSequenceAnnotation).toHaveBeenCalledWith(
+      201,
+      expect.objectContaining({ processing_stage: 'annotated', is_unsure: true })
+    );
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled(), { timeout: 2000 });
+  });
+
   it('an alert-level missed-smoke-only change makes the primary lane "changed" and is saved on its PATCH', async () => {
     await renderAndSettle(<ClassifyAlertPage mode="done" />, { wrapper: makeDoneWrapper(101) });
 

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -1157,6 +1157,44 @@ describe('LocalizeAlertPage', () => {
       );
     });
 
+    it('blocks submit and explains why while a sibling object is still undecided', async () => {
+      // The queue hides such an alert; this covers a deep link or a stale
+      // tab, and mirrors the server guard on localize-submit (spec:
+      // 2026-08-05 unsure lanes gate the localize queue).
+      const detail = makeTwoLaneAlertDetail();
+      vi.mocked(apiClient.getAlertDetail).mockResolvedValue({
+        ...detail,
+        lanes: [
+          ...detail.lanes,
+          {
+            sequence: makeSequence({ id: 103, alert_api_id: 9003 }),
+            annotation: makeAnnotation({
+              id: 203,
+              sequence_id: 103,
+              is_unsure: true,
+              has_smoke: false,
+              processing_stage: 'seq_annotation_done',
+            }),
+          },
+        ],
+      });
+      mockAllFramesAccepted();
+
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      // Every workable object is boxed, so only the undecided sibling can be
+      // holding submit back.
+      await waitFor(() =>
+        expect(screen.getByText('2 of 2 objects localized')).toBeInTheDocument()
+      );
+      expect(screen.getByTestId('undecided-lanes-banner')).toBeInTheDocument();
+
+      const submit = screen.getByRole('button', { name: /Submit/ });
+      expect(submit).toBeDisabled();
+      fireEvent.click(submit);
+      expect(apiClient.localizeSubmit).not.toHaveBeenCalled();
+    });
+
     it('enables once every object is accepted, submits exactly the workable annotation ids, and navigates back to the queue', async () => {
       mockAllFramesAccepted();
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });

--- a/frontend/tests/utils/localizeUtils.test.ts
+++ b/frontend/tests/utils/localizeUtils.test.ts
@@ -69,6 +69,60 @@ describe('determineClassifySubmitStage', () => {
         hasMissedSmoke: false,
       })
     ).toBe('seq_annotation_done'));
+
+  it('deferred unsure settles at annotated', () =>
+    expect(
+      determineClassifySubmitStage({
+        currentStage: 'seq_annotation_done',
+        isUnsure: true,
+        hasSmoke: false,
+        hasMissedSmoke: false,
+        deferred: true,
+      })
+    ).toBe('annotated'));
+
+  it('undeferred unsure still parks at seq_annotation_done', () =>
+    expect(
+      determineClassifySubmitStage({
+        currentStage: 'seq_annotation_done',
+        isUnsure: true,
+        hasSmoke: false,
+        hasMissedSmoke: false,
+        deferred: false,
+      })
+    ).toBe('seq_annotation_done'));
+
+  it('a deferred lane re-decided as smoke returns to seq_annotation_done', () =>
+    expect(
+      determineClassifySubmitStage({
+        currentStage: 'annotated',
+        isUnsure: false,
+        hasSmoke: true,
+        hasMissedSmoke: false,
+        wasDeferredUnsure: true,
+      })
+    ).toBe('seq_annotation_done'));
+
+  it('a deferred lane re-decided as FP stays annotated', () =>
+    expect(
+      determineClassifySubmitStage({
+        currentStage: 'annotated',
+        isUnsure: false,
+        hasSmoke: false,
+        hasMissedSmoke: false,
+        wasDeferredUnsure: true,
+      })
+    ).toBe('annotated'));
+
+  it('a plain annotated lane is still never demoted', () =>
+    expect(
+      determineClassifySubmitStage({
+        currentStage: 'annotated',
+        isUnsure: false,
+        hasSmoke: true,
+        hasMissedSmoke: false,
+      })
+    ).toBe('annotated'));
 });
 
 describe('pickNextLocalizeLane', () => {

--- a/frontend/tests/utils/processingStage.test.ts
+++ b/frontend/tests/utils/processingStage.test.ts
@@ -3,6 +3,7 @@ import {
   ALL_CLASSIFIED_STAGES,
   stageFilterIncludes,
   getStageFilterLabel,
+  getProcessingStageLabel,
 } from '@/utils/processingStage';
 
 describe('ALL_CLASSIFIED_STAGES', () => {
@@ -34,5 +35,19 @@ describe('getStageFilterLabel', () => {
 
   it('falls back to the single-stage label', () => {
     expect(getStageFilterLabel('seq_annotation_done')).toBe('Awaiting localization');
+  });
+});
+
+describe('getProcessingStageLabel', () => {
+  it('labels a parked lane as awaiting localization', () => {
+    expect(getProcessingStageLabel('seq_annotation_done')).toBe('Awaiting localization');
+  });
+
+  it('labels an unsure parked lane as awaiting a decision', () => {
+    expect(getProcessingStageLabel('seq_annotation_done', true)).toBe('Awaiting decision');
+  });
+
+  it('ignores the unsure flag on other stages', () => {
+    expect(getProcessingStageLabel('annotated', true)).toBe('Fully annotated');
   });
 });


### PR DESCRIPTION
Spec: `docs/specs/2026-08-05-unsure-lane-localize-gate-design.md` (committed here).

## What

An alert no longer enters the Localize queue while any of its objects is still marked unsure, and annotators get an explicit **"Undecidable for now"** action that settles such an object without deciding smoke or false positive.

Today an unsure lane parks at `seq_annotation_done`, which counts as a done stage — so it satisfies the queue's completeness gate without ever being work. The alert is listed on the strength of a sibling smoke lane, and the unsure object rides along invisibly: excluded from the frame grid, from the status strip, and from the submit payload. It is left parked when the alert leaves the queue, reachable only through the "Only Unsure" filter on `/classify/done`.

Verified against a local database: alert `55664` has a wildfire lane (`seq_annotation_done`, auto-annotated), an FP lane (`annotated`), and an unsure lane (`seq_annotation_done`). It is in the queue today, and its row advertises `?` for the object you cannot act on.

This revises the earlier decision in `docs/specs/2026-07-28-smoke-localization-entry-point-design.md:92-97` ("without blocking siblings"): an unsure lane is an *undecided* object, and an alert is not ready to be boxed while one of its objects is undecided.

## How

A lane is **unsettled** when `is_unsure = true AND processing_stage = seq_annotation_done`. Everything else at a done stage is settled — including an unsure lane at `annotated`, which is settled-as-undecidable. No schema change, no migration, no new endpoint, no new queue.

- **Queue gate** — `localization_queue`'s `HAVING` gains one condition: no sibling may be unsettled-unsure. The rule lives in `localization_rule.py` next to `needs_localization`. The `#215` candidate pre-filter stays valid because the new condition only removes alerts.
- **Submit guard** — `localize-submit` returns 422 when any sibling is unsettled-unsure. The queue is a listing, not access control, so a deep link or a stale tab could otherwise complete a blocked alert.
- **Settling** — on `/classify/done`, an unsure object gets an "Undecidable for now" toggle that joins the existing pending-changes set and lands on *Save changes* via the done-mode PATCH. It writes `processing_stage: annotated` with `is_unsure: true`.
- **Localize screen** — a banner names the undecided objects and links to Classify (round-tripping back here via the existing Reclassify path); Submit is disabled. Boxes stay drawable, so work in progress is not thrown away.
- **Export** — `/export/detections` defaults to `processing_stage = annotated` with no unsure filter, so settled-undecidable lanes would newly reach training data. The default now excludes them; `is_unsure=true` still returns them.
- **Queue row outcome** — `LocalizeQueueTable` rolls up only lanes matching the localization rule, so `55664` shows `TP` rather than `?` for an object the screen never displays. `rollupOutcomes` itself is unchanged; `ClassifyDoneTable` and `LocalizeDoneQueueTable` still roll up every lane.
- **Stage label** — `getProcessingStageLabel` takes an optional `isUnsure` and renders "Awaiting decision" instead of "Awaiting localization" for an unsettled lane.

The auto-annotate sweep is deliberately **unchanged**: a blocked alert's smoke lane still gets its GPU pass, so the alert appears the moment the sibling is settled rather than waiting for the next sweep.

## Reviewer notes

**Overlaps with #288.** That PR changes the same function, `determineClassifySubmitStage`, and the two will conflict textually and semantically. Worth resolving deliberately rather than by merge order:

- #288 adds `previouslyNeededLocalization` and demotes an `annotated` lane that newly needs localization. That rule **subsumes** this PR's narrower `wasDeferredUnsure` exception — a deferred-unsure lane has `previouslyNeededLocalization = false`, so re-deciding it as smoke already returns `seq_annotation_done` under #288's rule. Whichever lands second should collapse the two into one.
- The branch order differs. This PR tests `isUnsure` first (so un-settling a deferred lane re-blocks its alert); #288 tests `currentStage === 'annotated'` first and states "FP → unsure stays `annotated`". Those disagree for a lane at `annotated` re-marked unsure without deferral.
- #288's backend demotion guard is complementary: an unsure lane never got `auto_create_detection_annotations` (that path skips `is_unsure`), so it carries no stale detection annotations and would pass that guard cleanly.

**Deviation from the spec.** The spec asked for SQL *and* Python forms of the settled rule, mirroring `needs_localization`. Only the SQL form has a caller — the queue and the guard are both queries — so the Python form is omitted rather than shipped dead.

**Behaviour change beyond the spec.** Scoping the rollup to localizable lanes also drops FP lanes from the `+N` count: a 3-object alert shows `FN +1` where it showed `FN +2`. That makes the badge agree with the Objects column, which already counted only localizable lanes. The existing test is updated with a comment rather than worked around.

**Known rough edge.** When an alert disappears from `/localize`, nothing says why — the annotator has to know to check `/classify/done` filtered by unsure. A dashboard counter was considered and deliberately scoped out.

## Effect on current data

Against a local database: `55664` leaves the queue; 13 alerts are unaffected; 4 more carry an unsettled unsure lane but have no smoke lane, so they were never queued. `56217` is a second multi-lane case that would have been blocked once its smoke lane got auto-annotated.

## Testing

Backend (`576 passed`): unsettled sibling blocks an otherwise-ready alert (previously untested in either direction); settled sibling does not block; all-unsure alert still yields nothing; `localize-submit` 422s and rolls back; the sweep still enqueues a blocked alert's smoke lane; export excludes unsure by default and returns them on request.

Frontend (`989 passed`): `determineClassifySubmitStage` across deferral and never-demote cases; the done-mode PATCH body for both settling and not settling; the blocked-alert banner and disabled Submit; the queue rollup ignoring non-localizable lanes; the stage label.

`origin/main` is merged in (#285) and both suites are green on the merged tree.
