### PR TITLE
feat(frontend): localize page keyboard shortcuts + help sheet

### DIFF
--- a/docs/specs/2026-08-06-localize-page-shortcuts-help-design.md
+++ b/docs/specs/2026-08-06-localize-page-shortcuts-help-design.md
@@ -15,7 +15,8 @@ are only documented, not changed.
 ## New bindings
 
 One new `window` keydown effect in `LocalizeAlertPage.tsx`, alongside the
-existing `C` effect (the `C` and Tab handlers are untouched):
+existing `C` effect. The `C` and Tab handlers keep their behavior, gaining
+only a sheet-open suspension (below):
 
 | Key | Action |
 | --- | --- |
@@ -38,8 +39,11 @@ These are the same suspension conditions as the Tab cycle handler, plus the
 typing guard. Matched keys call `preventDefault()`. Letter keys match
 case-insensitively (`s` and `S`), like the existing `C` handler.
 
-While the shortcuts modal is open, only `?` and `Escape` act; `S`/`M`/`L`/`P`
-are inert (the modal is a surface of its own, like the other overlays).
+While the shortcuts modal is open, only `?` and `Escape` act: `S`/`M`/`L`/`P`
+are inert, and the pre-existing `C` and Tab handlers are suspended too (the
+modal is a surface of its own, like the other overlays — and without the Tab
+suspension its close button would be keyboard-unreachable, the trap classify
+guards against on its own sheet).
 
 ## Help modal
 

--- a/docs/specs/2026-08-06-localize-page-shortcuts-help-design.md
+++ b/docs/specs/2026-08-06-localize-page-shortcuts-help-design.md
@@ -1,0 +1,98 @@
+# Localize page keyboard shortcuts + help modal
+
+**Date:** 2026-08-06
+**Status:** Approved
+
+## Goal
+
+Give the localize cockpit (`/localize/:sequenceId`, `LocalizeAlertPage`) the same
+keyboard-shortcuts affordance the classify page has — a lucide `Keyboard` icon
+button opening a help modal — and add the page-level bindings it documents:
+`S`/`M`/`L` for frame card size, `P` for the cropped-loop (PlayCircle) toggle,
+and `?` for the help itself. `Tab`/`Shift+Tab` cycling and `C` already exist and
+are only documented, not changed.
+
+## New bindings
+
+One new `window` keydown effect in `LocalizeAlertPage.tsx`, alongside the
+existing `C` effect (the `C` and Tab handlers are untouched):
+
+| Key | Action |
+| --- | --- |
+| `S` / `M` / `L` | `handleCardSizeChange('sm' \| 'md' \| 'lg')` — same path as clicking the ViewToolbar buttons, so the focus-size override is cleared identically |
+| `P` | Toggle `cropExpanded`. No-op when `canShowCrop` is false (no active lane with boxes) — same gate that hides the button |
+| `?` | Toggle the shortcuts modal |
+| `Escape` | Close the shortcuts modal, only while it is open (mirrors classify's `createKeyboardHandler`) |
+
+### Guards
+
+The handler returns early (keys stay inert) when:
+
+- the per-frame editor is open (`detectionIdNum != null`),
+- the add-object picker is open (`addObjectPickerOpen`),
+- the missed-smoke confirm dialog is open (`missedSmokeConfirm`),
+- `Ctrl`/`Meta`/`Alt` is held (`Shift` stays allowed — `?` requires it),
+- the event target is an input, textarea, or contenteditable element.
+
+These are the same suspension conditions as the Tab cycle handler, plus the
+typing guard. Matched keys call `preventDefault()`. Letter keys match
+case-insensitively (`s` and `S`), like the existing `C` handler.
+
+While the shortcuts modal is open, only `?` and `Escape` act; `S`/`M`/`L`/`P`
+are inert (the modal is a surface of its own, like the other overlays).
+
+## Help modal
+
+New `frontend/src/components/localize/LocalizeShortcutsModal.tsx`, a
+self-contained copy of `ClassifyShortcutsModal`'s structure (`Key` / `Row` /
+`Section` primitives and the modal shell), with a header comment noting the
+copy — the same pattern `EditorShortcutsModal` already uses. No shared
+extraction in this change.
+
+Content (all page-level shortcuts, including pre-existing ones):
+
+- **Navigate**
+  - Cycle objects — `Tab`, `Shift + Tab`
+  - Open the focused object — `Enter`, `Space`
+- **View**
+  - Frame card size — `S`, `M`, `L`
+  - Crop cells — `C`
+  - Cropped view — loop the object's crops — `P`
+- **Help**
+  - Toggle this help — `?`
+
+Backdrop click, the `X` button, and `Escape` all close it.
+
+## Entry point
+
+A `Keyboard` icon button identical in styling and title
+(`"Show keyboard shortcuts (?)"`) to classify's, placed in `LocalizeRail`'s
+`headerAction` slot next to the existing False-positives toggle (the slot
+receives a fragment containing both, shortcuts button after the toggle).
+State is a local `useState` in `LocalizeAlertPage`, as on classify.
+
+## FP toggle relabel + tooltip
+
+To make room in the rail header, the False-positives toggle's visible label
+shrinks from "False positives" to "FP" (count badge unchanged). Because "FP"
+alone is cryptic:
+
+- the button keeps its full accessible name via `aria-label="False positives"`,
+- the native `title` is replaced by the shared `ui/Tooltip` component (already
+  used on this page for the submit button), carrying the existing copy:
+  the "no false-positive objects" sentence when disabled, the "read-only
+  context" explanation otherwise. Placement `below` (the button sits at the
+  top of the rail, with the panel below it).
+
+## Testing
+
+Vitest page tests following the existing localize keyboard-test pattern
+(await arrival auto-select before pressing keys):
+
+- `S`/`M`/`L` flips `aria-pressed` on the corresponding ViewToolbar button.
+- `P` mounts/unmounts the cropped-loop view; inert when no lane has boxes.
+- `?` opens the modal (and the rail button opens it too); `Escape` and `?`
+  close it.
+- New keys are inert while the per-frame editor overlay is open.
+- The FP toggle shows "FP", keeps the accessible name "False positives", and
+  its tooltip carries the explanatory copy.

--- a/frontend/src/components/localize/LocalizeShortcutsModal.tsx
+++ b/frontend/src/components/localize/LocalizeShortcutsModal.tsx
@@ -1,0 +1,79 @@
+/**
+ * Keyboard shortcuts help for the localize cockpit, opened from the Keyboard
+ * button in the Objects rail header or with `?`.
+ *
+ * Static copy — the bindings live in LocalizeAlertPage's key handlers (the
+ * page-level S/M/L/P/? effect, the `c` crop effect, the Tab cycle) and
+ * LocalizeObjectRow's Enter/Space activation; keep this list in sync.
+ *
+ * The Key/Row/Section primitives mirror `ClassifyShortcutsModal`'s so the two
+ * help sheets look like one product. They are duplicated rather than shared:
+ * extracting them would mean editing the classify sheet, which works and is
+ * not what this change is about.
+ */
+
+import React from 'react';
+import { X } from 'lucide-react';
+
+const Key: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <kbd className="px-1.5 py-0.5 rounded border border-line bg-ash font-data text-[11px] font-medium text-char">
+    {children}
+  </kbd>
+);
+
+const Row: React.FC<{ label: string; keys: string[] }> = ({ label, keys }) => (
+  <div className="flex items-center justify-between gap-4 py-1">
+    <span className="font-body text-sm text-char">{label}</span>
+    <span className="flex flex-none items-center gap-1">
+      {keys.map(k => (
+        <Key key={k}>{k}</Key>
+      ))}
+    </span>
+  </div>
+);
+
+const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
+  <div>
+    <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze mb-1.5">
+      {title}
+    </div>
+    {children}
+  </div>
+);
+
+export interface LocalizeShortcutsModalProps {
+  onClose: () => void;
+}
+
+export const LocalizeShortcutsModal: React.FC<LocalizeShortcutsModalProps> = ({ onClose }) => (
+  <div className="fixed inset-0 bg-char/50 flex items-center justify-center z-50" onClick={onClose}>
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      className="bg-paper border border-line rounded-card w-full max-w-md max-h-[90vh] overflow-y-auto m-4"
+      onClick={e => e.stopPropagation()}
+    >
+      <div className="flex items-center justify-between px-6 py-4 border-b border-line">
+        <h2 className="font-display text-heading font-semibold text-char">Keyboard shortcuts</h2>
+        <button onClick={onClose} aria-label="Close" className="p-2 hover:bg-ash rounded-md">
+          <X className="w-5 h-5 text-haze" />
+        </button>
+      </div>
+      <div className="px-6 py-5 space-y-5">
+        <Section title="Navigate">
+          <Row label="Cycle objects" keys={['Tab', 'Shift + Tab']} />
+          <Row label="Open the focused object" keys={['Enter', 'Space']} />
+        </Section>
+        <Section title="View">
+          <Row label="Frame card size" keys={['S', 'M', 'L']} />
+          <Row label="Crop cells" keys={['C']} />
+          <Row label="Cropped view — loop the object's crops" keys={['P']} />
+        </Section>
+        <Section title="Help">
+          <Row label="Toggle this help" keys={['?']} />
+        </Section>
+      </div>
+    </div>
+  </div>
+);

--- a/frontend/src/components/localize/index.ts
+++ b/frontend/src/components/localize/index.ts
@@ -8,3 +8,5 @@ export { LocalizeObjectActions } from './LocalizeObjectActions';
 export type { LocalizeObjectActionsProps } from './LocalizeObjectActions';
 export { LocalizeMissedSmokeRow } from './LocalizeMissedSmokeRow';
 export type { LocalizeMissedSmokeRowProps } from './LocalizeMissedSmokeRow';
+export { LocalizeShortcutsModal } from './LocalizeShortcutsModal';
+export type { LocalizeShortcutsModalProps } from './LocalizeShortcutsModal';

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -111,7 +111,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useNavigate, useLocation, useSearchParams, useMatch } from 'react-router-dom';
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, PlayCircle, Plus, Upload } from 'lucide-react';
+import { ArrowLeft, Keyboard, PlayCircle, Plus, Upload } from 'lucide-react';
 import { apiClient } from '@/services/api';
 import { QUERY_KEYS } from '@/utils/constants';
 import { Detection, DetectionAnnotation, DetectionAnnotationBbox, SmokeType } from '@/types/api';
@@ -134,6 +134,7 @@ import {
   LocalizeObjectActions,
   LocalizeObjectRow,
   LocalizeRail,
+  LocalizeShortcutsModal,
 } from '@/components/localize';
 import { AlertFrameGrid, ViewToolbar } from '@/components/detection-sequence';
 import { LocalizeObjectEditor } from '@/components/localize/editor';
@@ -234,6 +235,8 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // so the choice follows them from object to object instead of resetting on
   // every selection.
   const [cropExpanded, setCropExpanded] = useState(false);
+  // The keyboard-shortcuts help sheet, opened from the rail button or `?`.
+  const [showShortcutsModal, setShowShortcutsModal] = useState(false);
   // Opt-in read-only context: objects classify settled as false positives.
   // Off by default so the default view matches the queue's own rule; on, it
   // answers "is that plume already accounted for?" before someone adds a
@@ -1214,6 +1217,36 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     return () => document.removeEventListener('keydown', handleTab, true);
   });
 
+  // `?` toggles the shortcuts sheet and Escape closes it — the same pair
+  // classify's createKeyboardHandler answers. Suspended under the same
+  // surfaces as the Tab cycle, and while typing in a field. Same
+  // deliberately-absent dependency array as the Tab handler above:
+  // re-subscribing every render keeps the closure fresh.
+  useEffect(() => {
+    const handleShortcutKeys = (e: KeyboardEvent) => {
+      if (detectionIdNum != null || addObjectPickerOpen || missedSmokeConfirm) return;
+      // Shift stays allowed: `?` requires it.
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+      const target = e.target;
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+      )
+        return;
+      if (e.key === '?') {
+        setShowShortcutsModal(prev => !prev);
+        e.preventDefault();
+        return;
+      }
+      if (e.key === 'Escape' && showShortcutsModal) {
+        setShowShortcutsModal(false);
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('keydown', handleShortcutKeys);
+    return () => window.removeEventListener('keydown', handleShortcutKeys);
+  });
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-96">
@@ -1417,29 +1450,39 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
             // The toggle governs which object ROWS exist, so it belongs with
             // Objects rather than with the frame grid's view controls.
             headerAction={
-              <button
-                type="button"
-                aria-pressed={showFalsePositives}
-                disabled={falsePositiveLaneCount === 0}
-                onClick={handleToggleFalsePositives}
-                title={
-                  falsePositiveLaneCount === 0
-                    ? 'This alert has no false-positive objects'
-                    : 'Show objects classify settled as false positives, as read-only context'
-                }
-                className={`inline-flex items-center gap-1.5 rounded-lg border px-2 py-1 font-body text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
-                  showFalsePositives
-                    ? 'border-char bg-ash text-char'
-                    : 'border-line bg-paper text-haze hover:text-char'
-                }`}
-              >
-                False positives
-                {falsePositiveLaneCount > 0 && (
-                  <span className="font-data text-[10px] font-semibold">
-                    {falsePositiveLaneCount}
-                  </span>
-                )}
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  aria-pressed={showFalsePositives}
+                  disabled={falsePositiveLaneCount === 0}
+                  onClick={handleToggleFalsePositives}
+                  title={
+                    falsePositiveLaneCount === 0
+                      ? 'This alert has no false-positive objects'
+                      : 'Show objects classify settled as false positives, as read-only context'
+                  }
+                  className={`inline-flex items-center gap-1.5 rounded-lg border px-2 py-1 font-body text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                    showFalsePositives
+                      ? 'border-char bg-ash text-char'
+                      : 'border-line bg-paper text-haze hover:text-char'
+                  }`}
+                >
+                  False positives
+                  {falsePositiveLaneCount > 0 && (
+                    <span className="font-data text-[10px] font-semibold">
+                      {falsePositiveLaneCount}
+                    </span>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowShortcutsModal(true)}
+                  className="p-1.5 rounded-lg border border-line bg-paper text-haze hover:bg-ash"
+                  title="Show keyboard shortcuts (?)"
+                >
+                  <Keyboard className="w-4 h-4" />
+                </button>
+              </div>
             }
             missedSmoke={
               <LocalizeMissedSmokeRow
@@ -1653,6 +1696,10 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
         toastType={toastType}
         onDismiss={dismissToast}
       />
+
+      {showShortcutsModal && (
+        <LocalizeShortcutsModal onClose={() => setShowShortcutsModal(false)} />
+      )}
     </>
   );
 }

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1167,17 +1167,18 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   };
 
   // 'c' toggles crop mode, matching the legacy grid — inert while the modal
-  // is open (mirrors the legacy page's showModal guard).
+  // is open (mirrors the legacy page's showModal guard) and while the
+  // shortcuts sheet is up (only `?`/Escape act there).
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.key === 'c' || e.key === 'C') && detectionIdNum == null) {
+      if ((e.key === 'c' || e.key === 'C') && detectionIdNum == null && !showShortcutsModal) {
         setCropMode(prev => !prev);
         e.preventDefault();
       }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [detectionIdNum]);
+  }, [detectionIdNum, showShortcutsModal]);
 
   // Tab / Shift+Tab step the objects exactly as the rail displays them —
   // smoke first, false positives only while shown — wrapping at the ends
@@ -1193,9 +1194,10 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       if (e.key !== 'Tab') return;
       // Suspended whenever a surface with its own focusables is up — the
       // per-frame editor, the (inline) add-object smoke-type picker, the
-      // missed-smoke submit dialog — so their controls stay
-      // keyboard-reachable (mirrors classify's modal guards).
+      // missed-smoke submit dialog, the shortcuts sheet — so their controls
+      // stay keyboard-reachable (mirrors classify's modal guards).
       if (detectionIdNum != null || addObjectPickerOpen || missedSmokeConfirm) return;
+      if (showShortcutsModal) return;
       if (orderedObjectRows.length === 0) return;
       e.preventDefault();
       const current = orderedObjectRows.findIndex(o => o.laneSequenceId === activeLaneId);

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1241,6 +1241,22 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       if (e.key === 'Escape' && showShortcutsModal) {
         setShowShortcutsModal(false);
         e.preventDefault();
+        return;
+      }
+      // The sheet is a surface of its own, like the overlays above: while it
+      // is up, only `?` and Escape act.
+      if (showShortcutsModal) return;
+      const key = e.key.toLowerCase();
+      if (key === 's' || key === 'm' || key === 'l') {
+        handleCardSizeChange(key === 's' ? 'sm' : key === 'm' ? 'md' : 'lg');
+        e.preventDefault();
+        return;
+      }
+      // Same gate as the PlayCircle button's render condition: no target
+      // object, nothing to loop.
+      if (key === 'p' && canShowCrop) {
+        setCropExpanded(prev => !prev);
+        e.preventDefault();
       }
     };
     window.addEventListener('keydown', handleShortcutKeys);

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1467,29 +1467,37 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
             // Objects rather than with the frame grid's view controls.
             headerAction={
               <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  aria-pressed={showFalsePositives}
-                  disabled={falsePositiveLaneCount === 0}
-                  onClick={handleToggleFalsePositives}
-                  title={
+                {/* "FP" to keep the header row tight; the aria-label keeps the
+                    full accessible name and the styled tooltip carries the
+                    explanation the old `title` held. */}
+                <Tooltip
+                  placement="below"
+                  tip={
                     falsePositiveLaneCount === 0
                       ? 'This alert has no false-positive objects'
                       : 'Show objects classify settled as false positives, as read-only context'
                   }
-                  className={`inline-flex items-center gap-1.5 rounded-lg border px-2 py-1 font-body text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
-                    showFalsePositives
-                      ? 'border-char bg-ash text-char'
-                      : 'border-line bg-paper text-haze hover:text-char'
-                  }`}
                 >
-                  False positives
-                  {falsePositiveLaneCount > 0 && (
-                    <span className="font-data text-[10px] font-semibold">
-                      {falsePositiveLaneCount}
-                    </span>
-                  )}
-                </button>
+                  <button
+                    type="button"
+                    aria-pressed={showFalsePositives}
+                    aria-label="False positives"
+                    disabled={falsePositiveLaneCount === 0}
+                    onClick={handleToggleFalsePositives}
+                    className={`inline-flex items-center gap-1.5 rounded-lg border px-2 py-1 font-body text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                      showFalsePositives
+                        ? 'border-char bg-ash text-char'
+                        : 'border-line bg-paper text-haze hover:text-char'
+                    }`}
+                  >
+                    FP
+                    {falsePositiveLaneCount > 0 && (
+                      <span className="font-data text-[10px] font-semibold">
+                        {falsePositiveLaneCount}
+                      </span>
+                    )}
+                  </button>
+                </Tooltip>
                 <button
                   type="button"
                   onClick={() => setShowShortcutsModal(true)}

--- a/frontend/tests/pages/ClassifyAlertPage.autoAdvance.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.autoAdvance.test.tsx
@@ -217,11 +217,21 @@ describe('ClassifyAlertPage auto-advance', () => {
     );
 
     // The destination alert's object must be active with its own seeded data —
-    // not a skeleton, and not the previous alert's sequence.
-    await waitFor(() => {
-      expect(screen.queryByTestId('media-panel-skeleton')).not.toBeInTheDocument();
-    });
-    expect(screen.getByTestId('full-image-sequence').getAttribute('data-sequence-id')).toBe('301');
-    expect(screen.getByTestId('full-image-sequence').getAttribute('data-bbox-count')).not.toBe('0');
+    // not a skeleton, and not the previous alert's sequence. Same generous
+    // timeout as the auto-advance wait above: this is the destination's own
+    // queries resolving, which loaded CI runners serve slowly (seen flaking
+    // at the 1s default).
+    await waitFor(
+      () => {
+        expect(screen.queryByTestId('media-panel-skeleton')).not.toBeInTheDocument();
+        expect(screen.getByTestId('full-image-sequence').getAttribute('data-sequence-id')).toBe(
+          '301'
+        );
+        expect(screen.getByTestId('full-image-sequence').getAttribute('data-bbox-count')).not.toBe(
+          '0'
+        );
+      },
+      { timeout: 5000 }
+    );
   }, 15000);
 });

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2084,6 +2084,12 @@ describe('LocalizeAlertPage', () => {
   describe('active object CTA, over the media column', () => {
     it('appears above the frames for the active object, following the selection', async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      // Await the arrival auto-select's navigation: the CTA only exists once
+      // an object is active, and asserting before the navigate commits races
+      // it (seen flaking on CI, where the DOM dump showed the bare URL).
+      await waitFor(() =>
+        expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101')
+      );
 
       // Arrival auto-selects Object 1, so its CTA is there from the start.
       const cta = within(screen.getByTestId('localize-active-object-actions'));

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -1885,7 +1885,7 @@ describe('LocalizeAlertPage', () => {
       const toggle = screen.getByRole('button', { name: /False positives/ });
       expect(toggle).toBeDisabled();
       // No count badge when there is nothing to reveal.
-      expect(toggle).toHaveTextContent(/^False positives$/);
+      expect(toggle).toHaveTextContent(/^FP$/);
     });
 
     it('shows how many false-positive objects the alert has', async () => {
@@ -1894,7 +1894,19 @@ describe('LocalizeAlertPage', () => {
 
       const toggle = screen.getByRole('button', { name: /False positives/ });
       expect(toggle).toBeEnabled();
-      expect(toggle).toHaveTextContent('False positives1');
+      expect(toggle).toHaveTextContent('FP1');
+    });
+
+    it('the FP toggle keeps its full name for screen readers and explains itself in a tooltip', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      // Default fixture has no FP lanes, so the disabled-state copy shows.
+      const toggle = screen.getByRole('button', { name: 'False positives' });
+      const tipId = toggle.getAttribute('aria-describedby');
+      expect(tipId).toBeTruthy();
+      expect(document.getElementById(tipId!)).toHaveTextContent(
+        'This alert has no false-positive objects'
+      );
+      expect(toggle).not.toHaveAttribute('title');
     });
 
     it('keeps false-positive frames read-only — visible, never openable in the editor', async () => {

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2755,6 +2755,29 @@ describe('LocalizeAlertPage', () => {
 
       expect(screen.queryByRole('dialog', { name: 'Keyboard shortcuts' })).not.toBeInTheDocument();
     });
+
+    it('Tab is inert while the sheet is open, so its close button stays reachable', async () => {
+      await arrive();
+      fireEvent.keyDown(window, { key: '?' });
+
+      fireEvent.keyDown(document, { key: 'Tab' });
+
+      // No cycling happened behind the dialog: the URL still names the
+      // arrival object, and the sheet is still up.
+      expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101');
+      expect(screen.getByRole('dialog', { name: 'Keyboard shortcuts' })).toBeInTheDocument();
+    });
+
+    it("'c' is inert while the sheet is open", async () => {
+      await arrive();
+      fireEvent.keyDown(window, { key: '?' });
+
+      const crop = screen.getByTitle('Crop cells (C)');
+      const before = crop.getAttribute('aria-pressed');
+      fireEvent.keyDown(window, { key: 'c' });
+
+      expect(crop).toHaveAttribute('aria-pressed', before!);
+    });
   });
 
   describe('page view keys', () => {

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2745,6 +2745,75 @@ describe('LocalizeAlertPage', () => {
     });
   });
 
+  describe('page view keys', () => {
+    const arrive = async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      await waitFor(() =>
+        expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101')
+      );
+    };
+
+    it("'l' switches to large cards", async () => {
+      await arrive();
+      fireEvent.keyDown(window, { key: 'l' });
+      expect(screen.getByTitle('Large cards')).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it("'M' (uppercase) switches to medium cards", async () => {
+      // NOT 'S': the arrival focus-mode override already presses Small, so an
+      // 'S' assertion would pass before the key exists. Medium starts
+      // unpressed under the override, so this genuinely fails first.
+      await arrive();
+      fireEvent.keyDown(window, { key: 'M' });
+      expect(screen.getByTitle('Medium cards')).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it("'p' opens and closes the cropped loop", async () => {
+      await arrive();
+      fireEvent.keyDown(window, { key: 'p' });
+      expect(screen.getByTestId('cropped-image-sequence')).toBeInTheDocument();
+      fireEvent.keyDown(window, { key: 'p' });
+      expect(screen.queryByTestId('cropped-image-sequence')).not.toBeInTheDocument();
+    });
+
+    it("'p' is inert when the active object has no boxes", async () => {
+      // Boxless variants of BOTH lanes, so wherever arrival lands, canShowCrop
+      // stays false (mirrors the button's own withheld state).
+      vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
+        if (id === 101)
+          return [{ ...makeDetection(1001, T1), auto_predictions: { predictions: [] } }];
+        if (id === 102)
+          return [
+            { ...makeDetection(1002, T1), auto_predictions: { predictions: [] } },
+            { ...makeDetection(1003, T2), auto_predictions: { predictions: [] } },
+          ];
+        return [];
+      });
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      await waitFor(() =>
+        expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/')
+      );
+      expect(screen.queryByRole('button', { name: 'Cropped view' })).not.toBeInTheDocument();
+      fireEvent.keyDown(window, { key: 'p' });
+      expect(screen.queryByTestId('cropped-image-sequence')).not.toBeInTheDocument();
+    });
+
+    it('size keys are inert while the add-object picker is open', async () => {
+      await arrive();
+      answerMissedSmokeYes();
+      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
+      fireEvent.keyDown(window, { key: 'l' });
+      expect(screen.getByTitle('Large cards')).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('size keys are inert while the shortcuts sheet is open', async () => {
+      await arrive();
+      fireEvent.keyDown(window, { key: '?' });
+      fireEvent.keyDown(window, { key: 'l' });
+      expect(screen.getByTitle('Large cards')).toHaveAttribute('aria-pressed', 'false');
+    });
+  });
+
   describe('reclassify', () => {
     it("navigates to the row's OWN lane in classify done mode, carrying a return to this page", async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2701,6 +2701,50 @@ describe('LocalizeAlertPage', () => {
     });
   });
 
+  describe('keyboard shortcuts help', () => {
+    const arrive = async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      // Wait out the arrival auto-select, as every keyboard test here does.
+      await waitFor(() =>
+        expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101')
+      );
+    };
+
+    it("'?' opens the shortcuts sheet and Escape closes it", async () => {
+      await arrive();
+      fireEvent.keyDown(window, { key: '?' });
+      expect(screen.getByRole('dialog', { name: 'Keyboard shortcuts' })).toBeInTheDocument();
+      fireEvent.keyDown(window, { key: 'Escape' });
+      expect(screen.queryByRole('dialog', { name: 'Keyboard shortcuts' })).not.toBeInTheDocument();
+    });
+
+    it("'?' pressed again closes the sheet", async () => {
+      await arrive();
+      fireEvent.keyDown(window, { key: '?' });
+      fireEvent.keyDown(window, { key: '?' });
+      expect(screen.queryByRole('dialog', { name: 'Keyboard shortcuts' })).not.toBeInTheDocument();
+    });
+
+    it('the rail button opens the sheet, which lists the page keys', async () => {
+      await arrive();
+      fireEvent.click(screen.getByTitle('Show keyboard shortcuts (?)'));
+      const dialog = screen.getByRole('dialog', { name: 'Keyboard shortcuts' });
+      expect(dialog).toHaveTextContent('Cycle objects');
+      expect(dialog).toHaveTextContent('Crop cells');
+      expect(dialog).toHaveTextContent('Toggle this help');
+    });
+
+    it("'?' is inert while the per-frame editor is open", async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      fireEvent.click(screen.getByTestId(`alert-frame-cell-${T1}`));
+      await screen.findByTestId('image-modal');
+
+      fireEvent.keyDown(window, { key: '?' });
+
+      expect(screen.queryByRole('dialog', { name: 'Keyboard shortcuts' })).not.toBeInTheDocument();
+    });
+  });
+
   describe('reclassify', () => {
     it("navigates to the row's OWN lane in classify done mode, carrying a return to this page", async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });


### PR DESCRIPTION
## What

Gives the localize cockpit the same keyboard-shortcuts affordance the classify page has, plus the page-level bindings it documents.

- **Help sheet**: new `LocalizeShortcutsModal` (self-contained copy of `ClassifyShortcutsModal`'s primitives, same pattern as the editor's sheet), opened from a classify-style Keyboard button in the Objects rail header or with `?`; `Escape` / `?` / backdrop / ✕ close it. Lists all page-level keys, including the pre-existing `Tab`/`Shift+Tab`, `Enter`/`Space`, and `C`.
- **New bindings**: `S`/`M`/`L` set the frame card size (same path as clicking the ViewToolbar buttons), `P` toggles the cropped loop (same gate as the PlayCircle button). Case-insensitive; suspended while the per-frame editor, add-object picker, or missed-smoke confirm is up, and while typing in a field.
- **FP toggle**: visible label shrinks to "FP" (count badge unchanged) to keep the rail header tight; `aria-label` keeps the full accessible name and the shared styled `Tooltip` replaces the native `title` with the same copy.

Spec: `docs/specs/2026-08-06-localize-page-shortcuts-help-design.md`

## Testing

- 11 new page tests (sheet open/close, each new key, canShowCrop gate, overlay/sheet inertness, FP relabel + tooltip wiring).
- Full suite green: 88 files, 1142 tests. `npm run quality` clean.