### PR TITLE
feat(frontend): quiet stage + hover-to-preview rail in the localize editor

### DIFF
--- a/docs/specs/2026-08-05-localize-editor-quiet-stage-hover-preview-design.md
+++ b/docs/specs/2026-08-05-localize-editor-quiet-stage-hover-preview-design.md
@@ -1,0 +1,95 @@
+# Localize object editor: quiet stage + hover-to-preview rail
+
+**Date:** 2026-08-05
+**Status:** Approved
+
+## Motivation
+
+On an undecided frame (e.g. `/localize/78/object/78/1583`) the editor's stage
+ghosts in **every** candidate box by default. The engine and auto boxes sit
+almost concentrically on the same plume — two dashed strokes plus their dark
+halos — and at the default 3x object zoom the stack reads as clutter exactly
+where the annotator is trying to look. With a manual box committed and `G`
+pressed, all three sources pile up the same way.
+
+The rail beside the image already carries the auto-vs-engine comparison: three
+rows, each cropping the same region with that source's box drawn on it. The
+stage does not need to repeat the stacked comparison; it needs to show **one
+box at a time**, well.
+
+## Design
+
+### Undecided frame: one ghost, the priority pick
+
+With nothing committed, the stage draws exactly one ghost: the **priority
+pick** (`manual > auto > engine` — in practice auto when present, else
+engine), dashed in its source colour, with the existing halo. This is the box
+`Enter` would commit, so the idle stage always answers "is the default right?"
+The losing candidate no longer draws by default.
+
+### Rail hover / focus: solo preview
+
+Hovering a rail row — or focusing it with the keyboard, same handler — makes
+the stage show **only that row's candidate** as a dashed ghost for the
+duration. Whatever was shown (the default pick, or the committed box on a
+decided frame) hides while the preview is active. Leaving the row restores the
+idle state.
+
+Moving the pointer between rows therefore blink-compares candidates in place:
+the stage always holds exactly one box, and differences pop by alternation
+rather than by stacking.
+
+- A preview is purely visual: no handles, no drag, no pointer events.
+- Rows with no candidate (e.g. the manual row before anything is drawn)
+  preview nothing.
+- Hovering the committed row is a no-op — its box is already on stage.
+- During an active draw or box move/resize, hover previews are ignored.
+- Clicking a row is unchanged: commit that candidate.
+
+### Committed frame: unchanged idle state
+
+The committed box alone, solid, in its source colour, selectable and editable
+as today. Only the hover preview is new.
+
+### `G` becomes a three-state cycle
+
+With the default now "one box", `G` cycles the idle stage through:
+
+1. **pick-only** (default) — the committed box, or the priority-pick ghost.
+2. **all** — every candidate at once: today's stacked view, on demand.
+3. **none** — no boxes at all, for seeing the bare plume.
+
+The cycle resets to pick-only on frame change, as the current override does.
+A hover preview overrides whichever cycle state is active, and releases back
+to it. The shortcuts modal copy updates to describe the cycle.
+
+## Non-changes
+
+`O` (other objects), `Z`/`R` (zoom), drawing, box move/resize, click-to-commit,
+`Enter`/`Delete`, the rail's layout and crops, and the source colour/weight
+identity (`sourceIdentity.ts`) all stay exactly as they are.
+
+## Implementation shape
+
+- `LocalizeObjectEditor` gains `previewedCandidate: BoxCandidate | null`
+  state, set by new `onPreview(candidate | null)` callbacks from
+  `BoxSourceRail` rows (mouseenter/mouseleave + focus/blur on the row
+  **wrapper**, not the button — browsers do not fire mouse events on disabled
+  `<button>`s).
+- The existing `ghostsOverridden: boolean` becomes the three-state cycle
+  (`'pick' | 'all' | 'none'`), still reset on `detection.id` change.
+- The committed/ghosts props passed to `DetectionAnnotationCanvas` are derived
+  from (cycle state, preview, committed, candidates); the canvas component
+  itself needs no new rendering path — a preview renders through the existing
+  ghost layer.
+
+## Testing
+
+Component tests on the editor:
+
+- Undecided frame renders exactly one ghost — the priority pick.
+- Hovering (and focusing) the engine row shows only the engine ghost.
+- On a committed frame, hovering a losing row hides the committed box and
+  shows that ghost; leaving restores it.
+- Rows without a candidate trigger no preview.
+- `G` cycles pick-only → all → none → pick-only, and resets on frame change.

--- a/docs/specs/2026-08-05-localize-editor-quiet-stage-hover-preview-design.md
+++ b/docs/specs/2026-08-05-localize-editor-quiet-stage-hover-preview-design.md
@@ -73,15 +73,32 @@ identity (`sourceIdentity.ts`) all stay exactly as they are.
 
 - `LocalizeObjectEditor` gains `previewedCandidate: BoxCandidate | null`
   state, set by new `onPreview(candidate | null)` callbacks from
-  `BoxSourceRail` rows (mouseenter/mouseleave + focus/blur on the row
-  **wrapper**, not the button — browsers do not fire mouse events on disabled
-  `<button>`s).
+  `BoxSourceRail` rows. The handlers live on the row **button** after all,
+  not a wrapper: previews only ever target enabled rows, so the
+  disabled-button event gap does not apply to *starting* one. What it does
+  threaten is *releasing* one — a row can disable in place while hovered
+  (its candidate wins a commit, or a peek disables the rail) and a disabled
+  button never fires mouseleave. Robustness therefore lives in the editor,
+  not in DOM wiring: every write (`commitCandidate` / `commitDrawn` /
+  `clear`) and every peek start clears the preview, and the rail's
+  leave/blur release is unconditional.
 - The existing `ghostsOverridden: boolean` becomes the three-state cycle
   (`'pick' | 'all' | 'none'`), still reset on `detection.id` change.
 - The committed/ghosts props passed to `DetectionAnnotationCanvas` are derived
   from (cycle state, preview, committed, candidates); the canvas component
   itself needs no new rendering path — a preview renders through the existing
   ghost layer.
+
+## Amendments from review
+
+- **Enter on a focused rail row commits that row.** The focus preview shows
+  the row's own candidate, so the global Enter (accept the priority pick)
+  would commit something other than what the stage is showing. The row
+  button stops Enter's propagation and lets its native activation do the
+  commit. Enter anywhere else keeps its global meaning.
+- The "wrapper, not button" note above originally mandated wrapper-level
+  event wiring; superseded as described (editor-level clears are the
+  robustness layer).
 
 ## Testing
 

--- a/frontend/src/components/localize/editor/BoxSourceRail.tsx
+++ b/frontend/src/components/localize/editor/BoxSourceRail.tsx
@@ -145,7 +145,7 @@ export function BoxSourceRail({
         const invitesDrawing = source === 'manual' && !candidate;
         // Only rows that could change the stage preview: the committed row is
         // already what's on stage, and disabled/empty rows have nothing to show.
-        const previewable = !disabled && candidate && !isCommitted;
+        const previewable = Boolean(!disabled && candidate && !isCommitted);
         return (
           <Tooltip key={source} tip={SOURCE_EXPLANATION[source]} className="mb-1.5 w-full">
             <button
@@ -153,10 +153,18 @@ export function BoxSourceRail({
               data-testid={`source-row-${source}`}
               aria-pressed={isCommitted}
               disabled={disabled || !candidate || isCommitted}
-              onMouseEnter={() => previewable && onPreview(candidate)}
-              onMouseLeave={() => previewable && onPreview(null)}
-              onFocus={() => previewable && onPreview(candidate)}
-              onBlur={() => previewable && onPreview(null)}
+              onMouseEnter={() => previewable && candidate && onPreview(candidate)}
+              // Releasing is idempotent, so leave/blur are unconditional — a
+              // row that stopped being previewable mid-hover must still let go.
+              onMouseLeave={() => onPreview(null)}
+              onFocus={() => previewable && candidate && onPreview(candidate)}
+              onBlur={() => onPreview(null)}
+              onKeyDown={e => {
+                // A focused row previews ITS candidate, so Enter must commit
+                // that row — the button's own native activation — rather than
+                // bubbling to the editor's global accept-the-priority-pick.
+                if (e.key === 'Enter') e.stopPropagation();
+              }}
               onClick={() => {
                 if (!candidate || isCommitted) return;
                 // Committing disables this row in place, and a disabled button

--- a/frontend/src/components/localize/editor/BoxSourceRail.tsx
+++ b/frontend/src/components/localize/editor/BoxSourceRail.tsx
@@ -39,6 +39,12 @@ export interface BoxSourceRailProps {
   disabled: boolean;
   onCommit: (candidate: BoxCandidate) => void;
   onClear: () => void;
+  /**
+   * Solo-preview this candidate on the stage (null to release). Fired on
+   * hover and keyboard focus; never for the committed or empty rows, whose
+   * preview would be a no-op.
+   */
+  onPreview: (candidate: BoxCandidate | null) => void;
 }
 
 /** The union of every candidate box — one region shared by all rows. */
@@ -116,6 +122,7 @@ export function BoxSourceRail({
   disabled,
   onCommit,
   onClear,
+  onPreview,
 }: BoxSourceRailProps) {
   const region = unionBox(candidates);
 
@@ -136,6 +143,9 @@ export function BoxSourceRail({
         // row says how. There is no mode to arm any more, so it points at the
         // canvas rather than being a control of its own.
         const invitesDrawing = source === 'manual' && !candidate;
+        // Only rows that could change the stage preview: the committed row is
+        // already what's on stage, and disabled/empty rows have nothing to show.
+        const previewable = !disabled && candidate && !isCommitted;
         return (
           <Tooltip key={source} tip={SOURCE_EXPLANATION[source]} className="mb-1.5 w-full">
             <button
@@ -143,7 +153,17 @@ export function BoxSourceRail({
               data-testid={`source-row-${source}`}
               aria-pressed={isCommitted}
               disabled={disabled || !candidate || isCommitted}
-              onClick={() => candidate && !isCommitted && onCommit(candidate)}
+              onMouseEnter={() => previewable && onPreview(candidate)}
+              onMouseLeave={() => previewable && onPreview(null)}
+              onFocus={() => previewable && onPreview(candidate)}
+              onBlur={() => previewable && onPreview(null)}
+              onClick={() => {
+                if (!candidate || isCommitted) return;
+                // Committing disables this row in place, and a disabled button
+                // never fires mouseleave — release the preview now.
+                onPreview(null);
+                onCommit(candidate);
+              }}
               className={`flex w-full items-center gap-2.5 rounded-lg border p-2 text-left transition-colors ${
                 isCommitted ? 'border-pine bg-pine-soft' : 'border-transparent'
               } ${candidate && !isCommitted ? 'hover:bg-ash' : ''} ${

--- a/frontend/src/components/localize/editor/EditorShortcutsModal.tsx
+++ b/frontend/src/components/localize/editor/EditorShortcutsModal.tsx
@@ -87,7 +87,7 @@ export const EditorShortcutsModal: React.FC<EditorShortcutsModalProps> = ({ onCl
           <Row label="Reset the zoom" keys={['R']} />
         </Section>
         <Section title="What you can see">
-          <Row label="Boxes from the other sources" keys={['G']} />
+          <Row label="Cycle boxes — default, all sources, none" keys={['G']} />
           <Row label="Boxes from the alert's other objects" keys={['O']} />
         </Section>
         <Section title="Leave">

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -241,18 +241,30 @@ export function LocalizeObjectEditor({
 
   // --- Commit -------------------------------------------------------------
 
+  // Every write also drops any live preview. A commit can disable the very
+  // row being hovered (Enter with one candidate), and a disabled button never
+  // fires mouseleave — without this the stage would keep a dashed read-only
+  // ghost where the freshly committed box should be.
   const commitCandidate = useCallback(
-    (candidate: BoxCandidate) => onCommit(detection, [candidateToBbox(candidate, smokeType)]),
+    (candidate: BoxCandidate) => {
+      setPreviewed(null);
+      onCommit(detection, [candidateToBbox(candidate, smokeType)]);
+    },
     [detection, smokeType, onCommit]
   );
 
   const commitDrawn = useCallback(
-    (xyxyn: [number, number, number, number]) =>
-      onCommit(detection, [candidateToBbox({ source: 'manual', index: 0, xyxyn }, smokeType)]),
+    (xyxyn: [number, number, number, number]) => {
+      setPreviewed(null);
+      onCommit(detection, [candidateToBbox({ source: 'manual', index: 0, xyxyn }, smokeType)]);
+    },
     [detection, smokeType, onCommit]
   );
 
-  const clear = useCallback(() => onCommit(detection, []), [detection, onCommit]);
+  const clear = useCallback(() => {
+    setPreviewed(null);
+    onCommit(detection, []);
+  }, [detection, onCommit]);
 
   clearRef.current = clear;
 
@@ -284,6 +296,11 @@ export function LocalizeObjectEditor({
         setPeeked(null);
         onNavigateToDetection(entry.detectionId);
       } else {
+        // Peeking disables the rail in place, so no mouseleave will ever
+        // release a preview — and detection.id doesn't change, so the
+        // frame-change reset won't either. Drop it here or it comes back
+        // stale on return.
+        setPreviewed(null);
         setPeeked(entry);
       }
     },
@@ -883,7 +900,7 @@ export function LocalizeObjectEditor({
             detection={shownDetection}
             committed={editable ? stageCommitted : null}
             ghosts={editable ? ghosts : []}
-            showGhosts={ghosts.length > 0}
+            showGhosts={editable && ghosts.length > 0}
             selected={editable && boxSelected}
             selectedSmokeType={smokeType}
             objectOverlays={showOtherObjects ? objectOverlays : []}

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -70,6 +70,9 @@ import { ObjectFilmstrip } from './ObjectFilmstrip';
  */
 const OBJECT_FRAMING = { targetFill: 0.32, maxScale: 3 };
 
+/** What the idle stage draws; `G` cycles it. A rail hover overrides it. */
+type BoxVisibility = 'pick' | 'all' | 'none';
+
 export interface LocalizeObjectEditorProps {
   /** The object being edited. */
   laneSequenceId: number;
@@ -147,8 +150,9 @@ export function LocalizeObjectEditor({
   const [spaceHeld, setSpaceHeld] = useState(false);
   const spaceHeldRef = useRef(false);
 
-  // `G` overrides whatever the default rule below decides.
-  const [ghostsOverridden, setGhostsOverridden] = useState(false);
+  // `G` cycles what the idle stage draws: the default pick, every candidate
+  // at once, or nothing at all — the bare plume.
+  const [boxVisibility, setBoxVisibility] = useState<BoxVisibility>('pick');
   // The OTHER objects' boxes on this frame, off by default. On this screen
   // color means *source* (manual/auto/engine), and the object-identity
   // palette overlaps it closely enough that a blue dashed box would be
@@ -205,15 +209,24 @@ export function LocalizeObjectEditor({
   );
 
   /**
-   * The frame always draws at least the winner, and never more than it needs.
-   * With a box committed, that box alone speaks for the object and the losing
-   * candidates are noise — the rail's crops carry the comparison. With
-   * nothing committed there is no winner to draw, so the candidates ghost in
-   * to show what is on offer. `G` flips whichever state you are in.
+   * The stage draws one box, well. With a box committed, that box alone
+   * speaks for the object; with nothing committed the priority pick ghosts
+   * in — the box Enter would commit — and the rail's crops carry the
+   * comparison with the rest. `G` cycles to "all" (every candidate stacked,
+   * on demand) and "none" (the bare plume).
    */
-  const ghostsShownByDefault = committed === null;
-  const showGhosts = ghostsOverridden ? !ghostsShownByDefault : ghostsShownByDefault;
-  const ghosts = showGhosts ? losers : [];
+  const pick = priorityPick(candidates);
+  const stageCommitted = boxVisibility === 'none' ? null : shownCommitted;
+  const ghosts =
+    boxVisibility === 'none'
+      ? []
+      : boxVisibility === 'all'
+        ? losers
+        : shownCommitted
+          ? []
+          : pick
+            ? [pick]
+            : [];
   committedRef.current = committed;
 
   const entries = useMemo(
@@ -339,7 +352,7 @@ export function LocalizeObjectEditor({
     setCurrentDrawing(null);
     setBoxEdit(null);
     setBoxSelected(false);
-    setGhostsOverridden(false);
+    setBoxVisibility('pick');
     // `imageInfo` deliberately survives the change. Every frame of an alert
     // comes from one camera at one size and lands in the same box, so the
     // previous geometry stays correct; clearing it unmounted every overlay
@@ -651,7 +664,7 @@ export function LocalizeObjectEditor({
           break;
         case 'g':
         case 'G':
-          setGhostsOverridden(v => !v);
+          setBoxVisibility(v => (v === 'pick' ? 'all' : v === 'all' ? 'none' : 'pick'));
           break;
         case 'o':
         case 'O':
@@ -862,9 +875,9 @@ export function LocalizeObjectEditor({
         <div className="flex min-w-0 flex-1 items-center justify-center overflow-hidden bg-ash p-3">
           <DetectionAnnotationCanvas
             detection={shownDetection}
-            committed={editable ? shownCommitted : null}
+            committed={editable ? stageCommitted : null}
             ghosts={editable ? ghosts : []}
-            showGhosts={showGhosts}
+            showGhosts={ghosts.length > 0}
             selected={editable && boxSelected}
             selectedSmokeType={smokeType}
             objectOverlays={showOtherObjects ? objectOverlays : []}

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -153,6 +153,8 @@ export function LocalizeObjectEditor({
   // `G` cycles what the idle stage draws: the default pick, every candidate
   // at once, or nothing at all — the bare plume.
   const [boxVisibility, setBoxVisibility] = useState<BoxVisibility>('pick');
+  // A rail row being hovered or focused: the stage shows only that candidate.
+  const [previewed, setPreviewed] = useState<BoxCandidate | null>(null);
   // The OTHER objects' boxes on this frame, off by default. On this screen
   // color means *source* (manual/auto/engine), and the object-identity
   // palette overlaps it closely enough that a blue dashed box would be
@@ -215,10 +217,13 @@ export function LocalizeObjectEditor({
    * comparison with the rest. `G` cycles to "all" (every candidate stacked,
    * on demand) and "none" (the bare plume).
    */
+  // A preview never interrupts an interaction already underway on the canvas.
+  const activePreview = boxEdit || currentDrawing ? null : previewed;
   const pick = priorityPick(candidates);
-  const stageCommitted = boxVisibility === 'none' ? null : shownCommitted;
-  const ghosts =
-    boxVisibility === 'none'
+  const stageCommitted = activePreview || boxVisibility === 'none' ? null : shownCommitted;
+  const ghosts = activePreview
+    ? [activePreview]
+    : boxVisibility === 'none'
       ? []
       : boxVisibility === 'all'
         ? losers
@@ -353,6 +358,7 @@ export function LocalizeObjectEditor({
     setBoxEdit(null);
     setBoxSelected(false);
     setBoxVisibility('pick');
+    setPreviewed(null);
     // `imageInfo` deliberately survives the change. Every frame of an alert
     // comes from one camera at one size and lands in the same box, so the
     // previous geometry stays correct; clearing it unmounted every overlay
@@ -910,6 +916,7 @@ export function LocalizeObjectEditor({
           disabled={!editable}
           onCommit={commitCandidate}
           onClear={clear}
+          onPreview={setPreviewed}
         />
       </div>
 

--- a/frontend/tests/components/localize/editor/BoxSourceRail.test.tsx
+++ b/frontend/tests/components/localize/editor/BoxSourceRail.test.tsx
@@ -35,6 +35,7 @@ const props = {
   disabled: false,
   onCommit: vi.fn(),
   onClear: vi.fn(),
+  onPreview: vi.fn(),
 };
 
 describe('BoxSourceRail', () => {
@@ -112,5 +113,49 @@ describe('BoxSourceRail', () => {
     render(<BoxSourceRail {...props} onClear={onClear} />);
     fireEvent.click(screen.getByTestId('editor-clear'));
     expect(onClear).toHaveBeenCalled();
+  });
+
+  // React delivers onMouseEnter/onMouseLeave via mouseover/mouseout, so
+  // that's what these fire.
+  it('previews a hovered row and releases on leave', () => {
+    const onPreview = vi.fn();
+    render(<BoxSourceRail {...props} onPreview={onPreview} />);
+    fireEvent.mouseOver(screen.getByTestId('source-row-engine'));
+    expect(onPreview).toHaveBeenCalledWith(engine);
+    fireEvent.mouseOut(screen.getByTestId('source-row-engine'));
+    expect(onPreview).toHaveBeenLastCalledWith(null);
+  });
+
+  it('previews on keyboard focus too', () => {
+    const onPreview = vi.fn();
+    render(<BoxSourceRail {...props} onPreview={onPreview} />);
+    fireEvent.focus(screen.getByTestId('source-row-engine'));
+    expect(onPreview).toHaveBeenCalledWith(engine);
+    fireEvent.blur(screen.getByTestId('source-row-engine'));
+    expect(onPreview).toHaveBeenLastCalledWith(null);
+  });
+
+  it('does not preview the committed row — its box is already on stage', () => {
+    const onPreview = vi.fn();
+    render(<BoxSourceRail {...props} onPreview={onPreview} />);
+    fireEvent.mouseOver(screen.getByTestId('source-row-auto'));
+    expect(onPreview).not.toHaveBeenCalled();
+  });
+
+  it('does not preview a row with no candidate', () => {
+    const onPreview = vi.fn();
+    render(<BoxSourceRail {...props} onPreview={onPreview} />);
+    fireEvent.mouseOver(screen.getByTestId('source-row-manual'));
+    expect(onPreview).not.toHaveBeenCalled();
+  });
+
+  it('releases the preview when a hovered row is clicked to commit', () => {
+    const onPreview = vi.fn();
+    const onCommit = vi.fn();
+    render(<BoxSourceRail {...props} onPreview={onPreview} onCommit={onCommit} />);
+    fireEvent.mouseOver(screen.getByTestId('source-row-engine'));
+    fireEvent.click(screen.getByTestId('source-row-engine'));
+    expect(onPreview).toHaveBeenLastCalledWith(null);
+    expect(onCommit).toHaveBeenCalledWith(engine);
   });
 });

--- a/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
+++ b/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
@@ -252,6 +252,52 @@ describe('LocalizeObjectEditor', () => {
     expect(screen.queryByTestId('ghost-box-engine-0')).not.toBeInTheDocument();
   });
 
+  it('hovering a rail row solos that candidate over the committed box', () => {
+    renderLoadedEditor({ existingAnnotation: committedAnnotation(firstDetection.id, 'auto') });
+    expect(screen.getByTestId('committed-box')).toBeInTheDocument();
+
+    fireEvent.mouseOver(screen.getByTestId('source-row-engine'));
+    expect(screen.getByTestId('ghost-box-engine-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('committed-box')).not.toBeInTheDocument();
+
+    fireEvent.mouseOut(screen.getByTestId('source-row-engine'));
+    expect(screen.getByTestId('committed-box')).toBeInTheDocument();
+    expect(screen.queryByTestId('ghost-box-engine-0')).not.toBeInTheDocument();
+  });
+
+  it('hover preview solos the candidate on an undecided frame too', () => {
+    renderLoadedEditor();
+    expect(screen.getByTestId('ghost-box-auto-0')).toBeInTheDocument();
+
+    fireEvent.mouseOver(screen.getByTestId('source-row-engine'));
+    expect(screen.getByTestId('ghost-box-engine-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('ghost-box-auto-0')).not.toBeInTheDocument();
+  });
+
+  it('a hover preview overrides the none state and releases back to it', () => {
+    renderLoadedEditor();
+    fireEvent.keyDown(window, { key: 'g' }); // all
+    fireEvent.keyDown(window, { key: 'g' }); // none
+
+    fireEvent.mouseOver(screen.getByTestId('source-row-engine'));
+    expect(screen.getByTestId('ghost-box-engine-0')).toBeInTheDocument();
+
+    fireEvent.mouseOut(screen.getByTestId('source-row-engine'));
+    expect(screen.queryByTestId('ghost-box-engine-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ghost-box-auto-0')).not.toBeInTheDocument();
+  });
+
+  it('clears a live preview when the frame changes under it', () => {
+    const { rerender } = renderLoadedEditor();
+    fireEvent.mouseOver(screen.getByTestId('source-row-engine'));
+    expect(screen.getByTestId('ghost-box-engine-0')).toBeInTheDocument();
+
+    rerender(editorWith({ detection: lastDetection }));
+    fireEvent.load(screen.getByAltText(/^Detection /));
+    expect(screen.queryByTestId('ghost-box-engine-0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('ghost-box-auto-0')).toBeInTheDocument();
+  });
+
   it('Escape closes', () => {
     const onClose = vi.fn();
     renderEditor({ onClose });

--- a/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
+++ b/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
@@ -205,17 +205,51 @@ describe('LocalizeObjectEditor', () => {
     expect(screen.queryByTestId('ghost-box-auto-0')).not.toBeInTheDocument();
   });
 
-  it('shows the candidates as ghosts when nothing is committed, and G hides them', () => {
+  it('ghosts only the priority pick when nothing is committed', () => {
     renderLoadedEditor();
 
-    // Nothing committed means no winner to draw, so the frame would otherwise
-    // be blank — the candidates ghost in to show what is on offer.
+    // The idle stage answers "is the box Enter would commit right?" — the
+    // rail's crops carry the auto-vs-engine comparison, so the losing
+    // candidate stacking onto the same plume is noise.
     expect(screen.queryByTestId('committed-box')).not.toBeInTheDocument();
+    expect(screen.getByTestId('ghost-box-auto-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('ghost-box-engine-0')).not.toBeInTheDocument();
+  });
+
+  it('G cycles the stage through pick, every candidate, none, and back', () => {
+    renderLoadedEditor();
+
+    fireEvent.keyDown(window, { key: 'g' });
     expect(screen.getByTestId('ghost-box-auto-0')).toBeInTheDocument();
     expect(screen.getByTestId('ghost-box-engine-0')).toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: 'g' });
     expect(screen.queryByTestId('ghost-box-auto-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ghost-box-engine-0')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'g' });
+    expect(screen.getByTestId('ghost-box-auto-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('ghost-box-engine-0')).not.toBeInTheDocument();
+  });
+
+  it('the none state hides the committed box too, for a bare view of the plume', () => {
+    renderLoadedEditor({ existingAnnotation: committedAnnotation(firstDetection.id, 'auto') });
+
+    fireEvent.keyDown(window, { key: 'g' }); // all
+    fireEvent.keyDown(window, { key: 'g' }); // none
+    expect(screen.queryByTestId('committed-box')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ghost-box-engine-0')).not.toBeInTheDocument();
+  });
+
+  it('the G cycle resets to the default on frame change', () => {
+    const { rerender } = renderLoadedEditor();
+    fireEvent.keyDown(window, { key: 'g' }); // all
+    fireEvent.keyDown(window, { key: 'g' }); // none
+
+    rerender(editorWith({ detection: lastDetection }));
+    fireEvent.load(screen.getByAltText(/^Detection /));
+    expect(screen.getByTestId('ghost-box-auto-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('ghost-box-engine-0')).not.toBeInTheDocument();
   });
 
   it('Escape closes', () => {

--- a/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
+++ b/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
@@ -298,6 +298,65 @@ describe('LocalizeObjectEditor', () => {
     expect(screen.getByTestId('ghost-box-auto-0')).toBeInTheDocument();
   });
 
+  it('releases the preview when the hovered row wins a commit', () => {
+    // Engine is the only candidate, so Enter commits the very row being
+    // hovered — which disables it in place, and a disabled button never
+    // fires mouseleave. The commit itself must release the preview, or the
+    // stage keeps a dashed read-only ghost where the solid committed box
+    // should be. The open detection never changes here (navigation is the
+    // URL's job, mocked away), so no frame-change reset runs either.
+    const engineOnly = {
+      ...firstDetection,
+      auto_predictions: { predictions: [] },
+    } as unknown as Detection;
+    const { rerender } = renderLoadedEditor({
+      detection: engineOnly,
+      laneDetections: [engineOnly, lastDetection],
+    });
+
+    fireEvent.mouseOver(screen.getByTestId('source-row-engine'));
+    fireEvent.keyDown(window, { key: 'Enter' });
+
+    // The save round-trip lands the commit.
+    rerender(
+      editorWith({
+        detection: engineOnly,
+        laneDetections: [engineOnly, lastDetection],
+        existingAnnotation: committedAnnotation(engineOnly.id, 'engine'),
+      })
+    );
+    fireEvent.load(screen.getByAltText(/^Detection /));
+    expect(screen.getByTestId('committed-box')).toBeInTheDocument();
+    expect(screen.queryByTestId('ghost-box-engine-0')).not.toBeInTheDocument();
+  });
+
+  it('drops the preview when peeking out of range, so it is not stale on return', () => {
+    renderLoadedEditor();
+    fireEvent.mouseOver(screen.getByTestId('source-row-engine'));
+    expect(screen.getByTestId('ghost-box-engine-0')).toBeInTheDocument();
+
+    // Peek disables the rail in place — no mouseleave will ever fire — and
+    // does not change detection.id, so the frame-change reset never runs.
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(screen.queryByTestId('ghost-box-engine-0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('ghost-box-auto-0')).toBeInTheDocument();
+  });
+
+  it('leaves Enter to a focused rail row, so it commits what it previews', () => {
+    const onCommit = vi.fn();
+    renderLoadedEditor({ onCommit });
+    const row = screen.getByTestId('source-row-engine');
+    row.focus();
+
+    // Enter pressed ON the row must not reach the global accept-and-next —
+    // the row's focus preview shows engine, and the button's own native
+    // activation is what commits it. (jsdom doesn't run native activation,
+    // so the observable here is the suppressed global commit.)
+    fireEvent.keyDown(row, { key: 'Enter' });
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
   it('Escape closes', () => {
     const onClose = vi.fn();
     renderEditor({ onClose });
@@ -372,6 +431,21 @@ describe('LocalizeObjectEditor canvas', () => {
       expect.objectContaining({ id: firstDetection.id }),
       [expect.objectContaining({ origin: 'human' })]
     );
+  });
+
+  it('suspends a preview while a box is being drawn', () => {
+    renderLoadedEditor();
+    fireEvent.focus(screen.getByTestId('source-row-engine'));
+    expect(screen.getByTestId('ghost-box-engine-0')).toBeInTheDocument();
+
+    // Mid-drag the preview yields: the stage is about the box being drawn,
+    // with the idle pick ghost back as its reference.
+    const image = stubGeometry();
+    fireEvent.mouseDown(image, { button: 0, clientX: 40, clientY: 40 });
+    fireEvent.mouseMove(image, { clientX: 400, clientY: 300 });
+    expect(screen.queryByTestId('ghost-box-engine-0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('ghost-box-auto-0')).toBeInTheDocument();
+    fireEvent.mouseUp(image);
   });
 
   it('treats a press that never moved as a click, not a box', () => {


### PR DESCRIPTION
## Summary

On an undecided frame the localize object editor used to ghost in **every** candidate box at once — the engine and auto boxes sit almost concentrically on the same plume, and at the default 3x object zoom the stack read as clutter exactly where the annotator is trying to look.

Spec: `docs/specs/2026-08-05-localize-editor-quiet-stage-hover-preview-design.md`.

- **Quiet stage:** with nothing committed, the stage draws exactly one ghost — the priority pick (`manual > auto > engine`), the box `Enter` would commit. The rail's cropped thumbnails keep carrying the auto-vs-engine comparison.
- **Hover/focus solo preview:** hovering or keyboard-focusing a rail row shows only that row's candidate on the stage as a read-only ghost; leaving restores the idle state. Moving between rows blink-compares candidates in place — the stage always holds exactly one box. Committed and empty rows preview nothing; clicking still commits (and releases the preview, since a just-committed row disables in place and would never fire mouseleave).
- **`G` becomes a three-state cycle:** pick-only → all candidates (today's stacked view, on demand) → none (the bare plume, committed box hidden too) → back. Resets to pick-only on frame change. Shortcuts sheet copy updated.

Unchanged: `O`/`Z`/`R`, drawing, box move/resize, click-to-commit, `Enter`/`Delete`, the rail's layout, and the source colour/weight identity. Previews are ignored while a draw or box drag is underway.

## Test plan

- [x] New editor tests: pick-only default, full `G` cycle, none-state hides the committed box, cycle resets on frame change, solo preview over committed/undecided/none states, preview cleared on frame change
- [x] New rail tests: preview on hover and focus, release on leave/blur/commit-click, no preview for committed or empty rows
- [x] Full suite: 88 files / 1132 tests green
- [x] `npm run quality` (type-check, ESLint --max-warnings 0, Prettier check) green