### PR TITLE
fix(frontend): harden the localize editor transition (post-#307 review fixes)

### DIFF
--- a/docs/specs/2026-08-06-localize-editor-zoom-transition-design.md
+++ b/docs/specs/2026-08-06-localize-editor-zoom-transition-design.md
@@ -45,7 +45,8 @@ nothing — the component stays mounted and only the stage content changes.
 cell's viewport rect — `translate(cell.x, cell.y) scale(cell.w / vw, cell.h /
 vh)` with `transform-origin: 0 0` (non-uniform scale, FLIP-style) — and
 animates to identity. ~340ms, `cubic-bezier(.2, 0, 0, 1)`, with opacity
-ramping ~0.55 → 1 and border-radius rounding off from the cell's radius to 0.
+ramping ~0.55 → 1. (The mockup also rounded off a border radius; the real
+grid cells are unrounded, so the keyframes are transform + opacity only.)
 
 **Close.** The reverse, targeting the **current frame's** cell — not
 necessarily the one that opened the editor, since the annotator steps frames

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -182,14 +182,45 @@ export function LocalizeObjectEditor({
       root.animate([{ opacity: 0 }, { opacity: 1 }], { duration: FADE_MS, easing: 'linear' });
       return;
     }
+    // Input is off for the grow: getImageInfo's containerOffset is the
+    // visual rect, so pointer maths run mid-animation would mix transformed
+    // and layout space. Restored on finish — unless a close already began,
+    // whose own pointer-events lockout must not be undone.
+    root.style.pointerEvents = 'none';
     root.style.transformOrigin = '0 0';
+    // The root's own layout size, not window.innerWidth: a classic
+    // scrollbar makes the viewport wider than the laid-out root.
     const { atCell, full } = zoomKeyframes(rect, {
-      width: window.innerWidth,
-      height: window.innerHeight,
+      width: root.offsetWidth,
+      height: root.offsetHeight,
     });
-    root.animate([atCell, full], { duration: ZOOM_OPEN_MS, easing: ZOOM_OPEN_EASING });
+    const animation = root.animate([atCell, full], {
+      duration: ZOOM_OPEN_MS,
+      easing: ZOOM_OPEN_EASING,
+    });
+    const restore = () => {
+      if (!isClosingRef.current) root.style.pointerEvents = '';
+    };
+    animation.addEventListener('finish', restore);
+    animation.addEventListener('cancel', restore);
     // Mount-only by design; the origin rect is consumed exactly once.
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // The exit animation runs on the document timeline and survives this
+  // component's removal — after a browser back during the shrink, its finish
+  // listener would navigate AGAIN from the still-mounted page. The unmount
+  // cleanup detaches that path (and cancelling also releases the forwards
+  // fill). The flag is re-armed in the effect body so StrictMode's dev
+  // mount-cleanup-remount cycle doesn't leave it stuck false.
+  const mountedRef = useRef(true);
+  const exitAnimationRef = useRef<Animation | null>(null);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      exitAnimationRef.current?.cancel();
+    };
   }, []);
 
   const [imageInfo, setImageInfo] = useState<{
@@ -746,8 +777,8 @@ export function LocalizeObjectEditor({
     if (target) {
       root.style.transformOrigin = '0 0';
       const { atCell, full } = zoomKeyframes(target, {
-        width: window.innerWidth,
-        height: window.innerHeight,
+        width: root.offsetWidth,
+        height: root.offsetHeight,
       });
       // fill: 'forwards' holds the end pose until React unmounts the node
       // on navigation — without it the editor would snap back full-screen
@@ -764,8 +795,13 @@ export function LocalizeObjectEditor({
         fill: 'forwards',
       });
     }
-    animation.addEventListener('finish', onClose);
-    animation.addEventListener('cancel', onClose);
+    exitAnimationRef.current = animation;
+    // Guarded, not bare onClose: see the unmount cleanup above.
+    const done = () => {
+      if (mountedRef.current) onClose();
+    };
+    animation.addEventListener('finish', done);
+    animation.addEventListener('cancel', done);
   }, [onClose, frameCellRect, peeked, detection]);
 
   // --- Keyboard -----------------------------------------------------------

--- a/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
+++ b/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
@@ -1025,12 +1025,14 @@ describe('open/close transition', () => {
   /** WAAPI stub: records calls, lets the test fire the finish listener. */
   const makeAnimateMock = () => {
     const listeners: Record<string, () => void> = {};
+    const cancel = vi.fn();
     const animate = vi.fn().mockReturnValue({
       addEventListener: (type: string, cb: () => void) => {
         listeners[type] = cb;
       },
+      cancel,
     });
-    return { animate, finish: () => listeners.finish?.() };
+    return { animate, cancel, finish: () => listeners.finish?.() };
   };
 
   afterEach(() => {
@@ -1076,6 +1078,38 @@ describe('open/close transition', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
     // A second close attempt during/after the exit is a no-op.
     fireEvent.click(screen.getByTestId('editor-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('a late exit-animation finish after unmount does not navigate again', () => {
+    const { animate, cancel, finish } = makeAnimateMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Element.prototype as any).animate = animate;
+    const onClose = vi.fn();
+    const { unmount } = renderEditor({
+      onClose,
+      frameCellRect: () => ({ left: 5, top: 6, width: 100, height: 60 }),
+    });
+    fireEvent.click(screen.getByTestId('editor-close'));
+    // Browser back during the shrink: the route unmounts the editor while
+    // the WAAPI animation (document timeline) is still running.
+    unmount();
+    expect(cancel).toHaveBeenCalled();
+    finish();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a fade on close when no target cell rect is available', () => {
+    const { animate, finish } = makeAnimateMock();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Element.prototype as any).animate = animate;
+    const onClose = vi.fn();
+    renderEditor({ onClose, frameCellRect: () => null });
+    fireEvent.click(screen.getByTestId('editor-close'));
+    const closeCall = animate.mock.calls[animate.mock.calls.length - 1];
+    expect(closeCall[0][0]).toEqual({ opacity: 1 });
+    expect(closeCall[0][1]).toEqual({ opacity: 0 });
+    finish();
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #307 (merged before its review pass landed). A dedicated review of that diff found no critical issues; this PR applies the fixes it did surface:

- **Exit animation outliving unmount (the real bug here).** WAAPI animations run on the document timeline and survive their element's removal, and the shrink's `finish` listener calls `onClose` → navigate. Browser-back *during* the 260ms shrink therefore navigated a second time from the still-mounted page, yanking the user forward again. The editor now re-arms a mounted flag (StrictMode-safe), guards `onClose` behind it, and cancels the tracked exit animation in the unmount cleanup — which also releases the `fill: 'forwards'` hold.
- **Keyframe basis is the root's own layout size** (`root.offsetWidth/offsetHeight`) instead of `window.innerWidth/innerHeight`, which over-counts by the scrollbar width on classic-scrollbar platforms.
- **Input is off during the entrance grow**: pointer math mixes visual and layout space mid-animation, so a fast drag started inside the 340ms window could begin a box at the wrong point. Restored on finish unless a close already began.
- **Spec amendment**: the Motion section claimed a border-radius keyframe carried over from the mockup; real grid cells are unrounded, so the keyframes are transform + opacity only. Doc now matches code.

## Test plan

- 2 new tests: a late exit-animation finish after unmount does not call `onClose` (and the animation is cancelled); close falls back to opacity-only keyframes when no target cell rect is available.
- Full frontend suite green: 92 files, 1226 tests; `npm run quality` clean.