### PR TITLE
feat(frontend): zoom boxless localize grid cells to the neighbors' region in crop mode

### DIFF
--- a/docs/specs/2026-08-06-grid-gap-inferred-crop-design.md
+++ b/docs/specs/2026-08-06-grid-gap-inferred-crop-design.md
@@ -1,0 +1,88 @@
+# Inferred crop-mode zoom for boxless cells in the localize frame grid
+
+**Date:** 2026-08-06
+**Status:** Approved
+**Scope:** `frontend/src/components/detection-sequence/AlertFrameGrid.tsx`, `frontend/src/utils/annotation/gridCropUtils.ts`
+
+## Problem
+
+On `LocalizeAlertPage` (`/localize/:sequenceId/object/:laneId`), crop mode
+zooms each grid cell around the active object's boxes on that frame
+(`computeCellCrop`). Cells where the object has no boxes stay full-frame:
+
+- **Gap frames** — the active lane has a detection on the frame but no
+  boxes to draw (`cellState: 'empty'`, including the materialized gap
+  frames from PR #293). `computeCellCrop([])` returns identity.
+- **Before/after context frames** — the active lane has no detection on
+  the frame at all (`isActiveLaneCell` false). The crop is explicitly
+  skipped ("no object to focus on"), and the cell is faded to
+  `opacity-40 saturate-50` and unclickable.
+
+Reviewing a sequence with gaps means the eye jumps between tight crops
+and full frames, and checking "did smoke actually appear here?" on a
+boxless frame requires re-locating the region by hand. All frames in an
+alert share one camera pose, so a crop window borrowed from neighboring
+frames is geometrically valid on boxless frames.
+
+## Behavior
+
+In crop mode with an active object:
+
+1. **Boxed cells are unchanged** — each still computes its own crop from
+   its own boxes (`targetFill 0.8`, `maxScale 8`).
+2. **Boxless cells zoom to the neighbor union**: the union of the boxes
+   on the nearest boxed frame *before* and the nearest boxed frame
+   *after* it (chronologically, within the active lane). Before the
+   object's first boxed frame or after its last, only one neighbor
+   exists, so the crop degenerates to that single frame's boxes. Same
+   tuning as boxed cells — the two-frame union is naturally a touch
+   wider.
+3. **No boxed frames anywhere** in the active lane → boxless cells stay
+   full-frame, as today.
+4. **No ghost indicator** of the borrowed region — the visible region is
+   the area of interest; a drawn rectangle would collide with the
+   dashed "uncommitted box" vocabulary.
+5. **Context-cell fade lightens in crop mode**: before/after context
+   cells drop `opacity-40 saturate-50` for a subtle `opacity-75` (no
+   desaturation) so faint smoke in the zoomed region is judgeable.
+   Outside crop mode the current fade is unchanged. Context cells stay
+   read-only and unclickable in both modes.
+
+The rule applies uniformly to gap cells (which remain clickable — the
+active lane is present) and context cells (which remain inert).
+
+## Implementation
+
+- **`gridCropUtils.ts`**: new pure function, e.g.
+  `computeFallbackCrops(frames, activeLaneId)`, returning a
+  `recordedAt → CellCrop` map covering only the frames where the active
+  lane has no boxes. Internally: collect the active lane's boxed frames
+  in chronological order; for each boxless frame, find nearest boxed
+  neighbors on each side and feed the union of their boxes to
+  `computeCellCrop`.
+- **`AlertFrameGrid.tsx`**: memoize the map (`frames`, `activeLaneId`,
+  `cropMode`) at grid level and pass each `AlertFrameCellView` its
+  fallback crop. Cell logic becomes: active-lane cell with boxes → own
+  crop (as today); otherwise in crop mode → fallback crop when one
+  exists. The context-cell class string gains the crop-mode fade
+  variant.
+
+## Testing
+
+- **Unit (`gridCropUtils`)**: mid-gap frame uses the union of both
+  neighbors; frames before the first / after the last boxed frame use
+  the single nearest; a lane with no boxed frames produces no entries;
+  boxed frames never appear in the map.
+- **Component (`AlertFrameGrid`)**: in crop mode, a gap cell and a
+  context cell each get a scale transform derived from neighbors; the
+  context cell uses the lightened fade in crop mode and the original
+  `opacity-40 saturate-50` outside it; without an active object nothing
+  changes.
+
+## Out of scope
+
+- Changing the crop of boxed cells or the crop-mode tuning constants.
+- The object editor / cropped-loop strip (`CroppedImageSequence`),
+  which have their own framing logic.
+- Behavior outside crop mode — full-frame rendering and the existing
+  fade stay as-is.

--- a/frontend/src/components/detection-sequence/AlertFrameGrid.tsx
+++ b/frontend/src/components/detection-sequence/AlertFrameGrid.tsx
@@ -176,7 +176,7 @@ function AlertFrameCellView({
   // or when the crop transform changes the image's rendered rect.
   useEffect(() => {
     if (imgRef.current?.complete) handleImageLoad();
-  }, [activeCell.detectionId, crop.scale, handleImageLoad]);
+  }, [activeCell.detectionId, crop.scale, crop.originX, crop.originY, handleImageLoad]);
 
   useEffect(() => {
     const el = containerRef.current;

--- a/frontend/src/components/detection-sequence/AlertFrameGrid.tsx
+++ b/frontend/src/components/detection-sequence/AlertFrameGrid.tsx
@@ -15,18 +15,22 @@
  *
  * Crop mode (`cropMode`, active only when an object is active) zooms each
  * cell around that object's boxes on that frame, mirroring the legacy
- * grid's crop-mode zoom (`gridCropUtils.computeCellCrop`) — a frame where
- * the active lane isn't present stays full-frame (no object to focus on).
+ * grid's crop-mode zoom (`gridCropUtils.computeCellCrop`). A boxless frame
+ * — a gap in the object's track, or a before/after context frame where the
+ * lane is absent — zooms to the union of the nearest boxed neighbors
+ * instead (`computeFallbackCrops`), so the eye stays on one region across
+ * the whole sequence; while cropped, context cells swap their heavy fade
+ * for a lighter dim so faint smoke in that region stays judgeable.
  *
  * `highlightedFrame` (a `recordedAt`) gives that one cell a temporary accent
  * ring — the page sets it on a segment click or a `?frame=` deep-link
  * arrival, then clears it after a couple of seconds.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDetectionImage } from '@/hooks/useDetectionImage';
 import { normalizedToPixelBox, ImageInfo } from '@/utils/annotation/coordinateUtils';
-import { computeCellCrop } from '@/utils/annotation/gridCropUtils';
+import { CellCrop, computeCellCrop, computeFallbackCrops } from '@/utils/annotation/gridCropUtils';
 import { AlertFrame, AlertFrameCell } from '@/utils/annotation/alertLocalizeUtils';
 import { formatDateTime } from '@/utils/datetime';
 
@@ -54,6 +58,16 @@ export function AlertFrameGrid({
   cropMode = false,
   highlightedFrame = null,
 }: AlertFrameGridProps) {
+  // Inferred zoom for boxless cells (gap frames, before/after context): the
+  // union of the nearest boxed frames on each side, so the eye stays on one
+  // region across the whole sequence instead of jumping between tight crops
+  // and full frames. Computed before the empty-frames early return — hooks
+  // must run unconditionally.
+  const fallbackCrops = useMemo(
+    () => (cropMode ? computeFallbackCrops(frames, activeLaneId) : new Map<string, CellCrop>()),
+    [frames, activeLaneId, cropMode]
+  );
+
   if (frames.length === 0) return null;
 
   return (
@@ -69,6 +83,7 @@ export function AlertFrameGrid({
           frame={frame}
           activeLaneId={activeLaneId}
           cropMode={cropMode}
+          fallbackCrop={fallbackCrops.get(frame.recordedAt)}
           highlighted={highlightedFrame === frame.recordedAt}
           onClick={activeCell =>
             onCellClick(frame.recordedAt, activeCell.laneSequenceId, activeCell.detectionId)
@@ -84,6 +99,8 @@ interface AlertFrameCellViewProps {
   frame: AlertFrame;
   activeLaneId: number | null;
   cropMode: boolean;
+  /** Borrowed crop for a frame where the active lane has no boxes (gap / context). */
+  fallbackCrop?: CellCrop;
   highlighted: boolean;
   onClick: (activeCell: AlertFrameCell) => void;
   cellRef?: (el: HTMLDivElement | null) => void;
@@ -93,6 +110,7 @@ function AlertFrameCellView({
   frame,
   activeLaneId,
   cropMode,
+  fallbackCrop,
   highlighted,
   onClick,
   cellRef,
@@ -104,14 +122,18 @@ function AlertFrameCellView({
     frame.cells.find(c => c.laneSequenceId === activeLaneId) ??
     frame.cells.find(c => !c.isFalsePositive) ??
     frame.cells[0];
-  // Crop only applies when the active lane is actually present on this
-  // frame — a fallback cell (active lane absent here) has no "the object"
-  // box to focus on, so it stays full-frame.
   const isActiveLaneCell = activeLaneId !== null && activeCell.laneSequenceId === activeLaneId;
-  const crop =
-    cropMode && isActiveLaneCell
+  // A cell with the active object's boxes crops around them. A boxless cell
+  // — gap frame (lane present, nothing drawn) or context frame (lane
+  // absent) — borrows the grid-level fallback crop inferred from its
+  // nearest boxed neighbors, so "did smoke appear here?" is judged at the
+  // same zoom as the frames around it.
+  const identityCrop: CellCrop = { scale: 1, originX: 50, originY: 50 };
+  const crop = !cropMode
+    ? identityCrop
+    : isActiveLaneCell && activeCell.boxes.length > 0
       ? computeCellCrop(activeCell.boxes)
-      : { scale: 1, originX: 50, originY: 50 };
+      : (fallbackCrop ?? identityCrop);
   const cropStyle =
     crop.scale > 1
       ? { transform: `scale(${crop.scale})`, transformOrigin: `${crop.originX}% ${crop.originY}%` }
@@ -188,7 +210,7 @@ function AlertFrameCellView({
       data-context={isContextFrame ? 'true' : undefined}
       data-readonly={isReadOnly ? 'true' : undefined}
       className={`group aspect-video relative overflow-hidden bg-ash transition-shadow duration-700 ${
-        isContextFrame ? 'opacity-40 saturate-50' : ''
+        isContextFrame ? (cropMode ? 'opacity-75' : 'opacity-40 saturate-50') : ''
       } ${isReadOnly ? 'cursor-default' : 'cursor-pointer'} ${
         highlighted ? 'ring-2 ring-pine ring-offset-2' : ''
       }`}

--- a/frontend/src/utils/annotation/gridCropUtils.ts
+++ b/frontend/src/utils/annotation/gridCropUtils.ts
@@ -85,3 +85,58 @@ export function computeCellCrop(
     originY: round2(((y1 + y2) / 2) * 100),
   };
 }
+
+/**
+ * Minimal structural shape of `alertLocalizeUtils`' `AlertFrame` — declared
+ * here rather than imported, because that module already imports from this
+ * one and a real import would be a cycle.
+ */
+export interface FallbackCropFrame {
+  recordedAt: string;
+  cells: { laneSequenceId: number; boxes: { xyxyn: number[] }[] }[];
+}
+
+/**
+ * Inferred crops for the frames where the active lane has no boxes — gap
+ * frames (lane present, nothing drawn) and before/after context frames
+ * (lane absent). All frames of an alert share one camera pose, so a region
+ * borrowed from neighbors is geometrically valid: each boxless frame gets
+ * the crop of the union of the nearest boxed frame on each side (only one
+ * side exists beyond the object's span). Frames must be chronologically
+ * ordered, as `buildAlertFrames` returns them. Boxed frames get no entry —
+ * they compute their own crop — and a lane with no boxed frames at all
+ * yields an empty map (those cells stay full-frame).
+ */
+export function computeFallbackCrops(
+  frames: FallbackCropFrame[],
+  activeLaneId: number | null
+): Map<string, CellCrop> {
+  const crops = new Map<string, CellCrop>();
+  if (activeLaneId === null) return crops;
+
+  type CropBox = { xyxyn: number[] };
+  const boxed: (CropBox[] | null)[] = frames.map(f => {
+    const cell = f.cells.find(c => c.laneSequenceId === activeLaneId);
+    return cell && cell.boxes.length > 0 ? cell.boxes : null;
+  });
+
+  const prevNeighbor: (CropBox[] | null)[] = new Array(frames.length);
+  let carry: CropBox[] | null = null;
+  for (let i = 0; i < frames.length; i++) {
+    carry = boxed[i] ?? carry;
+    prevNeighbor[i] = carry;
+  }
+  const nextNeighbor: (CropBox[] | null)[] = new Array(frames.length);
+  carry = null;
+  for (let i = frames.length - 1; i >= 0; i--) {
+    carry = boxed[i] ?? carry;
+    nextNeighbor[i] = carry;
+  }
+
+  frames.forEach((frame, i) => {
+    if (boxed[i]) return;
+    const neighbors = [...(prevNeighbor[i] ?? []), ...(nextNeighbor[i] ?? [])];
+    if (neighbors.length > 0) crops.set(frame.recordedAt, computeCellCrop(neighbors));
+  });
+  return crops;
+}

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -895,6 +895,58 @@ describe('LocalizeAlertPage', () => {
     });
   });
 
+  it('crop mode zooms a gap frame (active lane present, no boxes) to the nearest boxed neighbors', async () => {
+    // Lane 101 gains a boxless detection at T2 (no predictions -> 'empty'
+    // cell state), making T2 a gap frame for Object 1.
+    vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
+      if (id === 101)
+        return [
+          makeDetection(1001, T1),
+          { ...makeDetection(1004, T2), auto_predictions: { predictions: [] } },
+        ];
+      if (id === 102) return [makeDetection(1002, T1), makeDetection(1003, T2)];
+      return [];
+    });
+
+    await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+    // Arrival auto-focus: Object 1 active, crop on. T2 has none of its boxes,
+    // so it borrows T1's box region (0.1–0.3 -> scale 4 about 20% 20%).
+    await waitFor(() => {
+      const img = within(screen.getByTestId(`alert-frame-cell-${T2}`)).getByRole('img');
+      expect(img.style.transform).toContain('scale(');
+      expect(img.style.transformOrigin).toBe('20% 20%');
+    });
+    // A gap frame is the object's own (clickable) cell, not context.
+    expect(screen.getByTestId(`alert-frame-cell-${T2}`)).not.toHaveAttribute('data-context');
+  });
+
+  it('crop mode zooms context frames to the borrowed region and lightens their fade', async () => {
+    await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+    // Arrival auto-focus: Object 1 (lane 101, present only at T1) active,
+    // crop on. T2 is context — zoomed to T1's borrowed region, not full-frame.
+    await waitFor(() => {
+      const img = within(screen.getByTestId(`alert-frame-cell-${T2}`)).getByRole('img');
+      expect(img.style.transform).toContain('scale(');
+    });
+    const cell = screen.getByTestId(`alert-frame-cell-${T2}`);
+    expect(cell).toHaveAttribute('data-context', 'true');
+    // The heavy fade would bury faint smoke in the zoomed region: crop mode
+    // swaps it for a subtle dim.
+    expect(cell.className).toContain('opacity-75');
+    expect(cell.className).not.toContain('opacity-40');
+
+    // Crop off: back to full-frame and the strong fade.
+    fireEvent.keyDown(window, { key: 'c' });
+    await waitFor(() => {
+      const img = within(screen.getByTestId(`alert-frame-cell-${T2}`)).getByRole('img');
+      expect(img.style.transform).toBe('');
+    });
+    expect(cell.className).toContain('opacity-40');
+    expect(cell.className).toContain('saturate-50');
+  });
+
   it('a segment click gives its target cell an arrival highlight that fades after ~2s', async () => {
     await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 

--- a/frontend/tests/utils/annotation/gridCropUtils.test.ts
+++ b/frontend/tests/utils/annotation/gridCropUtils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { computeCellCrop, focusOnMainObject } from '@/utils/annotation/gridCropUtils';
+import {
+  computeCellCrop,
+  computeFallbackCrops,
+  focusOnMainObject,
+} from '@/utils/annotation/gridCropUtils';
 import type { Detection } from '@/types/api';
 
 const box = (x1: number, y1: number, x2: number, y2: number) => ({ xyxyn: [x1, y1, x2, y2] });
@@ -55,5 +59,81 @@ describe('computeCellCrop', () => {
   it('never zooms out for large boxes', () => {
     const crop = computeCellCrop([box(0.05, 0.05, 0.95, 0.95)]);
     expect(crop.scale).toBe(1);
+  });
+});
+
+describe('computeFallbackCrops', () => {
+  const frameAt = (recordedAt: string, cells: { lane: number; boxes: number[][] }[]) => ({
+    recordedAt,
+    cells: cells.map(c => ({
+      laneSequenceId: c.lane,
+      boxes: c.boxes.map(xyxyn => ({ xyxyn })),
+    })),
+  });
+  const boxA = [0.1, 0.1, 0.2, 0.2];
+  const boxB = [0.5, 0.3, 0.7, 0.4];
+
+  it('crops a mid-gap frame to the union of its nearest boxed neighbors', () => {
+    const frames = [
+      frameAt('t1', [{ lane: 1, boxes: [boxA] }]),
+      frameAt('t2', [{ lane: 1, boxes: [] }]),
+      frameAt('t3', [{ lane: 1, boxes: [boxB] }]),
+    ];
+    const crops = computeFallbackCrops(frames, 1);
+    expect(crops.get('t2')).toEqual(computeCellCrop([{ xyxyn: boxA }, { xyxyn: boxB }]));
+  });
+
+  it('never emits entries for boxed frames', () => {
+    const frames = [
+      frameAt('t1', [{ lane: 1, boxes: [boxA] }]),
+      frameAt('t2', [{ lane: 1, boxes: [] }]),
+      frameAt('t3', [{ lane: 1, boxes: [boxB] }]),
+    ];
+    const crops = computeFallbackCrops(frames, 1);
+    expect(crops.has('t1')).toBe(false);
+    expect(crops.has('t3')).toBe(false);
+  });
+
+  it('a frame before the first boxed frame borrows that frame alone (lane absent there)', () => {
+    const frames = [
+      frameAt('t1', [{ lane: 2, boxes: [boxB] }]),
+      frameAt('t2', [{ lane: 1, boxes: [boxA] }]),
+    ];
+    const crops = computeFallbackCrops(frames, 1);
+    expect(crops.get('t1')).toEqual(computeCellCrop([{ xyxyn: boxA }]));
+  });
+
+  it('a frame after the last boxed frame borrows that frame alone', () => {
+    const frames = [
+      frameAt('t1', [{ lane: 1, boxes: [boxA] }]),
+      frameAt('t2', [{ lane: 1, boxes: [] }]),
+    ];
+    const crops = computeFallbackCrops(frames, 1);
+    expect(crops.get('t2')).toEqual(computeCellCrop([{ xyxyn: boxA }]));
+  });
+
+  it("ignores other lanes' boxes when deriving the region", () => {
+    const frames = [
+      frameAt('t1', [
+        { lane: 1, boxes: [boxA] },
+        { lane: 2, boxes: [boxB] },
+      ]),
+      frameAt('t2', [{ lane: 2, boxes: [boxB] }]),
+    ];
+    const crops = computeFallbackCrops(frames, 1);
+    expect(crops.get('t2')).toEqual(computeCellCrop([{ xyxyn: boxA }]));
+  });
+
+  it('returns an empty map when the active lane has no boxed frame anywhere', () => {
+    const frames = [
+      frameAt('t1', [{ lane: 1, boxes: [] }]),
+      frameAt('t2', [{ lane: 2, boxes: [boxB] }]),
+    ];
+    expect(computeFallbackCrops(frames, 1).size).toBe(0);
+  });
+
+  it('returns an empty map with no active lane', () => {
+    const frames = [frameAt('t1', [{ lane: 1, boxes: [boxA] }])];
+    expect(computeFallbackCrops(frames, null).size).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

On `/localize/:sequenceId/object/:laneId`, crop mode zoomed each grid cell around the active object's boxes — but frames without boxes stayed zoomed out, forcing the reviewer to re-locate the region by hand:

- **Gap frames** (active lane present, nothing drawn — including materialized gap frames from #293) fell back to identity crop.
- **Before/after context frames** (active lane absent) explicitly skipped the crop and faded to `opacity-40 saturate-50`.

All frames of an alert share one camera pose, so a region borrowed from neighboring frames is geometrically valid. Now, in crop mode:

- A boxless cell zooms to the **union of the nearest boxed frame on each side** (degenerating to the single nearest one before the object's first / after its last boxed frame), with the same tuning as boxed cells. A lane with no boxed frames anywhere keeps full-frame cells.
- Context cells swap the heavy fade for a subtle `opacity-75` dim while cropped, so faint smoke in the zoomed region stays judgeable. Outside crop mode the fade is unchanged, and context cells remain read-only.
- Boxed cells are untouched.

Spec: `docs/specs/2026-08-06-grid-gap-inferred-crop-design.md`

## Implementation

- `computeFallbackCrops(frames, activeLaneId)` in `gridCropUtils.ts`: pure `recordedAt → CellCrop` map for boxless frames, built from the active lane's boxed neighbors (structural frame type — no import cycle with `alertLocalizeUtils`).
- `AlertFrameGrid` memoizes the map and each cell falls back to it when it has no own-boxes crop; the context fade class is now crop-mode-aware.

## Testing

- 7 unit tests for `computeFallbackCrops` (mid-gap union, single-sided edges, other-lane isolation, no-boxes/no-lane empty maps).
- 2 page tests pinning the gap-frame zoom (transform + origin) and the context-cell zoom + fade swap, plus crop-off restoration.
- Full suite: 90 files, 1171 tests green.