### PR TITLE
Tab/Shift+Tab cycle the localize cockpit's objects

### DIFF
--- a/docs/specs/2026-08-05-localize-tab-object-cycling-design.md
+++ b/docs/specs/2026-08-05-localize-tab-object-cycling-design.md
@@ -1,0 +1,63 @@
+# Localize cockpit: Tab / Shift+Tab object cycling
+
+**Date:** 2026-08-05
+**Status:** Approved
+
+## Motivation
+
+The classify cockpit's rail is fully keyboard-drivable: Tab / Shift+Tab cycle
+its stops and a row activates the moment it is reached. The localize cockpit
+(`/localize/:sequenceId`, `/localize/done/:sequenceId`) has no equivalent —
+native Tab moves a focus ring across the rows, but nothing activates until
+Enter/Space, and the ring escapes into the header and media chrome. Stepping
+through objects — the page's core review motion — takes a click per object.
+
+This design gives Tab / Shift+Tab classify-style one-step cycling: each press
+lands on the next object and it is live immediately.
+
+## Behavior
+
+A capture-phase `keydown` listener on `LocalizeAlertPage` (the same pattern as
+`ClassifyAlertPage`'s focus cycle) intercepts Tab / Shift+Tab and always calls
+`preventDefault` — the key strictly cycles objects and never escapes to the
+header or media chrome.
+
+- **Cycle membership:** exactly the rows the rail displays, in rail order —
+  `orderedObjectRows` (smoke objects first, false-positive rows appended when
+  "show false positives" is on). Submit is not a stop.
+- **Step:** Tab advances to the next row, Shift+Tab to the previous, wrapping
+  at both ends.
+- **Activation:** each step calls `activateFocus(laneId)` — the same path as
+  a rail-row click. The URL replace-navigates to the object's selection route,
+  the row shows selected, and the media column crops around the new object.
+- **No active object** (FP-only alert sitting on the bare URL): Tab activates
+  the first visible row.
+- **Single object:** stepping re-activates the same lane — a harmless
+  self-navigation.
+
+## Suspension
+
+The handler is inert whenever an overlay with its own focusables is up, so
+those stay keyboard-reachable (mirrors classify's modal guards):
+
+- the per-frame editor (`detectionIdNum != null`),
+- the "+ Add object" smoke-type picker (`addObjectPickerOpen`),
+- the missed-smoke submit dialog (`missedSmokeConfirm`).
+
+## Accepted tradeoff
+
+Intercepting Tab makes the active row's inline Accept-boxes / Reclassify
+buttons and the "+ Add object" button unreachable by native Tab; they become
+mouse-only. Deferred to a future dedicated-shortcuts pass rather than
+complicating the cycle with per-row inner stops.
+
+## Testing
+
+Page-level tests alongside the existing `LocalizeAlertPage.test.tsx` patterns:
+
+- Tab advances to the next object: URL changes to its selection route and
+  focus mode follows.
+- Shift+Tab steps back.
+- Both directions wrap at the ends.
+- FP rows join the cycle only while "show false positives" is on.
+- Inert while the per-frame editor is open.

--- a/docs/specs/2026-08-05-localize-tab-object-cycling-design.md
+++ b/docs/specs/2026-08-05-localize-tab-object-cycling-design.md
@@ -30,6 +30,10 @@ header or media chrome.
 - **Activation:** each step calls `activateFocus(laneId)` — the same path as
   a rail-row click. The URL replace-navigates to the object's selection route,
   the row shows selected, and the media column crops around the new object.
+- **DOM focus follows the cycle** (as in classify): the landed row receives
+  real focus, giving it the focus ring and screen-reader announcement — and
+  keeping Enter/Space acting on the row the cycle is on, never on an element
+  a previous click left focused.
 - **No active object** (FP-only alert sitting on the bare URL): Tab activates
   the first visible row.
 - **Single object:** stepping re-activates the same lane — a harmless
@@ -37,19 +41,23 @@ header or media chrome.
 
 ## Suspension
 
-The handler is inert whenever an overlay with its own focusables is up, so
+The handler is inert whenever a surface with its own focusables is up, so
 those stay keyboard-reachable (mirrors classify's modal guards):
 
 - the per-frame editor (`detectionIdNum != null`),
-- the "+ Add object" smoke-type picker (`addObjectPickerOpen`),
+- the "+ Add object" smoke-type picker (`addObjectPickerOpen`, inline in the
+  rail),
 - the missed-smoke submit dialog (`missedSmokeConfirm`).
 
 ## Accepted tradeoff
 
-Intercepting Tab makes the active row's inline Accept-boxes / Reclassify
-buttons and the "+ Add object" button unreachable by native Tab; they become
-mouse-only. Deferred to a future dedicated-shortcuts pass rather than
-complicating the cycle with per-row inner stops.
+Intercepting Tab makes everything outside the cycle unreachable by native
+Tab — the active row's inline Accept-boxes / Reclassify buttons, the
+"+ Add object" button, the missed-smoke Yes/No radios, and Submit; they
+become mouse-only. (Classify's cycle includes its missed-smoke row and
+Submit as stops; localize deliberately does not — Submit was excluded by
+design choice, and the rest is deferred to a future dedicated-shortcuts
+pass rather than complicating the cycle with non-object stops.)
 
 ## Testing
 

--- a/frontend/src/components/localize/LocalizeObjectRow.tsx
+++ b/frontend/src/components/localize/LocalizeObjectRow.tsx
@@ -65,140 +65,148 @@ export interface LocalizeObjectRowProps {
   onReclassify?: () => void;
 }
 
-export const LocalizeObjectRow: React.FC<LocalizeObjectRowProps> = ({
-  label,
-  color,
-  confirmedCount,
-  presentCount,
-  workable,
-  smokeType,
-  isFalsePositive = false,
-  falsePositiveTypes,
-  dimmed = false,
-  isActive,
-  onActivate,
-  onAcceptBoxes,
-  isAccepting = false,
-  onReclassify,
-}) => {
-  const pendingCount = presentCount - confirmedCount;
+// forwardRef so the page's Tab cycle can move real DOM focus onto the row it
+// lands on — see the cycle effect in `LocalizeAlertPage`.
+export const LocalizeObjectRow = React.forwardRef<HTMLDivElement, LocalizeObjectRowProps>(
+  function LocalizeObjectRow(
+    {
+      label,
+      color,
+      confirmedCount,
+      presentCount,
+      workable,
+      smokeType,
+      isFalsePositive = false,
+      falsePositiveTypes,
+      dimmed = false,
+      isActive,
+      onActivate,
+      onAcceptBoxes,
+      isAccepting = false,
+      onReclassify,
+    },
+    ref
+  ) {
+    const pendingCount = presentCount - confirmedCount;
 
-  // The right-hand swap. A row the page gave no actions (a false positive)
-  // has nothing to swap in, so selecting it must not blank the one thing it
-  // says about itself.
-  const showActions = isActive && !!(onAcceptBoxes || onReclassify);
+    // The right-hand swap. A row the page gave no actions (a false positive)
+    // has nothing to swap in, so selecting it must not blank the one thing it
+    // says about itself.
+    const showActions = isActive && !!(onAcceptBoxes || onReclassify);
 
-  const status = isFalsePositive
-    ? { label: 'False positive', tone: 'bg-ash text-haze' }
-    : !workable
-      ? // Past localization: say what it is rather than "Context", which
-        // described its role beside live work rather than its own state.
-        { label: 'Localized', tone: 'bg-pine-soft text-pine' }
-      : pendingCount === 0
-        ? { label: 'Done', tone: 'bg-pine-soft text-pine' }
-        : { label: `${pendingCount} left`, tone: 'bg-ember-soft text-ember' };
+    const status = isFalsePositive
+      ? { label: 'False positive', tone: 'bg-ash text-haze' }
+      : !workable
+        ? // Past localization: say what it is rather than "Context", which
+          // described its role beside live work rather than its own state.
+          { label: 'Localized', tone: 'bg-pine-soft text-pine' }
+        : pendingCount === 0
+          ? { label: 'Done', tone: 'bg-pine-soft text-pine' }
+          : { label: `${pendingCount} left`, tone: 'bg-ember-soft text-ember' };
 
-  // What this object is, under its name: the smoke type classify chose, or
-  // the false-positive types it was rejected as.
-  const subtitle = isFalsePositive
-    ? (falsePositiveTypes ?? []).map(t => t.replace(/_/g, ' ')).join(', ') || null
-    : (smokeType ?? null);
+    // What this object is, under its name: the smoke type classify chose, or
+    // the false-positive types it was rejected as.
+    const subtitle = isFalsePositive
+      ? (falsePositiveTypes ?? []).map(t => t.replace(/_/g, ' ')).join(', ') || null
+      : (smokeType ?? null);
 
-  // Selection is checked BEFORE dimming. A non-workable row (a false
-  // positive, or an already-localized context lane) is still clickable and
-  // still drives the media column, so it needs the same "this is what
-  // you're looking at" feedback — and leaving it dimmed while it is the
-  // active object contradicts the selection. Its accent is neutral rather
-  // than pine, which on this page means workable / positive / in progress —
-  // a claim a settled object shouldn't make.
-  const frame = isActive
-    ? `border border-line border-l-[3px] bg-paper ${workable ? 'border-l-pine' : 'border-l-char'}`
-    : dimmed
-      ? 'border border-line bg-paper opacity-60'
-      : 'border border-line bg-paper hover:bg-ash';
+    // Selection is checked BEFORE dimming. A non-workable row (a false
+    // positive, or an already-localized context lane) is still clickable and
+    // still drives the media column, so it needs the same "this is what
+    // you're looking at" feedback — and leaving it dimmed while it is the
+    // active object contradicts the selection. Its accent is neutral rather
+    // than pine, which on this page means workable / positive / in progress —
+    // a claim a settled object shouldn't make.
+    const frame = isActive
+      ? `border border-line border-l-[3px] bg-paper ${workable ? 'border-l-pine' : 'border-l-char'}`
+      : dimmed
+        ? 'border border-line bg-paper opacity-60'
+        : 'border border-line bg-paper hover:bg-ash';
 
-  return (
-    <div
-      data-testid={`localize-object-row-${label.replace(/\s+/g, '-').toLowerCase()}`}
-      data-active={isActive ? 'true' : undefined}
-      data-dimmed={dimmed ? 'true' : undefined}
-      // role="group" rather than a button: workable rows contain their own
-      // action buttons, and nesting interactive controls is invalid HTML.
-      // It still has to be reachable and operable from the keyboard, because
-      // selecting the row is now the ONLY way to reach those buttons — a
-      // mouse-only affordance in front of them would put the actions out of
-      // keyboard reach entirely. Enter/Space rather than activate-on-focus:
-      // tabbing across the rail shouldn't drag the media column (and
-      // crop-mode) along with it.
-      role="group"
-      aria-label={label}
-      tabIndex={0}
-      onKeyDown={e => {
-        if (e.target !== e.currentTarget) return;
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onActivate();
-        }
-      }}
-      className={`cursor-pointer rounded-lg px-3.5 py-2.5 transition-colors focus:outline-none focus:ring-2 focus:ring-pine ${frame}`}
-      onClick={onActivate}
-    >
-      <div className="flex items-center justify-between gap-2">
-        <span className="flex min-w-0 items-center gap-2">
-          <span
-            className="inline-block h-2.5 w-2.5 shrink-0 rounded-full ring-1 ring-char/10"
-            style={{ backgroundColor: color }}
-            aria-hidden="true"
-          />
-          {/* Name and what-it-is on one line: the row is a one-line summary,
+    return (
+      <div
+        ref={ref}
+        data-testid={`localize-object-row-${label.replace(/\s+/g, '-').toLowerCase()}`}
+        data-active={isActive ? 'true' : undefined}
+        data-dimmed={dimmed ? 'true' : undefined}
+        // role="group" rather than a button: workable rows contain their own
+        // action buttons, and nesting interactive controls is invalid HTML.
+        // Keyboard reach comes from the page's Tab cycle, which activates each
+        // row it lands on and moves real DOM focus here (via the forwarded
+        // ref) — focus, selection and the media column stay one thing. The
+        // Enter/Space handling remains for anything else that focuses the row
+        // (a click, assistive tech), where Enter must act on THIS row rather
+        // than whichever one the cycle last left.
+        role="group"
+        aria-label={label}
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.target !== e.currentTarget) return;
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onActivate();
+          }
+        }}
+        className={`cursor-pointer rounded-lg px-3.5 py-2.5 transition-colors focus:outline-none focus:ring-2 focus:ring-pine ${frame}`}
+        onClick={onActivate}
+      >
+        <div className="flex items-center justify-between gap-2">
+          <span className="flex min-w-0 items-center gap-2">
+            <span
+              className="inline-block h-2.5 w-2.5 shrink-0 rounded-full ring-1 ring-char/10"
+              style={{ backgroundColor: color }}
+              aria-hidden="true"
+            />
+            {/* Name and what-it-is on one line: the row is a one-line summary,
               and stacking them made it two lines tall for a word. Both
               truncate rather than push: the selected row's buttons are wider
               than the metadata they replace, and at the narrow end of the
               rail something has to give — better a clipped word than a row
               that overflows into a horizontal scrollbar. */}
-          <span className="flex min-w-0 items-baseline gap-1.5">
-            <span className="truncate font-body text-sm font-semibold text-char">{label}</span>
-            {subtitle && (
-              <>
-                {/* Same separator the alert header uses between organisation
+            <span className="flex min-w-0 items-baseline gap-1.5">
+              <span className="truncate font-body text-sm font-semibold text-char">{label}</span>
+              {subtitle && (
+                <>
+                  {/* Same separator the alert header uses between organisation
                     and camera. Hidden from screen readers, which get the two
                     spans as separate phrases already. */}
-                <span className="shrink-0 font-body text-detail text-haze" aria-hidden="true">
-                  ·
-                </span>
-                <span className="truncate font-body text-detail capitalize text-haze">
-                  {subtitle}
+                  <span className="shrink-0 font-body text-detail text-haze" aria-hidden="true">
+                    ·
+                  </span>
+                  <span className="truncate font-body text-detail capitalize text-haze">
+                    {subtitle}
+                  </span>
+                </>
+              )}
+            </span>
+          </span>
+          <span className="flex shrink-0 items-center gap-1.5">
+            {showActions ? (
+              <LocalizeObjectActions
+                label={label}
+                onAcceptBoxes={onAcceptBoxes}
+                isAccepting={isAccepting}
+                onReclassify={onReclassify}
+              />
+            ) : (
+              <>
+                {/* A false positive has no localization work, so a progress
+                  fraction over its frames would be meaningless. */}
+                {!isFalsePositive && (
+                  <span className="font-data text-detail text-haze">
+                    {confirmedCount}/{presentCount}
+                  </span>
+                )}
+                <span
+                  className={`whitespace-nowrap rounded-full px-2 py-0.5 font-body text-xs font-semibold ${status.tone}`}
+                >
+                  {status.label}
                 </span>
               </>
             )}
           </span>
-        </span>
-        <span className="flex shrink-0 items-center gap-1.5">
-          {showActions ? (
-            <LocalizeObjectActions
-              label={label}
-              onAcceptBoxes={onAcceptBoxes}
-              isAccepting={isAccepting}
-              onReclassify={onReclassify}
-            />
-          ) : (
-            <>
-              {/* A false positive has no localization work, so a progress
-                  fraction over its frames would be meaningless. */}
-              {!isFalsePositive && (
-                <span className="font-data text-detail text-haze">
-                  {confirmedCount}/{presentCount}
-                </span>
-              )}
-              <span
-                className={`whitespace-nowrap rounded-full px-2 py-0.5 font-body text-xs font-semibold ${status.tone}`}
-              >
-                {status.label}
-              </span>
-            </>
-          )}
-        </span>
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+);

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1170,6 +1170,32 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [detectionIdNum]);
 
+  // Tab / Shift+Tab step the objects exactly as the rail displays them —
+  // smoke first, false positives only while shown — wrapping at the ends
+  // and activating each step immediately (classify-style one-step cycling;
+  // spec: 2026-08-05 localize tab object cycling). Capture-phase and always
+  // preventDefault: the key strictly cycles objects and never escapes to
+  // the header or media chrome. Deliberately NO dependency array, matching
+  // the arrival effect above: everything the handler closes over
+  // (`orderedObjectRows`, `activateFocus`) is rebuilt every render anyway,
+  // and re-subscribing is a cheap way to never read stale rows.
+  useEffect(() => {
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      if (orderedObjectRows.length === 0) return;
+      e.preventDefault();
+      const current = orderedObjectRows.findIndex(o => o.laneSequenceId === activeLaneId);
+      const delta = e.shiftKey ? -1 : 1;
+      const next =
+        current === -1
+          ? 0
+          : (current + delta + orderedObjectRows.length) % orderedObjectRows.length;
+      activateFocus(orderedObjectRows[next].laneSequenceId);
+    };
+    document.addEventListener('keydown', handleTab, true);
+    return () => document.removeEventListener('keydown', handleTab, true);
+  });
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-96">

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -223,6 +223,9 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   );
 
   const frameRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  // Rail rows by lane, so the Tab cycle can move real DOM focus onto the row
+  // it lands on — see the cycle effect below.
+  const rowRefs = useRef<Record<number, HTMLDivElement | null>>({});
 
   const [cardSize, setCardSize] = usePersistedTabState<CardSize>('detectionAnnotateCardSize', 'md');
   const [cropMode, setCropMode] = useState(false);
@@ -831,6 +834,9 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     return (
       <LocalizeObjectRow
         key={object.laneSequenceId}
+        ref={el => {
+          rowRefs.current[object.laneSequenceId] = el;
+        }}
         label={object.label}
         color={object.color}
         confirmedCount={progress.confirmedCount}
@@ -1182,8 +1188,8 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   useEffect(() => {
     const handleTab = (e: KeyboardEvent) => {
       if (e.key !== 'Tab') return;
-      // Suspended whenever an overlay with its own focusables is up — the
-      // per-frame editor, the add-object smoke-type picker, the
+      // Suspended whenever a surface with its own focusables is up — the
+      // per-frame editor, the (inline) add-object smoke-type picker, the
       // missed-smoke submit dialog — so their controls stay
       // keyboard-reachable (mirrors classify's modal guards).
       if (detectionIdNum != null || addObjectPickerOpen || missedSmokeConfirm) return;
@@ -1195,7 +1201,14 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
         current === -1
           ? 0
           : (current + delta + orderedObjectRows.length) % orderedObjectRows.length;
-      activateFocus(orderedObjectRows[next].laneSequenceId);
+      const landed = orderedObjectRows[next].laneSequenceId;
+      activateFocus(landed);
+      // DOM focus follows the cycle, as in classify. Without this the
+      // element focused by an earlier click keeps focus, and Enter/Space
+      // fires that stale row's own activation — yanking the selection back
+      // to wherever the mouse last was. Following also gives the landed row
+      // its focus ring and screen-reader announcement.
+      rowRefs.current[landed]?.focus();
     };
     document.addEventListener('keydown', handleTab, true);
     return () => document.removeEventListener('keydown', handleTab, true);

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1182,6 +1182,11 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   useEffect(() => {
     const handleTab = (e: KeyboardEvent) => {
       if (e.key !== 'Tab') return;
+      // Suspended whenever an overlay with its own focusables is up — the
+      // per-frame editor, the add-object smoke-type picker, the
+      // missed-smoke submit dialog — so their controls stay
+      // keyboard-reachable (mirrors classify's modal guards).
+      if (detectionIdNum != null || addObjectPickerOpen || missedSmokeConfirm) return;
       if (orderedObjectRows.length === 0) return;
       e.preventDefault();
       const current = orderedObjectRows.findIndex(o => o.laneSequenceId === activeLaneId);

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2613,6 +2613,39 @@ describe('LocalizeAlertPage', () => {
     });
   });
 
+  describe('Tab object cycling', () => {
+    it('Tab activates the next object: URL moves to its selection route and focus mode follows', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      // Arrival auto-focused Object 1 (lane 101).
+      expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101');
+
+      fireEvent.keyDown(document, { key: 'Tab' });
+
+      expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/102');
+      // Focus mode came along: the rail row shows the selected treatment.
+      await waitFor(() =>
+        expect(screen.getByTestId('localize-object-row-object-2')).toHaveAttribute(
+          'data-active',
+          'true'
+        )
+      );
+    });
+
+    it('Tab wraps past the last object; Shift+Tab steps back and wraps past the first', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      // 101 -> 102 -> wrap -> 101.
+      fireEvent.keyDown(document, { key: 'Tab' });
+      expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/102');
+      fireEvent.keyDown(document, { key: 'Tab' });
+      expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101');
+
+      // Backward from the first wraps to the last.
+      fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+      expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/102');
+    });
+  });
+
   describe('reclassify', () => {
     it("navigates to the row's OWN lane in classify done mode, carrying a return to this page", async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2058,6 +2058,12 @@ describe('LocalizeAlertPage', () => {
     it('Tab includes false-positive rows only while the toggle shows them', async () => {
       alertWithFalsePositive();
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      // Arrival barrier: only after the auto-select lands does a Tab prove
+      // self-cycling — fired earlier it would select lane 101 itself and
+      // pass vacuously.
+      await waitFor(() =>
+        expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101')
+      );
 
       // Toggle off: the lone smoke object cycles onto itself.
       fireEvent.keyDown(document, { key: 'Tab' });
@@ -2638,8 +2644,12 @@ describe('LocalizeAlertPage', () => {
   describe('Tab object cycling', () => {
     it('Tab activates the next object: URL moves to its selection route and focus mode follows', async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-      // Arrival auto-focused Object 1 (lane 101).
-      expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101');
+      // Wait out the arrival auto-focus of Object 1 (lane 101): a Tab fired
+      // before that effect's navigation commits would legitimately select
+      // lane 101 itself (the no-active-object branch), not step off it.
+      await waitFor(() =>
+        expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101')
+      );
 
       fireEvent.keyDown(document, { key: 'Tab' });
 
@@ -2655,6 +2665,12 @@ describe('LocalizeAlertPage', () => {
 
     it('Tab wraps past the last object; Shift+Tab steps back and wraps past the first', async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      // Arrival barrier — see the first test; without it the first Tab can
+      // race the auto-select and land on lane 101 as the no-active-object
+      // branch (CI caught exactly that).
+      await waitFor(() =>
+        expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101')
+      );
 
       // 101 -> 102 -> wrap -> 101.
       fireEvent.keyDown(document, { key: 'Tab' });
@@ -2664,6 +2680,28 @@ describe('LocalizeAlertPage', () => {
 
       // Backward from the first wraps to the last.
       fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+      expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/102');
+    });
+
+    it('moves DOM focus with the cycle, so Enter acts on the landed row — not one left behind', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      await waitFor(() =>
+        expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101')
+      );
+
+      // As after a real click: the browser focuses the clicked row, and the
+      // rows keep their own Enter/Space activation.
+      const row1 = screen.getByTestId('localize-object-row-object-1');
+      row1.focus();
+
+      fireEvent.keyDown(document, { key: 'Tab' });
+
+      expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/102');
+      const row2 = screen.getByTestId('localize-object-row-object-2');
+      expect(document.activeElement).toBe(row2);
+      // Enter lands on the cycled-to row: without focus following the cycle,
+      // it would fire row 1's own handler and yank the selection back.
+      fireEvent.keyDown(row2, { key: 'Enter' });
       expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/102');
     });
 

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2054,6 +2054,28 @@ describe('LocalizeAlertPage', () => {
         within(screen.getByTestId('localize-object-row-object-1')).getByText('wildfire')
       ).toBeInTheDocument();
     });
+
+    it('Tab includes false-positive rows only while the toggle shows them', async () => {
+      alertWithFalsePositive();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      // Toggle off: the lone smoke object cycles onto itself.
+      fireEvent.keyDown(document, { key: 'Tab' });
+      expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101');
+
+      fireEvent.click(screen.getByRole('button', { name: /False positives/ }));
+      await waitFor(() => {
+        expect(screen.getByTestId('localize-object-row-object-2')).toBeInTheDocument();
+      });
+
+      // Toggle on: the FP row joins the cycle and Tab lands on it.
+      fireEvent.keyDown(document, { key: 'Tab' });
+      expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/102');
+      expect(screen.getByTestId('localize-object-row-object-2')).toHaveAttribute(
+        'data-active',
+        'true'
+      );
+    });
   });
 
   describe('active object CTA, over the media column', () => {
@@ -2643,6 +2665,22 @@ describe('LocalizeAlertPage', () => {
       // Backward from the first wraps to the last.
       fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
       expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/102');
+    });
+
+    it('is inert while the per-frame editor is open, so the editor keeps its own keys', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      // Open the editor on the arrival object's T1 frame (lane 101,
+      // detection 1001).
+      fireEvent.click(screen.getByTestId(`alert-frame-cell-${T1}`));
+      await screen.findByTestId('image-modal');
+      const editorUrl = screen.getByTestId('location').textContent;
+
+      fireEvent.keyDown(document, { key: 'Tab' });
+
+      // No cycling happened: the URL still names the open editor.
+      expect(screen.getByTestId('location')).toHaveTextContent(editorUrl!);
+      expect(screen.getByTestId('image-modal')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

Classify-style one-step keyboard cycling for `/localize/:sequenceId` (and `/localize/done/:sequenceId`): **Tab / Shift+Tab** step through the rail's object rows, wrapping at the ends, and each step activates the object immediately — the URL replace-navigates to its selection route and focus mode (crop-on, small cards) follows, exactly as if its rail row had been clicked.

Spec: `docs/specs/2026-08-05-localize-tab-object-cycling-design.md` (included in this PR).

## Behavior

- Cycle membership is exactly what the rail displays: smoke objects first, false-positive rows joining only while "show false positives" is on. Submit is not a stop.
- Capture-phase listener, always `preventDefault` — Tab strictly cycles objects and never escapes to the header/media chrome (same pattern as `ClassifyAlertPage`'s focus cycle).
- Suspended while an overlay with its own focusables is up (per-frame editor, add-object picker, missed-smoke submit dialog), so those stay keyboard-reachable.
- No active object (FP-only alert on the bare URL): Tab activates the first visible row.

## Accepted tradeoff

Intercepting Tab makes the active row's inline Accept-boxes / Reclassify buttons and "+ Add object" unreachable by native Tab (mouse-only for now); deferred to a future dedicated-shortcuts pass.

## Testing

4 new page-level tests (advance + focus mode follows, wrap both directions, FP membership tied to the toggle, inert while the editor is open). Full frontend suite: 1119 passing; `npm run quality` clean.