### PR TITLE
Show annotators on the classify and localize done pages

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -36,6 +36,7 @@ from sqlalchemy.orm import aliased
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.dependencies import get_current_user, get_sequence_crud
+from app.core.config import settings
 from app.crud import SequenceCRUD
 from app.db import get_session
 from app.services.localization_rule import (
@@ -1080,6 +1081,55 @@ async def localization_queue(
     return Page.create(items=items, total=total, params=params)
 
 
+async def _human_annotators(
+    session: AsyncSession, sequence_ids: list[int]
+) -> dict[int, list[tuple[datetime, str]]]:
+    """Per-sequence (contributed_at, username) pairs of human contributors,
+    earliest first. Machine writes are attributed to the seeded worker user
+    and excluded — they are not annotators."""
+    if not sequence_ids:
+        return {}
+    rows = (
+        await session.execute(
+            select(
+                SequenceAnnotation.sequence_id,
+                SequenceAnnotationContribution.contributed_at,
+                User.username,
+            )
+            .join(
+                SequenceAnnotationContribution,
+                SequenceAnnotationContribution.sequence_annotation_id
+                == SequenceAnnotation.id,
+            )
+            .join(User, SequenceAnnotationContribution.user_id == User.id)
+            .where(
+                SequenceAnnotation.sequence_id.in_(sequence_ids),
+                User.username != settings.WORKER_USERNAME,
+            )
+            .order_by(asc(SequenceAnnotationContribution.contributed_at))
+        )
+    ).all()
+    by_seq: dict[int, list[tuple[datetime, str]]] = {}
+    for sequence_id, contributed_at, username in rows:
+        by_seq.setdefault(sequence_id, []).append((contributed_at, username))
+    return by_seq
+
+
+def _merge_annotators(
+    by_seq: dict[int, list[tuple[datetime, str]]], sequence_ids: list[int]
+) -> list[str]:
+    """Distinct usernames across an alert's lanes, ordered by first contribution."""
+    seen: set[str] = set()
+    merged: list[str] = []
+    for _, username in sorted(
+        pair for sequence_id in sequence_ids for pair in by_seq.get(sequence_id, [])
+    ):
+        if username not in seen:
+            seen.add(username)
+            merged.append(username)
+    return merged
+
+
 async def _build_queue_item(
     session: AsyncSession,
     source_api: SourceApi,
@@ -1479,7 +1529,7 @@ async def classify_done(
             .limit(params.size)
         )
     ).all()
-    items = []
+    page_lanes = []
     for row in page_rows:
         lane_rows = (
             await session.execute(
@@ -1497,6 +1547,12 @@ async def classify_done(
         ).all()
         if not lane_rows:  # concurrent delete
             continue
+        page_lanes.append((row, lane_rows))
+    annotators_by_seq = await _human_annotators(
+        session, [seq.id for _, lane_rows in page_lanes for seq, _ in lane_rows]
+    )
+    items = []
+    for row, lane_rows in page_lanes:
         primary = lane_rows[0][0]
         items.append(
             ClassifyDoneItem(
@@ -1519,6 +1575,9 @@ async def classify_done(
                     )
                     for seq, ann in lane_rows
                 ],
+                annotators=_merge_annotators(
+                    annotators_by_seq, [seq.id for seq, _ in lane_rows]
+                ),
             )
         )
     return Page.create(items=items, total=total, params=params)

--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -1115,6 +1115,25 @@ async def _human_annotators(
     return by_seq
 
 
+def _lane_contributed_by(annotator_id: int):
+    """EXISTS: some contribution by this user on the current (outer)
+    Sequence row's annotation. Correlates on Sequence.id so it composes
+    with the grouped any-lane HAVING pattern."""
+    contrib_ann = aliased(SequenceAnnotation)
+    return (
+        select(SequenceAnnotationContribution.id)
+        .join(
+            contrib_ann,
+            contrib_ann.id == SequenceAnnotationContribution.sequence_annotation_id,
+        )
+        .where(
+            contrib_ann.sequence_id == Sequence.id,
+            SequenceAnnotationContribution.user_id == annotator_id,
+        )
+        .exists()
+    )
+
+
 def _merge_annotators(
     by_seq: dict[int, list[tuple[datetime, str]]], sequence_ids: list[int]
 ) -> list[str]:
@@ -1410,6 +1429,9 @@ async def classify_done(
         description="Alerts with any lane of this derived accuracy "
         "(missed smoke → fn, else smoke → tp, else fp)",
     ),
+    annotator_id: Optional[int] = Query(
+        None, description="Alerts with any lane contributed to by this user"
+    ),
     session: AsyncSession = Depends(get_session),
     params: Params = Depends(),
     current_user: User = Depends(get_current_user),
@@ -1512,6 +1534,8 @@ async def classify_done(
                 )
             )
         )
+    if annotator_id is not None:
+        alerts = alerts.having(any_lane(_lane_contributed_by(annotator_id)))
 
     alerts_sq = alerts.subquery()
     total = (

--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -1331,6 +1331,9 @@ async def localize_done_queue(
     source_api: Optional[SourceApi] = Query(None),
     recorded_at_gte: Optional[datetime] = Query(None),
     recorded_at_lte: Optional[datetime] = Query(None),
+    annotator_id: Optional[int] = Query(
+        None, description="Alerts with any lane contributed to by this user"
+    ),
     session: AsyncSession = Depends(get_session),
     params: Params = Depends(),
     current_user: User = Depends(get_current_user),
@@ -1364,7 +1367,7 @@ async def localize_done_queue(
     if recorded_at_lte is not None:
         candidates = candidates.where(cand_seq.recorded_at <= recorded_at_lte)
 
-    alerts = (
+    alerts_query = (
         select(
             Sequence.source_api,
             Sequence.platform_alert_id,
@@ -1372,8 +1375,14 @@ async def localize_done_queue(
         )
         .where(tuple_(Sequence.source_api, Sequence.platform_alert_id).in_(candidates))
         .group_by(Sequence.source_api, Sequence.platform_alert_id)
-        .subquery()
     )
+    if annotator_id is not None:
+        # Any-lane semantics via HAVING (a WHERE would drop non-matching
+        # lanes from the group and skew min(recorded_at)).
+        alerts_query = alerts_query.having(
+            func.sum(case((_lane_contributed_by(annotator_id), 1), else_=0)) > 0
+        )
+    alerts = alerts_query.subquery()
     total = (
         await session.execute(select(func.count()).select_from(alerts))
     ).scalar_one()
@@ -1398,6 +1407,13 @@ async def localize_done_queue(
     # An alert can lose its sequences between the page query and item build
     # (concurrent delete); drop such rows rather than 500.
     items = [item for item in maybe_items if item is not None]
+    annotators_by_seq = await _human_annotators(
+        session, [lane.sequence_id for item in items for lane in item.lanes]
+    )
+    for item in items:
+        item.annotators = _merge_annotators(
+            annotators_by_seq, [lane.sequence_id for lane in item.lanes]
+        )
     return Page.create(items=items, total=total, params=params)
 
 

--- a/annotation_api/src/app/api/api_v1/endpoints/users.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/users.py
@@ -3,7 +3,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.sqlalchemy import apaginate
-from sqlalchemy import desc
+from sqlalchemy import desc, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.auth.dependencies import get_current_active_user, get_current_superuser
@@ -11,7 +11,13 @@ from app.core.config import settings
 from app.crud import UserCRUD
 from app.db import get_session
 from app.models import User
-from app.schemas.user import UserCreate, UserRead, UserUpdate, UserPasswordUpdate
+from app.schemas.user import (
+    ContributorRead,
+    UserCreate,
+    UserPasswordUpdate,
+    UserRead,
+    UserUpdate,
+)
 
 router = APIRouter()
 
@@ -22,6 +28,27 @@ async def read_current_user(
 ) -> User:
     """Get current user information."""
     return current_user
+
+
+# NOTE: declared before GET /{user_id} — the int path converter would
+# otherwise turn /users/annotators into a 422.
+@router.get("/annotators", response_model=list[ContributorRead])
+async def list_annotators(
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_active_user),
+) -> list[User]:
+    """Active human users, for the done-pages annotator filter dropdown.
+
+    Open to every authenticated user (unlike the superuser-only user list):
+    it exposes only id + username, which annotators already see elsewhere
+    (e.g. group review attribution). The seeded worker user is machine
+    attribution, not an annotator."""
+    result = await session.execute(
+        select(User)
+        .where(User.is_active.is_(True), User.username != settings.WORKER_USERNAME)
+        .order_by(User.username)
+    )
+    return list(result.scalars().all())
 
 
 @router.get("/", response_model=Page[UserRead])

--- a/annotation_api/src/app/schemas/sequence.py
+++ b/annotation_api/src/app/schemas/sequence.py
@@ -172,6 +172,7 @@ class LocalizeDoneQueueItem(BaseModel):
     azimuth: Optional[int]
     recorded_at: datetime
     lanes: List[LocalizationQueueLane]
+    annotators: List[str] = []
 
 
 class ClassifyQueueItem(BaseModel):

--- a/annotation_api/src/app/schemas/sequence.py
+++ b/annotation_api/src/app/schemas/sequence.py
@@ -212,6 +212,7 @@ class ClassifyDoneItem(BaseModel):
     is_wildfire_alertapi: Optional[AnnotationType] = None
     primary_sequence_id: int
     lanes: List[ClassifyDoneLane]
+    annotators: List[str] = []
 
 
 class AlertLane(BaseModel):

--- a/annotation_api/src/tests/endpoints/test_classify_done.py
+++ b/annotation_api/src/tests/endpoints/test_classify_done.py
@@ -503,3 +503,62 @@ async def test_is_wildfire_alertapi_filter(
     null_data = null_response.json()
     assert null_data["total"] == 1
     assert null_data["items"][0]["platform_alert_id"] == 1120
+
+
+@pytest.mark.asyncio
+async def test_annotator_id_filters_to_contributed_alerts(
+    authenticated_client: AsyncClient, async_session, test_user, regular_user
+):
+    mine = await _lane(
+        async_session,
+        alert_api_id=960,
+        platform_alert_id=960,
+        stage=Stage.ANNOTATED,
+        has_smoke=True,
+    )
+    theirs = await _lane(
+        async_session,
+        alert_api_id=970,
+        platform_alert_id=970,
+        stage=Stage.ANNOTATED,
+        has_smoke=True,
+    )
+    await _contribute(async_session, mine, test_user.id, NOW)
+    await _contribute(async_session, theirs, regular_user.id, NOW)
+
+    response = await authenticated_client.get(
+        f"/sequences/classify-done?annotator_id={test_user.id}"
+    )
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["platform_alert_id"] == 960
+
+    unfiltered = await authenticated_client.get("/sequences/classify-done")
+    assert unfiltered.json()["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_annotator_id_matches_any_lane(
+    authenticated_client: AsyncClient, async_session, test_user
+):
+    primary = await _lane(
+        async_session,
+        alert_api_id=980,
+        platform_alert_id=980,
+        stage=Stage.ANNOTATED,
+        has_smoke=True,
+    )
+    await _lane(
+        async_session,
+        alert_api_id=981,
+        platform_alert_id=980,
+        stage=Stage.ANNOTATED,
+        false_positive_types=["antenna"],
+    )
+    await _contribute(async_session, primary, test_user.id, NOW)
+
+    response = await authenticated_client.get(
+        f"/sequences/classify-done?annotator_id={test_user.id}"
+    )
+    assert response.json()["total"] == 1
+    assert response.json()["items"][0]["platform_alert_id"] == 980

--- a/annotation_api/src/tests/endpoints/test_classify_done.py
+++ b/annotation_api/src/tests/endpoints/test_classify_done.py
@@ -2,10 +2,12 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
+from sqlmodel import select
 
 from app.models import (
     Sequence,
     SequenceAnnotation,
+    SequenceAnnotationContribution,
     SequenceAnnotationProcessingStage as Stage,
     SourceApi,
 )
@@ -60,6 +62,79 @@ async def _lane(
         )
     await session.commit()
     return seq
+
+
+async def _contribute(session, seq, user_id, at):
+    annotation_id = (
+        await session.execute(
+            select(SequenceAnnotation.id).where(
+                SequenceAnnotation.sequence_id == seq.id
+            )
+        )
+    ).scalar_one()
+    session.add(
+        SequenceAnnotationContribution(
+            sequence_annotation_id=annotation_id, user_id=user_id, contributed_at=at
+        )
+    )
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_annotators_lists_distinct_humans_by_first_contribution(
+    authenticated_client: AsyncClient,
+    async_session,
+    test_user,
+    regular_user,
+    worker_user,
+):
+    primary = await _lane(
+        async_session,
+        alert_api_id=940,
+        platform_alert_id=940,
+        stage=Stage.ANNOTATED,
+        has_smoke=True,
+        smoke_types=["wildfire"],
+    )
+    sibling = await _lane(
+        async_session,
+        alert_api_id=941,
+        platform_alert_id=940,
+        stage=Stage.ANNOTATED,
+        false_positive_types=["antenna"],
+    )
+    # regular_user touched the sibling first, test_user the primary later,
+    # then regular_user again (duplicate collapses); the worker row is
+    # machine attribution and must not appear at all.
+    await _contribute(async_session, primary, worker_user.id, NOW)
+    await _contribute(
+        async_session, sibling, regular_user.id, NOW + timedelta(minutes=1)
+    )
+    await _contribute(async_session, primary, test_user.id, NOW + timedelta(minutes=2))
+    await _contribute(
+        async_session, primary, regular_user.id, NOW + timedelta(minutes=3)
+    )
+
+    response = await authenticated_client.get("/sequences/classify-done")
+    item = response.json()["items"][0]
+    assert item["annotators"] == [regular_user.username, test_user.username]
+
+
+@pytest.mark.asyncio
+async def test_annotators_empty_without_human_contributions(
+    authenticated_client: AsyncClient, async_session, worker_user
+):
+    seq = await _lane(
+        async_session,
+        alert_api_id=950,
+        platform_alert_id=950,
+        stage=Stage.ANNOTATED,
+        has_smoke=True,
+    )
+    await _contribute(async_session, seq, worker_user.id, NOW)
+
+    response = await authenticated_client.get("/sequences/classify-done")
+    assert response.json()["items"][0]["annotators"] == []
 
 
 @pytest.mark.asyncio

--- a/annotation_api/src/tests/endpoints/test_localize_done_queue.py
+++ b/annotation_api/src/tests/endpoints/test_localize_done_queue.py
@@ -2,10 +2,12 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
+from sqlmodel import select
 
 from app.models import (
     Sequence,
     SequenceAnnotation,
+    SequenceAnnotationContribution,
     SequenceAnnotationProcessingStage as Stage,
     SourceApi,
 )
@@ -61,6 +63,79 @@ async def _lane(
         )
     await session.commit()
     return seq
+
+
+async def _contribute(session, seq, user_id, at):
+    annotation_id = (
+        await session.execute(
+            select(SequenceAnnotation.id).where(
+                SequenceAnnotation.sequence_id == seq.id
+            )
+        )
+    ).scalar_one()
+    session.add(
+        SequenceAnnotationContribution(
+            sequence_annotation_id=annotation_id, user_id=user_id, contributed_at=at
+        )
+    )
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_annotators_listed_and_worker_excluded(
+    authenticated_client: AsyncClient,
+    async_session,
+    test_user,
+    regular_user,
+    worker_user,
+):
+    seq = await _lane(
+        async_session,
+        alert_api_id=800,
+        platform_alert_id=800,
+        stage=Stage.ANNOTATED,
+        has_smoke=True,
+        smoke_types=["wildfire"],
+    )
+    await _contribute(async_session, seq, worker_user.id, NOW)
+    await _contribute(async_session, seq, test_user.id, NOW + timedelta(minutes=1))
+    await _contribute(async_session, seq, regular_user.id, NOW + timedelta(minutes=2))
+
+    resp = await authenticated_client.get("/sequences/localize-done-queue")
+    item = resp.json()["items"][0]
+    assert item["annotators"] == [test_user.username, regular_user.username]
+
+
+@pytest.mark.asyncio
+async def test_annotator_id_filters_alerts(
+    authenticated_client: AsyncClient, async_session, test_user, regular_user
+):
+    mine = await _lane(
+        async_session,
+        alert_api_id=810,
+        platform_alert_id=810,
+        stage=Stage.ANNOTATED,
+        has_smoke=True,
+    )
+    theirs = await _lane(
+        async_session,
+        alert_api_id=820,
+        platform_alert_id=820,
+        stage=Stage.ANNOTATED,
+        has_smoke=True,
+    )
+    await _contribute(async_session, mine, test_user.id, NOW)
+    await _contribute(async_session, theirs, regular_user.id, NOW)
+
+    resp = await authenticated_client.get(
+        f"/sequences/localize-done-queue?annotator_id={test_user.id}"
+    )
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["items"][0]["platform_alert_id"] == 810
+
+    unfiltered = await authenticated_client.get("/sequences/localize-done-queue")
+    assert unfiltered.json()["total"] == 2
 
 
 @pytest.mark.asyncio

--- a/annotation_api/src/tests/endpoints/test_localize_done_queue.py
+++ b/annotation_api/src/tests/endpoints/test_localize_done_queue.py
@@ -139,6 +139,43 @@ async def test_annotator_id_filters_alerts(
 
 
 @pytest.mark.asyncio
+async def test_annotator_id_matches_any_lane_and_keeps_min_recorded_at(
+    authenticated_client: AsyncClient, async_session, test_user
+):
+    # Two-lane alert where only the LATER-recorded sibling has the
+    # contribution: the alert must still match (any-lane), keep both lanes,
+    # and keep min(recorded_at) from the uncontributed lane (HAVING, not
+    # WHERE — a WHERE would drop that lane from the group).
+    await _lane(
+        async_session,
+        alert_api_id=830,
+        platform_alert_id=830,
+        stage=Stage.ANNOTATED,
+        has_smoke=True,
+        recorded_at=NOW - timedelta(hours=1),
+    )
+    contributed = await _lane(
+        async_session,
+        alert_api_id=831,
+        platform_alert_id=830,
+        stage=Stage.ANNOTATED,
+        has_smoke=True,
+        recorded_at=NOW,
+    )
+    await _contribute(async_session, contributed, test_user.id, NOW)
+
+    resp = await authenticated_client.get(
+        f"/sequences/localize-done-queue?annotator_id={test_user.id}"
+    )
+    data = resp.json()
+    assert data["total"] == 1
+    item = data["items"][0]
+    assert item["platform_alert_id"] == 830
+    assert len(item["lanes"]) == 2
+    assert item["recorded_at"].startswith("2026-07-28T11:00")
+
+
+@pytest.mark.asyncio
 async def test_alert_with_annotated_smoke_lane_appears(
     authenticated_client: AsyncClient, async_session
 ):

--- a/annotation_api/src/tests/endpoints/test_users.py
+++ b/annotation_api/src/tests/endpoints/test_users.py
@@ -583,3 +583,32 @@ class TestWorkerUserCanLocalizeGuard:
         )
         assert response.status_code == 403
         assert "Cannot modify the system worker user" in response.json()["detail"]
+
+
+class TestListAnnotators:
+    @pytest.mark.asyncio
+    async def test_requires_auth(self, async_client: AsyncClient):
+        response = await async_client.get("/users/annotators")
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_regular_user_gets_active_humans_sorted(
+        self,
+        async_client: AsyncClient,
+        regular_user_token: str,
+        test_user: User,
+        regular_user: User,
+        inactive_user: User,
+        worker_user: User,
+    ):
+        headers = {"Authorization": f"Bearer {regular_user_token}"}
+        response = await async_client.get("/users/annotators", headers=headers)
+        assert response.status_code == 200
+        users = response.json()
+        usernames = [u["username"] for u in users]
+        assert test_user.username in usernames
+        assert regular_user.username in usernames
+        assert inactive_user.username not in usernames
+        assert worker_user.username not in usernames
+        assert usernames == sorted(usernames)
+        assert set(users[0].keys()) == {"id", "username"}

--- a/docs/specs/2026-08-06-done-pages-annotators-column-design.md
+++ b/docs/specs/2026-08-06-done-pages-annotators-column-design.md
@@ -1,0 +1,122 @@
+# Done Pages Annotators Column — Design
+
+**Date:** 2026-08-06
+**Status:** Approved
+
+## Problem
+
+The `/classify/done` and `/localize/done` tables show *what* was annotated
+but not *who* did it. Attribution already exists in the database —
+`SequenceAnnotationContribution` records `user_id` + `contributed_at` for
+every classify and localize submit — but neither done endpoint joins it,
+and neither page displays or filters by it.
+
+**Goal:** see at a glance who did what on the done pages, and filter the
+tables by annotator.
+
+## Scope
+
+- An **Annotators** column, last column of both done tables.
+- An **annotator filter** (single-select dropdown) in the existing filter
+  popover on both pages.
+
+Out of scope, deliberately:
+
+- Distinguishing classify vs localize contributions. Both submit paths
+  write `SequenceAnnotationContribution` rows on the sequence annotation
+  and are not distinguishable there today; both pages show the full
+  contributor set.
+- Showing contribution timestamps.
+- Backfilling attribution for annotations completed before the
+  contribution table existed (those rows render an empty marker).
+- Surfacing `DetectionAnnotationContribution` (per-detection localize
+  attribution) — the sequence-level table already captures the localizer.
+
+## Backend
+
+### Response fields
+
+`ClassifyDoneItem` and `LocalizeDoneQueueItem`
+(`annotation_api/src/app/schemas/sequence.py`) gain:
+
+- `annotators: list[str]` — distinct usernames of **human** contributors
+  across all of the row's lanes/annotations, ordered by first contribution
+  (`contributed_at`). The seeded system user (`WORKER_USERNAME`) is
+  excluded: machine writes (auto-annotation, group fan-out, bulk
+  annotate) are attributed to it and are not "annotators".
+
+Built with one batched query per page: collect the page's sequence
+annotation ids, join `SequenceAnnotationContribution` → `User`, group in
+Python — the same pattern as the existing batch contributor lookup in
+`sequences.py` (`get_annotation_contributors` usage).
+
+### Filter param
+
+`GET /sequences/classify-done` and `GET /sequences/localize-done-queue`
+gain `annotator_id: int | None`. A row matches when **any** of its lanes'
+sequence annotations has a contribution by that user — the same
+row-group ("any lane") semantics as existing classify-done filters.
+Filtering by id, not username, so renames don't break saved filters.
+The param does not exclude rows that *also* have worker contributions;
+it only requires the selected human to have contributed.
+
+### Dropdown source
+
+New `GET /api/v1/users/annotators`, accessible to any authenticated user
+(the existing `GET /users/` list is superuser-only and stays that way):
+
+- Returns `list[ContributorRead]` (`{id, username}`), unpaginated.
+- Active users only, worker excluded, ordered by username.
+- Usernames are already visible to annotators elsewhere (groups Reviewed
+  column), so this exposes nothing new.
+
+## Frontend
+
+### Column
+
+Both `ClassifyDoneTable.tsx` and `LocalizeDoneQueueTable.tsx` add an
+**Annotators** `ColumnHeader` as the literal last column (after Result),
+with a matching `<td>`:
+
+| State                       | Cell                          |
+| --------------------------- | ----------------------------- |
+| One or more human annotators | `alice, bob` (comma-separated) |
+| Empty (machine-only or legacy) | muted `—`                  |
+
+### Filter
+
+- `annotator_id?: number` added to `ExtendedSequenceFilters`
+  (`types/api.ts`) and to the param objects of `getClassifyDone` /
+  `getLocalizeDoneQueue` (`services/api.ts`).
+- New `useAnnotators` hook mirroring `useCameras` (TanStack Query,
+  5 min `staleTime`, new `QUERY_KEYS` entry) feeding a plain `<select>`
+  in `FilterPopover.tsx`, modeled on the Camera dropdown.
+- Full filter wiring: pill in `filterPills.ts`, clear-switch case and
+  "more filters" count in `FilterPopover.tsx`, active-filter detection in
+  `filterHelpers.ts`, and the empty-value cleanup in
+  `usePersistedFilters.ts`.
+- `DetectionReviewPage.tsx` builds its query params field-by-field — the
+  new param is added there explicitly, and to the `SequencesPage.tsx`
+  classify-done query.
+- Filter state persists in the existing localStorage filter state
+  (`filters-classify-done`, `filters-localize-done-v3`); no key-version
+  bump needed since the new field defaults to absent.
+
+## Testing
+
+Backend (endpoint tests, both done endpoints):
+
+- `annotators` lists distinct human contributors ordered by first
+  contribution; duplicate contributions collapse to one name.
+- Worker contributions are excluded from `annotators`; a machine-only row
+  returns `[]`.
+- `annotator_id` filters to rows where that user contributed to any lane;
+  other rows drop out; no param returns everything.
+- `GET /users/annotators`: requires auth, excludes worker and inactive
+  users, returns `{id, username}` sorted by username.
+
+Frontend (Vitest):
+
+- Both table tests: Annotators column renders names, and `—` when empty.
+- FilterPopover: annotator select renders options, sets the filter,
+  produces a pill, clears correctly.

--- a/frontend/src/components/filters/FilterPopover.tsx
+++ b/frontend/src/components/filters/FilterPopover.tsx
@@ -1,7 +1,7 @@
 import { clsx } from 'clsx';
 import { Popover } from '@headlessui/react';
 import { ChevronDown, SlidersHorizontal, X } from 'lucide-react';
-import { ExtendedSequenceFilters } from '@/types/api';
+import { Contributor, ExtendedSequenceFilters } from '@/types/api';
 import { ModelAccuracyType } from '@/utils/modelAccuracy';
 import { usePersistedTabState } from '@/hooks/usePersistedTabState';
 import { buildFilterPills, FilterPillId } from '@/utils/filterPills';
@@ -54,15 +54,18 @@ interface FilterPopoverProps {
   cameras: Camera[];
   organizations: Organization[];
   sourceApis: SourceApi[];
+  annotators?: Contributor[];
   camerasLoading: boolean;
   organizationsLoading: boolean;
   sourceApisLoading: boolean;
+  annotatorsLoading?: boolean;
 
   // Configuration
   showModelAccuracy?: boolean; // for review pages only
   showFalsePositiveTypes?: boolean; // for review pages only
   showSmokeTypes?: boolean; // for review pages only
   showUnsureFilter?: boolean; // for sequence review page only
+  showAnnotatorFilter?: boolean; // for done pages only
 
   // Reset handler
   onResetFilters?: () => void;
@@ -90,13 +93,16 @@ export default function FilterPopover({
   cameras,
   organizations,
   sourceApis,
+  annotators = [],
   camerasLoading,
   organizationsLoading,
   sourceApisLoading,
+  annotatorsLoading = false,
   showModelAccuracy = false,
   showFalsePositiveTypes = false,
   showSmokeTypes = false,
   showUnsureFilter = false,
+  showAnnotatorFilter = false,
   onResetFilters,
   className = '',
 }: FilterPopoverProps) {
@@ -118,7 +124,9 @@ export default function FilterPopover({
     showFalsePositiveTypes,
     showSmokeTypes,
     showUnsureFilter,
+    showAnnotatorFilter,
     sourceApis,
+    annotators,
   });
 
   const clearPill = (id: FilterPillId) => {
@@ -128,6 +136,9 @@ export default function FilterPopover({
         break;
       case 'organization':
         onFiltersChange({ organisation_name: undefined });
+        break;
+      case 'annotator':
+        onFiltersChange({ annotator_id: undefined });
         break;
       case 'source':
         onFiltersChange({ source_api: undefined });
@@ -230,6 +241,35 @@ export default function FilterPopover({
                 ))}
               </select>
             </div>
+
+            {showAnnotatorFilter && (
+              <div>
+                <label
+                  htmlFor="filter-annotator"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  Annotator
+                </label>
+                <select
+                  id="filter-annotator"
+                  value={filters.annotator_id ?? ''}
+                  onChange={e =>
+                    onFiltersChange({
+                      annotator_id: e.target.value === '' ? undefined : Number(e.target.value),
+                    })
+                  }
+                  className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-primary-500 focus:border-primary-500"
+                  disabled={annotatorsLoading}
+                >
+                  <option value="">All Annotators</option>
+                  {annotators.map(annotator => (
+                    <option key={annotator.id} value={annotator.id}>
+                      {annotator.username}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
 
             <DateRangeFilter
               label="Date Range (Recorded)"

--- a/frontend/src/components/sequences/ClassifyDoneTable.tsx
+++ b/frontend/src/components/sequences/ClassifyDoneTable.tsx
@@ -76,11 +76,7 @@ export function ClassifyDoneTable({ items, onItemClick }: ClassifyDoneTableProps
               tip="Model outcome — TP correct, FP false alarm, ⚑ FN missed smoke, ? unsure — and the classification detail"
               align="right"
             />
-            <ColumnHeader
-              label="Annotators"
-              tip="Who classified or localized this alert"
-              align="right"
-            />
+            <ColumnHeader label="Annotators" tip="Who classified or localized this alert" />
           </tr>
         </thead>
         <tbody className={TBODY_CLASSES}>
@@ -121,7 +117,7 @@ export function ClassifyDoneTable({ items, onItemClick }: ClassifyDoneTableProps
                     </>
                   )}
                 </td>
-                <td className={`${CELL_CLASSES} ${CELL_TEXT} text-right`}>
+                <td className={`${CELL_CLASSES} ${CELL_TEXT}`}>
                   {item.annotators.length > 0 ? (
                     item.annotators.join(', ')
                   ) : (

--- a/frontend/src/components/sequences/ClassifyDoneTable.tsx
+++ b/frontend/src/components/sequences/ClassifyDoneTable.tsx
@@ -76,6 +76,11 @@ export function ClassifyDoneTable({ items, onItemClick }: ClassifyDoneTableProps
               tip="Model outcome — TP correct, FP false alarm, ⚑ FN missed smoke, ? unsure — and the classification detail"
               align="right"
             />
+            <ColumnHeader
+              label="Annotators"
+              tip="Who classified or localized this alert"
+              align="right"
+            />
           </tr>
         </thead>
         <tbody className={TBODY_CLASSES}>
@@ -114,6 +119,13 @@ export function ClassifyDoneTable({ items, onItemClick }: ClassifyDoneTableProps
                         <span className="ml-2.5 font-body text-detail text-haze">{detail}</span>
                       )}
                     </>
+                  )}
+                </td>
+                <td className={`${CELL_CLASSES} ${CELL_TEXT} text-right`}>
+                  {item.annotators.length > 0 ? (
+                    item.annotators.join(', ')
+                  ) : (
+                    <span className="text-haze">—</span>
                   )}
                 </td>
               </tr>

--- a/frontend/src/components/sequences/LocalizeDoneQueueTable.tsx
+++ b/frontend/src/components/sequences/LocalizeDoneQueueTable.tsx
@@ -72,6 +72,11 @@ export function LocalizeDoneQueueTable({ items, onItemClick }: LocalizeDoneQueue
               tip="Model outcome — TP correct, FP false alarm, ⚑ FN missed smoke, ? unsure — dominant across the alert's objects; +N counts the others"
               align="right"
             />
+            <ColumnHeader
+              label="Annotators"
+              tip="Who classified or localized this alert"
+              align="right"
+            />
           </tr>
         </thead>
         <tbody className={TBODY_CLASSES}>
@@ -102,6 +107,13 @@ export function LocalizeDoneQueueTable({ items, onItemClick }: LocalizeDoneQueue
                 <td className={CELL_CLASSES}>
                   {rollup && (
                     <OutcomeCode outcome={rollup.outcome} extraCount={rollup.extraCount} />
+                  )}
+                </td>
+                <td className={`${CELL_CLASSES} ${CELL_TEXT} text-right`}>
+                  {item.annotators.length > 0 ? (
+                    item.annotators.join(', ')
+                  ) : (
+                    <span className="text-haze">—</span>
                   )}
                 </td>
               </tr>

--- a/frontend/src/components/sequences/LocalizeDoneQueueTable.tsx
+++ b/frontend/src/components/sequences/LocalizeDoneQueueTable.tsx
@@ -72,11 +72,7 @@ export function LocalizeDoneQueueTable({ items, onItemClick }: LocalizeDoneQueue
               tip="Model outcome — TP correct, FP false alarm, ⚑ FN missed smoke, ? unsure — dominant across the alert's objects; +N counts the others"
               align="right"
             />
-            <ColumnHeader
-              label="Annotators"
-              tip="Who classified or localized this alert"
-              align="right"
-            />
+            <ColumnHeader label="Annotators" tip="Who classified or localized this alert" />
           </tr>
         </thead>
         <tbody className={TBODY_CLASSES}>
@@ -109,7 +105,7 @@ export function LocalizeDoneQueueTable({ items, onItemClick }: LocalizeDoneQueue
                     <OutcomeCode outcome={rollup.outcome} extraCount={rollup.extraCount} />
                   )}
                 </td>
-                <td className={`${CELL_CLASSES} ${CELL_TEXT} text-right`}>
+                <td className={`${CELL_CLASSES} ${CELL_TEXT}`}>
                   {item.annotators.length > 0 ? (
                     item.annotators.join(', ')
                   ) : (

--- a/frontend/src/hooks/useAnnotators.ts
+++ b/frontend/src/hooks/useAnnotators.ts
@@ -3,10 +3,11 @@ import { apiClient } from '@/services/api';
 import { QUERY_KEYS } from '@/utils/constants';
 import { Contributor } from '@/types/api';
 
-export function useAnnotators() {
+export function useAnnotators(enabled = true) {
   return useQuery<Contributor[]>({
     queryKey: QUERY_KEYS.ANNOTATORS,
     queryFn: () => apiClient.getAnnotators(),
+    enabled,
     staleTime: 5 * 60 * 1000, // 5 minutes - the user list rarely changes
     gcTime: 10 * 60 * 1000, // 10 minutes
   });

--- a/frontend/src/hooks/useAnnotators.ts
+++ b/frontend/src/hooks/useAnnotators.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/services/api';
+import { QUERY_KEYS } from '@/utils/constants';
+import { Contributor } from '@/types/api';
+
+export function useAnnotators() {
+  return useQuery<Contributor[]>({
+    queryKey: QUERY_KEYS.ANNOTATORS,
+    queryFn: () => apiClient.getAnnotators(),
+    staleTime: 5 * 60 * 1000, // 5 minutes - the user list rarely changes
+    gcTime: 10 * 60 * 1000, // 10 minutes
+  });
+}

--- a/frontend/src/hooks/usePersistedFilters.ts
+++ b/frontend/src/hooks/usePersistedFilters.ts
@@ -66,6 +66,7 @@ export function usePersistedFilters(storageKey: string, defaultState: PersistedF
         if (cleanedFilters.organisation_name === '') delete cleanedFilters.organisation_name;
         // source_api is an enum type, so we check differently
         if (!cleanedFilters.source_api) delete cleanedFilters.source_api;
+        if (!cleanedFilters.annotator_id) delete cleanedFilters.annotator_id;
 
         // Merge with defaults to handle missing properties in stored data
         // Always preserve the processing_stage from defaultState as it's a system filter

--- a/frontend/src/pages/DetectionReviewPage.tsx
+++ b/frontend/src/pages/DetectionReviewPage.tsx
@@ -10,6 +10,7 @@ import { TABLE_CARD_CLASSES } from '@/components/sequences/tableStyles';
 import { useCameras } from '@/hooks/useCameras';
 import { useOrganizations } from '@/hooks/useOrganizations';
 import { useSourceApis } from '@/hooks/useSourceApis';
+import { useAnnotators } from '@/hooks/useAnnotators';
 import { usePersistedFilters, createDefaultFilterState } from '@/hooks/usePersistedFilters';
 import { calculatePresetDateRange } from '@/components/filters/shared/dateRangeUtils';
 import { hasActiveUserFilters } from '@/utils/filterHelpers';
@@ -50,6 +51,7 @@ export default function DetectionReviewPage() {
   const { data: cameras = [], isLoading: camerasLoading } = useCameras();
   const { data: organizations = [], isLoading: organizationsLoading } = useOrganizations();
   const { data: sourceApis = [], isLoading: sourceApisLoading } = useSourceApis();
+  const { data: annotators = [], isLoading: annotatorsLoading } = useAnnotators();
 
   // Date range helper functions
   const setDateRange = (preset: string) => {
@@ -99,6 +101,7 @@ export default function DetectionReviewPage() {
         source_api: filters.source_api,
         recorded_at_gte: filters.recorded_at_gte,
         recorded_at_lte: filters.recorded_at_lte,
+        annotator_id: filters.annotator_id,
       }),
   });
 
@@ -188,9 +191,12 @@ export default function DetectionReviewPage() {
             cameras={cameras}
             organizations={organizations}
             sourceApis={sourceApis}
+            annotators={annotators}
             camerasLoading={camerasLoading}
             organizationsLoading={organizationsLoading}
             sourceApisLoading={sourceApisLoading}
+            annotatorsLoading={annotatorsLoading}
+            showAnnotatorFilter
           />
         </div>
 
@@ -294,9 +300,12 @@ export default function DetectionReviewPage() {
             cameras={cameras}
             organizations={organizations}
             sourceApis={sourceApis}
+            annotators={annotators}
             camerasLoading={camerasLoading}
             organizationsLoading={organizationsLoading}
             sourceApisLoading={sourceApisLoading}
+            annotatorsLoading={annotatorsLoading}
+            showAnnotatorFilter
           />
         </div>
       </div>

--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -24,6 +24,7 @@ import { useAuthStore } from '@/store/useAuthStore';
 import { useCameras } from '@/hooks/useCameras';
 import { useOrganizations } from '@/hooks/useOrganizations';
 import { useSourceApis } from '@/hooks/useSourceApis';
+import { useAnnotators } from '@/hooks/useAnnotators';
 import { usePersistedFilters, createDefaultFilterState } from '@/hooks/usePersistedFilters';
 import { calculatePresetDateRange } from '@/components/filters/shared/dateRangeUtils';
 import { hasActiveUserFilters } from '@/utils/filterHelpers';
@@ -92,6 +93,7 @@ export default function SequencesPage({
   const { data: cameras = [], isLoading: camerasLoading } = useCameras();
   const { data: organizations = [], isLoading: organizationsLoading } = useOrganizations();
   const { data: sourceApis = [], isLoading: sourceApisLoading } = useSourceApis();
+  const { data: annotators = [], isLoading: annotatorsLoading } = useAnnotators();
 
   // Date range helper functions
   const setDateRange = (preset: string) => {
@@ -298,13 +300,16 @@ export default function SequencesPage({
               cameras={cameras}
               organizations={organizations}
               sourceApis={sourceApis}
+              annotators={annotators}
               camerasLoading={camerasLoading}
               organizationsLoading={organizationsLoading}
               sourceApisLoading={sourceApisLoading}
+              annotatorsLoading={annotatorsLoading}
               showModelAccuracy={defaultProcessingStage === 'annotated'}
               showFalsePositiveTypes={defaultProcessingStage === 'annotated'}
               showSmokeTypes={defaultProcessingStage === 'annotated'}
               showUnsureFilter={defaultProcessingStage === 'annotated'}
+              showAnnotatorFilter={isReviewPage}
             />
           </div>
         </div>
@@ -446,13 +451,16 @@ export default function SequencesPage({
             cameras={cameras}
             organizations={organizations}
             sourceApis={sourceApis}
+            annotators={annotators}
             camerasLoading={camerasLoading}
             organizationsLoading={organizationsLoading}
             sourceApisLoading={sourceApisLoading}
+            annotatorsLoading={annotatorsLoading}
             showModelAccuracy={isAnnotatedView}
             showFalsePositiveTypes={isAnnotatedView}
             showSmokeTypes={isAnnotatedView}
             showUnsureFilter={isAnnotatedView}
+            showAnnotatorFilter={isReviewPage}
           />
         </div>
       </div>

--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -93,7 +93,8 @@ export default function SequencesPage({
   const { data: cameras = [], isLoading: camerasLoading } = useCameras();
   const { data: organizations = [], isLoading: organizationsLoading } = useOrganizations();
   const { data: sourceApis = [], isLoading: sourceApisLoading } = useSourceApis();
-  const { data: annotators = [], isLoading: annotatorsLoading } = useAnnotators();
+  // Only the done page shows the annotator filter — don't fetch on the queue
+  const { data: annotators = [], isLoading: annotatorsLoading } = useAnnotators(isReviewPage);
 
   // Date range helper functions
   const setDateRange = (preset: string) => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -6,6 +6,7 @@ import {
   DetectionAnnotation,
   Detection,
   Camera,
+  Contributor,
   Organization,
   SourceApi,
   User,
@@ -254,6 +255,7 @@ class ApiClient {
       source_api?: string;
       recorded_at_gte?: string;
       recorded_at_lte?: string;
+      annotator_id?: number;
     } = {}
   ): Promise<PaginatedResponse<LocalizeDoneQueueItem>> {
     const response: AxiosResponse<PaginatedResponse<LocalizeDoneQueueItem>> = await this.client.get(
@@ -278,6 +280,7 @@ class ApiClient {
       smoke_types?: string[];
       is_unsure?: boolean;
       model_accuracy?: 'tp' | 'fp' | 'fn';
+      annotator_id?: number;
     } = {}
   ): Promise<PaginatedResponse<ClassifyDoneItem>> {
     const response: AxiosResponse<PaginatedResponse<ClassifyDoneItem>> = await this.client.get(
@@ -530,6 +533,14 @@ class ApiClient {
 
   async getUser(id: number): Promise<User> {
     const response: AxiosResponse<User> = await this.client.get(`/users/${id}`);
+    return response.data;
+  }
+
+  // Active human users for the done-pages annotator filter (any authenticated user)
+  async getAnnotators(): Promise<Contributor[]> {
+    const response: AxiosResponse<Contributor[]> = await this.client.get(
+      `${API_ENDPOINTS.USERS}annotators`
+    );
     return response.data;
   }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -64,6 +64,7 @@ export interface LocalizeDoneQueueItem {
   azimuth: number | null;
   recorded_at: string;
   lanes: LocalizationQueueLane[];
+  annotators: string[];
 }
 
 // One object-sequence of an alert with annotation, as returned by the alert-detail endpoint.

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -433,6 +433,7 @@ export interface ExtendedSequenceFilters extends SequenceFilters {
   smoke_types?: string[]; // Array of smoke types for OR filtering
   is_unsure?: boolean;
   include_annotation?: boolean;
+  annotator_id?: number; // filter done pages by contributing user
 }
 
 // Sequence with complete annotation information

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -117,6 +117,7 @@ export interface ClassifyDoneItem {
   is_wildfire_alertapi: AnnotationType | null;
   primary_sequence_id: number;
   lanes: ClassifyDoneLane[];
+  annotators: string[];
 }
 
 // Submission payload for bulk classification of all objects in an alert.

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -334,4 +334,5 @@ export const QUERY_KEYS = {
   DETECTION_ANNOTATION: (id: number) => ['detection-annotations', id],
   USERS: ['users'],
   USER: (id: number) => ['users', id],
+  ANNOTATORS: ['annotators'],
 } as const;

--- a/frontend/src/utils/filterHelpers.ts
+++ b/frontend/src/utils/filterHelpers.ts
@@ -37,7 +37,7 @@ export function hasActiveUserFilters(
   }
 
   // Check basic filters
-  if (filters.camera_name || filters.organisation_name) {
+  if (filters.camera_name || filters.organisation_name || filters.annotator_id) {
     return true;
   }
 

--- a/frontend/src/utils/filterPills.ts
+++ b/frontend/src/utils/filterPills.ts
@@ -10,6 +10,7 @@ import { detectActivePreset } from '@/components/filters/shared/dateRangeUtils';
 export type FilterPillId =
   | 'camera'
   | 'organization'
+  | 'annotator'
   | 'source'
   | 'wildfire'
   | 'accuracy'
@@ -35,7 +36,9 @@ export interface FilterPillInput {
   showFalsePositiveTypes: boolean;
   showSmokeTypes: boolean;
   showUnsureFilter: boolean;
+  showAnnotatorFilter?: boolean;
   sourceApis: { id: string; name: string }[];
+  annotators?: { id: number; username: string }[];
 }
 
 const PRESET_LABELS: Record<string, string> = {
@@ -71,6 +74,13 @@ export function buildFilterPills(input: FilterPillInput): FilterPill[] {
   }
   if (filters.organisation_name) {
     pills.push({ id: 'organization', label: `Org: ${filters.organisation_name}` });
+  }
+  if (input.showAnnotatorFilter && filters.annotator_id !== undefined) {
+    const annotator = (input.annotators ?? []).find(a => a.id === filters.annotator_id);
+    pills.push({
+      id: 'annotator',
+      label: `Annotator: ${annotator ? annotator.username : filters.annotator_id}`,
+    });
   }
   if (filters.source_api) {
     const source = input.sourceApis.find(s => s.id === filters.source_api);

--- a/frontend/tests/components/filters/FilterPopover.test.tsx
+++ b/frontend/tests/components/filters/FilterPopover.test.tsx
@@ -121,4 +121,37 @@ describe('FilterPopover', () => {
     fireEvent.click(screen.getByRole('button', { name: /more filters/i }));
     expect(localStorage.getItem('filter-popover-more-expanded')).toBe('expanded');
   });
+
+  it('hides the Annotator filter unless showAnnotatorFilter is set', () => {
+    render(<FilterPopover {...makeProps()} />);
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    expect(screen.queryByLabelText('Annotator')).not.toBeInTheDocument();
+  });
+
+  it('renders the Annotator select and reports a numeric annotator_id', () => {
+    const props = makeProps({
+      showAnnotatorFilter: true,
+      annotators: [
+        { id: 3, username: 'alice' },
+        { id: 5, username: 'bob' },
+      ],
+      annotatorsLoading: false,
+    });
+    render(<FilterPopover {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    fireEvent.change(screen.getByLabelText('Annotator'), { target: { value: '5' } });
+    expect(props.onFiltersChange).toHaveBeenCalledWith({ annotator_id: 5 });
+  });
+
+  it('shows an annotator pill and clears it on ✕ click', () => {
+    const props = makeProps({
+      showAnnotatorFilter: true,
+      annotators: [{ id: 3, username: 'alice' }],
+      filters: { annotator_id: 3 } as ExtendedSequenceFilters,
+    });
+    render(<FilterPopover {...props} />);
+    expect(screen.getByText('Annotator: alice')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /clear annotator: alice/i }));
+    expect(props.onFiltersChange).toHaveBeenCalledWith({ annotator_id: undefined });
+  });
 });

--- a/frontend/tests/components/sequences/ClassifyDoneTable.test.tsx
+++ b/frontend/tests/components/sequences/ClassifyDoneTable.test.tsx
@@ -35,6 +35,7 @@ const createItem = (overrides: Partial<ClassifyDoneItem> = {}): ClassifyDoneItem
   is_wildfire_alertapi: 'wildfire_smoke',
   primary_sequence_id: 1,
   lanes: [createLane()],
+  annotators: [],
   ...overrides,
 });
 
@@ -56,6 +57,7 @@ describe('ClassifyDoneTable', () => {
       'Azimuth',
       'Alert API annotation',
       'Result',
+      'Annotators',
     ];
     const positions = labels.map(l => {
       const el = screen.getByText(l);
@@ -63,6 +65,21 @@ describe('ClassifyDoneTable', () => {
     });
     expect(positions).toEqual([...positions].sort((a, b) => a - b));
     expect(positions.every(p => p > 0)).toBe(true);
+  });
+
+  it('renders comma-separated annotators in the last column', () => {
+    render(
+      <ClassifyDoneTable
+        items={[createItem({ annotators: ['alice', 'bob'] })]}
+        onItemClick={onItemClick}
+      />
+    );
+    expect(screen.getByText('alice, bob')).toBeInTheDocument();
+  });
+
+  it('renders a muted dash when the alert has no human annotators', () => {
+    render(<ClassifyDoneTable items={[createItem({ annotators: [] })]} onItemClick={onItemClick} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
   });
 
   it('uses the primary sequence for the thumbnail', () => {

--- a/frontend/tests/components/sequences/LocalizeDoneQueueTable.test.tsx
+++ b/frontend/tests/components/sequences/LocalizeDoneQueueTable.test.tsx
@@ -39,6 +39,7 @@ const createItem = (
   azimuth: 180,
   recorded_at: '2024-01-01T10:00:00Z',
   lanes: [createLane()],
+  annotators: [],
   ...overrides,
 });
 
@@ -60,9 +61,27 @@ describe('LocalizeDoneQueueTable', () => {
       'Azimuth',
       'Objects',
       'Result',
+      'Annotators',
     ]) {
       expect(screen.getByText(header)).toBeInTheDocument();
     }
+  });
+
+  it('renders comma-separated annotators in the last column', () => {
+    render(
+      <LocalizeDoneQueueTable
+        items={[createItem({ annotators: ['alice', 'bob'] })]}
+        onItemClick={onItemClick}
+      />
+    );
+    expect(screen.getByText('alice, bob')).toBeInTheDocument();
+  });
+
+  it('renders a muted dash when the alert has no human annotators', () => {
+    render(
+      <LocalizeDoneQueueTable items={[createItem({ annotators: [] })]} onItemClick={onItemClick} />
+    );
+    expect(screen.getByText('—')).toBeInTheDocument();
   });
 
   it('shows "N objects" with no localized suffix once every smoke object is localized', () => {

--- a/frontend/tests/pages/DetectionReviewPage.test.tsx
+++ b/frontend/tests/pages/DetectionReviewPage.test.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 vi.mock('@/services/api', () => ({
   apiClient: {
     getLocalizeDoneQueue: vi.fn(),
+    getAnnotators: vi.fn(),
   },
 }));
 
@@ -100,12 +101,14 @@ const queueItem = {
       auto_annotated_at: null,
     },
   ],
+  annotators: [],
 };
 
 describe('DetectionReviewPage (/localize/done)', () => {
   beforeEach(() => {
     navigateMock.mockClear();
     mockedFilters = {};
+    vi.mocked(apiClient.getAnnotators).mockResolvedValue([]);
     vi.mocked(apiClient.getLocalizeDoneQueue).mockResolvedValue({
       items: [queueItem],
       page: 1,


### PR DESCRIPTION
## Summary

Adds a **who did what** view to both done pages, per the approved spec (`docs/specs/2026-08-06-done-pages-annotators-column-design.md`):

- **Annotators column** (last column) on `/classify/done` and `/localize/done`: distinct human contributors ordered by first contribution, from the existing `sequence_annotation_contributions` table. The seeded `worker` user (machine attribution: auto-annotate, group fan-out, bulk annotate) is excluded; rows with no human contribution show a muted dash.
- **Annotator filter** in the filter popover on both pages: single-select by user, `annotator_id` query param with any-lane semantics (the alert matches if any of its lanes has a contribution by that user). Persisted with the existing localStorage filter state.
- **`GET /users/annotators`**: lightweight `{id, username}` dropdown source for active human users, open to any authenticated user (the full user list stays superuser-only).

### Backend notes

- One batched contributions⨝users query per page on both done endpoints (no N+1).
- Filter uses a correlated EXISTS inside the established any-lane HAVING pattern, so `min(recorded_at)` and the membership predicate are unaffected.

## Test plan

- Backend: full suite in isolated stack — **596 passed** (8 new: dropdown auth/content, annotators content + worker exclusion, filter semantics on both endpoints).
- Frontend: **1184 passed** (7 new: column rendering + empty state on both tables, filter select/pill/clear); `npm run quality` clean.