### PR TITLE
Drop the Clear button from the localize object editor's source rail

### DIFF
--- a/frontend/src/components/localize/editor/BoxSourceRail.tsx
+++ b/frontend/src/components/localize/editor/BoxSourceRail.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { Eraser, Check } from 'lucide-react';
+import { Check } from 'lucide-react';
 import type { BoxCandidate } from '@/utils/annotation/objectBoxCandidates';
 import { computeSquareCrop } from '@/utils/annotation/squareCropUtils';
 import { Tooltip } from '@/components/ui/Tooltip';
@@ -38,7 +38,6 @@ export interface BoxSourceRailProps {
   /** True on a frame outside the object's range: view only. */
   disabled: boolean;
   onCommit: (candidate: BoxCandidate) => void;
-  onClear: () => void;
   /**
    * Solo-preview this candidate on the stage (null to release). Fired on
    * hover and keyboard focus; never for the committed or empty rows, whose
@@ -121,15 +120,14 @@ export function BoxSourceRail({
   imageUrl,
   disabled,
   onCommit,
-  onClear,
   onPreview,
 }: BoxSourceRailProps) {
   const region = unionBox(candidates);
 
   // No scroll box on the rail, on purpose: `overflow-y: auto` makes overflow-x
   // `auto` too, which clipped the row tooltips — they are wider than this rail
-  // and are meant to spill left over the image. The rail holds three rows and
-  // two buttons; it has nothing to scroll.
+  // and are meant to spill left over the image. The rail holds three rows; it
+  // has nothing to scroll.
   return (
     <div className="w-60 flex-none border-l border-line bg-paper p-4">
       <p className="mb-2.5 font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
@@ -204,21 +202,8 @@ export function BoxSourceRail({
         );
       })}
 
-      {/* No Draw button: the canvas has no modes, so there is nothing to arm.
-          Clear stays, because removing a box is not something a drag can
-          express. */}
-      <div className="mt-3 flex gap-2">
-        <button
-          type="button"
-          data-testid="editor-clear"
-          disabled={disabled || !committed}
-          onClick={onClear}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-line bg-paper px-3 py-2 font-body text-sm font-medium text-char hover:bg-ash focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:opacity-40"
-        >
-          <Eraser className="h-3.5 w-3.5" /> Clear
-        </button>
-      </div>
-
+      {/* No buttons: the canvas has no modes, so there is nothing to arm, and
+          removing a box is Delete's job (see the shortcuts sheet). */}
       <p className="mt-3 font-body text-detail leading-relaxed text-haze">
         Drag on the image to draw. It replaces the box on this frame — each object carries one box
         per frame.

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -106,7 +106,7 @@ export interface LocalizeObjectEditorProps {
   onCommitGapFrame: (recordedAt: string, items: DetectionAnnotationBbox[]) => void;
   /**
    * Remove a model-evidence-free frame from the lane entirely (issue #287's
-   * un-materialize) — Clear, for a frame whose only reason to exist is a
+   * un-materialize) — Delete, for a frame whose only reason to exist is a
    * human's box.
    */
   onUnmaterialize: (detection: Detection) => void;
@@ -698,10 +698,9 @@ export function LocalizeObjectEditor({
           break;
         case 'Delete':
         case 'Backspace':
-          // Removes whatever is committed, not only a hand-drawn box — the
-          // same action the Clear button performs, which for a model box is
-          // the review's "reject". A no-op on a frame with nothing committed
-          // or one outside the object's range.
+          // Removes whatever is committed, not only a hand-drawn box — for a
+          // model box this is the review's "reject". A no-op on a frame with
+          // nothing committed or one outside the object's range.
           if (!editable || !committedRef.current) return;
           clearRef.current();
           break;
@@ -971,7 +970,6 @@ export function LocalizeObjectEditor({
           imageUrl={editable ? (imageData?.url ?? null) : null}
           disabled={!editable}
           onCommit={commitCandidate}
-          onClear={clear}
           onPreview={setPreviewed}
         />
       </div>

--- a/frontend/tests/components/localize/editor/BoxSourceRail.test.tsx
+++ b/frontend/tests/components/localize/editor/BoxSourceRail.test.tsx
@@ -34,7 +34,6 @@ const props = {
   imageUrl: 'blob:image',
   disabled: false,
   onCommit: vi.fn(),
-  onClear: vi.fn(),
   onPreview: vi.fn(),
 };
 
@@ -100,19 +99,6 @@ describe('BoxSourceRail', () => {
   it('disables every action when the frame is not editable', () => {
     render(<BoxSourceRail {...props} candidates={[]} committed={null} disabled />);
     expect(screen.getByTestId('source-row-auto')).toBeDisabled();
-    expect(screen.getByTestId('editor-clear')).toBeDisabled();
-  });
-
-  it('disables Clear when nothing is committed', () => {
-    render(<BoxSourceRail {...props} committed={null} />);
-    expect(screen.getByTestId('editor-clear')).toBeDisabled();
-  });
-
-  it('clears when Clear is pressed', () => {
-    const onClear = vi.fn();
-    render(<BoxSourceRail {...props} onClear={onClear} />);
-    fireEvent.click(screen.getByTestId('editor-clear'));
-    expect(onClear).toHaveBeenCalled();
   });
 
   // React delivers onMouseEnter/onMouseLeave via mouseover/mouseout, so

--- a/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
+++ b/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
@@ -958,14 +958,19 @@ describe('LocalizeObjectEditor out-of-range frames', () => {
   });
 
   it('Delete un-materializes an evidence-free frame with a committed box', () => {
+    const onCommit = vi.fn();
     const onUnmaterialize = vi.fn();
     renderLoadedEditor({
       detection: detectionWithNoBoxes,
       existingAnnotation: committedAnnotation(detectionWithNoBoxes.id, 'human'),
+      onCommit,
       onUnmaterialize,
     });
     fireEvent.keyDown(window, { key: 'Delete' });
-    expect(onUnmaterialize).toHaveBeenCalled();
+    expect(onUnmaterialize).toHaveBeenCalledWith(
+      expect.objectContaining({ id: detectionWithNoBoxes.id })
+    );
+    expect(onCommit).not.toHaveBeenCalled();
   });
 
   it('does not step past the very first alert frame', () => {

--- a/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
+++ b/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
@@ -142,16 +142,6 @@ describe('LocalizeObjectEditor', () => {
     );
   });
 
-  it('commits nothing when Clear is pressed', () => {
-    const onCommit = vi.fn();
-    renderEditor({
-      onCommit,
-      existingAnnotation: committedAnnotation(firstDetection.id, 'auto'),
-    });
-    fireEvent.click(screen.getByTestId('editor-clear'));
-    expect(onCommit).toHaveBeenCalledWith(expect.objectContaining({ id: firstDetection.id }), []);
-  });
-
   it('Enter commits the priority pick and advances', () => {
     const onCommit = vi.fn();
     const onNavigateToDetection = vi.fn();
@@ -904,7 +894,6 @@ describe('LocalizeObjectEditor out-of-range frames', () => {
     renderEditor();
     fireEvent.keyDown(window, { key: 'ArrowLeft' });
     expect(screen.getByTestId('source-row-auto')).toBeDisabled();
-    expect(screen.getByTestId('editor-clear')).toBeDisabled();
   });
 
   it('Enter does nothing on an out-of-range frame', () => {
@@ -966,22 +955,6 @@ describe('LocalizeObjectEditor out-of-range frames', () => {
     renderEditor();
     fireEvent.keyDown(window, { key: 'ArrowLeft' });
     expect(screen.getByTestId('out-of-range-banner')).toHaveTextContent(/draw a box/i);
-  });
-
-  it('Clear un-materializes a frame with no model evidence', () => {
-    const onCommit = vi.fn();
-    const onUnmaterialize = vi.fn();
-    renderEditor({
-      detection: detectionWithNoBoxes,
-      existingAnnotation: committedAnnotation(detectionWithNoBoxes.id, 'human'),
-      onCommit,
-      onUnmaterialize,
-    });
-    fireEvent.click(screen.getByTestId('editor-clear'));
-    expect(onUnmaterialize).toHaveBeenCalledWith(
-      expect.objectContaining({ id: detectionWithNoBoxes.id })
-    );
-    expect(onCommit).not.toHaveBeenCalled();
   });
 
   it('Delete un-materializes an evidence-free frame with a committed box', () => {


### PR DESCRIPTION
## What

Removes the **Clear** button from the object editor's right panel (the "Box for this frame" source rail) on `/localize/:sequenceId/object/:laneId/:detectionId`.

## Why

Clear duplicated the **Delete/Backspace** shortcut, which stays and remains the way to remove a committed box — including the evidence-free un-materialize path from #287. The shortcuts sheet already documents "Remove the box — Del", so no capability is lost; the rail is now rows-only.

## Changes

- `BoxSourceRail.tsx`: remove the Clear button, the `onClear` prop, and the `Eraser` import; update the comments that referenced the button.
- `LocalizeObjectEditor.tsx`: stop passing `onClear`; the `clear` callback stays wired to Delete/Backspace.
- Tests: drop the three click-on-Clear tests and two disabled-state assertions — the same behaviors are covered by the existing Delete/Backspace keyboard tests.

## Verification

- Full frontend suite: 89 files, 1140 tests, all passing
- `npm run quality` (type-check + ESLint strict + Prettier) clean