### PR TITLE
Draw a box on a frame outside an object's detected range (#287)

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -31,6 +31,7 @@ from sqlalchemy import (
     ARRAY,
     String,
 )
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import aliased
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -56,6 +57,7 @@ from app.models import (
     AnnotationType,
 )
 from app.schemas.annotation_validation import SequenceAnnotationData, SequenceBBox
+from app.schemas.detection import DetectionRead
 from app.schemas.sequence import (
     AddObjectRequest,
     AlertDetail,
@@ -66,6 +68,7 @@ from app.schemas.sequence import (
     LocalizationQueueItem,
     LocalizationQueueLane,
     LocalizeDoneQueueItem,
+    MaterializeFrameRequest,
     SequenceCreate,
     SequenceRead,
 )
@@ -834,6 +837,101 @@ async def add_object(
         sequence=SequenceRead(**seq_dict),
         annotation=SequenceAnnotationRead(**annotation_dict),
     )
+
+
+def _detection_read(det: Detection) -> DetectionRead:
+    return DetectionRead(
+        **{c.name: getattr(det, c.name) for c in det.__table__.columns}
+    )
+
+
+@router.post(
+    "/{sequence_id}/frames",
+    status_code=status.HTTP_201_CREATED,
+    summary="Materialize a gap frame into a lane so a human can box it",
+)
+async def materialize_frame(
+    response: Response,
+    sequence_id: int = Path(..., gt=0),
+    payload: MaterializeFrameRequest = Body(...),
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> DetectionRead:
+    """Issue #287: a lane holds Detection rows only for the frames its object
+    was detected on, so earlier frames — where the plume was fainter — cannot
+    be annotated. This inserts the one-frame equivalent of add_object's clone:
+    the sibling's photo (shared bucket_key, no S3 traffic) with an empty
+    engine track, because the AI did not detect this object here. Idempotent:
+    posting a frame the lane already has returns it with 200."""
+    lane = await session.get(Sequence, sequence_id)
+    if lane is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Sequence not found"
+        )
+
+    existing = (
+        (
+            await session.execute(
+                select(Detection).where(
+                    Detection.sequence_id == sequence_id,
+                    Detection.recorded_at == payload.recorded_at,
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if existing is not None:
+        response.status_code = status.HTTP_200_OK
+        return _detection_read(existing)
+
+    if lane.platform_alert_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Sequence has no alert siblings",
+        )
+
+    sibling = (
+        (
+            await session.execute(
+                select(Detection)
+                .join(Sequence, Detection.sequence_id == Sequence.id)
+                .where(
+                    Sequence.source_api == lane.source_api,
+                    Sequence.platform_alert_id == lane.platform_alert_id,
+                    Sequence.id != sequence_id,
+                    Detection.recorded_at == payload.recorded_at,
+                )
+                .order_by(asc(Detection.alert_api_id))
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if sibling is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="No sibling lane has a detection at this recorded_at",
+        )
+
+    detection = Detection(
+        sequence_id=sequence_id,
+        recorded_at=payload.recorded_at,
+        alert_api_id=sibling.alert_api_id,
+        bucket_key=sibling.bucket_key,
+        algo_predictions={"predictions": []},
+    )
+    session.add(detection)
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="The sibling frame's alert_api_id is already present in this lane",
+        )
+    await session.refresh(detection)
+    return _detection_read(detection)
 
 
 # NOTE: declared before GET /{sequence_id} — the int path converter would

--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -934,6 +934,53 @@ async def materialize_frame(
     return _detection_read(detection)
 
 
+def _frame_has_model_evidence(det: Detection) -> bool:
+    return bool((det.algo_predictions or {}).get("predictions")) or bool(
+        (det.auto_predictions or {}).get("predictions")
+    )
+
+
+@router.delete(
+    "/{sequence_id}/frames/{detection_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Remove a model-evidence-free frame from a lane",
+)
+async def unmaterialize_frame(
+    sequence_id: int = Path(..., gt=0),
+    detection_id: int = Path(..., gt=0),
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    """The inverse of materialize_frame (issue #287). Only a frame whose
+    existence a human's box alone justifies can be removed — any model
+    evidence makes it part of the import record — and never the lane's last
+    frame. Deletes the row only: bucket_key is shared with the sibling the
+    frame was materialized from, so S3 is untouched (unlike
+    DELETE /detections/{id}). The DetectionAnnotation goes via FK cascade."""
+    detection = await session.get(Detection, detection_id)
+    if detection is None or detection.sequence_id != sequence_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Detection not found"
+        )
+    if _frame_has_model_evidence(detection):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Frame has model evidence and cannot be removed",
+        )
+    count = (
+        await session.execute(
+            select(func.count(Detection.id)).where(Detection.sequence_id == sequence_id)
+        )
+    ).scalar_one()
+    if count <= 1:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot remove the lane's last frame",
+        )
+    await session.delete(detection)
+    await session.commit()
+
+
 # NOTE: declared before GET /{sequence_id} — the int path converter would
 # otherwise turn /localization-queue into a 422.
 @router.get("/localization-queue")

--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -885,12 +885,6 @@ async def materialize_frame(
         response.status_code = status.HTTP_200_OK
         return _detection_read(existing)
 
-    if lane.platform_alert_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Sequence has no alert siblings",
-        )
-
     sibling = (
         (
             await session.execute(
@@ -926,6 +920,25 @@ async def materialize_frame(
         await session.commit()
     except IntegrityError:
         await session.rollback()
+        # A concurrent POST for the same frame won the insert: idempotency
+        # applies to it exactly as to a sequential re-POST, so re-select
+        # rather than surfacing a misleading conflict. Anything else holding
+        # the alert_api_id is a genuine collision.
+        raced = (
+            (
+                await session.execute(
+                    select(Detection).where(
+                        Detection.sequence_id == sequence_id,
+                        Detection.recorded_at == payload.recorded_at,
+                    )
+                )
+            )
+            .scalars()
+            .first()
+        )
+        if raced is not None:
+            response.status_code = status.HTTP_200_OK
+            return _detection_read(raced)
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="The sibling frame's alert_api_id is already present in this lane",
@@ -967,6 +980,8 @@ async def unmaterialize_frame(
             status_code=status.HTTP_409_CONFLICT,
             detail="Frame has model evidence and cannot be removed",
         )
+    # Advisory under concurrency: two simultaneous DELETEs in a two-frame
+    # lane can both pass this count. Accepted for a single-annotator tool.
     count = (
         await session.execute(
             select(func.count(Detection.id)).where(Detection.sequence_id == sequence_id)

--- a/annotation_api/src/app/schemas/sequence.py
+++ b/annotation_api/src/app/schemas/sequence.py
@@ -23,6 +23,7 @@ __all__ = [
     "ClassifyQueueItem",
     "LocalizationQueueItem",
     "LocalizationQueueLane",
+    "MaterializeFrameRequest",
     "SequenceCreate",
     "SequenceRead",
     "SequenceUpdateBboxAuto",
@@ -239,3 +240,10 @@ class AddObjectRequest(BaseModel):
     source_api: SourceApi
     platform_alert_id: int
     smoke_type: SmokeType
+
+
+class MaterializeFrameRequest(BaseModel):
+    """Issue #287: materialize one gap frame into a lane, so a human can box
+    the object on a frame the detector missed it on."""
+
+    recorded_at: datetime

--- a/annotation_api/src/tests/endpoints/test_lane_frames.py
+++ b/annotation_api/src/tests/endpoints/test_lane_frames.py
@@ -1,0 +1,145 @@
+"""Lane-frame endpoints (issue #287): materialize a gap frame into a lane so
+a human can box it, and un-materialize it when the box is cleared. See
+docs/specs/2026-08-05-gap-frame-materialization-design.md."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.models import (
+    Detection,
+    Sequence,
+    SourceApi,
+)
+
+NOW = datetime(2026, 8, 5, 12, 0, tzinfo=UTC)
+T1 = NOW
+T2 = NOW + timedelta(minutes=1)
+T3 = NOW + timedelta(minutes=2)
+T_NOBODY = NOW + timedelta(hours=1)
+
+ALGO_BOX = {
+    "predictions": [
+        {"xyxyn": [0.1, 0.1, 0.2, 0.2], "confidence": 0.9, "class_name": "smoke"}
+    ]
+}
+
+
+async def _lane(session, *, alert_api_id, platform_alert_id, detections=()):
+    """detections: sequence of (bucket_key, recorded_at, algo_predictions)."""
+    seq = Sequence(
+        source_api=SourceApi.PYRONEAR_FRENCH_API,
+        alert_api_id=alert_api_id,
+        platform_alert_id=platform_alert_id,
+        created_at=NOW,
+        recorded_at=NOW,
+        last_seen_at=NOW,
+        camera_name="cam",
+        camera_id=1,
+        lat=1.0,
+        lon=2.0,
+        organisation_name="org",
+        organisation_id=1,
+    )
+    session.add(seq)
+    await session.flush()
+    dets = []
+    for i, (bucket_key, det_recorded_at, algo) in enumerate(detections):
+        det = Detection(
+            alert_api_id=alert_api_id * 1000 + i,
+            sequence_id=seq.id,
+            recorded_at=det_recorded_at,
+            bucket_key=bucket_key,
+            created_at=det_recorded_at,
+            algo_predictions=algo,
+        )
+        session.add(det)
+        dets.append(det)
+    await session.commit()
+    await session.refresh(seq)
+    for det in dets:
+        await session.refresh(det)
+    return seq, dets
+
+
+async def _alert(session):
+    """Alert 900: rich lane A (T1..T3, engine boxes), sparse lane B (T3 only,
+    evidence-free — the shape add_object produces)."""
+    lane_a, dets_a = await _lane(
+        session,
+        alert_api_id=900,
+        platform_alert_id=900,
+        detections=[
+            ("a1.jpg", T1, ALGO_BOX),
+            ("a2.jpg", T2, ALGO_BOX),
+            ("a3.jpg", T3, ALGO_BOX),
+        ],
+    )
+    lane_b, dets_b = await _lane(
+        session,
+        alert_api_id=901,
+        platform_alert_id=900,
+        detections=[("a3.jpg", T3, {"predictions": []})],
+    )
+    return lane_a, dets_a, lane_b, dets_b
+
+
+@pytest.mark.asyncio
+async def test_materialize_copies_the_sibling_frame(
+    authenticated_client: AsyncClient, async_session
+):
+    lane_a, dets_a, lane_b, _ = await _alert(async_session)
+    resp = await authenticated_client.post(
+        f"/sequences/{lane_b.id}/frames", json={"recorded_at": T1.isoformat()}
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["sequence_id"] == lane_b.id
+    assert body["bucket_key"] == "a1.jpg"
+    assert body["alert_api_id"] == dets_a[0].alert_api_id
+    assert body["algo_predictions"] == {"predictions": []}
+    assert body["auto_predictions"] is None
+
+    row = (
+        await async_session.execute(select(Detection).where(Detection.id == body["id"]))
+    ).scalar_one()
+    assert row.sequence_id == lane_b.id
+
+
+@pytest.mark.asyncio
+async def test_materialize_is_idempotent(
+    authenticated_client: AsyncClient, async_session
+):
+    _, _, lane_b, _ = await _alert(async_session)
+    first = await authenticated_client.post(
+        f"/sequences/{lane_b.id}/frames", json={"recorded_at": T1.isoformat()}
+    )
+    again = await authenticated_client.post(
+        f"/sequences/{lane_b.id}/frames", json={"recorded_at": T1.isoformat()}
+    )
+    assert first.status_code == 201
+    assert again.status_code == 200
+    assert again.json()["id"] == first.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_materialize_unknown_sequence_is_404(
+    authenticated_client: AsyncClient, async_session
+):
+    resp = await authenticated_client.post(
+        "/sequences/999999/frames", json={"recorded_at": T1.isoformat()}
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_materialize_without_sibling_frame_is_422(
+    authenticated_client: AsyncClient, async_session
+):
+    _, _, lane_b, _ = await _alert(async_session)
+    resp = await authenticated_client.post(
+        f"/sequences/{lane_b.id}/frames", json={"recorded_at": T_NOBODY.isoformat()}
+    )
+    assert resp.status_code == 422

--- a/annotation_api/src/tests/endpoints/test_lane_frames.py
+++ b/annotation_api/src/tests/endpoints/test_lane_frames.py
@@ -10,6 +10,8 @@ from sqlalchemy import select
 
 from app.models import (
     Detection,
+    DetectionAnnotation,
+    DetectionAnnotationProcessingStage,
     Sequence,
     SourceApi,
 )
@@ -143,3 +145,96 @@ async def test_materialize_without_sibling_frame_is_422(
         f"/sequences/{lane_b.id}/frames", json={"recorded_at": T_NOBODY.isoformat()}
     )
     assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_unmaterialize_deletes_frame_and_cascades_annotation(
+    authenticated_client: AsyncClient, async_session
+):
+    _, dets_a, lane_b, _ = await _alert(async_session)
+    created = await authenticated_client.post(
+        f"/sequences/{lane_b.id}/frames", json={"recorded_at": T1.isoformat()}
+    )
+    det_id = created.json()["id"]
+    async_session.add(
+        DetectionAnnotation(
+            detection_id=det_id,
+            annotation={"annotation": []},
+            processing_stage=DetectionAnnotationProcessingStage.ANNOTATED,
+        )
+    )
+    await async_session.commit()
+
+    resp = await authenticated_client.delete(f"/sequences/{lane_b.id}/frames/{det_id}")
+    assert resp.status_code == 204
+
+    gone = (
+        await async_session.execute(select(Detection).where(Detection.id == det_id))
+    ).scalar_one_or_none()
+    assert gone is None
+    ann_gone = (
+        await async_session.execute(
+            select(DetectionAnnotation).where(
+                DetectionAnnotation.detection_id == det_id
+            )
+        )
+    ).scalar_one_or_none()
+    assert ann_gone is None
+    # The sibling lane's own frame — same photo, same bucket_key — is intact.
+    sibling_row = (
+        await async_session.execute(
+            select(Detection).where(Detection.id == dets_a[0].id)
+        )
+    ).scalar_one()
+    assert sibling_row.bucket_key == "a1.jpg"
+
+
+@pytest.mark.asyncio
+async def test_unmaterialize_refuses_engine_evidence(
+    authenticated_client: AsyncClient, async_session
+):
+    lane_a, dets_a, _, _ = await _alert(async_session)
+    resp = await authenticated_client.delete(
+        f"/sequences/{lane_a.id}/frames/{dets_a[0].id}"
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_unmaterialize_refuses_auto_evidence(
+    authenticated_client: AsyncClient, async_session
+):
+    _, _, lane_b, dets_b = await _alert(async_session)
+    # Give the (engine-empty) frame an auto-model box: still model evidence.
+    det = dets_b[0]
+    det.auto_predictions = ALGO_BOX
+    async_session.add(det)
+    await async_session.commit()
+    # Second evidence-free frame so the last-frame guard is not what trips.
+    await authenticated_client.post(
+        f"/sequences/{lane_b.id}/frames", json={"recorded_at": T1.isoformat()}
+    )
+    resp = await authenticated_client.delete(f"/sequences/{lane_b.id}/frames/{det.id}")
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_unmaterialize_refuses_the_lanes_last_frame(
+    authenticated_client: AsyncClient, async_session
+):
+    _, _, lane_b, dets_b = await _alert(async_session)
+    resp = await authenticated_client.delete(
+        f"/sequences/{lane_b.id}/frames/{dets_b[0].id}"
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_unmaterialize_wrong_lane_is_404(
+    authenticated_client: AsyncClient, async_session
+):
+    lane_a, _, _, dets_b = await _alert(async_session)
+    resp = await authenticated_client.delete(
+        f"/sequences/{lane_a.id}/frames/{dets_b[0].id}"
+    )
+    assert resp.status_code == 404

--- a/docs/specs/2026-08-05-gap-frame-materialization-design.md
+++ b/docs/specs/2026-08-05-gap-frame-materialization-design.md
@@ -1,7 +1,7 @@
 # Drawing on frames outside an object's detected range
 
 Date: 2026-08-05
-Status: approved, not implemented
+Status: implemented
 Issue: #287
 
 ## Problem
@@ -183,3 +183,14 @@ stack; frontend `npm run quality` clean and full suite green.
 - Backend one-box-per-annotation validator (#286).
 - "Remove added object" and any `is_manual` marker.
 - Auto-advance or bulk operations over gap frames.
+
+## Amendments from implementation
+
+- **After un-materialize the editor lands on the nearest earlier in-object
+  frame** (else the first later one), rather than re-peeking the removed
+  frame's timestamp. The peek holds a filmstrip-entry snapshot; re-peeking
+  mid-refetch would show a stale identity, and stepping back onto the
+  now-gap frame is one keypress.
+- **`ApiError` gained an optional `status`** (set by the axios interceptor)
+  so the page recognizes the DELETE's 409 without string-matching the detail
+  message.

--- a/docs/specs/2026-08-05-gap-frame-materialization-design.md
+++ b/docs/specs/2026-08-05-gap-frame-materialization-design.md
@@ -168,7 +168,8 @@ Frontend (Vitest):
 - Drawing on a gap frame issues POST then annotation save, and the URL moves
   to the new detection.
 - POST failure leaves the frame a gap with a toast; save failure leaves a
-  boxless frame and a retry redraws without a second POST.
+  boxless in-object frame, and a retry redraw re-fires the POST, which
+  returns the existing row (idempotent 200) before saving again.
 - Clear on an evidence-free frame calls DELETE and reverts the frame to a
   gap; Clear on an evidence-bearing frame saves an empty annotation as
   today.
@@ -194,3 +195,7 @@ stack; frontend `npm run quality` clean and full suite green.
 - **`ApiError` gained an optional `status`** (set by the axios interceptor)
   so the page recognizes the DELETE's 409 without string-matching the detail
   message.
+- **A concurrent double-POST resolves idempotently**: the losing insert
+  re-selects the winner's row and returns it with 200, so 409 is reserved
+  for a genuine `alert_api_id` collision. The DELETE's last-frame guard
+  stays advisory under concurrency — accepted for a single-annotator tool.

--- a/docs/specs/2026-08-05-gap-frame-materialization-design.md
+++ b/docs/specs/2026-08-05-gap-frame-materialization-design.md
@@ -1,0 +1,185 @@
+# Drawing on frames outside an object's detected range
+
+Date: 2026-08-05
+Status: approved, not implemented
+Issue: #287
+
+## Problem
+
+A lane holds Detection rows only for the frames where its object was detected
+(`object_split.py:198` builds each object's records from `own_by_frame`). When
+the detector first picks a plume up late, the earlier frames — where it was
+visible but fainter — are not part of that object. On the development database
+35 of 475 lanes (7.4%) cover fewer frames than their alert, missing 12.6
+frames on average.
+
+Since the editor revamp
+(`docs/specs/2026-08-05-localize-object-editor-revamp-design.md`), those
+frames are *viewable*: the filmstrip spans the alert's full range, a gap frame
+borrows a sibling lane's photo (same `recorded_at`, same photograph), renders
+an out-of-range banner, and disables drawing. This spec makes them
+**drawable**: drawing on a gap frame materializes a Detection row in the lane
+and saves the box, in one flow.
+
+## Decisions taken
+
+- **Implicit materialization.** Drag-to-draw simply works on a gap frame. No
+  "add frame" button; committing the drawn box materializes the row. The
+  banner softens to say drawing will add this frame to the object.
+- **Two orchestrated calls, not one atomic endpoint.** The backend gains a
+  minimal frame-materialization endpoint; the box then flows through the
+  existing `saveDetectionReview` path unchanged. A failure between the calls
+  leaves a boxless in-object frame — already a first-class, visible,
+  retryable state.
+- **Un-materialize on clear.** Clearing or deleting the box on a
+  model-evidence-free frame deletes the Detection row; the frame reverts to a
+  gap. Symmetric, self-healing, no stuck states.
+
+## Backend
+
+Two additive endpoints on the sequences router. Both use `get_current_user`,
+matching `add_object` (`sequences.py:684`), whose insert this narrows to one
+frame.
+
+### `POST /api/v1/sequences/{sequence_id}/frames`
+
+Request `{ recorded_at: datetime }` → 201 `DetectionRead`.
+
+1. 404 if the sequence does not exist.
+2. Find a Detection at exactly that `recorded_at` in a sibling lane (same
+   `source_api` + `platform_alert_id`). 422 if none — only frames the alert
+   actually has can be materialized.
+3. If this lane already has a Detection at that `recorded_at`, return it with
+   200 — idempotent, so a double-fire or a stale client is not an error.
+4. Insert and return:
+
+   ```
+   Detection(sequence_id=sequence_id,
+             recorded_at=recorded_at,
+             bucket_key=sibling.bucket_key,      # shared S3 object, no copy
+             alert_api_id=sibling.alert_api_id,
+             algo_predictions={"predictions": []})
+   ```
+
+   The same field set `add_object` copies (`sequences.py:769–780`);
+   `auto_predictions` and `others_bboxes` stay null — the sibling's model
+   evidence belongs to *its* object, not this one.
+5. An IntegrityError against `uq_detection_sequence_alert_api_id` → 409.
+
+No `DetectionAnnotation` is seeded: `saveDetectionReview` already creates one
+when none exists, and `add_object`'s `BBOX_ANNOTATION` seeding exists to feed
+a different flow.
+
+### `DELETE /api/v1/sequences/{sequence_id}/frames/{detection_id}`
+
+→ 204. The un-materialize.
+
+- 404 if the detection does not exist or does not belong to the sequence.
+- 409 unless the detection is **model-evidence-free**: `algo_predictions` and
+  `auto_predictions` both empty or null. An imported frame's engine track —
+  the record of where the detector saw the object — is never deletable this
+  way.
+- 409 if it is the lane's last remaining detection. A zero-frame lane is
+  degenerate: the object vanishes from the frame model while its
+  `SequenceAnnotation` still claims a smoke object. (Real object removal is a
+  separate feature blocked on an `is_manual` marker.)
+- Deletes the row only. **Never touches S3** — `bucket_key` is shared with
+  the sibling, which is why `DELETE /detections/{id}` (which unconditionally
+  deletes the S3 object, `detections.py:343`) cannot be reused. The
+  `DetectionAnnotation` and its contributions go via FK cascade
+  (`models.py:417`).
+
+### Why "model-evidence-free" and not a marker column
+
+There is no `is_materialized` column, and adding one is schema work this
+feature does not otherwise need. "No model evidence" is an exact proxy for
+imported lanes: importer-created frames always carry the engine track the
+lane was split on; human-materialized frames never do.
+
+The proxy over-matches on one population — **human-added lanes**, whose
+frames are all evidence-free because `add_object` copies the sibling's frame
+set with empty predictions. Consequence, accepted deliberately: in an added
+lane, clearing a box removes the frame from the lane (back to gap,
+re-drawable) instead of leaving it confirmed-empty. That is the better
+semantics for both populations: a frame whose only content is a human's box
+has no reason to exist once the box is gone. "Confirmed empty" remains the
+behavior for frames with model evidence, where a human is overruling the
+detector.
+
+## Frontend
+
+All in the localize object editor and its page; the filmstrip, cockpit grid
+and submit gate need **no logic changes** — they derive from the per-lane
+detections query, so invalidating `QUERY_KEYS.SEQUENCE_DETECTIONS(laneId)`
+makes the new cell appear and the gate count it.
+
+### Drawing on a gap frame
+
+On a peeked frame (`LocalizeObjectEditor.tsx` `peeked` state), drag-to-draw
+becomes enabled. The rail stays empty (no candidates), `Enter` stays a no-op,
+Accept-remaining and Reclassify stay hidden. The out-of-range banner stays
+but its text changes: the object was never detected here, and drawing will
+add this frame to it.
+
+Commit flow for a box drawn on a gap frame:
+
+1. `POST /sequences/{laneId}/frames { recorded_at }` → new Detection.
+2. `saveDetectionReview` against the new `detectionId` (creates the
+   annotation with the drawn box, `origin: 'human'`, stage `annotated`).
+3. Invalidate `SEQUENCE_DETECTIONS(laneId)`.
+4. Navigate the URL to the new detection — it is now legitimately
+   addressable under the route guard (`:detectionId` belongs to `:laneId`),
+   clearing `peeked`. No route change needed.
+
+Failure handling:
+
+- Step 1 fails → toast, nothing changed, frame still a gap.
+- Step 2 fails → the frame exists boxless: it visibly blocks submit (no
+  annotation ⇒ not `'done'` in `getCellState`), and drawing again retries
+  without re-materializing (the POST's idempotent 200 covers a retry that
+  re-fires it).
+
+### Clearing
+
+The frontend applies the same rule as the server: on a frame whose detection
+is model-evidence-free, Clear / the `Delete` key calls the DELETE endpoint
+instead of saving an empty annotation. On success, invalidate
+`SEQUENCE_DETECTIONS(laneId)` and drop the editor back to the peeked view of
+the same `recordedAt` (URL returns to the last in-object frame, as for any
+peek). A 409 (e.g. last-frame guard) falls back to the ordinary
+empty-annotation Clear.
+
+Frames with model evidence keep today's Clear: save an annotation with no
+smoke box — "confirmed empty".
+
+## Testing
+
+Backend (`tests/endpoints/`, isolated compose stack):
+
+- Materialize: 201 with sibling-copied fields; idempotent 200 on re-POST;
+  404 unknown sequence; 422 when no sibling has that `recorded_at`.
+- Delete: 204 removes row and cascades the annotation; S3 object untouched;
+  409 on a frame with `algo_predictions`; 409 on a frame with
+  `auto_predictions`; 409 on the lane's last detection; 404 for a detection
+  of another lane.
+
+Frontend (Vitest):
+
+- Drawing on a gap frame issues POST then annotation save, and the URL moves
+  to the new detection.
+- POST failure leaves the frame a gap with a toast; save failure leaves a
+  boxless frame and a retry redraws without a second POST.
+- Clear on an evidence-free frame calls DELETE and reverts the frame to a
+  gap; Clear on an evidence-bearing frame saves an empty annotation as
+  today.
+- The filmstrip and submit gate reflect a materialized frame after
+  invalidation (existing derivations, exercised through the page test).
+
+Success criteria: backend `make lint` + test suite green in an isolated
+stack; frontend `npm run quality` clean and full suite green.
+
+## Out of scope
+
+- Backend one-box-per-annotation validator (#286).
+- "Remove added object" and any `is_manual` marker.
+- Auto-advance or bulk operations over gap frames.

--- a/docs/specs/2026-08-05-localize-object-editor-revamp-design.md
+++ b/docs/specs/2026-08-05-localize-object-editor-revamp-design.md
@@ -389,7 +389,7 @@ Each is out of scope here and tracked separately.
 | | needs backend |
 |---|---|
 | Draw missed smoke as a new object | No — `add_object` (`sequences.py:766`) already copies the richest sibling's full frame set into the new lane, so a fresh object arrives drawable. Frontend-only follow-up. |
-| Draw on a frame outside an object's range (#287) | Yes — one additive endpoint (below). |
+| Draw on a frame outside an object's range (#287) | Yes — one additive endpoint (below). Shipped: see `2026-08-05-gap-frame-materialization-design.md`. |
 | Enforce ≤1 smoke box per detection annotation (#286) | Yes — a validator in `annotation_validation.py`. All 191 existing rows already comply. |
 
 The gap-frame endpoint, sketched so the follow-up starts from a known shape:

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -914,14 +914,20 @@ export function LocalizeObjectEditor({
 
           {/* Floated over the stage rather than stacked into the column, so
               stepping between in-object and gap frames never resizes the
-              photo or shifts the filmstrip. */}
+              photo or shifts the filmstrip. Pine, not signal: this is the
+              Localize lane's own invitation to act, not an error. */}
           {peeked && (
             <div
               data-testid="out-of-range-banner"
-              className="absolute inset-x-0 bottom-0 border-t border-line bg-signal-soft px-4 py-2 font-body text-detail text-signal"
+              className="absolute inset-x-0 bottom-0 flex flex-wrap items-baseline gap-x-3 gap-y-0.5 border-t border-line bg-pine-soft px-4 py-2"
             >
-              {objectLabel} was never detected on this frame. If you can see its smoke, draw a box
-              to add this frame to {objectLabel}.
+              <span className="whitespace-nowrap font-data text-eyebrow font-medium uppercase tracking-eyebrow text-pine">
+                Outside object range
+              </span>
+              <span className="font-body text-detail text-pine">
+                {objectLabel} was never detected on this frame. If you can see its smoke, draw a box
+                to add this frame to {objectLabel}.
+              </span>
             </div>
           )}
         </div>

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -882,7 +882,7 @@ export function LocalizeObjectEditor({
       </div>
 
       <div className="flex min-h-0 flex-1">
-        <div className="flex min-w-0 flex-1 items-center justify-center overflow-hidden bg-ash p-3">
+        <div className="relative flex min-w-0 flex-1 items-center justify-center overflow-hidden bg-ash p-3">
           <DetectionAnnotationCanvas
             detection={shownDetection}
             committed={editable ? shownCommitted : null}
@@ -911,6 +911,19 @@ export function LocalizeObjectEditor({
             normalizedToImage={normalizedToImage}
             overlaysVisible
           />
+
+          {/* Floated over the stage rather than stacked into the column, so
+              stepping between in-object and gap frames never resizes the
+              photo or shifts the filmstrip. */}
+          {peeked && (
+            <div
+              data-testid="out-of-range-banner"
+              className="absolute inset-x-0 bottom-0 border-t border-line bg-signal-soft px-4 py-2 font-body text-detail text-signal"
+            >
+              {objectLabel} was never detected on this frame. If you can see its smoke, draw a box
+              to add this frame to {objectLabel}.
+            </div>
+          )}
         </div>
 
         <BoxSourceRail
@@ -922,16 +935,6 @@ export function LocalizeObjectEditor({
           onClear={clear}
         />
       </div>
-
-      {peeked && (
-        <div
-          data-testid="out-of-range-banner"
-          className="flex-none border-t border-line bg-signal-soft px-4 py-2 font-body text-detail text-signal"
-        >
-          {objectLabel} was never detected on this frame. If you can see its smoke, draw a box to
-          add this frame to {objectLabel}.
-        </div>
-      )}
 
       <ObjectFilmstrip
         entries={entries}

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -32,6 +32,7 @@ import {
   boxCandidates,
   candidateToBbox,
   committedBox,
+  hasModelEvidence,
   priorityPick,
   type BoxCandidate,
 } from '@/utils/annotation/objectBoxCandidates';
@@ -95,6 +96,18 @@ export interface LocalizeObjectEditorProps {
   /** Navigate to another of THIS lane's detections; drives the URL. */
   onNavigateToDetection: (detectionId: number) => void;
   /**
+   * Draw on a gap frame (issue #287): materialize a Detection in this lane at
+   * recordedAt, then commit the drawn box to it. The page owns the two-call
+   * flow and the navigation to the new detection.
+   */
+  onCommitGapFrame: (recordedAt: string, items: DetectionAnnotationBbox[]) => void;
+  /**
+   * Remove a model-evidence-free frame from the lane entirely (issue #287's
+   * un-materialize) — Clear, for a frame whose only reason to exist is a
+   * human's box.
+   */
+  onUnmaterialize: (detection: Detection) => void;
+  /**
    * Commit the winning model box on every frame of this object that has
    * none. Never overwrites a frame the annotator already decided.
    */
@@ -118,6 +131,8 @@ export function LocalizeObjectEditor({
   isSaving,
   isAccepting,
   onCommit,
+  onCommitGapFrame,
+  onUnmaterialize,
   onNavigateToDetection,
   onAcceptRemaining,
   onReclassify,
@@ -221,32 +236,14 @@ export function LocalizeObjectEditor({
     [alertFrames, laneSequenceId, laneDetections, laneAnnotations]
   );
 
-  // --- Commit -------------------------------------------------------------
-
-  const commitCandidate = useCallback(
-    (candidate: BoxCandidate) => onCommit(detection, [candidateToBbox(candidate, smokeType)]),
-    [detection, smokeType, onCommit]
-  );
-
-  const commitDrawn = useCallback(
-    (xyxyn: [number, number, number, number]) =>
-      onCommit(detection, [candidateToBbox({ source: 'manual', index: 0, xyxyn }, smokeType)]),
-    [detection, smokeType, onCommit]
-  );
-
-  const clear = useCallback(() => onCommit(detection, []), [detection, onCommit]);
-
-  clearRef.current = clear;
-
-  // --- Navigation ---------------------------------------------------------
-
   /**
    * A frame outside this object's range, held locally. The route requires
    * `:detectionId` to belong to `:laneId`, and a gap frame has no detection
    * in this lane, so the URL cannot name it without weakening the guard that
    * makes an inconsistent editor link detectable at all. Peeking is therefore
    * component state; the URL keeps naming the last in-object frame. Drawing
-   * on one of these is issue #287.
+   * on one routes through `onCommitGapFrame`, which materializes the frame
+   * (issue #287).
    */
   const [peeked, setPeeked] = useState<FilmstripEntry | null>(null);
 
@@ -255,6 +252,33 @@ export function LocalizeObjectEditor({
   useEffect(() => setPeeked(null), [detection.id]);
 
   const editable = peeked === null;
+
+  // --- Commit -------------------------------------------------------------
+
+  const commitCandidate = useCallback(
+    (candidate: BoxCandidate) => onCommit(detection, [candidateToBbox(candidate, smokeType)]),
+    [detection, smokeType, onCommit]
+  );
+
+  const commitDrawn = useCallback(
+    (xyxyn: [number, number, number, number]) => {
+      const items = [candidateToBbox({ source: 'manual', index: 0, xyxyn }, smokeType)];
+      if (peeked) onCommitGapFrame(peeked.recordedAt, items);
+      else onCommit(detection, items);
+    },
+    [peeked, detection, smokeType, onCommit, onCommitGapFrame]
+  );
+
+  const clear = useCallback(() => {
+    // A frame with no model evidence exists only because a human boxed it;
+    // clearing removes the frame itself (issue #287's un-materialize).
+    if (hasModelEvidence(detection)) onCommit(detection, []);
+    else onUnmaterialize(detection);
+  }, [detection, onCommit, onUnmaterialize]);
+
+  clearRef.current = clear;
+
+  // --- Navigation ---------------------------------------------------------
 
   const currentEntryIndex = peeked
     ? entries.findIndex(en => en.recordedAt === peeked.recordedAt)
@@ -491,7 +515,7 @@ export function LocalizeObjectEditor({
       return;
     }
 
-    if (e.button !== 0 || !editable) return;
+    if (e.button !== 0) return;
     const coords = screenToImageCoords(e.clientX, e.clientY);
     setCurrentDrawing({
       startX: coords.x,
@@ -562,7 +586,6 @@ export function LocalizeObjectEditor({
 
   const getCursorStyle = () => {
     if (spaceHeld) return isDragging ? 'grabbing' : 'grab';
-    if (!editable) return 'default';
     return 'crosshair';
   };
 
@@ -905,7 +928,7 @@ export function LocalizeObjectEditor({
           data-testid="out-of-range-banner"
           className="flex-none border-t border-line bg-signal-soft px-4 py-2 font-body text-detail text-signal"
         >
-          {objectLabel} was never detected on this frame, so there is nothing here to draw on. The
+          {objectLabel} was never detected on this frame — draw a box to add it to the object. The
           image comes from another object in the same alert.
         </div>
       )}

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -928,8 +928,8 @@ export function LocalizeObjectEditor({
           data-testid="out-of-range-banner"
           className="flex-none border-t border-line bg-signal-soft px-4 py-2 font-body text-detail text-signal"
         >
-          {objectLabel} was never detected on this frame — draw a box to add it to the object. The
-          image comes from another object in the same alert.
+          {objectLabel} was never detected on this frame. If you can see its smoke, draw a box to
+          add this frame to {objectLabel}.
         </div>
       )}
 

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -648,8 +648,13 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // The URL names the open detection, so step off it before the refetch drops
   // the row; the frame reverts to a gap in the filmstrip.
   const unmaterializeFrame = useMutation({
-    mutationFn: (params: { laneId: number; detection: Detection }) =>
-      apiClient.unmaterializeFrame(params.laneId, params.detection.id),
+    mutationFn: (params: {
+      laneId: number;
+      detection: Detection;
+      // Captured at press time: by the time the 409 fallback runs, the open
+      // frame (and modalContext) may already be a different detection.
+      existingAnnotation: DetectionAnnotation | null;
+    }) => apiClient.unmaterializeFrame(params.laneId, params.detection.id),
     onSuccess: async (_result, variables) => {
       const remaining = laneDetectionsSorted.filter(d => d.id !== variables.detection.id);
       const target =
@@ -671,7 +676,7 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
         saveDetection.mutate({
           laneId: variables.laneId,
           detectionId: variables.detection.id,
-          existingAnnotation: modalContext?.existingAnnotation ?? null,
+          existingAnnotation: variables.existingAnnotation,
           items: [],
         });
         return;
@@ -722,7 +727,11 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
 
   const handleEditorUnmaterialize = (detection: Detection) => {
     if (!modalContext) return;
-    unmaterializeFrame.mutate({ laneId: modalContext.laneId, detection });
+    unmaterializeFrame.mutate({
+      laneId: modalContext.laneId,
+      detection,
+      existingAnnotation: modalContext.existingAnnotation,
+    });
   };
 
   // Shared step: accept the winning model boxes for every pending frame of
@@ -1641,7 +1650,11 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
           laneAnnotations={annotationsByLaneId[modalContext.laneId] ?? []}
           alertFrames={frameModel.frames}
           objectOverlays={objectOverlays}
-          isSaving={saveDetection.isPending || materializeAndCommit.isPending}
+          isSaving={
+            saveDetection.isPending ||
+            materializeAndCommit.isPending ||
+            unmaterializeFrame.isPending
+          }
           isAccepting={quickAcceptLane.isPending}
           onCommit={handleEditorCommit}
           onCommitGapFrame={handleEditorCommitGapFrame}

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -114,12 +114,19 @@ import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/rea
 import { ArrowLeft, PlayCircle, Plus, Upload } from 'lucide-react';
 import { apiClient } from '@/services/api';
 import { QUERY_KEYS } from '@/utils/constants';
-import { Detection, DetectionAnnotation, DetectionAnnotationBbox, SmokeType } from '@/types/api';
+import {
+  ApiError,
+  Detection,
+  DetectionAnnotation,
+  DetectionAnnotationBbox,
+  SmokeType,
+} from '@/types/api';
 import {
   buildAlertFrameModel,
   findFrameByDetectionId,
   AlertObjectStatus,
 } from '@/utils/annotation/alertLocalizeUtils';
+import { materializeGapFrame } from '@/utils/annotation/gapFrameMaterialize';
 import { laneNeedsLocalization } from '@/utils/annotation/localizeUtils';
 import {
   buildQuickSubmitPlan,
@@ -607,6 +614,69 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     },
   });
 
+  // Draw on a gap frame (issue #287): materialize the Detection, then save
+  // the drawn box to it. Navigation to the new frame waits for the detections
+  // refetch, so the editor never opens an id the loaded data cannot back.
+  const materializeAndCommit = useMutation({
+    mutationFn: (params: { laneId: number; recordedAt: string; items: DetectionAnnotationBbox[] }) =>
+      materializeGapFrame(params),
+    onSuccess: async ({ detection }, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.SEQUENCE_DETECTIONS(variables.laneId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [...QUERY_KEYS.DETECTION_ANNOTATIONS, 'by-sequence', variables.laneId],
+        }),
+      ]);
+      navigateModalTo(detection.id);
+    },
+    onError: (_error, variables) => {
+      // The materialize may have landed with only the save failing; refetch
+      // so a now-real frame renders as a boxless in-object frame, not a gap.
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.SEQUENCE_DETECTIONS(variables.laneId),
+      });
+      showToastNotification('Failed to save frame — try again', 'error');
+    },
+  });
+
+  // Un-materialize (issue #287): remove an evidence-free frame from the lane.
+  // The URL names the open detection, so step off it before the refetch drops
+  // the row; the frame reverts to a gap in the filmstrip.
+  const unmaterializeFrame = useMutation({
+    mutationFn: (params: { laneId: number; detection: Detection }) =>
+      apiClient.unmaterializeFrame(params.laneId, params.detection.id),
+    onSuccess: async (_result, variables) => {
+      const remaining = laneDetectionsSorted.filter(d => d.id !== variables.detection.id);
+      const target =
+        [...remaining].reverse().find(d => d.recorded_at < variables.detection.recorded_at) ??
+        remaining[0];
+      if (target) navigateModalTo(target.id);
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.SEQUENCE_DETECTIONS(variables.laneId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: [...QUERY_KEYS.DETECTION_ANNOTATIONS, 'by-sequence', variables.laneId],
+      });
+    },
+    onError: (error, variables) => {
+      // The server's guards (model evidence, last frame) refuse with 409;
+      // fall back to the ordinary confirmed-empty clear so the annotator's
+      // intent still lands.
+      if ((error as ApiError).status === 409) {
+        saveDetection.mutate({
+          laneId: variables.laneId,
+          detectionId: variables.detection.id,
+          existingAnnotation: modalContext?.existingAnnotation ?? null,
+          items: [],
+        });
+        return;
+      }
+      showToastNotification('Failed to remove frame — try again', 'error');
+    },
+  });
+
   // The alert-level missed-smoke flag. Written from two places: the rail's
   // own Yes/No row, and the soft-confirm's "Submit & clear flag" path.
   const setMissedSmokeFlag = useMutation({
@@ -640,6 +710,16 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       existingAnnotation: modalContext.existingAnnotation,
       items,
     });
+  };
+
+  const handleEditorCommitGapFrame = (recordedAt: string, items: DetectionAnnotationBbox[]) => {
+    if (!modalContext) return;
+    materializeAndCommit.mutate({ laneId: modalContext.laneId, recordedAt, items });
+  };
+
+  const handleEditorUnmaterialize = (detection: Detection) => {
+    if (!modalContext) return;
+    unmaterializeFrame.mutate({ laneId: modalContext.laneId, detection });
   };
 
   // Shared step: accept the winning model boxes for every pending frame of
@@ -1558,9 +1638,11 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
           laneAnnotations={annotationsByLaneId[modalContext.laneId] ?? []}
           alertFrames={frameModel.frames}
           objectOverlays={objectOverlays}
-          isSaving={saveDetection.isPending}
+          isSaving={saveDetection.isPending || materializeAndCommit.isPending}
           isAccepting={quickAcceptLane.isPending}
           onCommit={handleEditorCommit}
+          onCommitGapFrame={handleEditorCommitGapFrame}
+          onUnmaterialize={handleEditorUnmaterialize}
           onAcceptRemaining={() => quickAcceptLane.mutate(modalContext.laneId)}
           onReclassify={() => handleReclassify(modalContext.laneId)}
           onNavigateToDetection={navigateModalTo}

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -618,8 +618,11 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // the drawn box to it. Navigation to the new frame waits for the detections
   // refetch, so the editor never opens an id the loaded data cannot back.
   const materializeAndCommit = useMutation({
-    mutationFn: (params: { laneId: number; recordedAt: string; items: DetectionAnnotationBbox[] }) =>
-      materializeGapFrame(params),
+    mutationFn: (params: {
+      laneId: number;
+      recordedAt: string;
+      items: DetectionAnnotationBbox[];
+    }) => materializeGapFrame(params),
     onSuccess: async ({ detection }, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({
@@ -664,7 +667,7 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       // The server's guards (model evidence, last frame) refuse with 409;
       // fall back to the ordinary confirmed-empty clear so the annotator's
       // intent still lands.
-      if ((error as ApiError).status === 409) {
+      if ((error as unknown as ApiError).status === 409) {
         saveDetection.mutate({
           laneId: variables.laneId,
           detectionId: variables.detection.id,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -91,6 +91,7 @@ class ApiClient {
 
         const apiError: ApiError = {
           detail: error.response?.data?.detail || error.message || 'Unknown error occurred',
+          status: error.response?.status,
         };
         return Promise.reject(apiError);
       }
@@ -205,6 +206,23 @@ class ApiClient {
       { source_api: sourceApi, platform_alert_id: platformAlertId, smoke_type: smokeType }
     );
     return response.data;
+  }
+
+  // Issue #287: materialize a gap frame into a lane so a human can box it.
+  // Idempotent — returns the existing detection when the lane already has one
+  // at this recorded_at.
+  async materializeFrame(sequenceId: number, recordedAt: string): Promise<Detection> {
+    const response: AxiosResponse<Detection> = await this.client.post(
+      `${API_ENDPOINTS.SEQUENCES}${sequenceId}/frames`,
+      { recorded_at: recordedAt }
+    );
+    return response.data;
+  }
+
+  // Un-materialize: remove a model-evidence-free frame from a lane. 409 when
+  // the frame carries model evidence or is the lane's last.
+  async unmaterializeFrame(sequenceId: number, detectionId: number): Promise<void> {
+    await this.client.delete(`${API_ENDPOINTS.SEQUENCES}${sequenceId}/frames/${detectionId}`);
   }
 
   // Alerts ready for classification (alert-grouped Classify queue)

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -525,4 +525,6 @@ export interface UserFilters {
 // API Error Response
 export interface ApiError {
   detail: string | Record<string, string[]>;
+  /** HTTP status of the failed response, when one was received. */
+  status?: number;
 }

--- a/frontend/src/utils/annotation/gapFrameMaterialize.ts
+++ b/frontend/src/utils/annotation/gapFrameMaterialize.ts
@@ -1,0 +1,41 @@
+/**
+ * Draw-on-a-gap-frame orchestration (issue #287): materialize a Detection in
+ * the lane at this recordedAt (idempotent server-side), then commit the drawn
+ * box through the ordinary review save. Two calls by design — a failure
+ * between them leaves a boxless in-object frame, which is visible, blocks
+ * submit, and is retried by simply drawing again.
+ */
+
+import { apiClient as defaultApiClient } from '@/services/api';
+import { Detection, DetectionAnnotation, DetectionAnnotationBbox } from '@/types/api';
+import { saveDetectionReview } from './laneAnnotationSave';
+
+export interface MaterializeGapFrameParams {
+  laneId: number;
+  recordedAt: string;
+  items: DetectionAnnotationBbox[];
+  /** Injectable for tests; defaults to the real API client. */
+  apiClient?: Pick<
+    typeof defaultApiClient,
+    'materializeFrame' | 'createDetectionAnnotation' | 'updateDetectionAnnotation'
+  >;
+}
+
+export async function materializeGapFrame({
+  laneId,
+  recordedAt,
+  items,
+  apiClient = defaultApiClient,
+}: MaterializeGapFrameParams): Promise<{
+  detection: Detection;
+  annotation: DetectionAnnotation;
+}> {
+  const detection = await apiClient.materializeFrame(laneId, recordedAt);
+  const annotation = await saveDetectionReview({
+    detectionId: detection.id,
+    existingAnnotation: null,
+    items,
+    apiClient,
+  });
+  return { detection, annotation };
+}

--- a/frontend/src/utils/annotation/objectBoxCandidates.ts
+++ b/frontend/src/utils/annotation/objectBoxCandidates.ts
@@ -105,6 +105,17 @@ export function priorityPick(candidates: BoxCandidate[]): BoxCandidate | null {
   return null;
 }
 
+/** Whether any model layer put a box on this frame. A frame without model
+ *  evidence exists in its lane only because a human boxed it (a materialized
+ *  gap frame, or any frame of an added-object lane), so clearing it removes
+ *  the frame itself — issue #287's un-materialize. */
+export function hasModelEvidence(detection: Detection): boolean {
+  return (
+    (detection.algo_predictions?.predictions?.length ?? 0) > 0 ||
+    (detection.auto_predictions?.predictions?.length ?? 0) > 0
+  );
+}
+
 /** The single annotation item this candidate commits to. */
 export function candidateToBbox(
   candidate: BoxCandidate,

--- a/frontend/src/utils/annotation/objectFilmstrip.ts
+++ b/frontend/src/utils/annotation/objectFilmstrip.ts
@@ -6,8 +6,9 @@
  * (object_split.py:198), so an object that the detector picked up late has
  * earlier frames it is simply absent from — 35 of 475 lanes in the
  * development database, missing 12.6 frames on average. Those frames are
- * exactly where fainter smoke hides, so the strip surfaces them; they are
- * viewable but not editable until the endpoint in issue #287 exists.
+ * exactly where fainter smoke hides, so the strip surfaces them; drawing on
+ * one materializes a Detection row in the lane (issue #287 — see
+ * docs/specs/2026-08-05-gap-frame-materialization-design.md).
  */
 
 import type { Detection, DetectionAnnotation } from '@/types/api';

--- a/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
+++ b/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
@@ -92,6 +92,8 @@ const baseProps = (): Props => ({
   isSaving: false,
   isAccepting: false,
   onCommit: vi.fn(),
+  onCommitGapFrame: vi.fn(),
+  onUnmaterialize: vi.fn(),
   onAcceptRemaining: vi.fn(),
   onReclassify: vi.fn(),
   onNavigateToDetection: vi.fn(),
@@ -252,38 +254,38 @@ describe('LocalizeObjectEditor', () => {
   });
 });
 
+/**
+ * jsdom lays nothing out, so every rect is zero and the editor's coordinate
+ * maths collapses to a single point. These give the image a plausible
+ * geometry so a drag produces a real box; the numbers are arbitrary but
+ * consistent (an 800x450 element showing a 1600x900 frame).
+ */
+const stubGeometry = () => {
+  const image = screen.getByAltText(/^Detection /) as HTMLImageElement;
+  const container = image.parentElement as HTMLElement;
+  container.getBoundingClientRect = () =>
+    ({ left: 0, top: 0, right: 800, bottom: 450, width: 800, height: 450, x: 0, y: 0 }) as DOMRect;
+  for (const [prop, value] of [
+    ['naturalWidth', 1600],
+    ['naturalHeight', 900],
+    ['offsetWidth', 800],
+    ['offsetHeight', 450],
+  ] as const) {
+    Object.defineProperty(image, prop, { value, configurable: true });
+  }
+  // Full frame, so the drag maths is not also exercising the zoom transform.
+  fireEvent.keyDown(window, { key: 'r' });
+  return image;
+};
+
+const drag = (from: [number, number], to: [number, number], init: object = {}) => {
+  const image = stubGeometry();
+  fireEvent.mouseDown(image, { button: 0, clientX: from[0], clientY: from[1], ...init });
+  fireEvent.mouseMove(image, { clientX: to[0], clientY: to[1] });
+  fireEvent.mouseUp(image);
+};
+
 describe('LocalizeObjectEditor canvas', () => {
-  /**
-   * jsdom lays nothing out, so every rect is zero and the editor's coordinate
-   * maths collapses to a single point. These give the image a plausible
-   * geometry so a drag produces a real box; the numbers are arbitrary but
-   * consistent (an 800x450 element showing a 1600x900 frame).
-   */
-  const stubGeometry = () => {
-    const image = screen.getByAltText(/^Detection /) as HTMLImageElement;
-    const container = image.parentElement as HTMLElement;
-    container.getBoundingClientRect = () =>
-      ({ left: 0, top: 0, right: 800, bottom: 450, width: 800, height: 450, x: 0, y: 0 }) as DOMRect;
-    for (const [prop, value] of [
-      ['naturalWidth', 1600],
-      ['naturalHeight', 900],
-      ['offsetWidth', 800],
-      ['offsetHeight', 450],
-    ] as const) {
-      Object.defineProperty(image, prop, { value, configurable: true });
-    }
-    // Full frame, so the drag maths is not also exercising the zoom transform.
-    fireEvent.keyDown(window, { key: 'r' });
-    return image;
-  };
-
-  const drag = (from: [number, number], to: [number, number], init: object = {}) => {
-    const image = stubGeometry();
-    fireEvent.mouseDown(image, { button: 0, clientX: from[0], clientY: from[1], ...init });
-    fireEvent.mouseMove(image, { clientX: to[0], clientY: to[1] });
-    fireEvent.mouseUp(image);
-  };
-
   it('draws on a plain drag, with nothing to arm first', () => {
     const onCommit = vi.fn();
     renderLoadedEditor({ onCommit });
@@ -794,16 +796,22 @@ describe('LocalizeObjectEditor out-of-range frames', () => {
     expect(screen.getByTestId('out-of-range-banner')).toBeInTheDocument();
   });
 
-  it('refuses to draw while peeking, so no box lands on the wrong frame', () => {
+  it('drawing while peeking routes to onCommitGapFrame with the peeked timestamp', () => {
     const onCommit = vi.fn();
-    renderLoadedEditor({ onCommit });
-    fireEvent.keyDown(window, { key: 'ArrowLeft' });
-
-    const image = screen.getByAltText(/^Detection /);
-    fireEvent.mouseDown(image, { button: 0, clientX: 10, clientY: 10 });
-    fireEvent.mouseMove(image, { clientX: 90, clientY: 90 });
-    fireEvent.mouseUp(image);
+    const onCommitGapFrame = vi.fn();
+    renderLoadedEditor({ onCommit, onCommitGapFrame });
+    fireEvent.keyDown(window, { key: 'ArrowLeft' }); // t003 -> t002, a gap frame
+    drag([40, 40], [400, 300]);
+    expect(onCommitGapFrame).toHaveBeenCalledWith('t002', [
+      expect.objectContaining({ origin: 'human', smoke_type: 'wildfire' }),
+    ]);
     expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('invites drawing on a gap frame instead of forbidding it', () => {
+    renderEditor();
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    expect(screen.getByTestId('out-of-range-banner')).toHaveTextContent(/draw a box/i);
   });
 
   it('does not step past the very first alert frame', () => {

--- a/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
+++ b/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
@@ -814,6 +814,33 @@ describe('LocalizeObjectEditor out-of-range frames', () => {
     expect(screen.getByTestId('out-of-range-banner')).toHaveTextContent(/draw a box/i);
   });
 
+  it('Clear un-materializes a frame with no model evidence', () => {
+    const onCommit = vi.fn();
+    const onUnmaterialize = vi.fn();
+    renderEditor({
+      detection: detectionWithNoBoxes,
+      existingAnnotation: committedAnnotation(detectionWithNoBoxes.id, 'human'),
+      onCommit,
+      onUnmaterialize,
+    });
+    fireEvent.click(screen.getByTestId('editor-clear'));
+    expect(onUnmaterialize).toHaveBeenCalledWith(
+      expect.objectContaining({ id: detectionWithNoBoxes.id })
+    );
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('Delete un-materializes an evidence-free frame with a committed box', () => {
+    const onUnmaterialize = vi.fn();
+    renderLoadedEditor({
+      detection: detectionWithNoBoxes,
+      existingAnnotation: committedAnnotation(detectionWithNoBoxes.id, 'human'),
+      onUnmaterialize,
+    });
+    fireEvent.keyDown(window, { key: 'Delete' });
+    expect(onUnmaterialize).toHaveBeenCalled();
+  });
+
   it('does not step past the very first alert frame', () => {
     renderEditor();
     fireEvent.keyDown(window, { key: 'ArrowLeft' });

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2790,6 +2790,38 @@ describe('LocalizeAlertPage', () => {
       expect(screen.getByTestId('image-modal-detection-id')).toHaveTextContent('1001');
     });
 
+    it('shows the frame as boxless in-object when the save fails after the materialize', async () => {
+      const newDet = { ...makeDetection(5001, T2), sequence_id: 101 };
+      let materialized = false;
+      vi.mocked(apiClient.materializeFrame).mockImplementation(async () => {
+        materialized = true;
+        return newDet;
+      });
+      vi.mocked(apiClient.createDetectionAnnotation).mockRejectedValue({
+        detail: 'boom',
+        status: 500,
+      });
+      vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
+        if (id === 101)
+          return materialized ? [makeDetection(1001, T1), newDet] : [makeDetection(1001, T1)];
+        if (id === 102) return [makeDetection(1002, T1), makeDetection(1003, T2)];
+        return [];
+      });
+
+      await renderAndSettle(<LocalizeAlertPage />, {
+        wrapper: makeWrapper('/localize/101/object/101/1001'),
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Mock Gap Draw' }));
+
+      await waitFor(() => expect(apiClient.materializeFrame).toHaveBeenCalled());
+      // The onError invalidation refetches the lane, so the materialized frame
+      // arrives as a boxless in-object frame; the URL stays on the old one.
+      await waitFor(() =>
+        expect(screen.getByTestId('image-modal-lane-frames')).toHaveTextContent('2')
+      );
+      expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101/1001');
+    });
+
     it('clearing an evidence-free frame un-materializes it and steps the URL off it', async () => {
       // Lane 102's T2 frame carries no model evidence — the materialized shape.
       const bare = {

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -44,6 +44,8 @@ vi.mock('@/services/api', () => ({
     updateSequenceAnnotation: vi.fn(),
     localizeSubmit: vi.fn(),
     addObject: vi.fn(),
+    materializeFrame: vi.fn(),
+    unmaterializeFrame: vi.fn(),
   },
 }));
 
@@ -90,6 +92,8 @@ vi.mock('@/components/localize/editor', () => ({
     onClose: () => void;
     onNavigateToDetection: (detectionId: number) => void;
     onCommit: (detection: Detection, items: unknown[]) => void;
+    onCommitGapFrame?: (recordedAt: string, items: unknown[]) => void;
+    onUnmaterialize?: (detection: Detection) => void;
     objectOverlays?: Array<{ color: string; label: string; boxes: unknown[] }>;
   }) => (
     <div data-testid="image-modal">
@@ -131,6 +135,26 @@ vi.mock('@/components/localize/editor', () => ({
         }}
       >
         Mock Next
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          // The alert's second frame (T2's literal value — the factory is
+          // hoisted, so it cannot read the T2 const below).
+          props.onCommitGapFrame?.('2026-01-01T10:05:00Z', [
+            {
+              xyxyn: [0.1, 0.1, 0.2, 0.2],
+              class_name: 'smoke',
+              smoke_type: 'wildfire',
+              origin: 'human',
+            },
+          ])
+        }
+      >
+        Mock Gap Draw
+      </button>
+      <button type="button" onClick={() => props.onUnmaterialize?.(props.detection)}>
+        Mock Unmaterialize
       </button>
       <button type="button" onClick={props.onClose}>
         Mock Close
@@ -2720,4 +2744,108 @@ describe('LocalizeAlertPage', () => {
     });
   });
 
+  describe('gap frames (issue #287)', () => {
+    it('drawing on a gap frame materializes it, saves the box, and moves the URL', async () => {
+      const newDet = { ...makeDetection(5001, T2), sequence_id: 101 };
+      let materialized = false;
+      vi.mocked(apiClient.materializeFrame).mockImplementation(async () => {
+        materialized = true;
+        return newDet;
+      });
+      vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
+        if (id === 101)
+          return materialized ? [makeDetection(1001, T1), newDet] : [makeDetection(1001, T1)];
+        if (id === 102) return [makeDetection(1002, T1), makeDetection(1003, T2)];
+        return [];
+      });
+
+      await renderAndSettle(<LocalizeAlertPage />, {
+        wrapper: makeWrapper('/localize/101/object/101/1001'),
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Mock Gap Draw' }));
+
+      await waitFor(() => expect(apiClient.materializeFrame).toHaveBeenCalledWith(101, T2));
+      await waitFor(() =>
+        expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
+          expect.objectContaining({ detection_id: 5001, processing_stage: 'annotated' })
+        )
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101/5001')
+      );
+    });
+
+    it('leaves the frame a gap when the materialize call fails', async () => {
+      vi.mocked(apiClient.materializeFrame).mockRejectedValue({ detail: 'boom', status: 500 });
+
+      await renderAndSettle(<LocalizeAlertPage />, {
+        wrapper: makeWrapper('/localize/101/object/101/1001'),
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Mock Gap Draw' }));
+
+      await waitFor(() => expect(apiClient.materializeFrame).toHaveBeenCalled());
+      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
+      // URL never moved: the frame is still a gap, the editor still open on 1001.
+      expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101/1001');
+      expect(screen.getByTestId('image-modal-detection-id')).toHaveTextContent('1001');
+    });
+
+    it('clearing an evidence-free frame un-materializes it and steps the URL off it', async () => {
+      // Lane 102's T2 frame carries no model evidence — the materialized shape.
+      const bare = {
+        ...makeDetection(1003, T2),
+        auto_predictions: null,
+      };
+      let deleted = false;
+      vi.mocked(apiClient.unmaterializeFrame).mockImplementation(async () => {
+        deleted = true;
+      });
+      vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
+        if (id === 101) return [makeDetection(1001, T1)];
+        if (id === 102) return deleted ? [makeDetection(1002, T1)] : [makeDetection(1002, T1), bare];
+        return [];
+      });
+
+      await renderAndSettle(<LocalizeAlertPage />, {
+        wrapper: makeWrapper('/localize/101/object/102/1003'),
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Mock Unmaterialize' }));
+
+      await waitFor(() => expect(apiClient.unmaterializeFrame).toHaveBeenCalledWith(102, 1003));
+      await waitFor(() =>
+        expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/102/1002')
+      );
+    });
+
+    it('falls back to a confirmed-empty clear when the un-materialize is refused', async () => {
+      const bare = {
+        ...makeDetection(1003, T2),
+        auto_predictions: null,
+      };
+      vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
+        if (id === 101) return [makeDetection(1001, T1)];
+        if (id === 102) return [bare]; // last frame -> the server would 409
+        return [];
+      });
+      vi.mocked(apiClient.unmaterializeFrame).mockRejectedValue({
+        detail: "Cannot remove the lane's last frame",
+        status: 409,
+      });
+
+      await renderAndSettle(<LocalizeAlertPage />, {
+        wrapper: makeWrapper('/localize/101/object/102/1003'),
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Mock Unmaterialize' }));
+
+      await waitFor(() =>
+        expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
+          expect.objectContaining({
+            detection_id: 1003,
+            annotation: { annotation: [] },
+            processing_stage: 'annotated',
+          })
+        )
+      );
+    });
+  });
 });

--- a/frontend/tests/utils/annotation/gapFrameMaterialize.test.ts
+++ b/frontend/tests/utils/annotation/gapFrameMaterialize.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { materializeGapFrame } from '@/utils/annotation/gapFrameMaterialize';
+import type { Detection, DetectionAnnotationBbox } from '@/types/api';
+
+const item: DetectionAnnotationBbox = {
+  xyxyn: [0.1, 0.1, 0.2, 0.2],
+  class_name: 'smoke',
+  smoke_type: 'wildfire',
+  origin: 'human',
+} as DetectionAnnotationBbox;
+
+const newDetection = { id: 5001, sequence_id: 27 } as Detection;
+
+describe('materializeGapFrame', () => {
+  it('materializes the frame, then creates the annotation on the new detection', async () => {
+    const apiClient = {
+      materializeFrame: vi.fn().mockResolvedValue(newDetection),
+      createDetectionAnnotation: vi.fn().mockResolvedValue({ id: 1 }),
+      updateDetectionAnnotation: vi.fn(),
+    };
+    const result = await materializeGapFrame({
+      laneId: 27,
+      recordedAt: '2026-08-05T12:00:00Z',
+      items: [item],
+      apiClient,
+    });
+    expect(apiClient.materializeFrame).toHaveBeenCalledWith(27, '2026-08-05T12:00:00Z');
+    expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith({
+      detection_id: 5001,
+      annotation: { annotation: [item] },
+      processing_stage: 'annotated',
+    });
+    expect(apiClient.updateDetectionAnnotation).not.toHaveBeenCalled();
+    expect(result.detection).toBe(newDetection);
+  });
+
+  it('does not touch annotations when the materialize call fails', async () => {
+    const apiClient = {
+      materializeFrame: vi.fn().mockRejectedValue(new Error('boom')),
+      createDetectionAnnotation: vi.fn(),
+      updateDetectionAnnotation: vi.fn(),
+    };
+    await expect(
+      materializeGapFrame({ laneId: 27, recordedAt: 't', items: [item], apiClient })
+    ).rejects.toThrow('boom');
+    expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/utils/objectBoxCandidates.test.ts
+++ b/frontend/tests/utils/objectBoxCandidates.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   boxCandidates,
   committedBox,
+  hasModelEvidence,
   priorityPick,
   candidateToBbox,
 } from '@/utils/annotation/objectBoxCandidates';
@@ -183,5 +184,38 @@ describe('candidateToBbox', () => {
     expect(candidateToBbox({ source: 'manual', index: 0, xyxyn: [0, 0, 1, 1] }, 'other').origin).toBe(
       'human'
     );
+  });
+});
+
+describe('hasModelEvidence', () => {
+  it('is true when the engine track has a box', () => {
+    expect(
+      hasModelEvidence({
+        algo_predictions: {
+          predictions: [{ xyxyn: [0, 0, 1, 1], confidence: 1, class_name: 'smoke' }],
+        },
+        auto_predictions: null,
+      } as unknown as Detection)
+    ).toBe(true);
+  });
+
+  it('is true when only the auto track has a box', () => {
+    expect(
+      hasModelEvidence({
+        algo_predictions: { predictions: [] },
+        auto_predictions: {
+          predictions: [{ xyxyn: [0, 0, 1, 1], confidence: 1, class_name: 'smoke' }],
+        },
+      } as unknown as Detection)
+    ).toBe(true);
+  });
+
+  it('is false when both tracks are empty or absent', () => {
+    expect(
+      hasModelEvidence({
+        algo_predictions: { predictions: [] },
+        auto_predictions: null,
+      } as unknown as Detection)
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #287.

A lane holds Detection rows only for the frames where its object was detected, so when the detector picks a plume up late, the earlier frames — where it was visible but fainter — could be viewed (since #290) but not annotated. This makes them drawable.

Spec: `docs/specs/2026-08-05-gap-frame-materialization-design.md`.

## Backend

- `POST /api/v1/sequences/{sequence_id}/frames` `{recorded_at}` — materializes a Detection in the lane from the alert sibling's detection at that instant (shared `bucket_key`, no S3 traffic, empty engine track). Idempotent: 200 with the existing row on a re-POST; 404 unknown sequence, 422 when no sibling has the frame, 409 on an `alert_api_id` collision.
- `DELETE /api/v1/sequences/{sequence_id}/frames/{detection_id}` — the un-materialize. Refuses (409) frames carrying model evidence (engine or auto track) and the lane's last frame; deletes the row only — never the shared S3 object (unlike `DELETE /detections/{id}`). Annotation goes via FK cascade.

## Frontend

- Drawing on a peeked (out-of-range) frame now works: commit materializes the frame, saves the box through the existing `saveDetectionReview`, and navigates the URL to the new detection once the refetch backs it. A failed materialize leaves the frame a gap; a failed save leaves a boxless in-object frame that visibly blocks submit and is retried by drawing again (the POST's idempotency covers the re-fire).
- Clear/Delete on a **model-evidence-free** frame un-materializes it — the frame reverts to a gap. On a 409 (evidence / last frame) it falls back to today's confirmed-empty clear. Frames with model evidence keep the old Clear.
- Deliberate consequence (spec'd): in a human-added lane, every frame is evidence-free, so clearing a box there removes the frame from the lane rather than leaving it confirmed-empty — a frame whose only content is a human's box has no reason to exist once the box is gone.
- `ApiError` gained an optional `status` (set in the axios interceptor) so the 409 fallback doesn't string-match detail messages.
- Filmstrip, cockpit grid and submit gate needed no logic changes — they derive from the invalidated detections query.

## Tests

- Backend: 9 new endpoint tests (`test_lane_frames.py`); full suite 588 passed in an isolated stack.
- Frontend: editor routing (draw-on-gap → `onCommitGapFrame`, Clear → un-materialize), orchestration util unit tests, page wiring tests (happy path, materialize failure, un-materialize navigation, 409 fallback); full suite 1127 passed, `npm run quality` clean.
