### PR TITLE
feat(frontend): shared timeline legend at the bottom of the localize rail

### DIFF
--- a/docs/specs/2026-08-06-localize-timeline-legend-design.md
+++ b/docs/specs/2026-08-06-localize-timeline-legend-design.md
@@ -53,7 +53,7 @@ teach the same words:
 `absent` is never listed — it is the neutral track showing through, and
 explaining the background is noise (the popover legend skips it too).
 
-Because hue varies per object, swatches are drawn in a neutral ink (`char`):
+Because hue varies per object, swatches are drawn in a single teal (`pine`):
 the legend explains the *treatment* (solid vs faded vs outline), not the
 color.
 

--- a/docs/specs/2026-08-06-localize-timeline-legend-design.md
+++ b/docs/specs/2026-08-06-localize-timeline-legend-design.md
@@ -1,0 +1,87 @@
+# Localize rail: shared timeline legend
+
+**Date**: 2026-08-06
+**Status**: Approved
+
+## Problem
+
+The localize cockpit's object rows (`LocalizeObjectRow`) each carry an inline
+per-frame timeline whose segments encode four states: `confirmed` (solid fill
+in the object's color), `pending` (40%-faded fill), `empty` (outline only) and
+`absent` (neutral track). Nothing on the page explains this encoding. The only
+legend lives inside the editor's `AcceptRemainingPopover`, which an annotator
+may never open — and which explains a different strip on a different screen.
+
+## Decision
+
+One shared legend for the whole rail, not a per-row legend. Every row uses the
+same vocabulary (only the hue changes per object), so repeating the same
+three-or-four words under every row would make the rail taller and noisier for
+no information gain.
+
+## Design
+
+### Placement
+
+At the bottom of the Objects rail on `LocalizeAlertPage`: below the object
+rows, above the missed-smoke divider. The legend is a footnote to the strips
+above it — reference material, not reading order.
+
+`LocalizeRail` gains an optional `legend` slot rendered immediately after
+`children`, following the rail's existing pattern (slots; the page owns the
+wiring).
+
+### Component
+
+A new presentational component `LocalizeTimelineLegend` in
+`src/components/localize/`. It renders one horizontal, wrap-capable line of
+chips: a small pill swatch (`h-1.5 w-4 rounded-full`) plus a label in
+`font-data text-detail text-haze` — the same visual language as the
+`AcceptRemainingPopover` legend.
+
+### Chips
+
+Three possible chips, using the popover's exact vocabulary so both surfaces
+teach the same words:
+
+| Status      | Label                 | Swatch treatment      |
+| ----------- | --------------------- | --------------------- |
+| `confirmed` | committed             | solid fill            |
+| `pending`   | model box to accept   | 40%-opacity fill      |
+| `empty`     | no box                | inset 1px outline     |
+
+`absent` is never listed — it is the neutral track showing through, and
+explaining the background is noise (the popover legend skips it too).
+
+Because hue varies per object, swatches are drawn in a neutral ink (`char`):
+the legend explains the *treatment* (solid vs faded vs outline), not the
+color.
+
+### Filtering
+
+Chips are filtered to the union of statuses actually present across all rows'
+`statusByTimestamp` maps — the popover's established pattern, applied
+rail-wide. A fully-localized alert shows only "committed"; "no box" appears
+only when some row actually has an outlined gap. If the union is empty (no
+rows), no legend renders.
+
+### Data flow
+
+`LocalizeAlertPage` already builds `statusByTimestamp` per row. A small pure
+helper in `src/utils/annotation/alertLocalizeUtils.ts` takes those maps and
+returns the present-status union (excluding `absent`). The page passes the
+result to `LocalizeTimelineLegend` via the rail's `legend` slot.
+
+## Testing
+
+- Unit tests for the helper: union across maps, `absent` excluded, empty
+  input → empty union.
+- Page-level tests on `LocalizeAlertPage`: an alert with committed, pending
+  and gap frames shows all three chips; a fully-localized alert shows only
+  "committed"; chips carry the right swatch treatment.
+
+## Out of scope
+
+- Any change to the per-segment encodings themselves.
+- Explaining `absent`.
+- The editor page and its popover legend stay as they are.

--- a/frontend/src/components/localize/LocalizeRail.tsx
+++ b/frontend/src/components/localize/LocalizeRail.tsx
@@ -14,6 +14,8 @@ import React from 'react';
 export interface LocalizeRailProps {
   /** Rendered top-right of the Objects header. */
   headerAction?: React.ReactNode;
+  /** The shared timeline legend — rendered below the rows, above the missed-smoke divider. */
+  legend?: React.ReactNode;
   /** The missed-smoke question, which carries "+ Add object" inside it — rendered below the rows. */
   missedSmoke?: React.ReactNode;
   /** The page's submit button. */
@@ -24,6 +26,7 @@ export interface LocalizeRailProps {
 
 export const LocalizeRail: React.FC<LocalizeRailProps> = ({
   headerAction,
+  legend,
   missedSmoke,
   footer,
   children,
@@ -37,6 +40,8 @@ export const LocalizeRail: React.FC<LocalizeRailProps> = ({
     </div>
 
     <div className="space-y-2">{children}</div>
+
+    {legend && <div className="mt-3">{legend}</div>}
 
     {missedSmoke && (
       <>

--- a/frontend/src/components/localize/LocalizeTimelineLegend.tsx
+++ b/frontend/src/components/localize/LocalizeTimelineLegend.tsx
@@ -1,0 +1,56 @@
+/**
+ * The rail's shared key to the object timelines: one wrap-capable line of
+ * swatch+label chips explaining the segment encodings the rows above use.
+ * Shared rather than per-row because every row speaks the same vocabulary —
+ * only the hue changes per object — so the swatches are neutral ink and the
+ * legend explains the treatment (solid / faded / outline), not the color.
+ *
+ * The caller passes only the statuses actually on screen (see
+ * `timelineLegendStatuses`), so the legend never names a state no row is in
+ * — the same filtering the accept popover's legend established. The labels
+ * are that popover's, verbatim, so both surfaces teach the same words.
+ * `absent` is deliberately not representable here: it is the track showing
+ * through, and explaining the background is noise.
+ */
+
+import type { TimelineLegendStatus } from '@/utils/annotation/alertLocalizeUtils';
+
+const CHIP_LABELS: Record<TimelineLegendStatus, string> = {
+  confirmed: 'committed',
+  pending: 'model box to accept',
+  empty: 'no box',
+};
+
+// Mirrors `segmentAppearance` in LocalizeObjectRow, in neutral ink: solid
+// fill, 40% fill, inset 1px outline.
+const SWATCH_CLASS: Record<TimelineLegendStatus, string> = {
+  confirmed: 'bg-char',
+  pending: 'bg-char opacity-40',
+  empty: 'ring-1 ring-inset ring-char',
+};
+
+export interface LocalizeTimelineLegendProps {
+  /** Statuses present across the rail's rows, already ordered and filtered. */
+  statuses: TimelineLegendStatus[];
+}
+
+export function LocalizeTimelineLegend({ statuses }: LocalizeTimelineLegendProps) {
+  if (statuses.length === 0) return null;
+  return (
+    <div
+      data-testid="localize-timeline-legend"
+      className="flex flex-wrap items-center gap-x-3 gap-y-1"
+    >
+      {statuses.map(status => (
+        <span
+          key={status}
+          data-testid={`legend-chip-${status}`}
+          className="flex items-center gap-1.5 font-data text-detail text-haze"
+        >
+          <span aria-hidden className={`h-1.5 w-4 rounded-full ${SWATCH_CLASS[status]}`} />
+          {CHIP_LABELS[status]}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/localize/LocalizeTimelineLegend.tsx
+++ b/frontend/src/components/localize/LocalizeTimelineLegend.tsx
@@ -2,8 +2,9 @@
  * The rail's shared key to the object timelines: one wrap-capable line of
  * swatch+label chips explaining the segment encodings the rows above use.
  * Shared rather than per-row because every row speaks the same vocabulary —
- * only the hue changes per object — so the swatches are neutral ink and the
- * legend explains the treatment (solid / faded / outline), not the color.
+ * only the hue changes per object — so the swatches are a single pine and
+ * the legend explains the treatment (solid / faded / outline), not the
+ * color.
  *
  * The caller passes only the statuses actually on screen (see
  * `timelineLegendStatuses`), so the legend never names a state no row is in
@@ -21,12 +22,12 @@ const CHIP_LABELS: Record<TimelineLegendStatus, string> = {
   empty: 'no box',
 };
 
-// Mirrors `segmentAppearance` in LocalizeObjectRow, in neutral ink: solid
-// fill, 40% fill, inset 1px outline.
+// Mirrors `segmentAppearance` in LocalizeObjectRow, in pine: solid fill,
+// 40% fill, inset 1px outline.
 const SWATCH_CLASS: Record<TimelineLegendStatus, string> = {
-  confirmed: 'bg-char',
-  pending: 'bg-char opacity-40',
-  empty: 'ring-1 ring-inset ring-char',
+  confirmed: 'bg-pine',
+  pending: 'bg-pine opacity-40',
+  empty: 'ring-1 ring-inset ring-pine',
 };
 
 export interface LocalizeTimelineLegendProps {

--- a/frontend/src/components/localize/index.ts
+++ b/frontend/src/components/localize/index.ts
@@ -2,6 +2,8 @@ export { LocalizeObjectRow } from './LocalizeObjectRow';
 export type { LocalizeObjectRowProps } from './LocalizeObjectRow';
 export { LocalizeRail } from './LocalizeRail';
 export type { LocalizeRailProps } from './LocalizeRail';
+export { LocalizeTimelineLegend } from './LocalizeTimelineLegend';
+export type { LocalizeTimelineLegendProps } from './LocalizeTimelineLegend';
 export { LocalizeActionPanel } from './LocalizeActionPanel';
 export type { LocalizeActionPanelProps } from './LocalizeActionPanel';
 export { LocalizeObjectActions } from './LocalizeObjectActions';

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -126,6 +126,7 @@ import {
 import {
   buildAlertFrameModel,
   findFrameByDetectionId,
+  timelineLegendStatuses,
   AlertObjectStatus,
 } from '@/utils/annotation/alertLocalizeUtils';
 import { materializeGapFrame } from '@/utils/annotation/gapFrameMaterialize';
@@ -143,6 +144,7 @@ import {
   LocalizeObjectRow,
   LocalizeRail,
   LocalizeShortcutsModal,
+  LocalizeTimelineLegend,
 } from '@/components/localize';
 import { AlertFrameGrid, ViewToolbar } from '@/components/detection-sequence';
 import { LocalizeObjectEditor } from '@/components/localize/editor';
@@ -831,6 +833,11 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   const smokeObjectRows = objectStatusRows.filter(o => !o.isFalsePositive);
   const falsePositiveRows = objectStatusRows.filter(o => o.isFalsePositive);
   const orderedObjectRows = [...smokeObjectRows, ...falsePositiveRows];
+
+  // The rail's shared legend explains only encodings some visible row uses —
+  // `orderedObjectRows` is exactly the visible set, since the alert-detail
+  // query already refetches without FP lanes when the toggle is off.
+  const legendStatuses = timelineLegendStatuses(orderedObjectRows.map(o => o.statusByTimestamp));
 
   // Arrival auto-select + URL-lane validation. A bare alert URL
   // replace-redirects to the first workable smoke object — the thing the
@@ -1605,6 +1612,11 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
                   <Keyboard className="w-4 h-4" />
                 </button>
               </div>
+            }
+            legend={
+              legendStatuses.length > 0 ? (
+                <LocalizeTimelineLegend statuses={legendStatuses} />
+              ) : undefined
             }
             missedSmoke={
               <LocalizeMissedSmokeRow

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -835,8 +835,8 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   const orderedObjectRows = [...smokeObjectRows, ...falsePositiveRows];
 
   // The rail's shared legend explains only encodings some visible row uses —
-  // `orderedObjectRows` is exactly the visible set, since the alert-detail
-  // query already refetches without FP lanes when the toggle is off.
+  // `orderedObjectRows` is exactly the visible set, since
+  // `buildAlertFrameModel` already drops FP lanes when the toggle is off.
   const legendStatuses = timelineLegendStatuses(orderedObjectRows.map(o => o.statusByTimestamp));
 
   // Arrival auto-select + URL-lane validation. A bare alert URL

--- a/frontend/src/utils/annotation/alertLocalizeUtils.ts
+++ b/frontend/src/utils/annotation/alertLocalizeUtils.ts
@@ -70,6 +70,27 @@ export interface AlertFrame {
  */
 export type ObjectFrameStatus = 'confirmed' | 'pending' | 'empty' | 'absent';
 
+/** Statuses the rail's shared legend can name — every encoding except the neutral track. */
+export type TimelineLegendStatus = Exclude<ObjectFrameStatus, 'absent'>;
+
+const LEGEND_STATUS_ORDER: TimelineLegendStatus[] = ['confirmed', 'pending', 'empty'];
+
+/**
+ * The union of statuses present across the rail's rows, in the legend's
+ * display order. `absent` is the track showing through rather than an
+ * encoding, so it is never returned — the legend must not explain the
+ * background, and must not name a state no row on screen is in.
+ */
+export function timelineLegendStatuses(
+  statusMaps: Record<string, ObjectFrameStatus>[]
+): TimelineLegendStatus[] {
+  const present = new Set<ObjectFrameStatus>();
+  for (const map of statusMaps) {
+    for (const status of Object.values(map)) present.add(status);
+  }
+  return LEGEND_STATUS_ORDER.filter(status => present.has(status));
+}
+
 /** One rail row: the object's identity, its per-frame statuses, and the bits `LocalizeAlertPage` needs to route clicks and split rows by workability. */
 export interface AlertObjectStatus {
   /** e.g. "Object 2" — same numbering as the object's rail row and grid overlays. */

--- a/frontend/tests/components/localize/LocalizeTimelineLegend.test.tsx
+++ b/frontend/tests/components/localize/LocalizeTimelineLegend.test.tsx
@@ -26,9 +26,9 @@ describe('LocalizeTimelineLegend', () => {
     render(<LocalizeTimelineLegend statuses={['confirmed', 'pending', 'empty']} />);
     const swatch = (status: string) =>
       screen.getByTestId(`legend-chip-${status}`).querySelector('span[aria-hidden]');
-    expect(swatch('confirmed')).toHaveClass('bg-char');
+    expect(swatch('confirmed')).toHaveClass('bg-pine');
     expect(swatch('confirmed')).not.toHaveClass('opacity-40');
-    expect(swatch('pending')).toHaveClass('bg-char', 'opacity-40');
-    expect(swatch('empty')).toHaveClass('ring-1', 'ring-inset', 'ring-char');
+    expect(swatch('pending')).toHaveClass('bg-pine', 'opacity-40');
+    expect(swatch('empty')).toHaveClass('ring-1', 'ring-inset', 'ring-pine');
   });
 });

--- a/frontend/tests/components/localize/LocalizeTimelineLegend.test.tsx
+++ b/frontend/tests/components/localize/LocalizeTimelineLegend.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LocalizeTimelineLegend } from '@/components/localize/LocalizeTimelineLegend';
+
+describe('LocalizeTimelineLegend', () => {
+  it('renders one chip per status, labelled with the popover vocabulary', () => {
+    render(<LocalizeTimelineLegend statuses={['confirmed', 'pending', 'empty']} />);
+    expect(screen.getByTestId('legend-chip-confirmed')).toHaveTextContent('committed');
+    expect(screen.getByTestId('legend-chip-pending')).toHaveTextContent('model box to accept');
+    expect(screen.getByTestId('legend-chip-empty')).toHaveTextContent('no box');
+  });
+
+  it('renders only the statuses it is given', () => {
+    render(<LocalizeTimelineLegend statuses={['confirmed']} />);
+    expect(screen.getByTestId('legend-chip-confirmed')).toBeInTheDocument();
+    expect(screen.queryByTestId('legend-chip-pending')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('legend-chip-empty')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing at all for an empty status list', () => {
+    const { container } = render(<LocalizeTimelineLegend statuses={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('gives each status its own swatch treatment: solid, faded, outline', () => {
+    render(<LocalizeTimelineLegend statuses={['confirmed', 'pending', 'empty']} />);
+    const swatch = (status: string) =>
+      screen.getByTestId(`legend-chip-${status}`).querySelector('span[aria-hidden]');
+    expect(swatch('confirmed')).toHaveClass('bg-char');
+    expect(swatch('confirmed')).not.toHaveClass('opacity-40');
+    expect(swatch('pending')).toHaveClass('bg-char', 'opacity-40');
+    expect(swatch('empty')).toHaveClass('ring-1', 'ring-inset', 'ring-char');
+  });
+});

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -3132,4 +3132,49 @@ describe('LocalizeAlertPage', () => {
       );
     });
   });
+
+  it('shows a shared timeline legend listing only the statuses on screen', async () => {
+    // Default fixture: every present frame carries an unaccepted model box.
+    await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+    const legend = screen.getByTestId('localize-timeline-legend');
+    expect(within(legend).getByText('model box to accept')).toBeInTheDocument();
+    expect(within(legend).queryByText('committed')).not.toBeInTheDocument();
+    expect(within(legend).queryByText('no box')).not.toBeInTheDocument();
+  });
+
+  it('collapses the legend to just "committed" once every frame is accepted', async () => {
+    mockAllFramesAccepted();
+    await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+    const legend = screen.getByTestId('localize-timeline-legend');
+    expect(within(legend).getByText('committed')).toBeInTheDocument();
+    expect(within(legend).queryByText('model box to accept')).not.toBeInTheDocument();
+    expect(within(legend).queryByText('no box')).not.toBeInTheDocument();
+  });
+
+  it('shows all three chips when the alert mixes committed, pending and boxless frames', async () => {
+    // Lane 101's frame is committed (annotated-stage annotation), lane 102's
+    // T1 keeps its default pending model box, and its T2 detection offers no
+    // box at all — the `empty` outline state.
+    vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
+      if (id === 101) return [makeDetection(1001, T1)];
+      if (id === 102)
+        return [
+          makeDetection(1002, T1),
+          { ...makeDetection(1003, T2), auto_predictions: { predictions: [] } },
+        ];
+      return [];
+    });
+    vi.mocked(apiClient.getDetectionAnnotations).mockImplementation(async filters => {
+      const items = filters?.sequence_id === 101 ? [makeDetectionAnnotation(1001)] : [];
+      return { ...emptyAnnotationsPage, items, total: items.length };
+    });
+    await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+    const legend = screen.getByTestId('localize-timeline-legend');
+    expect(within(legend).getByText('committed')).toBeInTheDocument();
+    expect(within(legend).getByText('model box to accept')).toBeInTheDocument();
+    expect(within(legend).getByText('no box')).toBeInTheDocument();
+  });
 });

--- a/frontend/tests/utils/annotation/alertLocalizeUtils.test.ts
+++ b/frontend/tests/utils/annotation/alertLocalizeUtils.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { buildAlertFrameModel } from '@/utils/annotation/alertLocalizeUtils';
+import {
+  buildAlertFrameModel,
+  timelineLegendStatuses,
+} from '@/utils/annotation/alertLocalizeUtils';
 import { getObjectColor } from '@/utils/annotation/objectColors';
 import type { AlertLane, Detection, DetectionAnnotation, SequenceAnnotation } from '@/types/api';
 
@@ -337,5 +340,25 @@ describe('buildAlertFrameModel', () => {
 
       expect(frames[0].cells[0].boxes.map(b => b.xyxyn)).toEqual([[0.2, 0.2, 0.3, 0.3]]);
     });
+  });
+});
+
+describe('timelineLegendStatuses', () => {
+  it('returns the union of statuses across rows, in display order', () => {
+    expect(
+      timelineLegendStatuses([
+        { t1: 'empty', t2: 'confirmed' },
+        { t1: 'pending', t2: 'absent' },
+      ])
+    ).toEqual(['confirmed', 'pending', 'empty']);
+  });
+
+  it('lists only statuses actually present', () => {
+    expect(timelineLegendStatuses([{ t1: 'confirmed', t2: 'confirmed' }])).toEqual(['confirmed']);
+  });
+
+  it('never lists absent, and returns nothing for no rows or all-absent rows', () => {
+    expect(timelineLegendStatuses([])).toEqual([]);
+    expect(timelineLegendStatuses([{ t1: 'absent' }])).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

The localize cockpit's object rows each carry an inline per-frame timeline, but nothing on the page explained the segment encodings — the only legend lived inside the editor's accept popover, which an annotator may never open. This adds one shared legend line at the bottom of the Objects rail (below the rows, above the missed-smoke divider).

- `timelineLegendStatuses` in `alertLocalizeUtils`: the union of statuses present across the rail's rows, in fixed display order, never listing `absent` (it is the track showing through, not an encoding).
- `LocalizeTimelineLegend`: one wrap-capable line of swatch+label chips reusing the accept popover's vocabulary verbatim (`committed`, `model box to accept`, `no box`) and its swatch treatments (solid / 40% faded / inset outline) in neutral ink — the legend explains the treatment, not the per-object hue.
- `LocalizeRail` gains an optional `legend` slot; `LocalizeAlertPage` passes the legend computed from the visible rows (`orderedObjectRows` is exactly the visible set, since the alert-detail query refetches without FP lanes when the toggle is off).

Chips are filtered to what is actually on screen, so a fully-localized alert shows only "committed" and "no box" appears only when some row has an outlined gap.

Spec: `docs/specs/2026-08-06-localize-timeline-legend-design.md`.

## Test plan

- [x] `timelineLegendStatuses` unit tests: union across rows, display order, `absent` excluded, empty input.
- [x] `LocalizeTimelineLegend` component tests: chip labels, filtering, empty → renders nothing, per-status swatch treatment.
- [x] `LocalizeAlertPage` tests: pending-only alert → only "model box to accept"; all-accepted → only "committed"; mixed committed/pending/boxless → all three chips.
- [x] `npm run quality` and full suite green (1187 tests).