### PR TITLE
feat(frontend): alert-page Accept boxes gets the editor's confirm popover + Enter shortcut

### DIFF
--- a/docs/specs/2026-08-06-alert-page-accept-popover-design.md
+++ b/docs/specs/2026-08-06-alert-page-accept-popover-design.md
@@ -49,7 +49,19 @@ object; while open, Enter confirms. Guards:
   dialog clicks that button (the editor's carve-out).
 
 Escape closes the popover before any other Escape layer. The shortcuts sheet
-(`LocalizeShortcutsModal`) gains a row: "Accept the model's boxes — Enter".
+(`LocalizeShortcutsModal`) gains an "Act" section: "Accept the model's boxes
+— Enter" and "Reclassify the object — R".
+
+**Addendum (same day):** both CTA buttons advertise their key on a kbd chip —
+Accept boxes wears the popover confirm's `Enter` chip (white-on-pine), and
+Reclassify wears an `R` chip (ash-on-paper, the sheet's key styling). `R`
+fires the same `handleReclassify` as the click, for any active object
+(false-positive rows keep Reclassify), under the same suspension guards as
+the other page keys. While the popover is open, the page's Tab cycle
+suspends (its X/Accept stay keyboard-reachable), Enter is owned by the
+dialog with the editor's carve-out (only a button inside `[role="dialog"]`
+keeps its own Enter), and the popover closes itself if a refetch empties the
+lane's pending count.
 
 ## Data
 

--- a/docs/specs/2026-08-06-alert-page-accept-popover-design.md
+++ b/docs/specs/2026-08-06-alert-page-accept-popover-design.md
@@ -1,0 +1,87 @@
+# Alert-page accept popover + Enter shortcut
+
+**Date:** 2026-08-06
+**Status:** Approved
+
+## Problem
+
+On `/localize/{sequenceId}`, the per-object **Accept boxes** button (Frames
+bar, `LocalizeObjectActions`) fires `quickAcceptLane` immediately, with only a
+text tooltip. On the object editor
+(`/localize/{sequenceId}/object/{laneId}/{detectionId}`), the same action
+opens `AcceptRemainingPopover` (PR #301): a looping preview of the post-accept
+track, a frame counter synced to a status strip, a legend, coverage/gap
+warnings, and an Enter-to-confirm Accept button. The two buttons are "the same
+motion from two places" (the editor's own comment) but only one of them shows
+the annotator what accepting will do.
+
+## Decision
+
+Bring the editor's exact popover to the alert page's Accept boxes button, and
+add a page-level **Enter** shortcut that triggers it.
+
+## Behavior
+
+- Clicking **Accept boxes** toggles `AcceptRemainingPopover` — the same
+  component, unmodified — anchored below the button. Confirm fires the
+  existing `quickAcceptLane.mutate(laneId)` and closes the popover.
+- Dismissal matches the editor: outside click, the X, Escape, or a second
+  press of the trigger.
+- The button's text `Tooltip` is removed: the popover now carries the
+  explanation, the editor's button has no tooltip, and a hover tooltip would
+  render on top of the open dialog.
+- **Visibility (behavior change):** the button appears only when
+  `acceptCount > 0` — the editor's rule — replacing the page's
+  `!isObjectLocalized` check in `objectActionProps`. Hand-added objects and
+  gap-only lanes lose a button that could not do anything for them.
+  `isObjectLocalized` stays for the progress badge and submit gate.
+
+## Enter shortcut
+
+A page-level keydown handler: **Enter** opens the popover for the active
+object; while open, Enter confirms. Guards:
+
+- inert when the frame editor route is open (`detectionIdNum != null`);
+- inert while any overlay is up (shortcuts sheet, add-object picker,
+  missed-smoke confirm);
+- inert when the event target is an interactive element — Enter on a focused
+  rail row still opens that object, and Enter on a focused button inside the
+  dialog clicks that button (the editor's carve-out).
+
+Escape closes the popover before any other Escape layer. The shortcuts sheet
+(`LocalizeShortcutsModal`) gains a row: "Accept the model's boxes — Enter".
+
+## Data
+
+No new fetches. For the active object the page builds:
+
+- `entries = buildFilmstripEntries(frameModel.frames, laneId,
+  detectionsByLaneId[laneId], annotationsByLaneId[laneId])`;
+- `acceptCount` / `gapCount` with the editor's exact expressions over
+  `entries`;
+- `previewBoxes` via `collectLaneBoxes` (already imported by the page), built
+  only while the popover is open, as the editor does.
+
+## Code placement
+
+`LocalizeObjectEditor` is untouched. Open state and keyboard wiring live in
+`LocalizeAlertPage`. `LocalizeObjectActions` changes minimally: the Accept
+button gains a relative anchor wrapper and an optional popover slot
+(`ReactNode` prop) so the page injects the configured popover next to the
+button it anchors to. The ~50 lines of dismissal/Enter wiring are deliberately
+duplicated with the editor's rather than extracted — the editor merged days
+ago (PR #301) and its layered Escape/Enter handling is not worth the
+regression risk of a refactor.
+
+## Testing
+
+- Clicking Accept boxes opens the popover instead of mutating.
+- Confirm fires `quickAcceptLane` with the right lane; the popover closes.
+- Enter opens the popover, a second Enter confirms.
+- Escape and outside click close without mutating.
+- No Accept button when `acceptCount === 0` (e.g. a lane whose every present
+  frame has a committed box but gaps remain).
+- Enter on a focused rail row still activates the row, not the popover.
+
+Reuses the popover's existing testids (`accept-remaining-popover`,
+`accept-remaining-confirm`, `accept-remaining-close`).

--- a/frontend/src/components/localize/LocalizeObjectActions.tsx
+++ b/frontend/src/components/localize/LocalizeObjectActions.tsx
@@ -44,9 +44,9 @@ export interface LocalizeObjectActionsProps {
 // same motion, one object at a time. Ember would read as the alert's headline
 // action and compete with Submit for it.
 const PRIMARY =
-  'inline-flex items-center whitespace-nowrap rounded-lg bg-pine px-3 py-1 font-body text-xs font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50';
+  'inline-flex items-center gap-1.5 whitespace-nowrap rounded-lg bg-pine px-3 py-1 font-body text-xs font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50';
 const SECONDARY =
-  'inline-flex items-center whitespace-nowrap rounded-lg border border-line bg-paper px-3 py-1 font-body text-xs font-medium text-char hover:bg-ash';
+  'inline-flex items-center gap-1.5 whitespace-nowrap rounded-lg border border-line bg-paper px-3 py-1 font-body text-xs font-medium text-char hover:bg-ash';
 
 export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
   label,
@@ -73,7 +73,18 @@ export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
           disabled={isAccepting}
           className={PRIMARY}
         >
-          {isAccepting ? 'Accepting…' : 'Accept boxes'}
+          {isAccepting ? (
+            'Accepting…'
+          ) : (
+            <>
+              Accept boxes
+              {/* Same chip the popover's confirm wears — the two are one
+                  motion, and Enter drives both ends of it. */}
+              <kbd className="rounded border border-white/40 px-1 py-0.5 font-data text-[11px] font-medium leading-none">
+                Enter
+              </kbd>
+            </>
+          )}
         </button>
         {acceptPopover}
       </div>
@@ -92,6 +103,9 @@ export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
           className={SECONDARY}
         >
           Reclassify
+          <kbd className="rounded border border-line bg-ash px-1 py-0.5 font-data text-[11px] font-medium leading-none">
+            R
+          </kbd>
         </button>
       </Tooltip>
     )}

--- a/frontend/src/components/localize/LocalizeObjectActions.tsx
+++ b/frontend/src/components/localize/LocalizeObjectActions.tsx
@@ -1,10 +1,13 @@
 /**
  * The two things you can do to one localize object: bulk-accept the model's
  * boxes, or send it back to classify. They live in one place — the bar above
- * the media column, on the active object — so there is exactly one copy of
- * the tooltip copy, which is where the explanation of what each one does
- * actually lives. (They used to also sit on the selected rail row, which
- * showed every button twice on one screen.)
+ * the media column, on the active object. (They used to also sit on the
+ * selected rail row, which showed every button twice on one screen.)
+ *
+ * Accept no longer explains itself in a tooltip: it opens the editor's
+ * confirm popover (`acceptPopover`), which shows what accepting will do —
+ * and a hover tooltip would paint over the open dialog. Reclassify keeps its
+ * tooltip; it is still a one-click action.
  *
  * Either action can be withheld by omitting its handler: false positives get
  * neither, and a lane past localization (or one with nothing left pending)
@@ -17,13 +20,17 @@ import { Tooltip } from '@/components/ui/Tooltip';
 export interface LocalizeObjectActionsProps {
   /** e.g. "Object 2" — names both buttons, so a screen reader hears which object it acts on. */
   label: string;
-  /** Bulk-accepts the winning model boxes for this lane's pending frames. */
+  /** Toggles the accept-remaining popover; the popover itself arrives via `acceptPopover`. */
   onAcceptBoxes?: () => void;
   isAccepting?: boolean;
   /** Opens this object's classification for correction (classify's done mode). */
   onReclassify?: () => void;
   /** Passed through to the tooltips — `above` where the panel edge is below the buttons. */
   tooltipPlacement?: 'below' | 'above';
+  /** Anchor for the popover's outside-click detection — wraps the Accept button. */
+  acceptAnchorRef?: React.Ref<HTMLDivElement>;
+  /** The page-configured AcceptRemainingPopover, present only while open. */
+  acceptPopover?: React.ReactNode;
 }
 
 // Prominence comes from fill and placement, not from size: these sit on the
@@ -47,15 +54,12 @@ export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
   isAccepting = false,
   onReclassify,
   tooltipPlacement = 'below',
+  acceptAnchorRef,
+  acceptPopover,
 }) => (
   <>
     {onAcceptBoxes && (
-      // Says what it commits and what it leaves alone: the action is bulk,
-      // and the object it belongs to is the only thing it touches.
-      <Tooltip
-        placement={tooltipPlacement}
-        tip={`Commits the model's predicted box on every frame of ${label} that still needs one. No other object is affected.`}
-      >
+      <div ref={acceptAnchorRef} className="relative">
         <button
           type="button"
           // The visible label stays short; the accessible name keeps naming
@@ -63,13 +67,16 @@ export const LocalizeObjectActions: React.FC<LocalizeObjectActionsProps> = ({
           // screen reader (and to the page tests, which address the actions
           // by object).
           aria-label={`Accept ${label}'s boxes`}
+          aria-haspopup="dialog"
+          aria-expanded={acceptPopover != null}
           onClick={onAcceptBoxes}
           disabled={isAccepting}
           className={PRIMARY}
         >
           {isAccepting ? 'Accepting…' : 'Accept boxes'}
         </button>
-      </Tooltip>
+        {acceptPopover}
+      </div>
     )}
     {onReclassify && (
       // Warns that it leaves the page — and that you come back, which is the

--- a/frontend/src/components/localize/LocalizeShortcutsModal.tsx
+++ b/frontend/src/components/localize/LocalizeShortcutsModal.tsx
@@ -68,6 +68,7 @@ export const LocalizeShortcutsModal: React.FC<LocalizeShortcutsModalProps> = ({ 
         </Section>
         <Section title="Act">
           <Row label="Accept the model's boxes" keys={['Enter']} />
+          <Row label="Reclassify the object" keys={['R']} />
         </Section>
         <Section title="View">
           <Row label="Frame card size" keys={['S', 'M', 'L']} />

--- a/frontend/src/components/localize/LocalizeShortcutsModal.tsx
+++ b/frontend/src/components/localize/LocalizeShortcutsModal.tsx
@@ -67,7 +67,7 @@ export const LocalizeShortcutsModal: React.FC<LocalizeShortcutsModalProps> = ({ 
           <Row label="Open the focused object" keys={['Enter', 'Space']} />
         </Section>
         <Section title="Act">
-          <Row label="Accept the object's boxes" keys={['Enter']} />
+          <Row label="Accept the model's boxes" keys={['Enter']} />
         </Section>
         <Section title="View">
           <Row label="Frame card size" keys={['S', 'M', 'L']} />

--- a/frontend/src/components/localize/LocalizeShortcutsModal.tsx
+++ b/frontend/src/components/localize/LocalizeShortcutsModal.tsx
@@ -3,7 +3,8 @@
  * button in the Objects rail header or with `?`.
  *
  * Static copy — the bindings live in LocalizeAlertPage's key handlers (the
- * page-level S/M/L/P/? effect, the `c` crop effect, the Tab cycle) and
+ * page-level S/M/L/P/? effect, which also answers Enter/Escape for the
+ * accept popover, the `c` crop effect, the Tab cycle) and
  * LocalizeObjectRow's Enter/Space activation; keep this list in sync.
  *
  * The Key/Row/Section primitives mirror `ClassifyShortcutsModal`'s so the two
@@ -64,6 +65,9 @@ export const LocalizeShortcutsModal: React.FC<LocalizeShortcutsModalProps> = ({ 
         <Section title="Navigate">
           <Row label="Cycle objects" keys={['Tab', 'Shift + Tab']} />
           <Row label="Open the focused object" keys={['Enter', 'Space']} />
+        </Section>
+        <Section title="Act">
+          <Row label="Accept the object's boxes" keys={['Enter']} />
         </Section>
         <Section title="View">
           <Row label="Frame card size" keys={['S', 'M', 'L']} />

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1365,10 +1365,11 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   });
 
   // `?` toggles the shortcuts sheet and Escape closes it — the same pair
-  // classify's createKeyboardHandler answers. Suspended under the same
-  // surfaces as the Tab cycle, and while typing in a field. Same
-  // deliberately-absent dependency array as the Tab handler above:
-  // re-subscribing every render keeps the closure fresh.
+  // classify's createKeyboardHandler answers — and, one layer under the
+  // sheet, Enter opens/confirms the accept popover and Escape closes it.
+  // Suspended under the same surfaces as the Tab cycle, and while typing in
+  // a field. Same deliberately-absent dependency array as the Tab handler
+  // above: re-subscribing every render keeps the closure fresh.
   useEffect(() => {
     const handleShortcutKeys = (e: KeyboardEvent) => {
       if (detectionIdNum != null || addObjectPickerOpen || missedSmokeConfirm) return;
@@ -1393,6 +1394,30 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       // The sheet is a surface of its own, like the overlays above: while it
       // is up, only `?` and Escape act.
       if (showShortcutsModal) return;
+      // The accept popover's keys, next layer under the sheet. Enter is
+      // never stolen from a focused control: a rail row opens its object, a
+      // button inside the popover clicks itself.
+      if (e.key === 'Escape' && acceptPopoverOpen) {
+        setAcceptPopoverOpen(false);
+        e.preventDefault();
+        return;
+      }
+      if (e.key === 'Enter') {
+        if (target instanceof HTMLElement && target.closest('button, a, [role="button"]')) return;
+        if (acceptPopoverOpen) {
+          if (!quickAcceptLane.isPending && activeLaneId != null) {
+            quickAcceptLane.mutate(activeLaneId);
+            setAcceptPopoverOpen(false);
+          }
+          e.preventDefault();
+          return;
+        }
+        if (activeObject?.workable && acceptRemainingCount > 0) {
+          setAcceptPopoverOpen(true);
+          e.preventDefault();
+        }
+        return;
+      }
       const key = e.key.toLowerCase();
       if (key === 's' || key === 'm' || key === 'l') {
         handleCardSizeChange(key === 's' ? 'sm' : key === 'm' ? 'md' : 'lg');

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -128,6 +128,7 @@ import {
   findFrameByDetectionId,
   AlertObjectStatus,
 } from '@/utils/annotation/alertLocalizeUtils';
+import { buildFilmstripEntries } from '@/utils/annotation/objectFilmstrip';
 import { materializeGapFrame } from '@/utils/annotation/gapFrameMaterialize';
 import { laneNeedsLocalization } from '@/utils/annotation/localizeUtils';
 import {
@@ -146,6 +147,9 @@ import {
 } from '@/components/localize';
 import { AlertFrameGrid, ViewToolbar } from '@/components/detection-sequence';
 import { LocalizeObjectEditor } from '@/components/localize/editor';
+// Imported from its file rather than the editor barrel: the page tests stub
+// the barrel down to LocalizeObjectEditor, and the popover must stay real.
+import { AcceptRemainingPopover } from '@/components/localize/editor/AcceptRemainingPopover';
 import type { CardSize } from '@/components/detection-sequence/ViewToolbar';
 import CroppedImageSequence from '@/components/annotation/CroppedImageSequence';
 import { usePersistedTabState } from '@/hooks/usePersistedTabState';
@@ -263,6 +267,13 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // soft-confirm gate below) and whether the picker is currently open.
   const [sessionAddedObjects, setSessionAddedObjects] = useState<number[]>([]);
   const [addObjectPickerOpen, setAddObjectPickerOpen] = useState(false);
+
+  // The Accept boxes confirm popover — the editor's AcceptRemainingPopover,
+  // anchored under the header button. Open/dismiss wiring mirrors the
+  // editor's rather than being extracted from it (spec: not worth the
+  // regression risk days after PR #301 merged).
+  const [acceptPopoverOpen, setAcceptPopoverOpen] = useState(false);
+  const acceptAnchorRef = useRef<HTMLDivElement | null>(null);
 
   // The rail's missed-smoke answer, and the gate in front of "+ Add object".
   // Deliberately NOT seeded from the lanes' inherited `has_missed_smoke`:
@@ -908,12 +919,14 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // summaries; giving the selected row the same pair showed every button
   // twice on one screen.
   const objectActionProps = (object: AlertObjectStatus) => ({
-    // Withheld once the lane has nothing pending: re-accepting would fire a
-    // mutation with an empty payload and toast success for a no-op. It is
-    // also the only way the bar can show that the accept landed.
+    // Withheld once no frame has an uncommitted model box on offer — the
+    // editor's rule for the same button, and the only way the bar can show
+    // that the accept landed. Clicking toggles the confirm popover; the
+    // popover's own Accept runs the mutation. Only ever called with the
+    // active object, so the active lane's acceptRemainingCount applies.
     onAcceptBoxes:
-      object.workable && !isObjectLocalized(object)
-        ? () => quickAcceptLane.mutate(object.laneSequenceId)
+      object.workable && acceptRemainingCount > 0
+        ? () => setAcceptPopoverOpen(open => !open)
         : undefined,
     isAccepting: quickAcceptLane.isPending && quickAcceptLane.variables === object.laneSequenceId,
     // Offered on false-positive rows too: promoting one back to smoke
@@ -1095,6 +1108,42 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       { falsePositive: activeLaneIsFalsePositive }
     );
   }, [activeLaneId, detectionsByLaneId, annotationsByLaneId, activeLaneIsFalsePositive]);
+
+  // Frames of the active object a bulk accept would fill, and frames no
+  // source can fill. Also the button's visibility rule: acceptRemainingCount
+  // is what the editor gates its own Accept boxes on, and a popover for a
+  // lane with nothing acceptable would render "0 frames have a model box".
+  const acceptEntries = useMemo(() => {
+    if (activeLaneId == null) return [];
+    return buildFilmstripEntries(
+      frameModel.frames,
+      activeLaneId,
+      detectionsByLaneId[activeLaneId] ?? [],
+      annotationsByLaneId[activeLaneId] ?? []
+    );
+  }, [frameModel.frames, activeLaneId, detectionsByLaneId, annotationsByLaneId]);
+  const acceptRemainingCount = acceptEntries.filter(
+    e => e.inObject && !e.committedSource && e.availableSource
+  ).length;
+  const acceptGapCount = acceptEntries.filter(
+    e => e.inObject && !e.committedSource && !e.availableSource
+  ).length;
+
+  // A popover left open while the selection moves would preview the wrong
+  // lane; the editor never needs this because its whole surface is one lane.
+  useEffect(() => {
+    setAcceptPopoverOpen(false);
+  }, [activeLaneId]);
+
+  // Outside mousedown closes — same listener the editor hangs off its anchor.
+  useEffect(() => {
+    if (!acceptPopoverOpen) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (!acceptAnchorRef.current?.contains(event.target as Node)) setAcceptPopoverOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    return () => document.removeEventListener('mousedown', onPointerDown);
+  }, [acceptPopoverOpen]);
 
   // Keyed on `activeLaneId` alone rather than on focus mode, matching the
   // panel's actions beside it: closing the frame editor leaves an object
@@ -1457,6 +1506,31 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
                 <LocalizeObjectActions
                   label={activeObject.label}
                   {...objectActionProps(activeObject)}
+                  acceptAnchorRef={acceptAnchorRef}
+                  acceptPopover={
+                    acceptPopoverOpen && activeLaneId != null ? (
+                      <AcceptRemainingPopover
+                        objectLabel={activeObject.label}
+                        objectColor={activeObject.color}
+                        sequenceId={activeLaneId}
+                        // Already what the cropped flipbook computes for this
+                        // lane: the post-accept track (committed boxes where
+                        // decided, winning model boxes elsewhere). The popover
+                        // only opens on workable smoke lanes, so the memo's
+                        // falsePositive branch never applies here.
+                        previewBoxes={activeLaneBoxes}
+                        entries={acceptEntries}
+                        acceptCount={acceptRemainingCount}
+                        gapCount={acceptGapCount}
+                        isAccepting={quickAcceptLane.isPending}
+                        onConfirm={() => {
+                          quickAcceptLane.mutate(activeLaneId);
+                          setAcceptPopoverOpen(false);
+                        }}
+                        onCancel={() => setAcceptPopoverOpen(false)}
+                      />
+                    ) : undefined
+                  }
                 />
               )
             }

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1135,6 +1135,14 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     setAcceptPopoverOpen(false);
   }, [activeLaneId]);
 
+  // And one left "open" after a refetch empties the lane's pending count
+  // (a concurrent session accepted it, or our own accept landed) has no
+  // anchor on screen any more — without this, Enter would still fire an
+  // invisible empty-payload accept.
+  useEffect(() => {
+    if (acceptRemainingCount === 0) setAcceptPopoverOpen(false);
+  }, [acceptRemainingCount]);
+
   // Outside mousedown closes — same listener the editor hangs off its anchor.
   useEffect(() => {
     if (!acceptPopoverOpen) return;
@@ -1339,10 +1347,11 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       if (e.key !== 'Tab') return;
       // Suspended whenever a surface with its own focusables is up — the
       // per-frame editor, the (inline) add-object smoke-type picker, the
-      // missed-smoke submit dialog, the shortcuts sheet — so their controls
-      // stay keyboard-reachable (mirrors classify's modal guards).
+      // missed-smoke submit dialog, the shortcuts sheet, the accept popover
+      // — so their controls stay keyboard-reachable (mirrors classify's
+      // modal guards).
       if (detectionIdNum != null || addObjectPickerOpen || missedSmokeConfirm) return;
-      if (showShortcutsModal) return;
+      if (showShortcutsModal || acceptPopoverOpen) return;
       if (orderedObjectRows.length === 0) return;
       e.preventDefault();
       const current = orderedObjectRows.findIndex(o => o.laneSequenceId === activeLaneId);
@@ -1394,24 +1403,35 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       // The sheet is a surface of its own, like the overlays above: while it
       // is up, only `?` and Escape act.
       if (showShortcutsModal) return;
-      // The accept popover's keys, next layer under the sheet. Enter is
-      // never stolen from a focused control: a rail row opens its object, a
-      // button inside the popover clicks itself.
+      // The accept popover's keys, next layer under the sheet.
       if (e.key === 'Escape' && acceptPopoverOpen) {
         setAcceptPopoverOpen(false);
         e.preventDefault();
         return;
       }
       if (e.key === 'Enter') {
-        if (target instanceof HTMLElement && target.closest('button, a, [role="button"]')) return;
         if (acceptPopoverOpen) {
-          if (!quickAcceptLane.isPending && activeLaneId != null) {
+          // The open dialog owns Enter — its button says so — with the
+          // editor's carve-out: only a button INSIDE the dialog keeps its
+          // own Enter (Tab to the close X must close, not accept). The
+          // trigger button is outside the dialog, so Enter on it confirms
+          // rather than letting the native click toggle the popover shut.
+          if (
+            target instanceof HTMLElement &&
+            target.closest('button') &&
+            target.closest('[role="dialog"]')
+          )
+            return;
+          if (!quickAcceptLane.isPending && activeLaneId != null && acceptRemainingCount > 0) {
             quickAcceptLane.mutate(activeLaneId);
             setAcceptPopoverOpen(false);
           }
           e.preventDefault();
           return;
         }
+        // Closed: never steal Enter from a focused control — a rail row
+        // opens its object, any other button clicks itself.
+        if (target instanceof HTMLElement && target.closest('button, a, [role="button"]')) return;
         if (activeObject?.workable && acceptRemainingCount > 0) {
           setAcceptPopoverOpen(true);
           e.preventDefault();

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1439,6 +1439,14 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
         return;
       }
       const key = e.key.toLowerCase();
+      // Same action the CTA bar's Reclassify button carries (its chip
+      // advertises this key). Any active object qualifies — false-positive
+      // rows keep Reclassify too.
+      if (key === 'r' && activeLaneId != null) {
+        handleReclassify(activeLaneId);
+        e.preventDefault();
+        return;
+      }
       if (key === 's' || key === 'm' || key === 'l') {
         handleCardSizeChange(key === 's' ? 'sm' : key === 'm' ? 'md' : 'lg');
         e.preventDefault();

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2099,6 +2099,13 @@ describe('LocalizeAlertPage', () => {
       const cta = within(screen.getByTestId('localize-active-object-actions'));
       expect(cta.getByRole('button', { name: "Accept Object 1's boxes" })).toBeInTheDocument();
       expect(cta.getByRole('button', { name: 'Reclassify Object 1' })).toBeInTheDocument();
+      // Each button advertises its page shortcut on a kbd chip.
+      expect(
+        within(cta.getByRole('button', { name: "Accept Object 1's boxes" })).getByText('Enter')
+      ).toBeInTheDocument();
+      expect(
+        within(cta.getByRole('button', { name: 'Reclassify Object 1' })).getByText('R')
+      ).toBeInTheDocument();
       // The column header still names whose frames these are.
       expect(screen.getByText(/Frames — Object 1/)).toBeInTheDocument();
 
@@ -3003,6 +3010,8 @@ describe('LocalizeAlertPage', () => {
       expect(dialog).toHaveTextContent('Cycle objects');
       expect(dialog).toHaveTextContent('Crop cells');
       expect(dialog).toHaveTextContent('Toggle this help');
+      expect(dialog).toHaveTextContent("Accept the model's boxes");
+      expect(dialog).toHaveTextContent('Reclassify the object');
     });
 
     it("'?' is inert while the per-frame editor is open", async () => {
@@ -3146,6 +3155,17 @@ describe('LocalizeAlertPage', () => {
       const destination = await screen.findByTestId('classify-destination');
       expect(destination.getAttribute('data-lane-id')).toBe('102');
       expect(destination.getAttribute('data-return')).toBe('/localize/done/101/object/102');
+    });
+
+    it("'R' reclassifies the active object from the keyboard", async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Object 2' }));
+      fireEvent.keyDown(window, { key: 'r' });
+
+      const destination = await screen.findByTestId('classify-destination');
+      expect(destination.getAttribute('data-lane-id')).toBe('102');
+      expect(destination.getAttribute('data-return')).toBe('/localize/101/object/102');
     });
 
     it('offers Reclassify on an already-localized context row', async () => {

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2266,6 +2266,81 @@ describe('LocalizeAlertPage', () => {
       });
       expect(cta.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
     });
+
+    // Key presses need the arrival auto-select to have landed first — the
+    // bare URL replace-redirects to the first workable object, and Enter
+    // before that has no active object to accept for.
+    const awaitAutoSelect = async () => {
+      await waitFor(() => {
+        expect(screen.getByTestId('localize-object-row-object-1')).toHaveAttribute(
+          'data-active',
+          'true'
+        );
+      });
+    };
+
+    it('Enter opens the popover for the active object; a second Enter confirms', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      await awaitAutoSelect();
+
+      fireEvent.keyDown(window, { key: 'Enter' });
+      expect(await screen.findByTestId('accept-remaining-popover')).toBeInTheDocument();
+      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(window, { key: 'Enter' });
+      await waitFor(() => {
+        expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
+          expect.objectContaining({ detection_id: 1001 })
+        );
+      });
+      await waitFor(() => {
+        expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
+      });
+    });
+
+    it('Escape closes the popover without accepting', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      await awaitAutoSelect();
+
+      fireEvent.keyDown(window, { key: 'Enter' });
+      await screen.findByTestId('accept-remaining-popover');
+      fireEvent.keyDown(window, { key: 'Escape' });
+
+      expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
+      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
+    });
+
+    it('Enter on a focused control is left to the control — a rail row keeps its own Enter', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      await awaitAutoSelect();
+
+      const row = screen.getByRole('button', { name: 'Object 2' });
+      row.focus();
+      fireEvent.keyDown(row, { key: 'Enter' });
+
+      expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
+    });
+
+    it('Enter does nothing when the active object has nothing acceptable', async () => {
+      vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
+        if (id === 101)
+          return [
+            {
+              ...makeDetection(1001, T1),
+              algo_predictions: { predictions: [] },
+              auto_predictions: undefined,
+            },
+          ];
+        if (id === 102) return [makeDetection(1002, T1), makeDetection(1003, T2)];
+        return [];
+      });
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      await awaitAutoSelect();
+
+      fireEvent.keyDown(window, { key: 'Enter' });
+
+      expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
+    });
   });
 
   describe('missed-smoke row', () => {

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2321,6 +2321,63 @@ describe('LocalizeAlertPage', () => {
       expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
     });
 
+    it('Enter confirms even when focus sits on the trigger button itself', async () => {
+      // The natural mouse flow: click "Accept boxes" (focus lands on the
+      // trigger), read the dialog, press the advertised Enter. Only buttons
+      // INSIDE the dialog keep their own Enter — the editor's carve-out.
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      const trigger = await screen.findByRole('button', { name: "Accept Object 1's boxes" });
+      fireEvent.click(trigger);
+      await screen.findByTestId('accept-remaining-popover');
+
+      trigger.focus();
+      fireEvent.keyDown(trigger, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
+          expect.objectContaining({ detection_id: 1001 })
+        );
+      });
+      await waitFor(() => {
+        expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
+      });
+    });
+
+    it('closes when the selection moves to another object', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      await openPopover();
+      fireEvent.click(screen.getByRole('button', { name: 'Object 2' }));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
+      });
+      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
+    });
+
+    it('Enter is inert while the shortcuts sheet is up', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      await awaitAutoSelect();
+
+      fireEvent.keyDown(window, { key: '?' });
+      await screen.findByRole('dialog', { name: 'Keyboard shortcuts' });
+      fireEvent.keyDown(window, { key: 'Enter' });
+
+      expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
+    });
+
+    it('Enter is inert while the add-object picker is open', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      await awaitAutoSelect();
+
+      answerMissedSmokeYes();
+      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
+      fireEvent.keyDown(window, { key: 'Enter' });
+
+      expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
+    });
+
     it('Enter does nothing when the active object has nothing acceptable', async () => {
       vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
         if (id === 101)

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2145,6 +2145,8 @@ describe('LocalizeAlertPage', () => {
           name: "Accept Object 1's boxes",
         })
       );
+      // The trigger opens the confirm popover; its Accept runs the mutation.
+      fireEvent.click(await screen.findByTestId('accept-remaining-confirm'));
 
       // Object 1's lane is detection 1001 only — the CTA acts on the active
       // object, not on the alert. Object 2's frames (1002, 1003) must never
@@ -2177,6 +2179,92 @@ describe('LocalizeAlertPage', () => {
         expect(cta.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
         expect(cta.getByRole('button', { name: 'Reclassify Object 1' })).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('accept popover', () => {
+    // The header's Accept boxes no longer fires the mutation itself — it
+    // opens the editor's confirm popover (the same AcceptRemainingPopover),
+    // and the popover's own Accept does. Arrival auto-selects Object 1, so
+    // its trigger is there without clicking a row first.
+    const openPopover = async () => {
+      fireEvent.click(await screen.findByRole('button', { name: "Accept Object 1's boxes" }));
+      return await screen.findByTestId('accept-remaining-popover');
+    };
+
+    it('opens the popover instead of accepting immediately, previewing the active lane', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      const popover = await openPopover();
+
+      // The preview loop is wired to the ACTIVE lane, boxes on.
+      const loop = within(popover).getByTestId('cropped-image-sequence');
+      expect(loop).toHaveAttribute('data-sequence-id', '101');
+      expect(loop).toHaveAttribute('data-show-boxes', 'true');
+      // Nothing was written by the click.
+      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
+      expect(apiClient.updateDetectionAnnotation).not.toHaveBeenCalled();
+    });
+
+    it("confirm accepts exactly the active object's lane and closes the popover", async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      await openPopover();
+      fireEvent.click(screen.getByTestId('accept-remaining-confirm'));
+
+      // Object 1's lane is detection 1001 only — the popover acts on the
+      // active object, never on Object 2's frames.
+      await waitFor(() => {
+        expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
+          expect.objectContaining({ detection_id: 1001 })
+        );
+      });
+      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalledWith(
+        expect.objectContaining({ detection_id: 1002 })
+      );
+      await waitFor(() => {
+        expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
+      });
+    });
+
+    it('the X and an outside click both close it without accepting', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      await openPopover();
+      fireEvent.click(screen.getByTestId('accept-remaining-close'));
+      expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
+
+      await openPopover();
+      fireEvent.mouseDown(document.body);
+      expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
+
+      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
+    });
+
+    it('offers no Accept button when the lane has nothing acceptable, even though it is not localized', async () => {
+      // Lane 101's only frame carries no model box from any source — the
+      // editor's rule (acceptRemainingCount > 0) governs the page button
+      // too, replacing "not yet localized". A dead trigger would open a
+      // popover promising "0 frames have a model box".
+      vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
+        if (id === 101)
+          return [
+            {
+              ...makeDetection(1001, T1),
+              algo_predictions: { predictions: [] },
+              auto_predictions: undefined,
+            },
+          ];
+        if (id === 102) return [makeDetection(1002, T1), makeDetection(1003, T2)];
+        return [];
+      });
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      const cta = within(screen.getByTestId('localize-active-object-actions'));
+      await waitFor(() => {
+        expect(cta.getByRole('button', { name: 'Reclassify Object 1' })).toBeInTheDocument();
+      });
+      expect(cta.queryByRole('button', { name: /Accept/ })).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## What

On `/localize/{sequenceId}`, the per-object **Accept boxes** button no longer fires the accept mutation immediately. It now opens the exact `AcceptRemainingPopover` the object editor uses (PR #301): the looping post-accept preview, frame counter synced to the status strip, legend, coverage/gap warnings, and a single Enter-hinted Accept button. Confirm runs the existing `quickAcceptLane` mutation.

- **Same component, not a fork** — the popover is imported from its file (the editor barrel is stubbed in page tests) and the editor itself is untouched.
- **Visibility rule change** — the button now appears only when the lane has an uncommitted model box on offer (`acceptRemainingCount > 0`, the editor's rule), replacing `!isObjectLocalized`. Hand-added objects and gap-only lanes lose a button that could not do anything for them.
- **Enter shortcut** — Enter opens the popover for the active object; a second Enter confirms; Escape closes it (one layer under the shortcuts sheet). While the dialog is open it owns Enter with the editor's carve-out: only a button *inside* `[role="dialog"]` keeps its own Enter — so Enter on the focused trigger confirms rather than toggling the popover shut. While closed, Enter is never stolen from a focused control (a rail row keeps its own Enter).
- **R shortcut** — R reclassifies the active object, same action as the CTA button.
- **Kbd chips** — Accept boxes wears the popover confirm's `Enter` chip; Reclassify wears an `R` chip. Both are listed in the shortcuts sheet's new "Act" section.
- **Tooltip removed** from the Accept button: the popover now carries the explanation, matching the editor's button, and a hover tooltip would paint over the open dialog.
- **Hardening** — the page's Tab cycle suspends while the popover is open (its X/Accept stay keyboard-reachable), and the popover closes itself if a refetch empties the lane's pending count (a concurrent session accepted it), so a stale Enter can never fire an invisible empty accept.

Dismissal matches the editor: outside click, the X, Escape, or a second press of the trigger.

## Spec

`docs/specs/2026-08-06-alert-page-accept-popover-design.md` (committed in this PR, including the chips/R addendum).

## Testing

14 new page tests (click-opens, confirm-mutates-right-lane, X/outside-click, visibility rule, Enter open/confirm, focused-trigger Enter, Escape, focused-control carve-out, nothing-acceptable guard, close-on-object-switch, Enter inert under the sheet and the add-object picker, R reclassify, kbd chips + sheet rows); one existing test updated to click through the popover confirm. Full suite green (1190), `npm run quality` clean.

An adversarial review round was run before merge; its one Important finding (Enter on the focused trigger fell through to the native click and toggled the popover shut without accepting) is fixed with the editor's dialog-scoped carve-out — confirmed in a real browser via Playwright, where the same flow now issues the per-frame accept POSTs.