### PR TITLE
feat(frontend): accept popover shows frame counter, object timeline, and coverage warnings

### DIFF
--- a/docs/specs/2026-08-06-accept-popover-frame-strip-design.md
+++ b/docs/specs/2026-08-06-accept-popover-frame-strip-design.md
@@ -80,8 +80,9 @@ Three additions, all reusing existing components and data:
 
 ## Edge cases
 
-- Loop still loading or errored: `onFrameChange` has not fired, so no
-  counter and no playhead — the strip renders static.
+- Loop still loading or errored: `onFrameChange` reports the starting
+  frame on mount, so the counter and playhead show the first boxed frame
+  immediately (accurately) while the crop still shows its spinner.
 - Reported `detection_id` not found in `entries` (should not happen —
   `previewBoxes` and `entries` derive from the same lane): counter hidden,
   strip static.

--- a/docs/specs/2026-08-06-accept-popover-frame-strip-design.md
+++ b/docs/specs/2026-08-06-accept-popover-frame-strip-design.md
@@ -37,8 +37,10 @@ Three additions, all reusing existing components and data:
   eyebrow so the strip embeds cleanly inside the popover. The rail's usage
   (`LocalizeAlertPage`) passes nothing and is untouched.
 - `playhead?: { objectIndex: number; timestamp: string }`. The segment of
-  that object at that timestamp renders highlighted (`ring-1 ring-ember`
-  plus full opacity). Undefined reproduces today's rendering exactly.
+  that object at that timestamp renders highlighted: full opacity plus an
+  inset white marker merged into the segment's `boxShadow` (the track is
+  `overflow-hidden`, so an outer ring would be clipped at this height), and
+  `data-playhead="true"`. Undefined reproduces today's rendering exactly.
 - Interactivity needs no change: `onSegmentClick` / `onObjectClick` are
   already optional; the popover omits them for a static strip.
 
@@ -69,11 +71,12 @@ Three additions, all reusing existing components and data:
 - Tracks the loop's current `detection_id` in local state via
   `onFrameChange`; maps it to an entry to derive both the playhead
   timestamp and the counter index.
-- Counter text "Frame {entryIndex + 1} of {entries.length}" beside the
-  "What {objectLabel} ends up with" label — position among *all* alert
-  frames, the same language as the filmstrip summary. Because the loop only
-  plays frames that have boxes, the counter visibly skips gap frames
-  (…4, 6…) and the outlined gap segment never receives the playhead.
+- Counter text "Frame {entryIndex + 1} of {entries.length}" right-aligned
+  directly above the strip (beside the eyebrow label it forced the label to
+  wrap) — position among *all* alert frames, the same language as the
+  filmstrip summary. Because the loop only plays frames that have boxes,
+  the counter visibly skips gap frames (…4, 6…) and the outlined gap
+  segment never receives the playhead.
 
 ## Edge cases
 

--- a/docs/specs/2026-08-06-accept-popover-frame-strip-design.md
+++ b/docs/specs/2026-08-06-accept-popover-frame-strip-design.md
@@ -1,0 +1,97 @@
+# Accept-boxes popover: frame counter + object timeline
+
+**Date:** 2026-08-06
+**Status:** Approved
+**Scope:** Frontend only — the localize object editor's "Accept boxes" popover.
+
+## Problem
+
+On `/localize/:sequenceId/object/:laneId/:detectionId`, clicking **Accept
+boxes** opens `AcceptRemainingPopover`: a count sentence, an animated
+`CroppedImageSequence` loop of the post-accept track, an optional gap
+warning, and the confirm button. The loop gives no sense of position — you
+cannot tell which frame you are looking at, how many frames the track
+covers, or where the accepted frames sit relative to committed ones and
+gaps. The rest of the page answers those questions with the rail's
+`ObjectStatusStrip` timeline; the popover should speak the same language.
+
+## Design
+
+Three additions, all reusing existing components and data:
+
+1. A **frame counter** ("Frame 5 of 12") that tracks the animated loop.
+2. A **single-object `ObjectStatusStrip`** embedded in the popover, showing
+   the object's per-frame status *as it is now* (pre-accept): committed
+   frames solid, to-be-accepted frames faded, gaps outlined, off-object
+   frames neutral. The faded segments visually answer "which frames does
+   this button fill?"; the outlined ones anchor the gap warning.
+3. A **playhead**: as the loop animates, the strip segment for the frame
+   currently shown is highlighted, in sync with the counter.
+
+### 1. `ObjectStatusStrip` (shared component — two optional props)
+
+`frontend/src/components/sequence-annotation/ObjectStatusStrip.tsx`
+
+- `variant?: 'card' | 'bare'` (default `'card'`). `bare` drops the outer
+  card chrome (`rounded-lg border border-line bg-paper p-4`) and the title
+  eyebrow so the strip embeds cleanly inside the popover. The rail's usage
+  (`LocalizeAlertPage`) passes nothing and is untouched.
+- `playhead?: { objectIndex: number; timestamp: string }`. The segment of
+  that object at that timestamp renders highlighted (`ring-1 ring-ember`
+  plus full opacity). Undefined reproduces today's rendering exactly.
+- Interactivity needs no change: `onSegmentClick` / `onObjectClick` are
+  already optional; the popover omits them for a static strip.
+
+### 2. `CroppedImageSequence` (shared component — one optional prop)
+
+`frontend/src/components/annotation/CroppedImageSequence.tsx`
+
+- `onFrameChange?: (index: number, detectionId?: number) => void`, invoked
+  from the existing animation interval tick and when the index resets to 0
+  (boxes changed). `detectionId` is `bboxes[index]?.detection_id`. No other
+  behavior changes; existing callers are unaffected.
+
+### 3. `AcceptRemainingPopover`
+
+`frontend/src/components/localize/editor/AcceptRemainingPopover.tsx`
+
+- New prop: `entries: FilmstripEntry[]` — already computed by
+  `LocalizeObjectEditor` and in scope at the popover's render site.
+- Status mapping (entry → `ObjectStatusStripStatus`), keyed by
+  `entry.recordedAt`:
+  - `committedSource` set → `confirmed`
+  - `inObject && availableSource` (no committed) → `pending`
+  - `inObject` with neither → `empty`
+  - `!inObject` → `absent`
+- Renders `ObjectStatusStrip` with
+  `objects={[{ label: objectLabel, color: objectColor, statusByTimestamp }]}`
+  and `variant="bare"`, below the crop loop.
+- Tracks the loop's current `detection_id` in local state via
+  `onFrameChange`; maps it to an entry to derive both the playhead
+  timestamp and the counter index.
+- Counter text "Frame {entryIndex + 1} of {entries.length}" beside the
+  "What {objectLabel} ends up with" label — position among *all* alert
+  frames, the same language as the filmstrip summary. Because the loop only
+  plays frames that have boxes, the counter visibly skips gap frames
+  (…4, 6…) and the outlined gap segment never receives the playhead.
+
+## Edge cases
+
+- Loop still loading or errored: `onFrameChange` has not fired, so no
+  counter and no playhead — the strip renders static.
+- Reported `detection_id` not found in `entries` (should not happen —
+  `previewBoxes` and `entries` derive from the same lane): counter hidden,
+  strip static.
+
+## Testing
+
+Vitest, under `frontend/tests/` (mirroring existing test locations):
+
+- **ObjectStatusStrip**: `bare` drops card chrome and title; `playhead`
+  highlights exactly the matching segment; no `playhead` → status-quo
+  rendering (existing tests keep passing).
+- **CroppedImageSequence**: with fake timers, `onFrameChange` fires with
+  advancing indices and the matching `detection_id`.
+- **AcceptRemainingPopover**: entries map to the four statuses correctly;
+  the counter renders "Frame N of M" from the reported frame; gap frames
+  render outlined and never highlighted.

--- a/frontend/src/components/annotation/CroppedImageSequence.tsx
+++ b/frontend/src/components/annotation/CroppedImageSequence.tsx
@@ -32,6 +32,12 @@ interface CroppedImageSequenceProps {
    */
   maxSize?: string;
   className?: string;
+  /**
+   * Reports the loop's position: fired when the loop (re)starts at index 0
+   * and on every animation advance, with that entry's detection id. Lets a
+   * host render a counter or playhead in sync with the animation.
+   */
+  onFrameChange?: (index: number, detectionId?: number) => void;
 }
 
 interface ImageData {
@@ -48,6 +54,7 @@ export default function CroppedImageSequence({
   showBoxes = false,
   maxSize,
   className = '',
+  onFrameChange,
 }: CroppedImageSequenceProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [images, setImages] = useState<ImageData[]>([]);
@@ -61,6 +68,13 @@ export default function CroppedImageSequence({
   const [viewportEl, setViewportEl] = useState<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Latest-callback ref: the position-report effect below must fire on index
+  // changes only, not every time the caller re-creates the callback.
+  const onFrameChangeRef = useRef(onFrameChange);
+  useEffect(() => {
+    onFrameChangeRef.current = onFrameChange;
+  });
 
   // Calculate average bounding box from all xyxyn coordinates (port from backend)
   const calculateAverageBbox = (bboxes: BoundingBox[]): [number, number, number, number] => {
@@ -169,6 +183,15 @@ export default function CroppedImageSequence({
     // `bboxes` is read through the closure on purpose — see `frameKey` above.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [frameKey, sequenceId]);
+
+  // `frameKey` in the deps re-reports index 0 when the frame list changes
+  // (the reset effect sets the index to 0, which alone would not re-fire if
+  // it was already 0). `bboxes` is read through the closure, like the fetch
+  // effect above.
+  useEffect(() => {
+    onFrameChangeRef.current?.(currentIndex, bboxes[currentIndex]?.detection_id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentIndex, frameKey]);
 
   // Auto-play animation with 200ms interval - only when images are loaded
   useEffect(() => {

--- a/frontend/src/components/localize/editor/AcceptRemainingPopover.tsx
+++ b/frontend/src/components/localize/editor/AcceptRemainingPopover.tsx
@@ -139,7 +139,7 @@ export function AcceptRemainingPopover({
 
   return (
     <div
-      className="absolute left-1/2 top-full z-20 mt-2 w-[38rem] -translate-x-1/2 rounded-card border border-line bg-paper p-5 shadow-[0_8px_24px_rgba(32,38,31,0.12)]"
+      className="absolute left-1/2 top-full z-20 mt-2 w-[38rem] max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-card border border-line bg-paper p-5 shadow-[0_8px_24px_rgba(32,38,31,0.12)]"
       role="dialog"
       aria-label={`Accept the model's boxes for ${objectLabel}`}
       data-testid="accept-remaining-popover"

--- a/frontend/src/components/localize/editor/AcceptRemainingPopover.tsx
+++ b/frontend/src/components/localize/editor/AcceptRemainingPopover.tsx
@@ -32,7 +32,7 @@
  * the playhead never lands on an outlined segment.
  */
 
-import { useState } from 'react';
+import { useState, type CSSProperties } from 'react';
 import { X } from 'lucide-react';
 import CroppedImageSequence from '@/components/annotation/CroppedImageSequence';
 import {
@@ -89,6 +89,27 @@ export function AcceptRemainingPopover({
 
   const statusByTimestamp: Record<string, ObjectStatusStripStatus> = {};
   for (const entry of entries) statusByTimestamp[entry.recordedAt] = entryStatus(entry);
+
+  // Legend under the strip, mirroring each status's segment styling — but
+  // only for statuses actually on the strip: a "no box" chip over a gapless
+  // track would name a problem the object does not have.
+  const present = new Set(Object.values(statusByTimestamp));
+  const legendItems: { label: string; swatchStyle: CSSProperties }[] = [];
+  if (present.has('confirmed')) {
+    legendItems.push({ label: 'committed', swatchStyle: { backgroundColor: objectColor } });
+  }
+  if (present.has('pending')) {
+    legendItems.push({
+      label: 'model box to accept',
+      swatchStyle: { backgroundColor: objectColor, opacity: 0.4 },
+    });
+  }
+  if (present.has('empty')) {
+    legendItems.push({
+      label: 'no box',
+      swatchStyle: { boxShadow: `inset 0 0 0 1px ${objectColor}` },
+    });
+  }
 
   return (
     <div
@@ -157,6 +178,19 @@ export function AcceptRemainingPopover({
               currentEntry ? { objectIndex: 0, timestamp: currentEntry.recordedAt } : undefined
             }
           />
+          {legendItems.length > 0 && (
+            <div data-testid="accept-remaining-legend" className="mt-2 space-y-1">
+              {legendItems.map(item => (
+                <div
+                  key={item.label}
+                  className="flex items-center gap-1.5 font-data text-detail text-haze"
+                >
+                  <span aria-hidden className="h-1.5 w-4 rounded-full" style={item.swatchStyle} />
+                  {item.label}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/components/localize/editor/AcceptRemainingPopover.tsx
+++ b/frontend/src/components/localize/editor/AcceptRemainingPopover.tsx
@@ -120,19 +120,9 @@ export function AcceptRemainingPopover({
       </p>
 
       <div className="mt-4">
-        <div className="mb-2 flex items-baseline justify-between gap-2">
-          <p className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
-            What {objectLabel} ends up with
-          </p>
-          {currentEntry && (
-            <span
-              data-testid="accept-remaining-frame-counter"
-              className="whitespace-nowrap font-data text-detail tabular-nums text-haze"
-            >
-              Frame {currentEntryIndex + 1} of {entries.length}
-            </span>
-          )}
-        </div>
+        <p className="mb-2 font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
+          What {objectLabel} ends up with
+        </p>
         <CroppedImageSequence
           bboxes={previewBoxes}
           sequenceId={sequenceId}
@@ -146,7 +136,20 @@ export function AcceptRemainingPopover({
           className="mx-auto"
           onFrameChange={(_index, detectionId) => setLoopDetectionId(detectionId ?? null)}
         />
+        {/* Counter above the strip, not beside the eyebrow: it counts the
+            same frames the strip draws, and up there it squeezed the label
+            into wrapping. */}
         <div className="mt-3">
+          {currentEntry && (
+            <div className="mb-1 text-right">
+              <span
+                data-testid="accept-remaining-frame-counter"
+                className="whitespace-nowrap font-data text-detail tabular-nums text-haze"
+              >
+                Frame {currentEntryIndex + 1} of {entries.length}
+              </span>
+            </div>
+          )}
           <ObjectStatusStrip
             variant="bare"
             objects={[{ label: objectLabel, color: objectColor, statusByTimestamp }]}

--- a/frontend/src/components/localize/editor/AcceptRemainingPopover.tsx
+++ b/frontend/src/components/localize/editor/AcceptRemainingPopover.tsx
@@ -132,17 +132,11 @@ export function AcceptRemainingPopover({
           <X className="h-4 w-4" />
         </button>
       </div>
-      <p className="mt-2 font-body text-sm text-char">
-        {acceptCount === 1
-          ? 'One frame has a model box you have not accepted.'
-          : `${acceptCount} frames have a model box you have not accepted.`}{' '}
-        Take them all, exactly as the loop below shows. Boxes you picked or drew yourself stay as
-        they are.
-      </p>
-
-      <div className="mt-4">
+      {/* The preview leads: it is the point of the dialog — the reader sees
+          the finished track first and the sentence then explains the deal. */}
+      <div className="mt-3">
         <p className="mb-2 font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
-          What {objectLabel} ends up with
+          After accepting
         </p>
         <CroppedImageSequence
           bboxes={previewBoxes}
@@ -194,6 +188,14 @@ export function AcceptRemainingPopover({
         </div>
       </div>
 
+      <p className="mt-4 font-body text-sm text-char">
+        {acceptCount === 1
+          ? 'One frame has a model box you have not accepted.'
+          : `${acceptCount} frames have a model box you have not accepted.`}{' '}
+        Take them all, exactly as the loop above shows. Boxes you picked or drew yourself stay as
+        they are.
+      </p>
+
       {gapCount > 0 && (
         <p
           data-testid="accept-remaining-gap-warning"
@@ -217,9 +219,18 @@ export function AcceptRemainingPopover({
           data-testid="accept-remaining-confirm"
           onClick={onConfirm}
           disabled={isAccepting}
-          className="inline-flex items-center rounded-lg bg-pine px-4 py-2 font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:opacity-40"
+          className="inline-flex items-center gap-2 rounded-lg bg-pine px-4 py-2 font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:opacity-40"
         >
-          {isAccepting ? 'Accepting…' : `Accept ${acceptCount}`}
+          {isAccepting ? (
+            'Accepting…'
+          ) : (
+            <>
+              Accept
+              <kbd className="rounded border border-white/40 px-1 py-0.5 font-data text-[11px] font-medium leading-none">
+                Enter
+              </kbd>
+            </>
+          )}
         </button>
       </div>
     </div>

--- a/frontend/src/components/localize/editor/AcceptRemainingPopover.tsx
+++ b/frontend/src/components/localize/editor/AcceptRemainingPopover.tsx
@@ -23,10 +23,23 @@
  * accepting cannot invent a box for them, and they are what will keep the
  * alert off the submit gate afterwards, so the annotator should know before
  * rather than after.
+ *
+ * Below the loop, a bare single-object status strip shows the object's frames
+ * as they stand NOW — committed solid, acceptable faded, gaps outlined — so
+ * the faded segments are exactly what the button will fill. The frame counter
+ * and the strip's playhead follow the loop's reported position; the loop only
+ * plays frames that have boxes, so the counter visibly skips gap frames and
+ * the playhead never lands on an outlined segment.
  */
 
+import { useState } from 'react';
 import { X } from 'lucide-react';
 import CroppedImageSequence from '@/components/annotation/CroppedImageSequence';
+import {
+  ObjectStatusStrip,
+  type ObjectStatusStripStatus,
+} from '@/components/sequence-annotation/ObjectStatusStrip';
+import type { FilmstripEntry } from '@/utils/annotation/objectFilmstrip';
 import type { BoundingBox } from '@/types/api';
 
 export interface AcceptRemainingPopoverProps {
@@ -35,6 +48,8 @@ export interface AcceptRemainingPopoverProps {
   sequenceId: number;
   /** The lane's boxes as they would stand after accepting. */
   previewBoxes: BoundingBox[];
+  /** One entry per alert frame (chronological) — drives the status strip, the frame counter and the playhead. */
+  entries: FilmstripEntry[];
   /** Frames that will gain a box. */
   acceptCount: number;
   /** Frames that will still have none, because no source offers one. */
@@ -44,17 +59,37 @@ export interface AcceptRemainingPopoverProps {
   onCancel: () => void;
 }
 
+/** Pre-accept status of one alert frame, in ObjectStatusStrip's vocabulary. */
+function entryStatus(entry: FilmstripEntry): ObjectStatusStripStatus {
+  if (!entry.inObject) return 'absent';
+  if (entry.committedSource) return 'confirmed';
+  if (entry.availableSource) return 'pending';
+  return 'empty';
+}
+
 export function AcceptRemainingPopover({
   objectLabel,
   objectColor,
   sequenceId,
   previewBoxes,
+  entries,
   acceptCount,
   gapCount,
   isAccepting,
   onConfirm,
   onCancel,
 }: AcceptRemainingPopoverProps) {
+  // The frame the crop loop is showing, as reported by onFrameChange. Held
+  // as the detection id (not the loop index): the loop iterates only frames
+  // that have boxes, while the strip and counter span every alert frame.
+  const [loopDetectionId, setLoopDetectionId] = useState<number | null>(null);
+
+  const currentEntryIndex = entries.findIndex(e => e.inObject && e.detectionId === loopDetectionId);
+  const currentEntry = currentEntryIndex >= 0 ? entries[currentEntryIndex] : null;
+
+  const statusByTimestamp: Record<string, ObjectStatusStripStatus> = {};
+  for (const entry of entries) statusByTimestamp[entry.recordedAt] = entryStatus(entry);
+
   return (
     <div
       className="absolute left-1/2 top-full z-20 mt-2 w-[22rem] -translate-x-1/2 rounded-card border border-line bg-paper p-5 shadow-[0_8px_24px_rgba(32,38,31,0.12)]"
@@ -85,9 +120,19 @@ export function AcceptRemainingPopover({
       </p>
 
       <div className="mt-4">
-        <p className="mb-2 font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
-          What {objectLabel} ends up with
-        </p>
+        <div className="mb-2 flex items-baseline justify-between gap-2">
+          <p className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
+            What {objectLabel} ends up with
+          </p>
+          {currentEntry && (
+            <span
+              data-testid="accept-remaining-frame-counter"
+              className="whitespace-nowrap font-data text-detail tabular-nums text-haze"
+            >
+              Frame {currentEntryIndex + 1} of {entries.length}
+            </span>
+          )}
+        </div>
         <CroppedImageSequence
           bboxes={previewBoxes}
           sequenceId={sequenceId}
@@ -99,7 +144,17 @@ export function AcceptRemainingPopover({
           showBoxes
           maxSize="min(100%, 15rem)"
           className="mx-auto"
+          onFrameChange={(_index, detectionId) => setLoopDetectionId(detectionId ?? null)}
         />
+        <div className="mt-3">
+          <ObjectStatusStrip
+            variant="bare"
+            objects={[{ label: objectLabel, color: objectColor, statusByTimestamp }]}
+            playhead={
+              currentEntry ? { objectIndex: 0, timestamp: currentEntry.recordedAt } : undefined
+            }
+          />
+        </div>
       </div>
 
       {gapCount > 0 && (

--- a/frontend/src/components/localize/editor/AcceptRemainingPopover.tsx
+++ b/frontend/src/components/localize/editor/AcceptRemainingPopover.tsx
@@ -33,10 +33,11 @@
  */
 
 import { useState, type CSSProperties } from 'react';
-import { X } from 'lucide-react';
+import { AlertCircle, X } from 'lucide-react';
 import CroppedImageSequence from '@/components/annotation/CroppedImageSequence';
 import {
   ObjectStatusStrip,
+  UNDETECTED_OUTLINE,
   type ObjectStatusStripStatus,
 } from '@/components/sequence-annotation/ObjectStatusStrip';
 import type { FilmstripEntry } from '@/utils/annotation/objectFilmstrip';
@@ -59,9 +60,15 @@ export interface AcceptRemainingPopoverProps {
   onCancel: () => void;
 }
 
-/** Pre-accept status of one alert frame, in ObjectStatusStrip's vocabulary. */
+/**
+ * Pre-accept status of one alert frame, in ObjectStatusStrip's vocabulary.
+ * A frame inside the object's run that the object was never detected on is
+ * `undetected` — a potential hole in the track (the importer only creates
+ * lane detections above threshold, and fainter smoke hides exactly there) —
+ * while frames before/after the run are plain `absent`.
+ */
 function entryStatus(entry: FilmstripEntry): ObjectStatusStripStatus {
-  if (!entry.inObject) return 'absent';
+  if (!entry.inObject) return entry.run === 'object' ? 'undetected' : 'absent';
   if (entry.committedSource) return 'confirmed';
   if (entry.availableSource) return 'pending';
   return 'empty';
@@ -110,10 +117,29 @@ export function AcceptRemainingPopover({
       swatchStyle: { boxShadow: `inset 0 0 0 1px ${objectColor}` },
     });
   }
+  if (present.has('undetected')) {
+    legendItems.push({
+      label: 'potential gap',
+      swatchStyle: { boxShadow: `inset 0 0 0 1px ${UNDETECTED_OUTLINE}` },
+    });
+  }
+
+  // Frames of the alert this object has no box on — before it first appears,
+  // holes inside its run, after it last appears. None of them block, but all
+  // of them are where missed smoke lives, so the nudge lists each stretch.
+  const beforeCount = entries.filter(e => !e.inObject && e.run === 'before').length;
+  const holeCount = entries.filter(e => !e.inObject && e.run === 'object').length;
+  const afterCount = entries.filter(e => !e.inObject && e.run === 'after').length;
+  const unboxedParts = [
+    beforeCount > 0 ? `${beforeCount} before it first appears` : null,
+    holeCount > 0 ? `${holeCount} inside its run it was never detected on` : null,
+    afterCount > 0 ? `${afterCount} after it last appears` : null,
+  ].filter((part): part is string => part !== null);
+  const unboxedTotal = beforeCount + holeCount + afterCount;
 
   return (
     <div
-      className="absolute left-1/2 top-full z-20 mt-2 w-[22rem] -translate-x-1/2 rounded-card border border-line bg-paper p-5 shadow-[0_8px_24px_rgba(32,38,31,0.12)]"
+      className="absolute left-1/2 top-full z-20 mt-2 w-[32rem] -translate-x-1/2 rounded-card border border-line bg-paper p-5 shadow-[0_8px_24px_rgba(32,38,31,0.12)]"
       role="dialog"
       aria-label={`Accept the model's boxes for ${objectLabel}`}
       data-testid="accept-remaining-popover"
@@ -134,57 +160,56 @@ export function AcceptRemainingPopover({
       </div>
       {/* The preview leads: it is the point of the dialog — the reader sees
           the finished track first and the sentence then explains the deal. */}
-      <div className="mt-3">
-        <p className="mb-2 font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
-          After accepting
-        </p>
-        <CroppedImageSequence
-          bboxes={previewBoxes}
-          sequenceId={sequenceId}
-          accentColor={objectColor}
-          // The boxes are the whole point of this preview: it answers "will
-          // these track the plume?", and without them it only shows that the
-          // plume is there. `showBoxes` arrived on main while this branch was
-          // in flight.
-          showBoxes
-          maxSize="min(100%, 15rem)"
-          className="mx-auto"
-          onFrameChange={(_index, detectionId) => setLoopDetectionId(detectionId ?? null)}
-        />
-        {/* Counter above the strip, not beside the eyebrow: it counts the
-            same frames the strip draws, and up there it squeezed the label
-            into wrapping. */}
-        <div className="mt-3">
-          {currentEntry && (
-            <div className="mb-1 text-right">
-              <span
-                data-testid="accept-remaining-frame-counter"
-                className="whitespace-nowrap font-data text-detail tabular-nums text-haze"
-              >
-                Frame {currentEntryIndex + 1} of {entries.length}
-              </span>
-            </div>
-          )}
-          <ObjectStatusStrip
-            variant="bare"
-            objects={[{ label: objectLabel, color: objectColor, statusByTimestamp }]}
-            playhead={
-              currentEntry ? { objectIndex: 0, timestamp: currentEntry.recordedAt } : undefined
-            }
+      {/* The loop and its timeline sit side by side: a grid with a definite
+          15rem track for the crop (never a flex row — the loop's root
+          shrink-fits to zero there), the counter/strip/legend column filling
+          the rest, anchored to the crop's bottom edge. */}
+      <div className="mt-4">
+        <div className="grid grid-cols-[15rem,1fr] items-end gap-4">
+          <CroppedImageSequence
+            bboxes={previewBoxes}
+            sequenceId={sequenceId}
+            accentColor={objectColor}
+            // The boxes are the whole point of this preview: it answers "will
+            // these track the plume?", and without them it only shows that the
+            // plume is there. `showBoxes` arrived on main while this branch was
+            // in flight.
+            showBoxes
+            maxSize="min(100%, 15rem)"
+            onFrameChange={(_index, detectionId) => setLoopDetectionId(detectionId ?? null)}
           />
-          {legendItems.length > 0 && (
-            <div data-testid="accept-remaining-legend" className="mt-2 space-y-1">
-              {legendItems.map(item => (
-                <div
-                  key={item.label}
-                  className="flex items-center gap-1.5 font-data text-detail text-haze"
+          <div>
+            {currentEntry && (
+              <div className="mb-1 text-right">
+                <span
+                  data-testid="accept-remaining-frame-counter"
+                  className="whitespace-nowrap font-data text-detail tabular-nums text-haze"
                 >
-                  <span aria-hidden className="h-1.5 w-4 rounded-full" style={item.swatchStyle} />
-                  {item.label}
-                </div>
-              ))}
-            </div>
-          )}
+                  Frame {currentEntryIndex + 1} of {entries.length}
+                </span>
+              </div>
+            )}
+            <ObjectStatusStrip
+              variant="bare"
+              objects={[{ label: objectLabel, color: objectColor, statusByTimestamp }]}
+              playhead={
+                currentEntry ? { objectIndex: 0, timestamp: currentEntry.recordedAt } : undefined
+              }
+            />
+            {legendItems.length > 0 && (
+              <div data-testid="accept-remaining-legend" className="mt-2 space-y-1">
+                {legendItems.map(item => (
+                  <div
+                    key={item.label}
+                    className="flex items-center gap-1.5 font-data text-detail text-haze"
+                  >
+                    <span aria-hidden className="h-1.5 w-4 rounded-full" style={item.swatchStyle} />
+                    {item.label}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </div>
 
@@ -195,6 +220,20 @@ export function AcceptRemainingPopover({
         Take them all, exactly as the loop above shows. Boxes you picked or drew yourself stay as
         they are.
       </p>
+
+      {unboxedTotal > 0 && (
+        <div
+          data-testid="accept-remaining-coverage-warning"
+          className="mt-4 flex items-start gap-2 rounded-lg bg-ash px-3 py-2 font-body text-detail text-char"
+        >
+          <AlertCircle aria-hidden className="mt-0.5 h-4 w-4 shrink-0 text-haze" />
+          <p>
+            {objectLabel} has no box on{' '}
+            {unboxedTotal === 1 ? 'one other frame' : `${unboxedTotal} other frames`} of the alert:{' '}
+            {unboxedParts.join(', ')}. Check them, smoke may be visible there too.
+          </p>
+        </div>
+      )}
 
       {gapCount > 0 && (
         <p

--- a/frontend/src/components/localize/editor/AcceptRemainingPopover.tsx
+++ b/frontend/src/components/localize/editor/AcceptRemainingPopover.tsx
@@ -139,7 +139,7 @@ export function AcceptRemainingPopover({
 
   return (
     <div
-      className="absolute left-1/2 top-full z-20 mt-2 w-[32rem] -translate-x-1/2 rounded-card border border-line bg-paper p-5 shadow-[0_8px_24px_rgba(32,38,31,0.12)]"
+      className="absolute left-1/2 top-full z-20 mt-2 w-[38rem] -translate-x-1/2 rounded-card border border-line bg-paper p-5 shadow-[0_8px_24px_rgba(32,38,31,0.12)]"
       role="dialog"
       aria-label={`Accept the model's boxes for ${objectLabel}`}
       data-testid="accept-remaining-popover"
@@ -165,7 +165,7 @@ export function AcceptRemainingPopover({
           shrink-fits to zero there), the counter/strip/legend column filling
           the rest, anchored to the crop's bottom edge. */}
       <div className="mt-4">
-        <div className="grid grid-cols-[15rem,1fr] items-end gap-4">
+        <div className="grid grid-cols-[15rem,1fr] items-start gap-4">
           <CroppedImageSequence
             bboxes={previewBoxes}
             sequenceId={sequenceId}

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -815,6 +815,7 @@ export function LocalizeObjectEditor({
                   objectColor={objectColor}
                   sequenceId={laneSequenceId}
                   previewBoxes={previewBoxes}
+                  entries={entries}
                   acceptCount={acceptRemainingCount}
                   gapCount={gapCount}
                   isAccepting={isAccepting}

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -674,7 +674,16 @@ export function LocalizeObjectEditor({
           step(1);
           break;
         case 'Enter':
-          acceptAndNext();
+          // The accept dialog owns Enter while it is open — its button says
+          // so — otherwise the frame-level accept would fire behind it.
+          if (acceptOpen) {
+            if (!isAccepting) {
+              onAcceptRemaining();
+              setAcceptOpen(false);
+            }
+          } else {
+            acceptAndNext();
+          }
           break;
         case 'Delete':
         case 'Backspace':
@@ -725,7 +734,18 @@ export function LocalizeObjectEditor({
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [step, acceptAndNext, boxSelected, acceptOpen, shortcutsOpen, resetZoom, onClose, editable]);
+  }, [
+    step,
+    acceptAndNext,
+    boxSelected,
+    acceptOpen,
+    shortcutsOpen,
+    resetZoom,
+    onClose,
+    editable,
+    isAccepting,
+    onAcceptRemaining,
+  ]);
 
   // --- Render -------------------------------------------------------------
 

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -675,8 +675,16 @@ export function LocalizeObjectEditor({
           break;
         case 'Enter':
           // The accept dialog owns Enter while it is open — its button says
-          // so — otherwise the frame-level accept would fire behind it.
+          // so — otherwise the frame-level accept would fire behind it. But
+          // a button focused inside the dialog keeps its own Enter: Tab to
+          // the close X must close, not accept out from under the focus.
           if (acceptOpen) {
+            if (
+              e.target instanceof HTMLElement &&
+              e.target.closest('button') &&
+              e.target.closest('[role="dialog"]')
+            )
+              return;
             if (!isAccepting) {
               onAcceptRemaining();
               setAcceptOpen(false);

--- a/frontend/src/components/sequence-annotation/ObjectStatusStrip.tsx
+++ b/frontend/src/components/sequence-annotation/ObjectStatusStrip.tsx
@@ -5,8 +5,9 @@
  * where each frame is its own button reporting that object's status at that
  * timestamp: `confirmed` (solid fill), `pending` (reduced-opacity fill — a
  * model box waiting to be accepted), `empty` (outline only — on this frame
- * but with nothing on it yet), or `absent` (neutral track, no fill — not on
- * this frame at all).
+ * but with nothing on it yet), `undetected` (haze outline — inside the
+ * object's span but never detected there, a potential hole in the track),
+ * or `absent` (neutral track, no fill — not on this frame at all).
  *
  * `empty` is deliberately distinct from `pending`: collapsing the two made a
  * frame with nothing on it look identical to one with a box to accept, which
@@ -42,7 +43,14 @@
 
 import React from 'react';
 
-export type ObjectStatusStripStatus = 'confirmed' | 'pending' | 'empty' | 'absent';
+export type ObjectStatusStripStatus = 'confirmed' | 'pending' | 'empty' | 'undetected' | 'absent';
+
+/**
+ * Outline for `undetected` segments — the haze token, hard-coded because
+ * inline styles cannot reach Tailwind's palette. Exported so a host's legend
+ * can draw a matching swatch.
+ */
+export const UNDETECTED_OUTLINE = '#767B72';
 
 export interface ObjectStatusStripObject {
   /** e.g. "Object 2" — same numbering as the object's card. */
@@ -134,6 +142,20 @@ function segmentAppearance(
         boxShadow: playhead
           ? `inset 0 0 0 1px ${color}, ${PLAYHEAD_SHADOW}`
           : `inset 0 0 0 1px ${color}`,
+      },
+    };
+  }
+  if (status === 'undetected') {
+    // Inside the object's detected span but never detected on this frame —
+    // a potential hole in the track. Haze outline, not the object's color:
+    // nothing of the object is here to show, but the frame is not blank
+    // context either.
+    return {
+      className: `${SEGMENT_BASE_CLASS} opacity-50`,
+      style: {
+        boxShadow: playhead
+          ? `inset 0 0 0 1px ${UNDETECTED_OUTLINE}, ${PLAYHEAD_SHADOW}`
+          : `inset 0 0 0 1px ${UNDETECTED_OUTLINE}`,
       },
     };
   }

--- a/frontend/src/components/sequence-annotation/ObjectStatusStrip.tsx
+++ b/frontend/src/components/sequence-annotation/ObjectStatusStrip.tsx
@@ -25,10 +25,11 @@
  * border) — LocalizeAlertPage's object-focus mode uses it to mark whichever
  * object is currently focused.
  *
- * `variant="bare"` drops the card chrome and title so the strip can embed
- * inside another surface (the accept popover). `playhead` highlights the
- * frame an external animation is currently showing — full-strength fill
- * with an inset marker, since the overflow-hidden track clips outer rings.
+ * `variant="bare"` drops the card chrome, title, and per-row label cluster
+ * so the strip can embed inside another surface (the accept popover) that
+ * already names the object. `playhead` highlights the frame an external
+ * animation is currently showing — full-strength fill with an inset
+ * marker, since the overflow-hidden track clips outer rings.
  *
  * No frame axis here (dropped — the strip's segments read fine without tick
  * labels at this scale); `ObjectPresenceStrip` (classify) is unaffected and
@@ -61,7 +62,7 @@ interface ObjectStatusStripProps {
   /** Called with an object's position in `objects` when its label is clicked — the caller owns turning that into "scroll to and activate that object's card." Omit to render labels non-interactively. */
   onObjectClick?: (objectIndex: number) => void;
   title?: string;
-  /** `bare` drops the card chrome and title so the strip can embed inside another surface (the accept popover). */
+  /** `bare` drops the card chrome, title, and per-row label cluster so the strip can embed inside another surface (the accept popover) that already names the object. */
   variant?: 'card' | 'bare';
   /** Highlights one object's segment at one timestamp — the frame an external animation is currently showing. */
   playhead?: { objectIndex: number; timestamp: string };
@@ -186,12 +187,14 @@ export const ObjectStatusStrip: React.FC<ObjectStatusStripProps> = ({
               selected ? 'border-l-pine bg-pine-soft' : 'border-l-transparent'
             }`}
           >
-            <ObjectLabelButton
-              objectIndex={objectIndex}
-              label={object.label}
-              color={object.color}
-              onClick={() => onObjectClick?.(objectIndex)}
-            />
+            {variant === 'card' && (
+              <ObjectLabelButton
+                objectIndex={objectIndex}
+                label={object.label}
+                color={object.color}
+                onClick={() => onObjectClick?.(objectIndex)}
+              />
+            )}
             <div className="flex h-1.5 flex-1 gap-px overflow-hidden rounded-full bg-ash">
               {frameUnion.map((timestamp, frameIndex) => {
                 const status = object.statusByTimestamp[timestamp] ?? 'absent';

--- a/frontend/src/components/sequence-annotation/ObjectStatusStrip.tsx
+++ b/frontend/src/components/sequence-annotation/ObjectStatusStrip.tsx
@@ -25,6 +25,11 @@
  * border) — LocalizeAlertPage's object-focus mode uses it to mark whichever
  * object is currently focused.
  *
+ * `variant="bare"` drops the card chrome and title so the strip can embed
+ * inside another surface (the accept popover). `playhead` highlights the
+ * frame an external animation is currently showing — full-strength fill
+ * with an inset marker, since the overflow-hidden track clips outer rings.
+ *
  * No frame axis here (dropped — the strip's segments read fine without tick
  * labels at this scale); `ObjectPresenceStrip` (classify) is unaffected and
  * keeps its own axis.
@@ -56,6 +61,10 @@ interface ObjectStatusStripProps {
   /** Called with an object's position in `objects` when its label is clicked — the caller owns turning that into "scroll to and activate that object's card." Omit to render labels non-interactively. */
   onObjectClick?: (objectIndex: number) => void;
   title?: string;
+  /** `bare` drops the card chrome and title so the strip can embed inside another surface (the accept popover). */
+  variant?: 'card' | 'bare';
+  /** Highlights one object's segment at one timestamp — the frame an external animation is currently showing. */
+  playhead?: { objectIndex: number; timestamp: string };
 }
 
 function ObjectLabelButton({
@@ -89,15 +98,29 @@ function ObjectLabelButton({
 const SEGMENT_BASE_CLASS =
   'h-full flex-1 rounded-sm p-0 transition-opacity focus:outline-none focus:ring-1 focus:ring-ember';
 
+// The playhead marker lives INSIDE the segment (inset, merged into the same
+// boxShadow as the status styling): the track is `overflow-hidden`, so an
+// outer ring or outline would be clipped away at this 6px height.
+const PLAYHEAD_SHADOW = 'inset 0 0 0 1px rgba(255,255,255,0.85)';
+
 function segmentAppearance(
   status: ObjectStatusStripStatus,
-  color: string
+  color: string,
+  playhead: boolean
 ): { className: string; style?: React.CSSProperties } {
   if (status === 'confirmed') {
-    return { className: SEGMENT_BASE_CLASS, style: { backgroundColor: color } };
+    return {
+      className: SEGMENT_BASE_CLASS,
+      style: { backgroundColor: color, ...(playhead ? { boxShadow: PLAYHEAD_SHADOW } : {}) },
+    };
   }
   if (status === 'pending') {
-    return { className: `${SEGMENT_BASE_CLASS} opacity-40`, style: { backgroundColor: color } };
+    // The playhead frame is the one an external animation is showing right
+    // now — it reads at full strength even though its box is still pending.
+    return {
+      className: playhead ? SEGMENT_BASE_CLASS : `${SEGMENT_BASE_CLASS} opacity-40`,
+      style: { backgroundColor: color, ...(playhead ? { boxShadow: PLAYHEAD_SHADOW } : {}) },
+    };
   }
   if (status === 'empty') {
     // Present on this frame, but nothing to show yet — no committed box and
@@ -106,11 +129,18 @@ function segmentAppearance(
     // imply content (a just-added object's whole timeline is this state).
     return {
       className: `${SEGMENT_BASE_CLASS} opacity-50`,
-      style: { boxShadow: `inset 0 0 0 1px ${color}` },
+      style: {
+        boxShadow: playhead
+          ? `inset 0 0 0 1px ${color}, ${PLAYHEAD_SHADOW}`
+          : `inset 0 0 0 1px ${color}`,
+      },
     };
   }
   // absent — neutral track, no fill; the row's track background shows through.
-  return { className: SEGMENT_BASE_CLASS };
+  return {
+    className: SEGMENT_BASE_CLASS,
+    style: playhead ? { boxShadow: PLAYHEAD_SHADOW } : undefined,
+  };
 }
 
 export const ObjectStatusStrip: React.FC<ObjectStatusStripProps> = ({
@@ -118,6 +148,8 @@ export const ObjectStatusStrip: React.FC<ObjectStatusStripProps> = ({
   onSegmentClick,
   onObjectClick,
   title = 'Object timeline',
+  variant = 'card',
+  playhead,
 }) => {
   if (objects.length < 1) return null;
 
@@ -130,10 +162,18 @@ export const ObjectStatusStrip: React.FC<ObjectStatusStripProps> = ({
   ).sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
 
   return (
-    <div className="space-y-2.5 rounded-lg border border-line bg-paper p-4">
-      <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze mb-2">
-        {title}
-      </div>
+    <div
+      className={
+        variant === 'card'
+          ? 'space-y-2.5 rounded-lg border border-line bg-paper p-4'
+          : 'space-y-2.5'
+      }
+    >
+      {variant === 'card' && (
+        <div className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze mb-2">
+          {title}
+        </div>
+      )}
 
       {objects.map((object, objectIndex) => {
         const selected = object.selected ?? false;
@@ -155,12 +195,15 @@ export const ObjectStatusStrip: React.FC<ObjectStatusStripProps> = ({
             <div className="flex h-1.5 flex-1 gap-px overflow-hidden rounded-full bg-ash">
               {frameUnion.map((timestamp, frameIndex) => {
                 const status = object.statusByTimestamp[timestamp] ?? 'absent';
-                const { className, style } = segmentAppearance(status, object.color);
+                const isPlayhead =
+                  playhead?.objectIndex === objectIndex && playhead.timestamp === timestamp;
+                const { className, style } = segmentAppearance(status, object.color, isPlayhead);
                 return (
                   <button
                     key={timestamp}
                     type="button"
                     data-testid={`status-segment-${objectIndex}-${frameIndex}`}
+                    data-playhead={isPlayhead ? 'true' : undefined}
                     aria-label={`${object.label}, frame ${frameIndex + 1}: ${status}`}
                     onClick={() => onSegmentClick?.(objectIndex, timestamp)}
                     className={className}

--- a/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
+++ b/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
@@ -137,6 +137,16 @@ describe('CroppedImageSequence', () => {
     expect(screen.getByText('1.1x')).toBeInTheDocument();
   });
 
+  it('reports the loop position through onFrameChange as the animation advances', async () => {
+    const onFrameChange = vi.fn();
+    render(<CroppedImageSequence bboxes={BBOXES} sequenceId={9} onFrameChange={onFrameChange} />);
+
+    // Fires for the starting frame once images resolve.
+    await waitFor(() => expect(onFrameChange).toHaveBeenCalledWith(0, 1));
+    // The 200ms interval advances the loop; BBOXES[1] is detection 2.
+    await waitFor(() => expect(onFrameChange).toHaveBeenCalledWith(1, 2), { timeout: 2000 });
+  });
+
   describe('winner box overlay', () => {
     // Geometry pinned by hand: bbox 0.45–0.55 of 1280x720 → 576,324–704,396
     // in image px (side 128). Default crop side = 128 * CONTEXT_FACTOR(3) =

--- a/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
+++ b/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
@@ -141,7 +141,7 @@ describe('CroppedImageSequence', () => {
     const onFrameChange = vi.fn();
     render(<CroppedImageSequence bboxes={BBOXES} sequenceId={9} onFrameChange={onFrameChange} />);
 
-    // Fires for the starting frame once images resolve.
+    // Reports the starting frame immediately on mount (before images load).
     await waitFor(() => expect(onFrameChange).toHaveBeenCalledWith(0, 1));
     // The 200ms interval advances the loop; BBOXES[1] is detection 2.
     await waitFor(() => expect(onFrameChange).toHaveBeenCalledWith(1, 2), { timeout: 2000 });

--- a/frontend/tests/components/localize/editor/AcceptRemainingPopover.test.tsx
+++ b/frontend/tests/components/localize/editor/AcceptRemainingPopover.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Tests for AcceptRemainingPopover's frame context: the single-object status
+ * strip (pre-accept statuses from filmstrip entries), and the frame counter +
+ * strip playhead that track the crop loop's reported position.
+ *
+ * CroppedImageSequence is stubbed: these tests drive `onFrameChange` by hand
+ * instead of waiting on image fetches and the 200ms animation interval.
+ */
+
+import { act, render, screen } from '@testing-library/react';
+import { AcceptRemainingPopover } from '@/components/localize/editor/AcceptRemainingPopover';
+import type { FilmstripEntry } from '@/utils/annotation/objectFilmstrip';
+
+let reportFrame: ((index: number, detectionId?: number) => void) | undefined;
+
+vi.mock('@/components/annotation/CroppedImageSequence', () => ({
+  default: ({ onFrameChange }: { onFrameChange?: (i: number, id?: number) => void }) => {
+    reportFrame = onFrameChange;
+    return <div data-testid="loop-stub" />;
+  },
+}));
+
+const t = (s: number) => `2024-01-01T00:00:0${s}.000Z`;
+
+// Four alert frames: committed, acceptable, gap (in object, no box on
+// offer), and a frame the object is absent from (sibling detection id).
+const ENTRIES: FilmstripEntry[] = [
+  {
+    recordedAt: t(0),
+    detectionId: 101,
+    inObject: true,
+    run: 'object',
+    committedSource: 'manual',
+    availableSource: null,
+    xyxyn: [0.1, 0.1, 0.2, 0.2],
+  },
+  {
+    recordedAt: t(1),
+    detectionId: 102,
+    inObject: true,
+    run: 'object',
+    committedSource: null,
+    availableSource: 'auto',
+    xyxyn: [0.1, 0.1, 0.2, 0.2],
+  },
+  {
+    recordedAt: t(2),
+    detectionId: 103,
+    inObject: true,
+    run: 'object',
+    committedSource: null,
+    availableSource: null,
+    xyxyn: null,
+  },
+  {
+    recordedAt: t(3),
+    detectionId: 999,
+    inObject: false,
+    run: 'after',
+    committedSource: null,
+    availableSource: null,
+    xyxyn: null,
+  },
+];
+
+function renderPopover() {
+  return render(
+    <AcceptRemainingPopover
+      objectLabel="Object 2"
+      objectColor="#3b82f6"
+      sequenceId={9}
+      previewBoxes={[
+        { detection_id: 101, xyxyn: [0.1, 0.1, 0.2, 0.2] },
+        { detection_id: 102, xyxyn: [0.1, 0.1, 0.2, 0.2] },
+      ]}
+      entries={ENTRIES}
+      acceptCount={1}
+      gapCount={1}
+      isAccepting={false}
+      onConfirm={vi.fn()}
+      onCancel={vi.fn()}
+    />
+  );
+}
+
+beforeEach(() => {
+  reportFrame = undefined;
+});
+
+describe('AcceptRemainingPopover frame context', () => {
+  it('renders a bare single-object strip with pre-accept statuses per frame', () => {
+    renderPopover();
+
+    // No card chrome/title inside the popover — just the row.
+    expect(screen.queryByText('Object timeline')).not.toBeInTheDocument();
+    expect(screen.getByText('Object 2')).toBeInTheDocument();
+
+    expect(screen.getByTestId('status-segment-0-0')).toHaveAttribute(
+      'aria-label',
+      'Object 2, frame 1: confirmed'
+    );
+    expect(screen.getByTestId('status-segment-0-1')).toHaveAttribute(
+      'aria-label',
+      'Object 2, frame 2: pending'
+    );
+    expect(screen.getByTestId('status-segment-0-2')).toHaveAttribute(
+      'aria-label',
+      'Object 2, frame 3: empty'
+    );
+    expect(screen.getByTestId('status-segment-0-3')).toHaveAttribute(
+      'aria-label',
+      'Object 2, frame 4: absent'
+    );
+  });
+
+  it('shows no counter and no playhead before the loop reports a frame', () => {
+    renderPopover();
+
+    expect(screen.queryByTestId('accept-remaining-frame-counter')).not.toBeInTheDocument();
+    expect(screen.getByTestId('status-segment-0-0')).not.toHaveAttribute('data-playhead');
+  });
+
+  it('tracks the reported frame: counter counts alert frames, playhead hits its segment', () => {
+    renderPopover();
+
+    // Loop entry 1 is detection 102 — the second of four ALERT frames.
+    act(() => reportFrame?.(1, 102));
+
+    expect(screen.getByTestId('accept-remaining-frame-counter')).toHaveTextContent('Frame 2 of 4');
+    expect(screen.getByTestId('status-segment-0-1')).toHaveAttribute('data-playhead', 'true');
+    expect(screen.getByTestId('status-segment-0-0')).not.toHaveAttribute('data-playhead');
+  });
+
+  it('hides the counter and playhead when the reported detection is not in the entries', () => {
+    renderPopover();
+
+    act(() => reportFrame?.(0, 424242));
+
+    expect(screen.queryByTestId('accept-remaining-frame-counter')).not.toBeInTheDocument();
+    expect(screen.getByTestId('status-segment-0-1')).not.toHaveAttribute('data-playhead');
+  });
+
+  it('never puts the playhead on a gap frame via a sibling detection id', () => {
+    renderPopover();
+
+    // 999 is the absent frame's sibling detection — not part of this lane's
+    // loop; the strip must not light it up.
+    act(() => reportFrame?.(0, 999));
+
+    expect(screen.queryByTestId('accept-remaining-frame-counter')).not.toBeInTheDocument();
+    expect(screen.getByTestId('status-segment-0-3')).not.toHaveAttribute('data-playhead');
+  });
+});

--- a/frontend/tests/components/localize/editor/AcceptRemainingPopover.test.tsx
+++ b/frontend/tests/components/localize/editor/AcceptRemainingPopover.test.tsx
@@ -141,6 +141,15 @@ describe('AcceptRemainingPopover frame context', () => {
     expect(screen.getByTestId('status-segment-0-1')).not.toHaveAttribute('data-playhead');
   });
 
+  it('advertises the Enter shortcut on the confirm button', () => {
+    renderPopover();
+
+    const confirm = screen.getByTestId('accept-remaining-confirm');
+    // Just "Accept" — the sentence above already carries the count.
+    expect(confirm).toHaveTextContent(/^Accept\s*Enter$/);
+    expect(confirm.querySelector('kbd')).toHaveTextContent('Enter');
+  });
+
   it('shows a legend naming the segment styles that are actually on the strip', () => {
     renderPopover();
 

--- a/frontend/tests/components/localize/editor/AcceptRemainingPopover.test.tsx
+++ b/frontend/tests/components/localize/editor/AcceptRemainingPopover.test.tsx
@@ -63,7 +63,7 @@ const ENTRIES: FilmstripEntry[] = [
   },
 ];
 
-function renderPopover() {
+function renderPopover(entries: FilmstripEntry[] = ENTRIES) {
   return render(
     <AcceptRemainingPopover
       objectLabel="Object 2"
@@ -73,7 +73,7 @@ function renderPopover() {
         { detection_id: 101, xyxyn: [0.1, 0.1, 0.2, 0.2] },
         { detection_id: 102, xyxyn: [0.1, 0.1, 0.2, 0.2] },
       ]}
-      entries={ENTRIES}
+      entries={entries}
       acceptCount={1}
       gapCount={1}
       isAccepting={false}
@@ -91,9 +91,10 @@ describe('AcceptRemainingPopover frame context', () => {
   it('renders a bare single-object strip with pre-accept statuses per frame', () => {
     renderPopover();
 
-    // No card chrome/title inside the popover — just the row.
+    // No card chrome/title/label cluster inside the popover — the popover
+    // already names the object; just the segments.
     expect(screen.queryByText('Object timeline')).not.toBeInTheDocument();
-    expect(screen.getByText('Object 2')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Go to Object 2' })).not.toBeInTheDocument();
 
     expect(screen.getByTestId('status-segment-0-0')).toHaveAttribute(
       'aria-label',
@@ -138,6 +139,25 @@ describe('AcceptRemainingPopover frame context', () => {
 
     expect(screen.queryByTestId('accept-remaining-frame-counter')).not.toBeInTheDocument();
     expect(screen.getByTestId('status-segment-0-1')).not.toHaveAttribute('data-playhead');
+  });
+
+  it('shows a legend naming the segment styles that are actually on the strip', () => {
+    renderPopover();
+
+    const legend = screen.getByTestId('accept-remaining-legend');
+    expect(legend).toHaveTextContent('committed');
+    expect(legend).toHaveTextContent('model box to accept');
+    expect(legend).toHaveTextContent('no box');
+  });
+
+  it('omits legend entries for statuses no frame has', () => {
+    // Only the committed and acceptable frames — no gap.
+    renderPopover([ENTRIES[0], ENTRIES[1]]);
+
+    const legend = screen.getByTestId('accept-remaining-legend');
+    expect(legend).toHaveTextContent('committed');
+    expect(legend).toHaveTextContent('model box to accept');
+    expect(legend).not.toHaveTextContent('no box');
   });
 
   it('never puts the playhead on a gap frame via a sibling detection id', () => {

--- a/frontend/tests/components/localize/editor/AcceptRemainingPopover.test.tsx
+++ b/frontend/tests/components/localize/editor/AcceptRemainingPopover.test.tsx
@@ -63,6 +63,22 @@ const ENTRIES: FilmstripEntry[] = [
   },
 ];
 
+// Committed, then a mid-run frame the object was never detected on (the
+// importer only creates lane detections above threshold), then acceptable.
+const ENTRIES_WITH_HOLE: FilmstripEntry[] = [
+  ENTRIES[0],
+  {
+    recordedAt: t(1),
+    detectionId: 998,
+    inObject: false,
+    run: 'object',
+    committedSource: null,
+    availableSource: null,
+    xyxyn: null,
+  },
+  { ...ENTRIES[1], recordedAt: t(2) },
+];
+
 function renderPopover(entries: FilmstripEntry[] = ENTRIES) {
   return render(
     <AcceptRemainingPopover
@@ -167,6 +183,35 @@ describe('AcceptRemainingPopover frame context', () => {
     expect(legend).toHaveTextContent('committed');
     expect(legend).toHaveTextContent('model box to accept');
     expect(legend).not.toHaveTextContent('no box');
+  });
+
+  it('flags mid-run frames the object was never detected on as potential gaps', () => {
+    renderPopover(ENTRIES_WITH_HOLE);
+
+    expect(screen.getByTestId('status-segment-0-1')).toHaveAttribute(
+      'aria-label',
+      'Object 2, frame 2: undetected'
+    );
+    expect(screen.getByTestId('accept-remaining-legend')).toHaveTextContent('potential gap');
+    expect(screen.getByTestId('accept-remaining-coverage-warning')).toHaveTextContent(
+      '1 inside its run it was never detected on'
+    );
+  });
+
+  it('nudges to check the frames before and after the object as well', () => {
+    // ENTRIES ends with one frame after the object's run and none before.
+    renderPopover();
+
+    const warning = screen.getByTestId('accept-remaining-coverage-warning');
+    expect(warning).toHaveTextContent('1 after it last appears');
+    expect(warning).not.toHaveTextContent('before');
+  });
+
+  it('shows no coverage nudge when the object spans every alert frame', () => {
+    renderPopover(ENTRIES.slice(0, 3));
+
+    expect(screen.queryByTestId('accept-remaining-coverage-warning')).not.toBeInTheDocument();
+    expect(screen.getByTestId('accept-remaining-legend')).not.toHaveTextContent('potential gap');
   });
 
   it('never puts the playhead on a gap frame via a sibling detection id', () => {

--- a/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
+++ b/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
@@ -696,6 +696,21 @@ describe('LocalizeObjectEditor accept remaining', () => {
     expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
   });
 
+  it('leaves Enter to a focused control inside the dialog instead of accepting', () => {
+    const onAcceptRemaining = vi.fn();
+    renderEditor({ onAcceptRemaining });
+    fireEvent.click(screen.getByTestId('editor-accept-remaining'));
+
+    // Tab put focus on the close X — Enter must activate IT (natively), not
+    // fire the accept out from under it.
+    const close = screen.getByTestId('accept-remaining-close');
+    close.focus();
+    fireEvent.keyDown(close, { key: 'Enter' });
+
+    expect(onAcceptRemaining).not.toHaveBeenCalled();
+    expect(screen.getByTestId('accept-remaining-popover')).toBeInTheDocument();
+  });
+
   it('Enter confirms while the dialog is open, not the frame-level accept', () => {
     const onAcceptRemaining = vi.fn();
     const onCommit = vi.fn();

--- a/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
+++ b/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
@@ -696,6 +696,20 @@ describe('LocalizeObjectEditor accept remaining', () => {
     expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
   });
 
+  it('Enter confirms while the dialog is open, not the frame-level accept', () => {
+    const onAcceptRemaining = vi.fn();
+    const onCommit = vi.fn();
+    renderEditor({ onAcceptRemaining, onCommit });
+    fireEvent.click(screen.getByTestId('editor-accept-remaining'));
+
+    fireEvent.keyDown(window, { key: 'Enter' });
+
+    expect(onAcceptRemaining).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
+    // The dialog owned that Enter — the frame's own accept must not fire.
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
   it('warns about frames no model found smoke on, without blocking', () => {
     // One frame has candidates, the other has none at all.
     renderEditor({

--- a/frontend/tests/components/sequence-annotation/ObjectStatusStrip.test.tsx
+++ b/frontend/tests/components/sequence-annotation/ObjectStatusStrip.test.tsx
@@ -319,4 +319,60 @@ describe('ObjectStatusStrip', () => {
     expect(selectedRow).toHaveClass('bg-pine-soft');
     expect(selectedRow).toHaveClass('border-l-pine');
   });
+
+  describe('bare variant', () => {
+    it('drops the card chrome and title, keeping rows and segments', () => {
+      const { container } = render(
+        <ObjectStatusStrip
+          variant="bare"
+          objects={[
+            {
+              label: 'Object 1',
+              color: '#3b82f6',
+              statusByTimestamp: { [t1]: 'confirmed', [t2]: 'pending' },
+            },
+          ]}
+        />
+      );
+
+      expect(screen.queryByText('Object timeline')).not.toBeInTheDocument();
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.className).not.toContain('border');
+      expect(root.className).not.toContain('bg-paper');
+      expect(screen.getByTestId('status-segment-0-0')).toBeInTheDocument();
+      expect(screen.getByTestId('status-segment-0-1')).toBeInTheDocument();
+    });
+  });
+
+  describe('playhead', () => {
+    const objects = [
+      {
+        label: 'Object 1',
+        color: '#3b82f6',
+        statusByTimestamp: { [t1]: 'confirmed', [t2]: 'pending', [t3]: 'empty' },
+      } as const,
+    ];
+
+    it('marks exactly the matching segment, at full opacity with an inset highlight', () => {
+      render(<ObjectStatusStrip objects={objects} playhead={{ objectIndex: 0, timestamp: t2 }} />);
+
+      const hit = screen.getByTestId('status-segment-0-1');
+      expect(hit).toHaveAttribute('data-playhead', 'true');
+      // pending normally fades to opacity-40 — the playhead frame must not.
+      expect(hit.className).not.toContain('opacity-40');
+      expect(hit.style.boxShadow).toContain('inset');
+      // fill keeps the object color under the highlight
+      expect(hit.style.backgroundColor).toBe('rgb(59, 130, 246)');
+
+      expect(screen.getByTestId('status-segment-0-0')).not.toHaveAttribute('data-playhead');
+      expect(screen.getByTestId('status-segment-0-2')).not.toHaveAttribute('data-playhead');
+    });
+
+    it('renders exactly as before when no playhead is given', () => {
+      render(<ObjectStatusStrip objects={objects} />);
+
+      expect(screen.getByTestId('status-segment-0-1').className).toContain('opacity-40');
+      expect(screen.getByTestId('status-segment-0-1')).not.toHaveAttribute('data-playhead');
+    });
+  });
 });

--- a/frontend/tests/components/sequence-annotation/ObjectStatusStrip.test.tsx
+++ b/frontend/tests/components/sequence-annotation/ObjectStatusStrip.test.tsx
@@ -320,6 +320,31 @@ describe('ObjectStatusStrip', () => {
     expect(selectedRow).toHaveClass('border-l-pine');
   });
 
+  it('renders undetected as a neutral outline, distinct from empty and absent', () => {
+    render(
+      <ObjectStatusStrip
+        objects={[
+          {
+            label: 'Object 1',
+            color: '#3b82f6',
+            statusByTimestamp: { [t1]: 'undetected', [t2]: 'empty', [t3]: 'absent' },
+          },
+        ]}
+      />
+    );
+
+    const undetected = screen.getByTestId('status-segment-0-0');
+    expect(undetected).toHaveAttribute('aria-label', 'Object 1, frame 1: undetected');
+    // Haze outline, not the object's color — nothing of the object is here.
+    expect(undetected).toHaveStyle({ boxShadow: 'inset 0 0 0 1px #767B72' });
+
+    // empty keeps the object-color outline; absent stays blank.
+    expect(screen.getByTestId('status-segment-0-1')).toHaveStyle({
+      boxShadow: 'inset 0 0 0 1px #3b82f6',
+    });
+    expect(screen.getByTestId('status-segment-0-2')).not.toHaveAttribute('style');
+  });
+
   describe('bare variant', () => {
     it('drops the card chrome, title, and label cluster, keeping the segments', () => {
       const { container } = render(

--- a/frontend/tests/components/sequence-annotation/ObjectStatusStrip.test.tsx
+++ b/frontend/tests/components/sequence-annotation/ObjectStatusStrip.test.tsx
@@ -321,7 +321,7 @@ describe('ObjectStatusStrip', () => {
   });
 
   describe('bare variant', () => {
-    it('drops the card chrome and title, keeping rows and segments', () => {
+    it('drops the card chrome, title, and label cluster, keeping the segments', () => {
       const { container } = render(
         <ObjectStatusStrip
           variant="bare"
@@ -339,6 +339,9 @@ describe('ObjectStatusStrip', () => {
       const root = container.firstElementChild as HTMLElement;
       expect(root.className).not.toContain('border');
       expect(root.className).not.toContain('bg-paper');
+      // The embedding surface names the object — no swatch/label cluster.
+      expect(screen.queryByText('Object 1')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Go to Object 1' })).not.toBeInTheDocument();
       expect(screen.getByTestId('status-segment-0-0')).toBeInTheDocument();
       expect(screen.getByTestId('status-segment-0-1')).toBeInTheDocument();
     });


### PR DESCRIPTION
## What

Enriches the localize object editor's **Accept boxes** popover with the temporal context it was missing:

- **Frame counter** ("Frame N of M") synced to the animated crop loop, counting alert frames — it visibly skips frames the loop cannot show.
- **Object timeline** beside the crop: the same segment language as the rail's Timeline (committed solid, model box to accept faded, in-object gap outlined), with a **playhead** tracking the loop.
- **Legend** naming exactly the segment styles present.
- **Coverage warning**: lists the frames this object has no box on — before it first appears, mid-run frames it was never detected on (new `undetected` status, haze outline, "potential gap" chip), and after it last appears.
- **Enter confirms** while the popover is open (advertised with a kbd chip on the button); a button focused inside the dialog keeps its own Enter.
- Two-column layout (crop | timeline column), 38rem wide, viewport-capped.

## How

- `ObjectStatusStrip`: additive `variant="bare"` (drops card chrome/title/label cluster), `playhead` prop (inset marker — the overflow-hidden track clips outer rings), and `undetected` status. Rail/classify usage untouched.
- `CroppedImageSequence`: additive `onFrameChange(index, detectionId?)` reported from an index-keyed effect via a latest-callback ref.
- `AcceptRemainingPopover`: new required `entries: FilmstripEntry[]` (already computed by the editor); maps entries → statuses, holds the loop position as a detection id so sibling-lane ids on absent frames never light the playhead.

Spec: `docs/specs/2026-08-06-accept-popover-frame-strip-design.md` (committed and amended in-branch as the design evolved).

## Testing

- 18 new Vitest cases (strip variant/playhead/undetected, loop position reporting, popover mapping/counter/legend/warnings, Enter routing incl. focused-control exemption). Full suite: 89 files / 1154 tests green; `npm run quality` clean.
- Verified live against the shared stack on `/localize/27/object/27/528` and `/localize/51/object/52/1004` (mid-run undetected frames + coverage warning).