### PR TITLE
feat(frontend): grow the localize editor out of its grid cell

### DIFF
--- a/docs/specs/2026-08-06-localize-editor-zoom-transition-design.md
+++ b/docs/specs/2026-08-06-localize-editor-zoom-transition-design.md
@@ -1,0 +1,103 @@
+# Localize editor zoom transition
+
+Date: 2026-08-06
+Status: approved, not implemented
+
+## Problem
+
+Clicking a cell on `/localize/:sequenceId` opens `LocalizeObjectEditor`, which
+is technically an overlay — a child route the page renders as a
+`fixed inset-0` div, with the cockpit staying mounted underneath — but it
+appears and disappears with no animation at all. To the annotator it reads as
+navigation to a different page, which misstates the model: the editor is the
+clicked cell's frame, enlarged, and closing it returns to the same cockpit in
+the same state.
+
+This spec adds a grow-from-the-cell open/close transition so the editor
+visibly comes out of, and returns into, the grid. Chosen over a plain
+fade-and-lift modal and a bottom-sheet treatment in a live mockup comparison
+(brainstorm session, 2026-08-06).
+
+## Scope
+
+**In:** the editor's mount/unmount motion, its degraded paths (deep link,
+browser back, reduced motion), the page↔editor contract that feeds it, and
+tests.
+
+**Out:** any change to routing, URL semantics, editor layout, or cockpit
+state. Stepping frames or switching objects while the editor is open animates
+nothing — the component stays mounted and only the stage content changes.
+
+## Motion
+
+**Open.** The editor's full-screen root starts as a transform of the clicked
+cell's viewport rect — `translate(cell.x, cell.y) scale(cell.w / vw, cell.h /
+vh)` with `transform-origin: 0 0` (non-uniform scale, FLIP-style) — and
+animates to identity. ~340ms, `cubic-bezier(.2, 0, 0, 1)`, with opacity
+ramping ~0.55 → 1 and border-radius rounding off from the cell's radius to 0.
+
+**Close.** The reverse, targeting the **current frame's** cell — not
+necessarily the one that opened the editor, since the annotator steps frames
+inside it. ~260ms, `cubic-bezier(.4, 0, 1, 1)`. If the target cell is scrolled
+out of view, it is scrolled into view instantly (`behavior: 'auto'`,
+`block: 'nearest'`) before measuring, so the editor lands where the eye should
+continue working.
+
+Durations are the mockup's values; they may be trimmed after use in the real
+app without a spec change.
+
+## Degraded paths
+
+Every path that cannot produce an origin/target rect degrades to something
+quieter rather than breaking:
+
+- **Deep link** (page loads with the editor already in the URL): no entrance
+  animation. Animation happens only when the open came from a click on an
+  already-rendered grid; the click handler captures the cell rect, and no
+  captured rect means no animation.
+- **Browser back/forward**: the route change unmounts the editor before any
+  exit animation could run — it closes instantly. Accepted degradation; the
+  in-app close controls (✕, Esc) are the common path.
+- **`prefers-reduced-motion: reduce`**: no transform animation in either
+  direction; a fast opacity fade only.
+- **Target cell missing** (defensive; every alert frame has a grid cell keyed
+  by `recordedAt`, but if lookup fails): same fade fallback.
+- **`element.animate` unavailable** (jsdom, old browsers): no animation,
+  behavior identical to today.
+
+## Mechanism
+
+No routing or state changes. The editor stays a child route; `closeModal`
+stays URL-driven navigation.
+
+- **`LocalizeAlertPage`** supplies two things:
+  - the entrance rect, captured in the existing grid-cell click handler at
+    click time (the moment the DOM is guaranteed laid out and visible) and
+    consumed once by the editor on mount;
+  - a `frameCellRect(recordedAt)` lookup that resolves the grid cell via its
+    existing `data-testid="alert-frame-cell-${recordedAt}"`, scrolling it
+    into view first when needed, and returns its `DOMRect` (or null).
+- **`LocalizeObjectEditor`** owns both animations, via the Web Animations API
+  (`element.animate` — no new dependency) on its root div:
+  - entrance runs in a mount-only layout effect, from the captured rect;
+  - exit intercepts the close controls: play the shrink toward
+    `frameCellRect(currentFrame.recordedAt)`, then call `onClose()`, which
+    navigates as today. An `isClosing` guard prevents double-close and sets
+    `pointer-events: none` during the exit.
+
+The rect→keyframes computation is a pure helper (viewport rect in, keyframe
+pair out) so it can be unit-tested without a DOM.
+
+## Testing
+
+jsdom does not implement `element.animate`, so the existence guard doubles as
+the test-environment path — existing editor tests keep passing unchanged.
+
+New tests:
+
+- rect→transform keyframe math (pure helper, no DOM);
+- no captured entrance rect → no entrance animation (deep-link path);
+- close calls `onClose` after the exit animation finishes when `animate`
+  exists (mocked, `onfinish` driven), and immediately when it does not;
+- `prefers-reduced-motion` (mocked `matchMedia`) uses the fade path — no
+  transform keyframes.

--- a/docs/specs/2026-08-06-localize-editor-zoom-transition-design.md
+++ b/docs/specs/2026-08-06-localize-editor-zoom-transition-design.md
@@ -1,7 +1,18 @@
 # Localize editor zoom transition
 
 Date: 2026-08-06
-Status: approved, not implemented
+Status: implemented
+
+## Amendments from use
+
+- Overlay geometry inside the editor must be computed from LAYOUT metrics
+  (`offsetWidth`/`offsetHeight`), never `getBoundingClientRect()`. The cached
+  frame image loads and renders its box overlays while the entrance animation
+  is still scaling the root, so the rect is the transformed visual size at
+  that moment — boxes measured from it came out ~6× too small and stuck that
+  way, since nothing re-renders after the animation ends. `getImageInfo` was
+  the one measurement on the rect path; `handleImageLoad` already knew this
+  trap.
 
 ## Problem
 

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -19,7 +19,7 @@
  * "Amendments from use" section).
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { X, Keyboard, Crop } from 'lucide-react';
 import type {
@@ -51,6 +51,16 @@ import {
   type Point,
   type ResizeHandle,
 } from '@/utils/annotation';
+import {
+  FADE_MS,
+  prefersReducedMotion,
+  zoomKeyframes,
+  ZOOM_CLOSE_EASING,
+  ZOOM_CLOSE_MS,
+  ZOOM_OPEN_EASING,
+  ZOOM_OPEN_MS,
+  type RectLike,
+} from '@/utils/annotation/zoomTransitionUtils';
 import type { ObjectOverlayItem } from '@/components/annotation/ImageOverlays';
 import { DetectionAnnotationCanvas } from '@/components/detection-annotation';
 import { useDetectionImage } from '@/hooks/useDetectionImage';
@@ -118,6 +128,18 @@ export interface LocalizeObjectEditorProps {
   /** Hand this object's classification back to the classify cockpit. */
   onReclassify: () => void;
   onClose: () => void;
+  /**
+   * Consume-once viewport rect of the grid cell the opening click came
+   * from. Absent or null — deep link, back/forward — means the editor
+   * appears without an entrance animation.
+   */
+  takeOpenOriginRect?: () => RectLike | null;
+  /**
+   * Viewport rect of the grid cell showing `recordedAt`, scrolled into
+   * view by the caller first. Close shrinks the editor into it; null
+   * falls back to a plain fade.
+   */
+  frameCellRect?: (recordedAt: string) => RectLike | null;
 }
 
 export function LocalizeObjectEditor({
@@ -140,9 +162,35 @@ export function LocalizeObjectEditor({
   onAcceptRemaining,
   onReclassify,
   onClose,
+  takeOpenOriginRect,
+  frameCellRect,
 }: LocalizeObjectEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
+
+  // Grow out of the clicked grid cell — on mount only: stepping frames
+  // re-renders this same instance and must not re-animate. No captured rect
+  // (deep link, back/forward) or no WAAPI (jsdom) means no animation, and
+  // reduced motion gets a plain fade. Layout effect: the first paint must
+  // already be the shrunk pose, not a full-screen flash.
+  const rootRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    const rect = takeOpenOriginRect?.() ?? null;
+    if (!root || !rect || typeof root.animate !== 'function') return;
+    if (prefersReducedMotion()) {
+      root.animate([{ opacity: 0 }, { opacity: 1 }], { duration: FADE_MS, easing: 'linear' });
+      return;
+    }
+    root.style.transformOrigin = '0 0';
+    const { atCell, full } = zoomKeyframes(rect, {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+    root.animate([atCell, full], { duration: ZOOM_OPEN_MS, easing: ZOOM_OPEN_EASING });
+    // Mount-only by design; the origin rect is consumed exactly once.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const [imageInfo, setImageInfo] = useState<{
     width: number;
@@ -673,6 +721,48 @@ export function LocalizeObjectEditor({
     return () => container.removeEventListener('wheel', onWheel);
   }, []);
 
+  // Close = shrink back into the grid, then let onClose navigate (which
+  // unmounts this component). The guard makes a second close attempt a
+  // no-op and pointer-events blankets the editor against input during the
+  // exit. Without WAAPI (jsdom, old browsers) this is exactly onClose.
+  const isClosingRef = useRef(false);
+  const requestClose = useCallback(() => {
+    if (isClosingRef.current) return;
+    const root = rootRef.current;
+    if (!root || typeof root.animate !== 'function') {
+      onClose();
+      return;
+    }
+    isClosingRef.current = true;
+    root.style.pointerEvents = 'none';
+    const shownRecordedAt = peeked?.recordedAt ?? detection.recorded_at;
+    const target = prefersReducedMotion() ? null : (frameCellRect?.(shownRecordedAt) ?? null);
+    let animation: Animation;
+    if (target) {
+      root.style.transformOrigin = '0 0';
+      const { atCell, full } = zoomKeyframes(target, {
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+      // fill: 'forwards' holds the end pose until React unmounts the node
+      // on navigation — without it the editor would snap back full-screen
+      // for a frame.
+      animation = root.animate([full, atCell], {
+        duration: ZOOM_CLOSE_MS,
+        easing: ZOOM_CLOSE_EASING,
+        fill: 'forwards',
+      });
+    } else {
+      animation = root.animate([{ opacity: 1 }, { opacity: 0 }], {
+        duration: FADE_MS,
+        easing: 'linear',
+        fill: 'forwards',
+      });
+    }
+    animation.addEventListener('finish', onClose);
+    animation.addEventListener('cancel', onClose);
+  }, [onClose, frameCellRect, peeked, detection]);
+
   // --- Keyboard -----------------------------------------------------------
 
   useEffect(() => {
@@ -751,7 +841,7 @@ export function LocalizeObjectEditor({
           } else if (boxSelected) {
             setBoxSelected(false);
           } else {
-            onClose();
+            requestClose();
           }
           break;
         default:
@@ -768,7 +858,7 @@ export function LocalizeObjectEditor({
     acceptOpen,
     shortcutsOpen,
     resetZoom,
-    onClose,
+    requestClose,
     editable,
     isAccepting,
     onAcceptRemaining,
@@ -811,7 +901,7 @@ export function LocalizeObjectEditor({
     : detection;
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-ash">
+    <div ref={rootRef} className="fixed inset-0 z-50 flex flex-col bg-ash">
       {/* z-40 gives the bar its own stacking context above the media row, so
           the accept popover hanging out of it is not painted behind the
           canvas — whose own box layer sits at z-30 in the same context
@@ -934,7 +1024,7 @@ export function LocalizeObjectEditor({
         <button
           type="button"
           data-testid="editor-close"
-          onClick={onClose}
+          onClick={requestClose}
           className="rounded-lg border border-line bg-paper p-1.5 text-char hover:bg-ash focus:outline-none focus:ring-2 focus:ring-char"
           aria-label="Close editor"
         >

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -507,12 +507,17 @@ export function LocalizeObjectEditor({
     transform: { zoomLevel: number; panOffset: Point; transformOrigin: Point };
   } | null => {
     if (!imgRef.current || !containerRef.current) return null;
-    const containerRect = containerRef.current.getBoundingClientRect();
+    const container = containerRef.current;
+    const containerRect = container.getBoundingClientRect();
     return {
       containerOffset: { x: containerRect.left, y: containerRect.top },
+      // LAYOUT metrics for the bounds — same trap as handleImageLoad: while
+      // the open/close animation scales the editor root, the rect is the
+      // transformed visual size, and overlays computed from it during that
+      // window keep the garbage geometry after the animation ends.
       imageBounds: calculateImageBounds({
-        containerWidth: containerRect.width,
-        containerHeight: containerRect.height,
+        containerWidth: container.offsetWidth,
+        containerHeight: container.offsetHeight,
         imageNaturalWidth: imgRef.current.naturalWidth,
         imageNaturalHeight: imgRef.current.naturalHeight,
       }),

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1257,16 +1257,39 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     frameRefs.current[recordedAt] = el;
   };
 
+  // The editor's entrance animation origin: measured at click time, when the
+  // clicked cell is guaranteed laid out, and consumed exactly once by the
+  // editor on mount. Deep links and back/forward never set it, so those
+  // opens are (deliberately) not animated.
+  const pendingEditorOriginRef = useRef<DOMRect | null>(null);
+  const takeEditorOpenRect = useCallback(() => {
+    const rect = pendingEditorOriginRef.current;
+    pendingEditorOriginRef.current = null;
+    return rect;
+  }, []);
+
+  // Close-target lookup for the editor's shrink: the cell showing
+  // `recordedAt`, brought into view instantly first so the exit lands on
+  // something visible. Instant (not smooth): the rect must be final when
+  // measured.
+  const editorFrameCellRect = useCallback((recordedAt: string) => {
+    const el = frameRefs.current[recordedAt];
+    if (!el) return null;
+    el.scrollIntoView?.({ behavior: 'auto', block: 'nearest' });
+    return el.getBoundingClientRect();
+  }, []);
+
   // Opens the shown (active, or first-present-fallback) object's detection
   // in the editor. The editor URL itself carries the lane, so opening it
   // selects the object — deliberately without `activateFocus`, so opening
   // the editor doesn't also silently flip the background grid into focus
   // mode.
-  const handleCellClick = (_recordedAt: string, laneSequenceId: number, detId: number) => {
-    if (sequenceIdNum != null)
-      navigate(
-        `${localizeObject(sequenceIdNum, laneSequenceId, detId, mode === 'done')}${location.search}`
-      );
+  const handleCellClick = (recordedAt: string, laneSequenceId: number, detId: number) => {
+    if (sequenceIdNum == null) return;
+    pendingEditorOriginRef.current = frameRefs.current[recordedAt]?.getBoundingClientRect() ?? null;
+    navigate(
+      `${localizeObject(sequenceIdNum, laneSequenceId, detId, mode === 'done')}${location.search}`
+    );
   };
 
   // 'c' toggles crop mode, matching the legacy grid — inert while the modal
@@ -1776,6 +1799,8 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
           onReclassify={() => handleReclassify(modalContext.laneId)}
           onNavigateToDetection={navigateModalTo}
           onClose={closeModal}
+          takeOpenOriginRect={takeEditorOpenRect}
+          frameCellRect={editorFrameCellRect}
         />
       )}
 

--- a/frontend/src/utils/annotation/zoomTransitionUtils.ts
+++ b/frontend/src/utils/annotation/zoomTransitionUtils.ts
@@ -1,0 +1,46 @@
+/**
+ * Keyframe math for the localize editor's grow-from-cell open/close
+ * transition. Pure: rects in, WAAPI keyframes out. See
+ * docs/specs/2026-08-06-localize-editor-zoom-transition-design.md.
+ */
+
+export interface RectLike {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export const ZOOM_OPEN_MS = 340;
+export const ZOOM_CLOSE_MS = 260;
+export const ZOOM_OPEN_EASING = 'cubic-bezier(0.2, 0, 0, 1)';
+export const ZOOM_CLOSE_EASING = 'cubic-bezier(0.4, 0, 1, 1)';
+/** Fallback (reduced motion, or no target rect on close): a fast plain fade. */
+export const FADE_MS = 120;
+
+/**
+ * The editor root's two poses: shrunk onto a grid cell, and full-screen.
+ * The root is `fixed inset-0`, so a cell rect in viewport coordinates (as
+ * getBoundingClientRect reports) maps to translate+scale with origin 0 0.
+ * The scale is non-uniform on purpose — the cell and the viewport have
+ * different aspect ratios, and the brief squish is the macOS-zoom feel the
+ * mockup comparison chose.
+ */
+export function zoomKeyframes(
+  cell: RectLike,
+  viewport: { width: number; height: number }
+): { atCell: Keyframe; full: Keyframe } {
+  const sx = cell.width / viewport.width;
+  const sy = cell.height / viewport.height;
+  return {
+    atCell: {
+      transform: `translate(${cell.left}px, ${cell.top}px) scale(${sx}, ${sy})`,
+      opacity: 0.55,
+    },
+    full: { transform: 'none', opacity: 1 },
+  };
+}
+
+export function prefersReducedMotion(): boolean {
+  return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+}

--- a/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
+++ b/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
@@ -394,6 +394,14 @@ const stubGeometry = () => {
   const container = image.parentElement as HTMLElement;
   container.getBoundingClientRect = () =>
     ({ left: 0, top: 0, right: 800, bottom: 450, width: 800, height: 450, x: 0, y: 0 }) as DOMRect;
+  // Layout metrics match the rect: the container is not mid-animation here,
+  // and the bounds maths reads these rather than the rect.
+  for (const [prop, value] of [
+    ['offsetWidth', 800],
+    ['offsetHeight', 450],
+  ] as const) {
+    Object.defineProperty(container, prop, { value, configurable: true });
+  }
   for (const [prop, value] of [
     ['naturalWidth', 1600],
     ['naturalHeight', 900],
@@ -1076,6 +1084,31 @@ describe('open/close transition', () => {
     renderEditor({ onClose, frameCellRect: () => ({ left: 0, top: 0, width: 1, height: 1 }) });
     fireEvent.click(screen.getByTestId('editor-close'));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('positions overlays from layout metrics, not the animation-scaled rect', () => {
+    renderEditor();
+    const img = screen.getByAltText(/^Detection /) as HTMLImageElement;
+    const container = img.parentElement as HTMLDivElement;
+    Object.defineProperties(img, {
+      naturalWidth: { value: 1280 },
+      naturalHeight: { value: 720 },
+      offsetWidth: { value: 1000 },
+      offsetHeight: { value: 562 },
+      offsetLeft: { value: 0 },
+      offsetTop: { value: 19 },
+    });
+    Object.defineProperties(container, {
+      offsetWidth: { value: 1000 },
+      offsetHeight: { value: 600 },
+    });
+    // Mid-entrance-animation: the visual rect is the layout scaled to ~16%.
+    // Overlay geometry must come from the layout metrics regardless.
+    container.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 160, height: 96 }) as DOMRect;
+    fireEvent.load(img);
+    // bounds fit 1280x720 into 1000x600 -> width 1000; ghost x1=0.2 -> 200px.
+    expect(screen.getByTestId('ghost-box-auto-0').style.left).toBe('200px');
   });
 
   it('uses an opacity-only fade under prefers-reduced-motion', () => {

--- a/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
+++ b/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LocalizeObjectEditor } from '@/components/localize/editor/LocalizeObjectEditor';
@@ -1010,5 +1010,86 @@ describe('LocalizeObjectEditor out-of-range frames', () => {
     // t003 -> t002 -> t001, then nothing left before it.
     expect(screen.getByTestId('out-of-range-banner')).toBeInTheDocument();
     expect(screen.getByTestId('filmstrip-cell-99001')).toHaveAttribute('aria-current', 'true');
+  });
+});
+
+describe('open/close transition', () => {
+  /** WAAPI stub: records calls, lets the test fire the finish listener. */
+  const makeAnimateMock = () => {
+    const listeners: Record<string, () => void> = {};
+    const animate = vi.fn().mockReturnValue({
+      addEventListener: (type: string, cb: () => void) => {
+        listeners[type] = cb;
+      },
+    });
+    return { animate, finish: () => listeners.finish?.() };
+  };
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (Element.prototype as any).animate;
+    vi.restoreAllMocks();
+  });
+
+  it('grows from the captured origin rect on mount', () => {
+    const { animate } = makeAnimateMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Element.prototype as any).animate = animate;
+    renderEditor({
+      takeOpenOriginRect: () => ({ left: 10, top: 20, width: 100, height: 50 }),
+    });
+    expect(animate).toHaveBeenCalledTimes(1);
+    const [keyframes] = animate.mock.calls[0];
+    expect(keyframes[0].transform).toContain('translate(10px, 20px)');
+    expect(keyframes[1].transform).toBe('none');
+  });
+
+  it('does not animate the entrance without a captured origin rect', () => {
+    const { animate } = makeAnimateMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Element.prototype as any).animate = animate;
+    renderEditor({ takeOpenOriginRect: () => null });
+    expect(animate).not.toHaveBeenCalled();
+  });
+
+  it('shrinks into the current frame cell and calls onClose only after the animation finishes', () => {
+    const { animate, finish } = makeAnimateMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Element.prototype as any).animate = animate;
+    const onClose = vi.fn();
+    const frameCellRect = vi.fn(() => ({ left: 5, top: 6, width: 100, height: 60 }));
+    renderEditor({ onClose, frameCellRect });
+    fireEvent.click(screen.getByTestId('editor-close'));
+    expect(frameCellRect).toHaveBeenCalledWith(firstDetection.recorded_at);
+    expect(onClose).not.toHaveBeenCalled();
+    const closeCall = animate.mock.calls[animate.mock.calls.length - 1];
+    expect(closeCall[0][1].transform).toContain('translate(5px, 6px)');
+    finish();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    // A second close attempt during/after the exit is a no-op.
+    fireEvent.click(screen.getByTestId('editor-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes immediately when element.animate is unavailable', () => {
+    const onClose = vi.fn();
+    renderEditor({ onClose, frameCellRect: () => ({ left: 0, top: 0, width: 1, height: 1 }) });
+    fireEvent.click(screen.getByTestId('editor-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses an opacity-only fade under prefers-reduced-motion', () => {
+    const { animate } = makeAnimateMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Element.prototype as any).animate = animate;
+    vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: true,
+    } as unknown as MediaQueryList);
+    renderEditor({
+      takeOpenOriginRect: () => ({ left: 10, top: 20, width: 100, height: 50 }),
+    });
+    const [keyframes] = animate.mock.calls[0];
+    expect(keyframes[0]).toEqual({ opacity: 0 });
+    expect(keyframes[1]).toEqual({ opacity: 1 });
   });
 });

--- a/frontend/tests/utils/annotation/zoomTransitionUtils.test.ts
+++ b/frontend/tests/utils/annotation/zoomTransitionUtils.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { zoomKeyframes } from '@/utils/annotation/zoomTransitionUtils';
+
+describe('zoomKeyframes', () => {
+  it('maps the cell rect to a translate+scale pose of the full viewport', () => {
+    const { atCell, full } = zoomKeyframes(
+      { left: 100, top: 50, width: 200, height: 150 },
+      { width: 1000, height: 600 }
+    );
+    expect(atCell.transform).toBe('translate(100px, 50px) scale(0.2, 0.25)');
+    expect(atCell.opacity).toBe(0.55);
+    expect(full).toEqual({ transform: 'none', opacity: 1 });
+  });
+
+  it('handles a cell at the viewport origin', () => {
+    const { atCell } = zoomKeyframes(
+      { left: 0, top: 0, width: 500, height: 300 },
+      { width: 1000, height: 600 }
+    );
+    expect(atCell.transform).toBe('translate(0px, 0px) scale(0.5, 0.5)');
+  });
+});


### PR DESCRIPTION
## Summary

The per-frame editor (`LocalizeObjectEditor`) is technically an overlay — a child route rendered over the still-mounted localize cockpit — but it popped in and out with no animation, so it read as navigation to a different page. This PR animates it as a layer on top of the grid:

- **Open**: the editor grows out of the clicked grid cell (~340ms, FLIP-style transform of the cell's viewport rect).
- **Close**: it shrinks back into the **current** frame's cell — not necessarily the one it opened from, since annotators step frames inside — scrolling that cell into view first so the exit lands where work continues.
- Stepping frames inside the editor never re-animates; only mount and close do.
- Quiet degradations: deep links and browser back/forward open/close instantly; `prefers-reduced-motion` gets a fast fade; missing `element.animate` (jsdom) means behavior identical to before.

Mechanism: a pure keyframe helper (`zoomTransitionUtils`), a click-captured origin rect + `frameCellRect(recordedAt)` lookup on the page, and Web Animations API calls owned by the editor (no new dependency, no routing changes).

Also fixes a measurement trap the animation exposed: `getImageInfo` computed overlay bounds from `getBoundingClientRect()`, so box overlays rendered during the entrance animation were measured against the scaled visual rect (~6× too small) and kept that geometry. Bounds now come from layout metrics, matching `handleImageLoad`'s existing rule.

Spec: `docs/specs/2026-08-06-localize-editor-zoom-transition-design.md`

## Test plan

- 8 new tests: keyframe math, entrance suppressed without a captured rect (deep link), close deferred until the exit animation finishes, instant close without WAAPI, reduced-motion fade, and overlay bounds from layout metrics while mid-animation.
- Full frontend suite green: 92 files, 1204 tests; `npm run quality` clean.
- Verified live against a local stack with Playwright: mid-animation captures show the grow anchored on the clicked cell and the shrink back into the grid; click-open vs deep-link overlay geometry now byte-identical.