### PR TITLE
Object-first copy for classify groups; truthful queue/done page headers

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -103,7 +103,7 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
           name: 'Recurring objects',
           href: ROUTES.CLASSIFY_GROUPS,
           badgeCount: groupCount,
-          badgeTitle: `${groupCount} objects need validation`,
+          badgeTitle: `${groupCount} recurring objects need validation`,
         },
         { name: 'Alerts', href: ROUTES.CLASSIFY, badgeCount: sequenceCount },
         { name: 'Done', href: ROUTES.CLASSIFY_DONE },

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -100,10 +100,10 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
       name: 'Classify',
       children: [
         {
-          name: 'Groups',
+          name: 'Recurring objects',
           href: ROUTES.CLASSIFY_GROUPS,
           badgeCount: groupCount,
-          badgeTitle: `${groupCount} groups need validation`,
+          badgeTitle: `${groupCount} objects need validation`,
         },
         { name: 'Alerts', href: ROUTES.CLASSIFY, badgeCount: sequenceCount },
         { name: 'Done', href: ROUTES.CLASSIFY_DONE },

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -48,7 +48,7 @@ export default function DashboardPage() {
           reviewTo={ROUTES.CLASSIFY_DONE}
           isLoading={stats.isLoading}
           secondaryLink={{
-            label: 'Classify by group',
+            label: 'Classify recurring objects',
             to: ROUTES.CLASSIFY_GROUPS,
             count: stats.groupsToLabel,
           }}

--- a/frontend/src/pages/DetectionAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionAnnotatePage.tsx
@@ -59,10 +59,10 @@ export default function DetectionAnnotatePage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Smoke Localization</h1>
+          <h1 className="text-2xl font-bold text-gray-900">Alerts to localize</h1>
           <p className="mt-1 text-sm text-gray-500">
-            Alerts whose objects are classified and auto-annotated — draw a tight box around the
-            smoke in every image
+            Smoke alerts with model-proposed boxes — accept or fix them so every frame has a tight
+            box around the smoke
           </p>
         </div>
       </div>

--- a/frontend/src/pages/DetectionReviewPage.tsx
+++ b/frontend/src/pages/DetectionReviewPage.tsx
@@ -137,7 +137,7 @@ export default function DetectionReviewPage() {
     return (
       <div className="flex items-center justify-center min-h-96">
         <div className="text-center">
-          <p className="text-red-600 mb-2">Failed to load sequences</p>
+          <p className="text-red-600 mb-2">Failed to load alerts</p>
           <p className="text-gray-500 text-sm">{String(error)}</p>
         </div>
       </div>

--- a/frontend/src/pages/DetectionReviewPage.tsx
+++ b/frontend/src/pages/DetectionReviewPage.tsx
@@ -166,10 +166,8 @@ export default function DetectionReviewPage() {
         {/* Header */}
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">Detections</h1>
-            <p className="text-gray-600">
-              Browse localized smoke detections and review past annotations
-            </p>
+            <h1 className="text-2xl font-bold text-gray-900">Localized alerts</h1>
+            <p className="text-gray-600">Browse localized alerts and review past annotations</p>
           </div>
           <FilterPopover
             filters={filters}
@@ -256,10 +254,8 @@ export default function DetectionReviewPage() {
       {/* Header */}
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Detections</h1>
-          <p className="text-gray-600">
-            Browse localized smoke detections and review past annotations
-          </p>
+          <h1 className="text-2xl font-bold text-gray-900">Localized alerts</h1>
+          <p className="text-gray-600">Browse localized alerts and review past annotations</p>
         </div>
         <div className="flex items-center gap-3">
           <div className="flex items-center space-x-2">

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -308,7 +308,7 @@ export default function SequenceGroupAnnotatePage() {
           to={ROUTES.CLASSIFY_GROUPS}
           className="font-body text-detail text-haze hover:text-char"
         >
-          ← Sequence groups
+          ← Recurring objects
         </Link>
         <div className="mt-1 flex items-center justify-between gap-4">
           <div className="flex items-center gap-2.5 min-w-0">
@@ -362,7 +362,7 @@ export default function SequenceGroupAnnotatePage() {
             {prevId ? (
               <Link
                 to={classifyGroup(prevId)}
-                title="Previous group"
+                title="Previous object"
                 className="p-1.5 rounded-lg border border-line bg-paper text-haze hover:bg-ash"
               >
                 <ChevronLeft className="w-4 h-4" />
@@ -378,7 +378,7 @@ export default function SequenceGroupAnnotatePage() {
             {nextId ? (
               <Link
                 to={classifyGroup(nextId)}
-                title="Next group"
+                title="Next object"
                 className="p-1.5 rounded-lg border border-line bg-paper text-haze hover:bg-ash"
               >
                 <ChevronRight className="w-4 h-4" />

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -148,8 +148,8 @@ export default function SequenceGroupsListPage({
               <span className="font-semibold">What is a recurring object?</span> After each import,
               sequences from the same camera looking in the same direction at the same spot are
               grouped automatically — usually one recurring smoke plume or false-positive source (an
-              antenna, a cloud bank…). Open one, label any of its sequences, and once the group is
-              validated the label propagates to every sequence. Only objects seen in 3+ sequences
+              antenna, a cloud bank…). Open one, validate the grouping, then label any of its
+              sequences — the label propagates to every sequence. Only objects seen in 3+ sequences
               are shown.
             </Popover.Panel>
           </Popover>
@@ -279,7 +279,7 @@ export default function SequenceGroupsListPage({
                   />
                   <ColumnHeader
                     label="Created"
-                    tip="When the object was first grouped"
+                    tip="When this object's sequences were first grouped"
                     sort={{
                       active: orderBy === 'created_at',
                       direction: orderDirection,

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -42,15 +42,15 @@ const FILTERS: {
     value: 'unlabeled',
     label: 'To label',
     countOf: 'unlabeled',
-    tip: "Groups that don't have a label yet",
+    tip: "Objects that don't have a label yet",
   },
   {
     value: 'labeled',
     label: 'Labeled',
     countOf: 'labeled',
-    tip: 'Groups that already have a label',
+    tip: 'Objects that already have a label',
   },
-  { value: 'all', label: 'All', countOf: 'total', tip: 'Every group, labeled or not' },
+  { value: 'all', label: 'All', countOf: 'total', tip: 'Every object, labeled or not' },
 ];
 
 // Same hover-tooltip bubble as components/sequences/ColumnHeader.tsx, used by
@@ -116,7 +116,7 @@ export default function SequenceGroupsListPage({
   if (isLoading && !data) {
     return (
       <div className="flex items-center justify-center h-96 text-gray-500">
-        <Loader2 className="animate-spin w-6 h-6 mr-2" /> Loading groups…
+        <Loader2 className="animate-spin w-6 h-6 mr-2" /> Loading objects…
       </div>
     );
   }
@@ -124,7 +124,7 @@ export default function SequenceGroupsListPage({
     return (
       <div className="flex items-center justify-center h-96 text-red-600">
         <AlertCircle className="w-6 h-6 mr-2" />
-        Failed to load groups
+        Failed to load objects
       </div>
     );
   }
@@ -136,25 +136,25 @@ export default function SequenceGroupsListPage({
     <div className="space-y-6">
       <div>
         <div className="flex items-center gap-2">
-          <h1 className="text-2xl font-bold text-gray-900">Sequence groups</h1>
+          <h1 className="text-2xl font-bold text-gray-900">Recurring objects</h1>
           <Popover className="relative flex">
             <Popover.Button
               className="text-gray-400 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-full"
-              aria-label="What is a sequence group?"
+              aria-label="What is a recurring object?"
             >
               <Info className="w-4 h-4" />
             </Popover.Button>
             <Popover.Panel className="absolute left-0 top-full z-20 mt-2 w-96 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900 shadow-lg">
-              <span className="font-semibold">What is a sequence group?</span> After each import,
+              <span className="font-semibold">What is a recurring object?</span> After each import,
               sequences from the same camera looking in the same direction at the same spot are
               grouped automatically — usually one recurring smoke plume or false-positive source (an
-              antenna, a cloud bank…). Open a group, label one of its sequences, and once the group
-              is validated the label propagates to every member. Only groups with 3+ sequences are
-              shown.
+              antenna, a cloud bank…). Open one, label any of its sequences, and once the group is
+              validated the label propagates to every sequence. Only objects seen in 3+ sequences
+              are shown.
             </Popover.Panel>
           </Popover>
         </div>
-        <p className="text-gray-600">Label many related sequences at once.</p>
+        <p className="text-gray-600">Label an object once to label every sequence it appears in.</p>
       </div>
 
       <div className="flex justify-center">
@@ -207,11 +207,11 @@ export default function SequenceGroupsListPage({
                   <Check className="h-7 w-7 text-pine" />
                 </span>
                 <h2 className="mt-4 font-display text-base font-semibold text-char">
-                  All groups labeled
+                  All objects labeled
                 </h2>
                 <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
-                  Nice work — every group is labeled. New groups form automatically a few minutes
-                  after each import.
+                  Nice work — every object is labeled. New objects appear automatically a few
+                  minutes after each import.
                 </p>
                 <Link
                   to={ROUTES.CLASSIFY}
@@ -230,16 +230,16 @@ export default function SequenceGroupsListPage({
                   <Layers className="h-6 w-6 text-ember" />
                 </span>
                 <h2 className="mt-4 font-display text-base font-semibold text-char">
-                  No labeled groups yet
+                  No labeled objects yet
                 </h2>
                 <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
-                  Groups you label land here.
+                  Objects you label land here.
                 </p>
                 <Link
                   to={classifyGroups('unlabeled')}
                   className="mt-5 inline-block rounded-lg bg-ember px-7 py-2.5 font-body text-[13.5px] font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2"
                 >
-                  Label groups
+                  Label objects
                 </Link>
               </>
             ) : (
@@ -252,11 +252,11 @@ export default function SequenceGroupsListPage({
                   <Layers className="h-6 w-6 text-haze" />
                 </span>
                 <h2 className="mt-4 font-display text-base font-semibold text-char">
-                  No groups yet
+                  No objects yet
                 </h2>
                 <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
-                  Groups form automatically after imports — only groups of 3 or more sequences
-                  appear here.
+                  Objects appear automatically after imports — only objects seen in 3 or more
+                  sequences are shown here.
                 </p>
               </>
             )}
@@ -270,7 +270,7 @@ export default function SequenceGroupsListPage({
                 <tr>
                   <ColumnHeader
                     label="Camera"
-                    tip="Camera that recorded the group's sequences"
+                    tip="Camera that recorded the object's sequences"
                     sort={{
                       active: orderBy === 'camera_name',
                       direction: orderDirection,
@@ -279,7 +279,7 @@ export default function SequenceGroupsListPage({
                   />
                   <ColumnHeader
                     label="Created"
-                    tip="When the group was created"
+                    tip="When the object was first grouped"
                     sort={{
                       active: orderBy === 'created_at',
                       direction: orderDirection,
@@ -297,7 +297,7 @@ export default function SequenceGroupsListPage({
                   />
                   <ColumnHeader
                     label="Sequences"
-                    tip="Number of sequences in the group"
+                    tip="Number of sequences showing this object"
                     sort={{
                       active: orderBy === 'member_count',
                       direction: orderDirection,
@@ -306,11 +306,11 @@ export default function SequenceGroupsListPage({
                   />
                   <ColumnHeader
                     label="Label"
-                    tip="Group label — propagates to every member once the group is validated"
+                    tip="Object label — propagates to every sequence once the group is validated"
                   />
                   <ColumnHeader
                     label="Reviewed"
-                    tip="Whether a human confirmed the group's sequences show the same object — the label propagates once confirmed"
+                    tip="Whether a human confirmed the sequences really show the same object — the label propagates once confirmed"
                     align="right"
                   />
                   <th className={HEADER_CELL_CLASSES}>
@@ -358,8 +358,8 @@ export default function SequenceGroupsListPage({
                               tell unvalidated ones to validate first. */}
                           {headerTip(
                             g.is_validated
-                              ? 'Classify any sequence in this group — its label will propagate to all members'
-                              : 'Validate the group, then classify any sequence — its label will propagate to all members'
+                              ? "Classify any of this object's sequences — the label will propagate to all of them"
+                              : "Validate the group first, then classify any of this object's sequences — the label will propagate to all of them"
                           )}
                         </span>
                       )}
@@ -397,7 +397,7 @@ export default function SequenceGroupsListPage({
             page={page}
             pages={totalPages}
             total={data?.total}
-            itemsLabel="groups"
+            itemsLabel="objects"
             onPageChange={setPage}
           />
         </div>

--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -266,11 +266,11 @@ export default function SequencesPage({
         <div className="flex items-start justify-between gap-4">
           <div>
             <h1 className="text-2xl font-bold text-gray-900">
-              {isQueueMode ? 'Alerts' : 'Sequences'}
+              {isQueueMode ? 'Alerts' : 'Classified alerts'}
             </h1>
             <p className="text-gray-600">
               {isReviewPage
-                ? 'Browse classified sequences and review past decisions'
+                ? 'Browse classified alerts and review past decisions'
                 : isQueueMode
                   ? 'Classify every object of each alert'
                   : 'Manage and annotate wildfire detection sequences'}
@@ -397,11 +397,11 @@ export default function SequencesPage({
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">
-            {isQueueMode ? 'Alerts' : 'Sequences'}
+            {isQueueMode ? 'Alerts' : 'Classified alerts'}
           </h1>
           <p className="text-gray-600">
             {isReviewPage
-              ? 'Browse classified sequences and review past decisions'
+              ? 'Browse classified alerts and review past decisions'
               : isQueueMode
                 ? 'Classify every object of each alert'
                 : 'Manage and annotate wildfire detection sequences'}

--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -233,7 +233,7 @@ export default function SequencesPage({
     return (
       <div className="flex items-center justify-center min-h-96">
         <div className="text-center">
-          <p className="text-red-600 mb-2">Failed to load sequences</p>
+          <p className="text-red-600 mb-2">Failed to load alerts</p>
           <p className="text-gray-500 text-sm">{String(error)}</p>
         </div>
       </div>
@@ -322,7 +322,7 @@ export default function SequencesPage({
                   <Search className="h-6 w-6 text-haze" />
                 </span>
                 <h2 className="mt-4 font-display text-base font-semibold text-char">
-                  {isQueueMode ? 'No matching alerts' : 'No matching sequences'}
+                  {isQueueMode ? 'No matching alerts' : 'No matching classified alerts'}
                 </h2>
                 <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
                   Nothing here matches your current filters. Loosen or clear them to see more.
@@ -346,11 +346,11 @@ export default function SequencesPage({
                 <h2 className="mt-4 font-display text-base font-semibold text-char">
                   {/* An array stage is the "All classified" pseudo-stage (see getStageFilterLabel) */}
                   {Array.isArray(defaultProcessingStage)
-                    ? 'No classified sequences yet'
+                    ? 'No classified alerts yet'
                     : `No sequences in "${getStageFilterLabel(defaultProcessingStage)}"`}
                 </h2>
                 <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
-                  Sequences you classify land here for review.
+                  Alerts you classify land here for review.
                 </p>
                 <Link
                   to={ROUTES.CLASSIFY}

--- a/frontend/tests/components/dashboard/DashboardPage.test.tsx
+++ b/frontend/tests/components/dashboard/DashboardPage.test.tsx
@@ -40,7 +40,7 @@ describe('DashboardPage', () => {
     expect(screen.getByText('Classify alerts')).toBeInTheDocument();
     expect(screen.getByText('Localize smoke')).toBeInTheDocument();
     expect(screen.getByText('How annotation works')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Classify by group/ })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /Classify recurring objects/ })).toHaveAttribute(
       'href',
       '/classify/groups'
     );

--- a/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
+++ b/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
@@ -91,9 +91,10 @@ describe('DetectionAnnotatePage (Localize queue)', () => {
     // Smoke type from the classify phase (smoke lanes only), plain text
     expect(screen.getByText(/Wildfire/)).toBeTruthy();
     // Old cell formats are gone (the header tooltip mentions "objects to
-    // localize", so match the old "N objects ..." cell text specifically)
+    // localize" and the page subtitle mentions "boxes", so match the old
+    // "N objects ..." / "N boxes ..." cell text specifically)
     expect(screen.queryByText(/\d+ objects to localize/)).toBeNull();
-    expect(screen.queryByText(/boxes/)).toBeNull();
+    expect(screen.queryByText(/\d+ boxes/)).toBeNull();
   });
 
   it('unions and dedupes smoke types across smoke lanes', async () => {

--- a/frontend/tests/components/layout/AppLayout.test.tsx
+++ b/frontend/tests/components/layout/AppLayout.test.tsx
@@ -100,7 +100,7 @@ describe('AppLayout sidebar navigation', () => {
     expect(objectsLink).toHaveAttribute('href', '/classify/groups');
 
     const badge = within(objectsLink).getByText('8');
-    expect(badge).toHaveAttribute('title', '8 objects need validation');
+    expect(badge).toHaveAttribute('title', '8 recurring objects need validation');
   });
 
   it('places Objects first among the Classify sub-items, after the section header', () => {

--- a/frontend/tests/components/layout/AppLayout.test.tsx
+++ b/frontend/tests/components/layout/AppLayout.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Sidebar navigation structure tests for AppLayout.
- * Focuses on the Classify section containing the Groups link with its badge.
+ * Focuses on the Classify section containing the Objects link with its badge.
  */
 
 import React from 'react';
@@ -57,9 +57,9 @@ describe('AppLayout sidebar navigation', () => {
   it('styles the active link with the pine accent and a left bar', () => {
     renderLayoutAt('/classify/groups');
 
-    const groupsLink = screen.getByRole('link', { name: /groups/i });
-    expect(groupsLink).toHaveClass('bg-pine-soft', 'text-pine', 'border-pine', 'border-l-[3px]');
-    expect(groupsLink).not.toHaveClass('bg-primary-50', 'border-r-4', 'rounded-l-md');
+    const objectsLink = screen.getByRole('link', { name: /objects/i });
+    expect(objectsLink).toHaveClass('bg-pine-soft', 'text-pine', 'border-pine', 'border-l-[3px]');
+    expect(objectsLink).not.toHaveClass('bg-primary-50', 'border-r-4', 'rounded-l-md');
   });
 
   it('styles inactive links with haze text, ash hover, and a transparent left bar', () => {
@@ -82,8 +82,8 @@ describe('AppLayout sidebar navigation', () => {
   it('stacks nav links without vertical gaps between them', () => {
     renderLayoutAt('/classify/groups');
 
-    const groupsLink = screen.getByRole('link', { name: /groups/i });
-    expect(groupsLink.parentElement).not.toHaveClass('space-y-1');
+    const objectsLink = screen.getByRole('link', { name: /objects/i });
+    expect(objectsLink.parentElement).not.toHaveClass('space-y-1');
   });
 
   it('lets nav links span the full sidebar width', () => {
@@ -93,21 +93,21 @@ describe('AppLayout sidebar navigation', () => {
     expect(nav).not.toHaveClass('px-2');
   });
 
-  it('renders Groups as a sub-item of the Classify section with its badge count', () => {
+  it('renders Objects as a sub-item of the Classify section with its badge count', () => {
     renderLayout();
 
-    const groupsLink = screen.getByRole('link', { name: /groups/i });
-    expect(groupsLink).toHaveAttribute('href', '/classify/groups');
+    const objectsLink = screen.getByRole('link', { name: /objects/i });
+    expect(objectsLink).toHaveAttribute('href', '/classify/groups');
 
-    const badge = within(groupsLink).getByText('8');
-    expect(badge).toHaveAttribute('title', '8 groups need validation');
+    const badge = within(objectsLink).getByText('8');
+    expect(badge).toHaveAttribute('title', '8 objects need validation');
   });
 
-  it('places Groups first among the Classify sub-items, after the section header', () => {
+  it('places Objects first among the Classify sub-items, after the section header', () => {
     renderLayout();
 
     const classifyHeader = screen.getByText('Classify');
-    const groupsLink = screen.getByRole('link', { name: /groups/i });
+    const objectsLink = screen.getByRole('link', { name: /objects/i });
     const alertsLinks = screen.getAllByRole('link', { name: /alerts/i });
     const classifyAlertsLink = alertsLinks.find(
       link => link.getAttribute('href') === '/classify'
@@ -115,10 +115,10 @@ describe('AppLayout sidebar navigation', () => {
 
     expect(classifyAlertsLink).toBeDefined();
     expect(
-      classifyHeader.compareDocumentPosition(groupsLink) & Node.DOCUMENT_POSITION_FOLLOWING
+      classifyHeader.compareDocumentPosition(objectsLink) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
-      groupsLink.compareDocumentPosition(classifyAlertsLink!) & Node.DOCUMENT_POSITION_FOLLOWING
+      objectsLink.compareDocumentPosition(classifyAlertsLink!) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
   });
 

--- a/frontend/tests/pages/SequenceGroupsListPage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupsListPage.test.tsx
@@ -74,8 +74,8 @@ describe('SequenceGroupsListPage', () => {
 
   it('To label empty shows all-groups-labeled state, CTA to classify, and no table', async () => {
     renderAt('/classify/groups');
-    await waitFor(() => expect(screen.getByText('All groups labeled')).toBeTruthy());
-    expect(screen.getByText(/every group is labeled/)).toBeTruthy();
+    await waitFor(() => expect(screen.getByText('All objects labeled')).toBeTruthy());
+    expect(screen.getByText(/every object is labeled/)).toBeTruthy();
     expect(screen.getByRole('link', { name: 'Start classifying' }).getAttribute('href')).toBe(
       '/classify'
     );
@@ -84,9 +84,9 @@ describe('SequenceGroupsListPage', () => {
 
   it('Labeled empty shows no-labeled-groups state with CTA to the To label tab', async () => {
     renderAt('/classify/groups/labeled');
-    await waitFor(() => expect(screen.getByText('No labeled groups yet')).toBeTruthy());
-    expect(screen.getByText(/Groups you label land here/)).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Label groups' }).getAttribute('href')).toBe(
+    await waitFor(() => expect(screen.getByText('No labeled objects yet')).toBeTruthy());
+    expect(screen.getByText(/Objects you label land here/)).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Label objects' }).getAttribute('href')).toBe(
       '/classify/groups'
     );
     expect(screen.queryByRole('table')).toBeNull();
@@ -94,10 +94,10 @@ describe('SequenceGroupsListPage', () => {
 
   it('All empty shows no-groups state with no action', async () => {
     renderAt('/classify/groups/all');
-    await waitFor(() => expect(screen.getByText('No groups yet')).toBeTruthy());
-    expect(screen.getByText(/only groups of 3 or more sequences/)).toBeTruthy();
+    await waitFor(() => expect(screen.getByText('No objects yet')).toBeTruthy());
+    expect(screen.getByText(/only objects seen in 3 or more sequences/)).toBeTruthy();
     expect(screen.queryByRole('link', { name: 'Start classifying' })).toBeNull();
-    expect(screen.queryByRole('link', { name: 'Label groups' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Label objects' })).toBeNull();
     expect(screen.queryByRole('table')).toBeNull();
   });
 
@@ -125,7 +125,7 @@ describe('SequenceGroupsListPage', () => {
     });
     renderAt('/classify/groups');
     await waitFor(() => expect(screen.getByRole('table')).toBeTruthy());
-    expect(screen.queryByText('All groups labeled')).toBeNull();
+    expect(screen.queryByText('All objects labeled')).toBeNull();
   });
 
   it('uses the fire-lookout row style and canonical column order', async () => {
@@ -194,9 +194,9 @@ describe('SequenceGroupsListPage', () => {
   it('filter tabs carry explanatory tooltips', async () => {
     renderAt('/classify/groups');
     await waitFor(() => expect(screen.getByRole('link', { name: /To label/ })).toBeTruthy());
-    expect(screen.getByText("Groups that don't have a label yet")).toBeTruthy();
-    expect(screen.getByText('Groups that already have a label')).toBeTruthy();
-    expect(screen.getByText('Every group, labeled or not')).toBeTruthy();
+    expect(screen.getByText("Objects that don't have a label yet")).toBeTruthy();
+    expect(screen.getByText('Objects that already have a label')).toBeTruthy();
+    expect(screen.getByText('Every object, labeled or not')).toBeTruthy();
     // Tooltip text must not leak into the tab links' accessible names
     // (exact names: label + mocked zero count).
     expect(screen.getByRole('link', { name: 'To label 0' })).toBeTruthy();
@@ -217,12 +217,12 @@ describe('SequenceGroupsListPage', () => {
     // One tooltip per labeled column (Camera, Azimuth, Sequences, Label,
     // Reviewed, Created) plus one on the row's "to label" badge.
     expect(within(screen.getByRole('table')).getAllByRole('tooltip')).toHaveLength(7);
-    expect(screen.getByText('Number of sequences in the group')).toBeTruthy();
-    expect(screen.getByText(/propagates to every member/)).toBeTruthy();
+    expect(screen.getByText('Number of sequences showing this object')).toBeTruthy();
+    expect(screen.getByText(/propagates to every sequence/)).toBeTruthy();
     expect(screen.getByText('Camera viewing direction, in degrees')).toBeTruthy();
     // Reviewed means the grouping was confirmed, not the label — a group can
     // be validated while still unlabeled.
-    expect(screen.getByText(/confirmed the group's sequences show the same object/)).toBeTruthy();
+    expect(screen.getByText(/confirmed the sequences really show the same object/)).toBeTruthy();
   });
 
   it('the "to label" badge explains how to get the group labeled, per validation state', async () => {
@@ -237,7 +237,7 @@ describe('SequenceGroupsListPage', () => {
     });
     renderAt('/classify/groups');
     await waitFor(() => expect(screen.getAllByText('to label')).toHaveLength(2));
-    expect(screen.getByText(/^Classify any sequence in this group/)).toBeTruthy();
-    expect(screen.getByText(/^Validate the group, then classify any sequence/)).toBeTruthy();
+    expect(screen.getByText(/^Classify any of this object's sequences/)).toBeTruthy();
+    expect(screen.getByText(/^Validate the group first, then classify/)).toBeTruthy();
   });
 });

--- a/frontend/tests/pages/SequencesPage.empty.test.tsx
+++ b/frontend/tests/pages/SequencesPage.empty.test.tsx
@@ -116,7 +116,7 @@ describe('SequencesPage empty states', () => {
     render(<SequencesPage defaultProcessingStage={ALL_CLASSIFIED_STAGES} isReviewPage />, {
       wrapper,
     });
-    await waitFor(() => expect(screen.getByText('No classified sequences yet')).toBeTruthy());
+    await waitFor(() => expect(screen.getByText('No classified alerts yet')).toBeTruthy());
     expect(screen.getByText(/land here for review/)).toBeTruthy();
     const cta = screen.getByRole('link', { name: 'Start classifying' });
     expect(cta.getAttribute('href')).toBe('/classify');
@@ -127,8 +127,8 @@ describe('SequencesPage empty states', () => {
     render(<SequencesPage defaultProcessingStage={ALL_CLASSIFIED_STAGES} isReviewPage />, {
       wrapper,
     });
-    await waitFor(() => expect(screen.getByText('No matching sequences')).toBeTruthy());
-    expect(screen.queryByText('No classified sequences yet')).toBeNull();
+    await waitFor(() => expect(screen.getByText('No matching classified alerts')).toBeTruthy());
+    expect(screen.queryByText('No classified alerts yet')).toBeNull();
     expect(screen.getByRole('button', { name: 'Clear filters' })).toBeTruthy();
   });
 


### PR DESCRIPTION
## Summary

User-facing copy only — no routes, components, identifiers, or behavior changed.

### /classify/groups → "Recurring objects"
Each group *is* one recurring object (a smoke plume or a false-positive source like an antenna) seen across sequences, so the page now leads with the concept instead of the container: title, subtitle ("Label an object once to label every sequence it appears in."), info popover, filter-tab tips, empty states, column/badge tooltips, pagination label. "Group" survives only as the mechanism word ("grouped automatically", "Validate the group"). Entry points follow: sidebar **Classify → Recurring objects**, dashboard "Classify recurring objects", annotate-page back-link and prev/next titles.

The rewritten popover also fixes an ordering trap: it now says **validate the grouping first, then label** — the label-then-validate order it used to describe is the #253 stranding path.

### Done lists say what their rows are
- **/classify/done**: "Sequences" → **"Classified alerts"** (header, empty states, error state) — rows are alerts.
- **/localize/done**: "Detections" → **"Localized alerts"** — the list has been alert-grouped for a while.

### /localize queue
"Smoke Localization" → **"Alerts to localize"** (pairs with "Localized alerts"); subtitle now describes the real work — *accept or fix model-proposed boxes so every frame has a tight box around the smoke* — instead of "draw a tight box around the smoke in every image" (annotators mostly accept/adjust, and the app's unit is the frame).

## Tests
Assertions updated to the new copy. One guard in `DetectionAnnotatePage.test.tsx` (`/boxes/` must not appear) was narrowed to `/\d+ boxes/`: the new subtitle legitimately contains "boxes", and the narrowed regex still catches the old "N/M boxes" cell format it guards against.

`npm test`: 1115 passed (88 files). `npm run quality` clean.