### PR TITLE
feat(frontend): drop Accept/Reclassify from localize rail rows

### DIFF
--- a/frontend/src/components/localize/LocalizeObjectActions.tsx
+++ b/frontend/src/components/localize/LocalizeObjectActions.tsx
@@ -1,9 +1,10 @@
 /**
  * The two things you can do to one localize object: bulk-accept the model's
- * boxes, or send it back to classify. Shared, because they appear in two
- * places at once — the object's rail row and the media column's CTA bar —
- * and a second copy of the buttons would mean a second copy of the tooltip
- * copy, which is where the explanation of what each one does actually lives.
+ * boxes, or send it back to classify. They live in one place — the bar above
+ * the media column, on the active object — so there is exactly one copy of
+ * the tooltip copy, which is where the explanation of what each one does
+ * actually lives. (They used to also sit on the selected rail row, which
+ * showed every button twice on one screen.)
  *
  * Either action can be withheld by omitting its handler: false positives get
  * neither, and a lane past localization (or one with nothing left pending)
@@ -23,18 +24,8 @@ export interface LocalizeObjectActionsProps {
   onReclassify?: () => void;
   /** Passed through to the tooltips — `above` where the panel edge is below the buttons. */
   tooltipPlacement?: 'below' | 'above';
-  /**
-   * `compact` fits the rail row's line, where these are one of several things
-   * competing for a narrow strip. `prominent` is the media column's call to
-   * action: the same height, so the control panel doesn't grow when an object
-   * is selected, but Accept carries the primary fill since it is the one that
-   * moves the work on.
-   */
-  size?: 'compact' | 'prominent';
 }
 
-const COMPACT =
-  'whitespace-nowrap rounded-lg border border-line bg-paper px-2 py-1 font-body text-xs font-medium text-char hover:bg-ash disabled:cursor-not-allowed disabled:opacity-50';
 // Prominence comes from fill and placement, not from size: these sit on the
 // control panel's line, and anything taller than the view toolbar beside them
 // would grow the panel the moment an object is selected — the page would
@@ -45,9 +36,9 @@ const COMPACT =
 // forward — it is what Submit wears — and accepting an object's boxes is the
 // same motion, one object at a time. Ember would read as the alert's headline
 // action and compete with Submit for it.
-const PROMINENT_PRIMARY =
+const PRIMARY =
   'inline-flex items-center whitespace-nowrap rounded-lg bg-pine px-3 py-1 font-body text-xs font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50';
-const PROMINENT_SECONDARY =
+const SECONDARY =
   'inline-flex items-center whitespace-nowrap rounded-lg border border-line bg-paper px-3 py-1 font-body text-xs font-medium text-char hover:bg-ash';
 
 export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
@@ -56,7 +47,6 @@ export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
   isAccepting = false,
   onReclassify,
   tooltipPlacement = 'below',
-  size = 'compact',
 }) => (
   <>
     {onAcceptBoxes && (
@@ -68,17 +58,14 @@ export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
       >
         <button
           type="button"
-          // The visible label stays short for the rail's width; the accessible
-          // name keeps naming the object, so "accept THIS object's boxes" is
-          // unambiguous to a screen reader (and to the page tests, which
-          // address rows by object).
+          // The visible label stays short; the accessible name keeps naming
+          // the object, so "accept THIS object's boxes" is unambiguous to a
+          // screen reader (and to the page tests, which address the actions
+          // by object).
           aria-label={`Accept ${label}'s boxes`}
-          onClick={e => {
-            e.stopPropagation();
-            onAcceptBoxes();
-          }}
+          onClick={onAcceptBoxes}
           disabled={isAccepting}
-          className={size === 'prominent' ? PROMINENT_PRIMARY : COMPACT}
+          className={PRIMARY}
         >
           {isAccepting ? 'Accepting…' : 'Accept boxes'}
         </button>
@@ -94,11 +81,8 @@ export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
         <button
           type="button"
           aria-label={`Reclassify ${label}`}
-          onClick={e => {
-            e.stopPropagation();
-            onReclassify();
-          }}
-          className={size === 'prominent' ? PROMINENT_SECONDARY : COMPACT}
+          onClick={onReclassify}
+          className={SECONDARY}
         >
           Reclassify
         </button>

--- a/frontend/src/components/localize/LocalizeObjectRow.tsx
+++ b/frontend/src/components/localize/LocalizeObjectRow.tsx
@@ -4,28 +4,22 @@
  * *classification*, this one carries a per-object *localization progress*:
  * how many of the frames the object appears on already have a committed box.
  *
- * Like classify's row, the actions hide behind activation — but they appear
- * on the header line's right rather than expanding the row, taking the place
- * of the progress count and status chip. The selected row is the one being
- * worked, so its right side turns into what you can DO to it; every other row
- * keeps saying where it stands. The buttons are wider than the metadata they
- * replace, so the name and subtitle truncate to absorb the difference. The
- * trade is deliberate: reaching Accept boxes costs the click that selects the
- * row (which also points the media column at the object), and in exchange the
- * rail stops showing a wall of buttons for lanes nobody is looking at. The
- * same pair of actions also sits above the media column, where the object's
- * frames are — see `LocalizeActiveObjectBar`.
+ * The row is a summary and a selector, nothing more: its right side always
+ * says where the object stands (progress count and status chip), whether or
+ * not the row is selected. What you can DO to the selected object — accept
+ * its boxes, send it back to classify — lives in one place, the bar above
+ * the media column where its frames are (see `LocalizeObjectActions` in
+ * `LocalizeAlertPage`). The rail used to swap the selected row's metadata
+ * for that same pair of buttons, which showed them twice on one screen and
+ * cost the row the one thing it says about itself.
  *
- * Rows past localization lose Accept boxes but keep Reclassify — a finished
- * lane can still have been classified wrong — and stay clickable: activating
- * one points the media column at its frames, which is the whole reason
- * they're on screen. Whether they also fade back is the caller's call
- * (`dimmed`) — that only reads as "context" when there is live work beside
- * them.
+ * Rows past localization stay clickable: activating one points the media
+ * column at its frames, which is the whole reason they're on screen. Whether
+ * they also fade back is the caller's call (`dimmed`) — that only reads as
+ * "context" when there is live work beside them.
  */
 
 import React from 'react';
-import { LocalizeObjectActions } from './LocalizeObjectActions';
 
 export interface LocalizeObjectRowProps {
   /** e.g. "Object 2" — the object's own label, shared with the timeline and grid overlays. */
@@ -54,15 +48,6 @@ export interface LocalizeObjectRowProps {
   /** True when this object drives the media column (focus mode). */
   isActive: boolean;
   onActivate: () => void;
-  /** Bulk-accepts the winning model boxes for this lane's pending frames. Omit on context rows. */
-  onAcceptBoxes?: () => void;
-  isAccepting?: boolean;
-  /**
-   * Opens this object's classification for correction (classify's done mode).
-   * Withheld on false-positive rows — promoting an FP back to smoke needs an
-   * auto-review pass first (issue #275).
-   */
-  onReclassify?: () => void;
 }
 
 // forwardRef so the page's Tab cycle can move real DOM focus onto the row it
@@ -81,18 +66,10 @@ export const LocalizeObjectRow = React.forwardRef<HTMLDivElement, LocalizeObject
       dimmed = false,
       isActive,
       onActivate,
-      onAcceptBoxes,
-      isAccepting = false,
-      onReclassify,
     },
     ref
   ) {
     const pendingCount = presentCount - confirmedCount;
-
-    // The right-hand swap. A row the page gave no actions (a false positive)
-    // has nothing to swap in, so selecting it must not blank the one thing it
-    // says about itself.
-    const showActions = isActive && !!(onAcceptBoxes || onReclassify);
 
     const status = isFalsePositive
       ? { label: 'False positive', tone: 'bg-ash text-haze' }
@@ -129,19 +106,17 @@ export const LocalizeObjectRow = React.forwardRef<HTMLDivElement, LocalizeObject
         data-testid={`localize-object-row-${label.replace(/\s+/g, '-').toLowerCase()}`}
         data-active={isActive ? 'true' : undefined}
         data-dimmed={dimmed ? 'true' : undefined}
-        // role="group" rather than a button: workable rows contain their own
-        // action buttons, and nesting interactive controls is invalid HTML.
-        // Keyboard reach comes from the page's Tab cycle, which activates each
-        // row it lands on and moves real DOM focus here (via the forwarded
-        // ref) — focus, selection and the media column stay one thing. The
-        // Enter/Space handling remains for anything else that focuses the row
-        // (a click, assistive tech), where Enter must act on THIS row rather
-        // than whichever one the cycle last left.
+        // role="group" with hand-rolled Enter/Space rather than a native
+        // button: keyboard reach comes from the page's Tab cycle, which
+        // activates each row it lands on and moves real DOM focus here (via
+        // the forwarded ref) — focus, selection and the media column stay one
+        // thing. The Enter/Space handling remains for anything else that
+        // focuses the row (a click, assistive tech), where Enter must act on
+        // THIS row rather than whichever one the cycle last left.
         role="group"
         aria-label={label}
         tabIndex={0}
         onKeyDown={e => {
-          if (e.target !== e.currentTarget) return;
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             onActivate();
@@ -159,10 +134,9 @@ export const LocalizeObjectRow = React.forwardRef<HTMLDivElement, LocalizeObject
             />
             {/* Name and what-it-is on one line: the row is a one-line summary,
               and stacking them made it two lines tall for a word. Both
-              truncate rather than push: the selected row's buttons are wider
-              than the metadata they replace, and at the narrow end of the
-              rail something has to give — better a clipped word than a row
-              that overflows into a horizontal scrollbar. */}
+              truncate rather than push: at the narrow end of the rail
+              something has to give — better a clipped word than a row that
+              overflows into a horizontal scrollbar. */}
             <span className="flex min-w-0 items-baseline gap-1.5">
               <span className="truncate font-body text-sm font-semibold text-char">{label}</span>
               {subtitle && (
@@ -181,29 +155,18 @@ export const LocalizeObjectRow = React.forwardRef<HTMLDivElement, LocalizeObject
             </span>
           </span>
           <span className="flex shrink-0 items-center gap-1.5">
-            {showActions ? (
-              <LocalizeObjectActions
-                label={label}
-                onAcceptBoxes={onAcceptBoxes}
-                isAccepting={isAccepting}
-                onReclassify={onReclassify}
-              />
-            ) : (
-              <>
-                {/* A false positive has no localization work, so a progress
-                  fraction over its frames would be meaningless. */}
-                {!isFalsePositive && (
-                  <span className="font-data text-detail text-haze">
-                    {confirmedCount}/{presentCount}
-                  </span>
-                )}
-                <span
-                  className={`whitespace-nowrap rounded-full px-2 py-0.5 font-body text-xs font-semibold ${status.tone}`}
-                >
-                  {status.label}
-                </span>
-              </>
+            {/* A false positive has no localization work, so a progress
+              fraction over its frames would be meaningless. */}
+            {!isFalsePositive && (
+              <span className="font-data text-detail text-haze">
+                {confirmedCount}/{presentCount}
+              </span>
             )}
+            <span
+              className={`whitespace-nowrap rounded-full px-2 py-0.5 font-body text-xs font-semibold ${status.tone}`}
+            >
+              {status.label}
+            </span>
           </span>
         </div>
       </div>

--- a/frontend/src/components/localize/LocalizeObjectRow.tsx
+++ b/frontend/src/components/localize/LocalizeObjectRow.tsx
@@ -106,14 +106,16 @@ export const LocalizeObjectRow = React.forwardRef<HTMLDivElement, LocalizeObject
         data-testid={`localize-object-row-${label.replace(/\s+/g, '-').toLowerCase()}`}
         data-active={isActive ? 'true' : undefined}
         data-dimmed={dimmed ? 'true' : undefined}
-        // role="group" with hand-rolled Enter/Space rather than a native
-        // button: keyboard reach comes from the page's Tab cycle, which
-        // activates each row it lands on and moves real DOM focus here (via
-        // the forwarded ref) — focus, selection and the media column stay one
-        // thing. The Enter/Space handling remains for anything else that
-        // focuses the row (a click, assistive tech), where Enter must act on
-        // THIS row rather than whichever one the cycle last left.
-        role="group"
+        // A div with role="button" rather than a <button>, because the page's
+        // Tab cycle needs to move real DOM focus here via the forwarded ref
+        // and manage the rail's focus order itself — but role "button" now,
+        // not the old "group": that role existed only because the row used to
+        // contain its own action buttons, and nesting interactive controls is
+        // invalid HTML. The hand-rolled Enter/Space keeps the button contract
+        // for anything else that focuses the row (a click, assistive tech),
+        // where Enter must act on THIS row rather than whichever one the
+        // cycle last left.
+        role="button"
         aria-label={label}
         tabIndex={0}
         onKeyDown={e => {

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -102,10 +102,10 @@
  * accounted for?" before someone adds a duplicate object for it. Unsure
  * lanes stay excluded either way.
  *
- * Each smoke object's row also carries a "Reclassify" action — workable and
- * already-localized rows alike — routing to `/classify/done/<lane>` with a
- * `return` param back to this page. False-positive rows deliberately don't
- * get it (see issue #275).
+ * The active object also carries a "Reclassify" action in the CTA bar above
+ * its frames — workable, already-localized and false-positive objects alike
+ * (promoting an FP back to smoke re-runs its auto-review pass, issue #275) —
+ * routing to `/classify/done/<lane>` with a `return` param back to this page.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -84,7 +84,7 @@
  *
  * Submit is also gated now: it enables only once every workable object
  * already carries a committed box on every frame it appears on, accepted
- * per object from its own rail row. Submit therefore no longer accepts
+ * per object from the bar above its frames. Submit therefore no longer accepts
  * anything itself, and the old per-frame "N frames with no box — submit
  * anyway?" two-step went with that: under the gate there is never a pending
  * no-box frame left at submit time. The missed-smoke soft-confirm is the
@@ -698,8 +698,8 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
 
   // The timeline's rows: identity + per-frame statuses + the "selected"
   // accent for whichever object is currently focused. The quick-accept
-  // action no longer rides along here — it lives on the selected object's
-  // rail row and above the media column, on the active object.
+  // action no longer rides along here — it lives above the media column, on
+  // the active object.
   const objectStatusRows: AlertObjectStatus[] = frameModel.objectStatus.map(object => ({
     ...object,
     selected: isFocused && activeLaneId === object.laneSequenceId,
@@ -807,13 +807,14 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
         !!lane.annotation && !laneNeedsLocalization(lane.annotation) && !lane.annotation.is_unsure
     ).length ?? 0;
 
-  // Which actions an object gets, and what they do — shared by the rail row
-  // and the media column's CTA bar so the two can't disagree about whether an
-  // object is acceptable or correctable.
+  // Which actions the active object gets, and what they do — feeds the media
+  // column's CTA bar, the actions' one home. The rail rows stay read-only
+  // summaries; giving the selected row the same pair showed every button
+  // twice on one screen.
   const objectActionProps = (object: AlertObjectStatus) => ({
     // Withheld once the lane has nothing pending: re-accepting would fire a
     // mutation with an empty payload and toast success for a no-op. It is
-    // also the only way the selected row/bar can show that the accept landed.
+    // also the only way the bar can show that the accept landed.
     onAcceptBoxes:
       object.workable && !isObjectLocalized(object)
         ? () => quickAcceptLane.mutate(object.laneSequenceId)
@@ -851,7 +852,6 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
         dimmed={object.isFalsePositive || (!object.workable && workableObjects.length > 0)}
         isActive={isActive}
         onActivate={() => handleObjectClick(object.laneSequenceId)}
-        {...objectActionProps(object)}
       />
     );
   };
@@ -863,8 +863,8 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   const activeObjectLabel = activeObject?.label ?? null;
 
   // Submit gate: every workable object must already have a committed box on
-  // every frame it appears on. An object is "accepted" either via its row's
-  // Accept-boxes action or by drawing its frames in the editor — submitting
+  // every frame it appears on. An object is "accepted" either via the CTA
+  // bar's Accept-boxes action or by drawing its frames in the editor — submitting
   // is the last step, not a shortcut past the per-object review.
   // Deliberately NOT the badge's count: submit only ships workable lanes, so
   // already-annotated objects must not satisfy (or block) the gate.
@@ -1309,7 +1309,6 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
               activeObject && (
                 <LocalizeObjectActions
                   label={activeObject.label}
-                  size="prominent"
                   {...objectActionProps(activeObject)}
                 />
               )

--- a/frontend/tests/components/localize/LocalizeObjectRow.test.tsx
+++ b/frontend/tests/components/localize/LocalizeObjectRow.test.tsx
@@ -14,7 +14,7 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { LocalizeObjectRow } from '@/components/localize';
 import { getObjectColor } from '@/utils/annotation/objectColors';
 
@@ -69,18 +69,22 @@ describe('LocalizeObjectRow selection treatment', () => {
 });
 
 describe('LocalizeObjectRow metadata', () => {
-  it('is selectable from the keyboard', () => {
-    // The page's Tab cycle moves real focus here; Enter/Space must activate
-    // the row for anything else that focuses it (a click, assistive tech).
+  it('is a button to assistive tech, selectable from the keyboard', () => {
+    // With the nested action buttons gone the row is a plain activate
+    // control, so it can finally say so — the old role="group" existed only
+    // because nesting interactive controls is invalid HTML. The page's Tab
+    // cycle moves real focus here; Enter/Space must activate the row for
+    // anything else that focuses it (a click, assistive tech).
     const onActivate = vi.fn();
     render(<LocalizeObjectRow {...baseProps} workable onActivate={onActivate} />);
 
-    expect(row()).toHaveAttribute('tabindex', '0');
+    const rowEl = screen.getByRole('button', { name: 'Object 2' });
+    expect(rowEl).toHaveAttribute('tabindex', '0');
 
-    fireEvent.keyDown(row(), { key: 'Enter' });
+    fireEvent.keyDown(rowEl, { key: 'Enter' });
     expect(onActivate).toHaveBeenCalledTimes(1);
 
-    fireEvent.keyDown(row(), { key: ' ' });
+    fireEvent.keyDown(rowEl, { key: ' ' });
     expect(onActivate).toHaveBeenCalledTimes(2);
   });
 
@@ -90,7 +94,8 @@ describe('LocalizeObjectRow metadata', () => {
     // row's accent and nothing else.
     render(<LocalizeObjectRow {...baseProps} workable isActive />);
 
-    expect(screen.queryAllByRole('button')).toHaveLength(0);
+    // Scoped inside the row: the row itself is a button, its content is not.
+    expect(within(row()).queryAllByRole('button')).toHaveLength(0);
     expect(screen.getByText('0/3')).toBeInTheDocument();
     expect(screen.getByText('3 left')).toBeInTheDocument();
   });

--- a/frontend/tests/components/localize/LocalizeObjectRow.test.tsx
+++ b/frontend/tests/components/localize/LocalizeObjectRow.test.tsx
@@ -7,13 +7,10 @@
  * column but the row itself gave no feedback and stayed dimmed while it was
  * the thing being looked at.
  *
- * Actions: `Accept boxes` is covered through the page; `Reclassify` is
- * covered here — which rows get it, and that it doesn't double as a row
- * activation.
- *
- * Action visibility: the actions live behind selection, and they take the
- * right-hand metadata's place rather than adding a line — so the rail reads
- * as one column of quiet rows plus whichever one you're working on.
+ * Metadata: the row is a read-only summary — progress count and status chip,
+ * selected or not. The actions (Accept boxes / Reclassify) live in the
+ * Frames panel's CTA bar, covered through the page; the row used to swap its
+ * metadata for them, which showed the buttons twice on one screen.
  */
 
 import React from 'react';
@@ -71,139 +68,47 @@ describe('LocalizeObjectRow selection treatment', () => {
   });
 });
 
-// Selected by default: the actions only exist on the selected row, so a
-// suite about the actions has to start there.
-function renderRow(overrides: Partial<React.ComponentProps<typeof LocalizeObjectRow>> = {}) {
-  const onActivate = vi.fn();
-  const onReclassify = vi.fn();
-  render(
-    <LocalizeObjectRow
-      label="Object 1"
-      color="#E4572E"
-      confirmedCount={0}
-      presentCount={2}
-      workable
-      smokeType="wildfire"
-      isActive
-      onActivate={onActivate}
-      onReclassify={onReclassify}
-      {...overrides}
-    />
-  );
-  return { onActivate, onReclassify };
-}
+describe('LocalizeObjectRow metadata', () => {
+  it('is selectable from the keyboard', () => {
+    // The page's Tab cycle moves real focus here; Enter/Space must activate
+    // the row for anything else that focuses it (a click, assistive tech).
+    const onActivate = vi.fn();
+    render(<LocalizeObjectRow {...baseProps} workable onActivate={onActivate} />);
 
-describe('LocalizeObjectRow reclassify action', () => {
-  it('renders Reclassify alongside Accept boxes on a workable row', () => {
-    renderRow({ onAcceptBoxes: vi.fn() });
+    expect(row()).toHaveAttribute('tabindex', '0');
 
-    expect(screen.getByRole('button', { name: 'Reclassify Object 1' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: "Accept Object 1's boxes" })).toBeInTheDocument();
-  });
-
-  it('calls onReclassify without also activating the row', () => {
-    const { onActivate, onReclassify } = renderRow({ onAcceptBoxes: vi.fn() });
-
-    fireEvent.click(screen.getByRole('button', { name: 'Reclassify Object 1' }));
-
-    expect(onReclassify).toHaveBeenCalledTimes(1);
-    expect(onActivate).not.toHaveBeenCalled();
-  });
-
-  it('renders Reclassify on an already-localized row, which has no Accept boxes', () => {
-    renderRow({ workable: false, onAcceptBoxes: undefined });
-
-    expect(screen.getByRole('button', { name: 'Reclassify Object 1' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
-  });
-
-});
-
-describe('LocalizeObjectRow action visibility', () => {
-  it('is selectable from the keyboard, since selection now gates the actions', () => {
-    // Without this the row is a mouse-only affordance in front of the only
-    // copy of these buttons in the rail — the actions would be unreachable
-    // by keyboard entirely.
-    const { onActivate } = renderRow({ isActive: false, onAcceptBoxes: vi.fn() });
-    const row = screen.getByTestId('localize-object-row-object-1');
-
-    expect(row).toHaveAttribute('tabindex', '0');
-
-    fireEvent.keyDown(row, { key: 'Enter' });
+    fireEvent.keyDown(row(), { key: 'Enter' });
     expect(onActivate).toHaveBeenCalledTimes(1);
 
-    fireEvent.keyDown(row, { key: ' ' });
+    fireEvent.keyDown(row(), { key: ' ' });
     expect(onActivate).toHaveBeenCalledTimes(2);
   });
 
-  it('withholds both actions until the row is selected', () => {
-    renderRow({ isActive: false, onAcceptBoxes: vi.fn() });
+  it('keeps the progress count and status chip when selected', () => {
+    // The selected row used to swap these for the Accept/Reclassify pair;
+    // those live only in the Frames panel now, so selection changes the
+    // row's accent and nothing else.
+    render(<LocalizeObjectRow {...baseProps} workable isActive />);
 
-    expect(screen.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Reclassify/ })).not.toBeInTheDocument();
-    // What an unselected row says instead: how far along it is.
-    expect(screen.getByText('0/2')).toBeInTheDocument();
-    expect(screen.getByText('2 left')).toBeInTheDocument();
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+    expect(screen.getByText('0/3')).toBeInTheDocument();
+    expect(screen.getByText('3 left')).toBeInTheDocument();
   });
 
-  it('reveals them in the metadata’s place once selected', () => {
-    renderRow({ onAcceptBoxes: vi.fn() });
-
-    expect(screen.getByRole('button', { name: "Accept Object 1's boxes" })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Reclassify Object 1' })).toBeInTheDocument();
-    // The count and status chip step aside rather than sharing the line —
-    // the rail is too narrow to carry both.
-    expect(screen.queryByText('0/2')).not.toBeInTheDocument();
-    expect(screen.queryByText('2 left')).not.toBeInTheDocument();
-  });
-
-  it('swaps a context row’s Localized chip for its one action when selected', () => {
-    // The rule is the same past localization: the chip is what the row says
-    // at rest, Reclassify is what it offers when you turn to it.
-    const { rerender } = render(
+  it('shows the status chip without a progress fraction on a false-positive row', () => {
+    // A false positive has no localization work, so a fraction over its
+    // frames would be meaningless.
+    render(
       <LocalizeObjectRow
-        label="Object 1"
-        color="#E4572E"
-        confirmedCount={2}
-        presentCount={2}
+        {...baseProps}
         workable={false}
-        isActive={false}
-        onActivate={() => {}}
-        onReclassify={() => {}}
-      />
-    );
-    expect(screen.getByText('Localized')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Reclassify/ })).not.toBeInTheDocument();
-
-    rerender(
-      <LocalizeObjectRow
-        label="Object 1"
-        color="#E4572E"
-        confirmedCount={2}
-        presentCount={2}
-        workable={false}
+        isFalsePositive
+        falsePositiveTypes={['cloud']}
         isActive
-        onActivate={() => {}}
-        onReclassify={() => {}}
       />
     );
-    expect(screen.getByRole('button', { name: 'Reclassify Object 1' })).toBeInTheDocument();
-    expect(screen.queryByText('Localized')).not.toBeInTheDocument();
-  });
-
-  it('keeps the status chip on a selected row that has no actions to show', () => {
-    // A false positive gets neither action, so there is nothing to swap in —
-    // blanking its right side would lose the only thing it says.
-    renderRow({
-      isActive: true,
-      isFalsePositive: true,
-      workable: false,
-      smokeType: undefined,
-      falsePositiveTypes: ['cloud'],
-      onAcceptBoxes: undefined,
-      onReclassify: undefined,
-    });
 
     expect(screen.getByText('False positive')).toBeInTheDocument();
+    expect(screen.queryByText('0/3')).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -831,45 +831,6 @@ describe('LocalizeAlertPage', () => {
     );
   });
 
-  it("per-object quick-accept saves only that lane's frames, scoped per lane", async () => {
-    vi.mocked(apiClient.createDetectionAnnotation).mockImplementation(async payload => ({
-      id: 9100 + payload.detection_id,
-      detection_id: payload.detection_id,
-      annotation: payload.annotation,
-      processing_stage: payload.processing_stage,
-      created_at: '2026-01-01T00:00:00Z',
-      updated_at: null,
-    }));
-
-    await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-
-    // The action lives on the selected row — and arrival auto-focus already
-    // selected Object 1, so it's reachable directly. Scoped to the row
-    // because the media column's CTA bar offers the same action for the
-    // same object.
-    fireEvent.click(
-      within(screen.getByTestId('localize-object-row-object-1')).getByRole('button', {
-        name: "Accept Object 1's boxes",
-      })
-    );
-
-    await waitFor(() => {
-      expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
-        expect.objectContaining({ detection_id: 1001 })
-      );
-    });
-
-    // Object 1's lane only has detection 1001 — Object 2's frames (1002, 1003)
-    // must never be touched by Object 1's quick-accept button.
-    expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalledWith(
-      expect.objectContaining({ detection_id: 1002 })
-    );
-    expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalledWith(
-      expect.objectContaining({ detection_id: 1003 })
-    );
-    expect(apiClient.updateDetectionAnnotation).not.toHaveBeenCalled();
-  });
-
   it('the S/M/L card-size control resizes the grid and persists to the key shared with the legacy page', async () => {
     const { container } = render(<LocalizeAlertPage />, { wrapper: wrapper });
     await waitFor(() => expect(screen.getByTestId('status-segment-0-0')).toBeInTheDocument());
@@ -2105,6 +2066,20 @@ describe('LocalizeAlertPage', () => {
       expect(screen.getByText(/Frames — Object 2/)).toBeInTheDocument();
     });
 
+    it('is the actions’ only home — the selected rail row keeps its metadata instead', async () => {
+      // The same pair used to also sit on the selected rail row, so every
+      // active object showed the buttons twice on one screen. The rail row
+      // now always reads as progress + status, buttons or no.
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      // Arrival auto-selects Object 1 — previously the trigger for the row's
+      // button swap.
+      const row = within(screen.getByTestId('localize-object-row-object-1'));
+      expect(row.queryAllByRole('button')).toHaveLength(0);
+      expect(row.getByText('0/1')).toBeInTheDocument();
+      expect(row.getByText('1 left')).toBeInTheDocument();
+    });
+
     it("accepts the active object's boxes from the header, then reports nothing left and drops the action", async () => {
       vi.mocked(apiClient.createDetectionAnnotation).mockImplementation(async payload => ({
         id: 9100 + payload.detection_id,
@@ -2124,7 +2099,8 @@ describe('LocalizeAlertPage', () => {
       );
 
       // Object 1's lane is detection 1001 only — the CTA acts on the active
-      // object, not on the alert.
+      // object, not on the alert. Object 2's frames (1002, 1003) must never
+      // be touched by Object 1's quick-accept.
       await waitFor(() => {
         expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
           expect.objectContaining({ detection_id: 1001 })
@@ -2132,6 +2108,9 @@ describe('LocalizeAlertPage', () => {
       });
       expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalledWith(
         expect.objectContaining({ detection_id: 1002 })
+      );
+      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalledWith(
+        expect.objectContaining({ detection_id: 1003 })
       );
 
       expect(apiClient.updateDetectionAnnotation).not.toHaveBeenCalled();
@@ -2726,10 +2705,11 @@ describe('LocalizeAlertPage', () => {
     it("navigates to the row's OWN lane in classify done mode, carrying a return to this page", async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
-      // Reclassify is on the selected row only, so select Object 2 first.
+      // Reclassify sits in the CTA bar for the active object, so select
+      // Object 2 first.
       fireEvent.click(screen.getByTestId('localize-object-row-object-2'));
       fireEvent.click(
-        within(screen.getByTestId('localize-object-row-object-2')).getByRole('button', {
+        within(screen.getByTestId('localize-active-object-actions')).getByRole('button', {
           name: 'Reclassify Object 2',
         })
       );
@@ -2751,7 +2731,7 @@ describe('LocalizeAlertPage', () => {
 
       fireEvent.click(screen.getByTestId('localize-object-row-object-2'));
       fireEvent.click(
-        within(screen.getByTestId('localize-object-row-object-2')).getByRole('button', {
+        within(screen.getByTestId('localize-active-object-actions')).getByRole('button', {
           name: 'Reclassify Object 2',
         })
       );
@@ -2782,10 +2762,10 @@ describe('LocalizeAlertPage', () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
       fireEvent.click(screen.getByTestId('localize-object-row-object-2'));
-      const contextRow = within(screen.getByTestId('localize-object-row-object-2'));
-      // Context rows carry no Accept boxes action, but stay correctable.
-      expect(contextRow.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
-      expect(contextRow.getByRole('button', { name: 'Reclassify Object 2' })).toBeInTheDocument();
+      const cta = within(screen.getByTestId('localize-active-object-actions'));
+      // Context objects carry no Accept boxes action, but stay correctable.
+      expect(cta.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
+      expect(cta.getByRole('button', { name: 'Reclassify Object 2' })).toBeInTheDocument();
     });
 
     it('offers Reclassify on a false-positive context row (FP -> smoke, issue #275)', async () => {
@@ -2815,9 +2795,9 @@ describe('LocalizeAlertPage', () => {
 
       // Still no localization action — but the classification is correctable.
       fireEvent.click(await screen.findByTestId('localize-object-row-object-2'));
-      const fpRow = within(screen.getByTestId('localize-object-row-object-2'));
-      expect(fpRow.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
-      fireEvent.click(fpRow.getByRole('button', { name: 'Reclassify Object 2' }));
+      const cta = within(screen.getByTestId('localize-active-object-actions'));
+      expect(cta.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
+      fireEvent.click(cta.getByRole('button', { name: 'Reclassify Object 2' }));
 
       // Same destination contract as smoke rows: the row's OWN lane, with a
       // return naming that object's selection URL. If the lane comes back


### PR DESCRIPTION
## What

On the localize alert page, the cockpit rail's selected object row no longer swaps its progress count and status chip for the **Accept boxes** / **Reclassify** buttons. The same pair — driven by the same `objectActionProps` — already sits in the Frames panel bar above the media column, so every active object showed its buttons twice on one screen, and the selected row lost the one thing it says about itself.

## Changes

- `LocalizeObjectRow` is now a read-only summary + selector: it always shows the progress fraction and status chip, selected or not. The action props (`onAcceptBoxes`, `isAccepting`, `onReclassify`) are gone, along with the keydown guard that existed for the nested buttons.
- `LocalizeAlertPage` feeds `objectActionProps` only to the Frames bar's `LocalizeObjectActions`.
- `LocalizeObjectActions` loses its now-unused `compact` size variant (and the `stopPropagation` that only mattered inside the clickable row) — it is the prominent CTA-bar pair only.

No capability is lost: selecting any row (workable, localized context, or false positive) surfaces its actions in the Frames bar, same as before.

## Tests

- New page test pins the rail row to metadata-only while active.
- The quick-accept lane-scoping and reclassify navigation tests now exercise the Frames-bar buttons; the row-button duplicates were removed.
- `LocalizeObjectRow.test.tsx` rewritten to the new API (selection treatment unchanged, metadata always visible).

Full suite: 1131 passing; `npm run quality` clean.