### PR TITLE
Localize: retire '+ Add object', nudge missed-smoke alerts toward Skip alert

### DIFF
--- a/docs/specs/2026-08-06-missed-smoke-skip-nudge-design.md
+++ b/docs/specs/2026-08-06-missed-smoke-skip-nudge-design.md
@@ -1,0 +1,92 @@
+# Missed smoke → Skip alert nudge on /localize/:id
+
+**Date**: 2026-08-06
+**Status**: Approved
+**Base**: `main` (the alert-skip escape hatch, PR #297, merged 2026-08-06 —
+the Skip alert button this design points at ships with it).
+
+## Problem
+
+The localize page's missed-smoke row offers "+ Add object", which spawns a new
+sibling lane server-side and drops the annotator into the editor to draw the
+missed object's boxes. That drawing flow is not developed enough to ship: we do
+not want annotators adding new boxes for missed smokes yet. But the alert can't
+just dead-end either — PR #297's skip escape hatch is exactly the right exit
+(park the alert, leave a note, move on), and nothing currently points the
+annotator at it.
+
+## Decision
+
+Remove the "+ Add object" control from the localize page and turn the
+missed-smoke Yes answer into a nudge toward **Skip alert**: explanatory copy in
+the row, a pulsing ember glow on the Skip alert button while the answer is Yes,
+and a reworked submit-time soft-confirm whose primary action is skipping.
+
+The backend `/alert/add-object` endpoint and `apiClient.addObject` stay
+untouched — only the page-side entry point goes away, so the feature can return
+by re-adding UI.
+
+## Design
+
+### 1. `LocalizeMissedSmokeRow`
+
+- The `addObject` slot prop is deleted.
+- New optional boolean prop `showSkipNudge` (the page passes `mode !== 'done'`).
+- When `hasMissedSmoke` and `showSkipNudge`, the explainer copy becomes the
+  nudge:
+
+  > Adding the missed object isn't supported yet. Use **Skip alert** below to
+  > park this alert so it can be annotated once it is.
+
+- In done mode (no Skip button, alert already submitted) the Yes answer shows
+  no extra copy — the Yes/No chips render exactly as today. The Yes/No question
+  stays in both modes: it still records `has_missed_smoke` on the annotation.
+
+### 2. Skip button glow (`LocalizeAlertPage`)
+
+While the missed-smoke answer is Yes (queue mode only — the button doesn't
+render in done mode), the footer's "Skip alert" button carries a pulsing ember
+glow: a new `skip-glow` animation in `tailwind.config.js` — keyframes cycling a
+soft ember `box-shadow` halo, ~2s ease-in-out infinite. Deliberately not
+`animate-pulse`: opacity flashing makes the label unreadable; a halo draws the
+eye without degrading the button.
+
+### 3. Soft-confirm rework
+
+`softConfirmNeeded` loses its `sessionAddedObjects` term (the state dies with
+the feature) and becomes `anyLaneFlagged && !softConfirmResolved`.
+
+Dialog copy: *"You flagged missed smoke, but adding the missed object isn't
+supported yet."* Buttons, top to bottom:
+
+1. **Skip alert** (primary) — closes this dialog, opens the existing skip
+   confirm from #297 (note + confirm).
+2. Submit & clear flag
+3. Submit anyway
+4. Go back
+
+### 4. Dead code removal
+
+Gone from `LocalizeAlertPage`: `addObjectPickerOpen`, `sessionAddedObjects`,
+the `addObject` mutation, the smoke-type picker JSX, and the
+`addObjectPickerOpen` terms in the two keyboard guards.
+
+### 5. Copy consistency
+
+`GuidePage` describes the "+ Add object" button in the localize section —
+reword to describe skipping the alert instead.
+
+## Testing
+
+`frontend/tests/pages/LocalizeAlertPage.test.tsx` (TDD; never run prettier on
+`tests/**`):
+
+- Delete the add-object flow tests: lane spawn, failure toast, and the
+  picker-inert keyboard guards.
+- Add: Yes answer → nudge copy visible and the Skip alert button carries the
+  glow class; No answer → no glow, no nudge; done mode with Yes → no nudge.
+- Soft-confirm: shows the reworded copy, Skip alert is the primary action and
+  opens the skip confirm dialog.
+
+Component-level behavior of the row is covered through the page tests, as
+today.

--- a/frontend/src/components/localize/LocalizeMissedSmokeRow.tsx
+++ b/frontend/src/components/localize/LocalizeMissedSmokeRow.tsx
@@ -25,6 +25,8 @@ export interface LocalizeMissedSmokeRowProps {
   isSaving?: boolean;
   /** No lane can carry the flag (nothing annotated yet) — render read-only. */
   disabled?: boolean;
+  /** Queue mode: the Yes answer points at the footer's Skip alert button. */
+  showSkipNudge?: boolean;
 }
 
 const chip = (selected: boolean, selectedClasses: string, disabled: boolean) =>
@@ -37,6 +39,7 @@ export const LocalizeMissedSmokeRow: React.FC<LocalizeMissedSmokeRowProps> = ({
   onChange,
   isSaving = false,
   disabled = false,
+  showSkipNudge = false,
 }) => (
   <div
     data-testid="localize-missed-smoke-row"
@@ -69,5 +72,12 @@ export const LocalizeMissedSmokeRow: React.FC<LocalizeMissedSmokeRowProps> = ({
         </button>
       </span>
     </div>
+    {hasMissedSmoke && showSkipNudge && (
+      <p className="mt-1.5 font-body text-detail text-haze">
+        Adding the missed object isn&apos;t supported yet. Use{' '}
+        <span className="font-semibold text-ember">Skip alert</span> below to park this alert so
+        it can be annotated once it is.
+      </p>
+    )}
   </div>
 );

--- a/frontend/src/components/localize/LocalizeMissedSmokeRow.tsx
+++ b/frontend/src/components/localize/LocalizeMissedSmokeRow.tsx
@@ -75,8 +75,8 @@ export const LocalizeMissedSmokeRow: React.FC<LocalizeMissedSmokeRowProps> = ({
     {hasMissedSmoke && showSkipNudge && (
       <p className="mt-1.5 font-body text-detail text-haze">
         Adding the missed object isn&apos;t supported yet. Use{' '}
-        <span className="font-semibold text-ember">Skip alert</span> below to park this alert so
-        it can be annotated once it is.
+        <span className="font-semibold text-ember">Skip alert</span> below to park this alert so it
+        can be annotated once it is.
       </p>
     )}
   </div>

--- a/frontend/src/components/localize/LocalizeMissedSmokeRow.tsx
+++ b/frontend/src/components/localize/LocalizeMissedSmokeRow.tsx
@@ -1,21 +1,18 @@
 /**
  * The localize rail's missed-smoke question — the counterpart of classify's
- * `DecisionRail` row, and the context for "+ Add object" sitting directly
- * below it.
+ * `DecisionRail` row.
  *
  * Localize used to READ `has_missed_smoke` without ever showing it: the flag
- * classify set only surfaced at submit time, in the "you flagged missed smoke
- * but added no object" dialog. Here it is visible up front and answerable in
- * place, so the reason to add an object is on screen before you need it.
+ * classify set only surfaced at submit time, in the "you flagged missed smoke"
+ * dialog. Here it is visible up front and answerable in place.
  *
  * Binary rather than classify's tri-state: classify's own submit already
  * requires the question to be answered, so by the time an alert reaches
  * localize `has_missed_smoke` is a real answer, not "not asked yet".
  *
- * The answer gates adding an object, and the control lives INSIDE this row
- * rather than beside it: "+ Add object" only exists once the answer is Yes,
- * so the question and the only action it authorizes read as one unit instead
- * of a button that is mysteriously dead until something above it is answered.
+ * A Yes answer records the flag — it no longer gates an add control. Drawing
+ * the missed object isn't supported yet, so the page points the annotator at
+ * its Skip alert escape hatch instead (the nudge rendered under the question).
  */
 
 import React from 'react';
@@ -28,8 +25,6 @@ export interface LocalizeMissedSmokeRowProps {
   isSaving?: boolean;
   /** No lane can carry the flag (nothing annotated yet) — render read-only. */
   disabled?: boolean;
-  /** The "+ Add object" control, rendered inside the row and only while the answer is Yes. */
-  addObject?: React.ReactNode;
 }
 
 const chip = (selected: boolean, selectedClasses: string, disabled: boolean) =>
@@ -42,7 +37,6 @@ export const LocalizeMissedSmokeRow: React.FC<LocalizeMissedSmokeRowProps> = ({
   onChange,
   isSaving = false,
   disabled = false,
-  addObject,
 }) => (
   <div
     data-testid="localize-missed-smoke-row"
@@ -75,13 +69,5 @@ export const LocalizeMissedSmokeRow: React.FC<LocalizeMissedSmokeRowProps> = ({
         </button>
       </span>
     </div>
-    {hasMissedSmoke && (
-      <>
-        <p className="mt-1.5 font-body text-detail text-haze">
-          Add the object the AI missed, so it gets its own row to localize.
-        </p>
-        {addObject && <div className="mt-2 flex flex-wrap items-center gap-2">{addObject}</div>}
-      </>
-    )}
   </div>
 );

--- a/frontend/src/components/localize/LocalizeRail.tsx
+++ b/frontend/src/components/localize/LocalizeRail.tsx
@@ -2,11 +2,7 @@
  * The localize cockpit's right-hand column: the whole alert's localization
  * state, mirroring classify's `DecisionRail`. Object rows come in as
  * children (the page owns their ordering and wiring); the rail owns only the
- * frame, the "+ Add object" slot below the rows, and the submit footer.
- *
- * Its own slot is `addObject` rather than classify's fixed missed-smoke row:
- * on the localize side, "the AI missed a plume entirely" is answered by
- * spawning a real sibling lane, not by ticking an alert-level flag.
+ * frame, the missed-smoke slot below the rows, and the submit footer.
  */
 
 import React from 'react';
@@ -16,7 +12,7 @@ export interface LocalizeRailProps {
   headerAction?: React.ReactNode;
   /** The shared timeline legend — rendered below the rows, above the missed-smoke divider. */
   legend?: React.ReactNode;
-  /** The missed-smoke question, which carries "+ Add object" inside it — rendered below the rows. */
+  /** The missed-smoke question — rendered below the rows. */
   missedSmoke?: React.ReactNode;
   /** The page's submit button. */
   footer?: React.ReactNode;

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -54,11 +54,12 @@ export default function GuidePage() {
         </p>
         <p className="font-body text-body leading-relaxed text-haze">
           Start from the dashboard’s “Start localizing” queue — it opens the alert page with every
-          object’s status, plus a “+ Add object” button for smoke the classify pass missed entirely:
-          pick a smoke type and it spawns a brand-new object row to draw. “Accept all & submit
-          alert” accepts every object’s pending predictions and submits the whole alert in one step.
-          The old per-object editor still exists, but only as a direct link to a specific frame —
-          it’s no longer part of the normal queue flow.
+          object’s status. If the classify pass missed smoke entirely, adding that object isn’t
+          supported yet: answer the missed-smoke question Yes and use “Skip alert” to park the whole
+          alert so it can be annotated once it is. “Accept all & submit alert” accepts every
+          object’s pending predictions and submits the whole alert in one step. The old per-object
+          editor still exists, but only as a direct link to a specific frame — it’s no longer part
+          of the normal queue flow.
         </p>
       </section>
 

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1078,11 +1078,12 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     },
   });
 
-  // The missed-smoke soft-confirm ("you flagged missed smoke but added no
-  // object") is the only gate left in front of submit — the old two-step
-  // no-box warning went away with the bulk-accept-on-submit it guarded:
-  // submit now requires every frame to already carry a committed box, so
-  // there is never a pending no-box frame left to warn about.
+  // The missed-smoke soft-confirm is the only gate left in front of submit:
+  // flagged missed smoke can't be annotated yet, so it leads with Skip alert
+  // before offering to submit anyway. The old two-step no-box warning went
+  // away with the bulk-accept-on-submit it guarded: submit now requires
+  // every frame to already carry a committed box, so there is never a
+  // pending no-box frame left to warn about.
   const handleSubmitClick = () => {
     if (submitBlocked || submitAlert.isPending) return;
     if (softConfirmNeeded) {
@@ -1907,20 +1908,30 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
         >
           <div className="w-full max-w-sm rounded-lg border border-line bg-paper p-5">
             <p className="font-body text-sm text-char mb-4">
-              You flagged missed smoke but added no object — submit anyway?
+              You flagged missed smoke, but adding the missed object isn&apos;t supported yet.
             </p>
             <div className="flex flex-col gap-2">
               <button
                 type="button"
-                onClick={handleSubmitAndClearFlag}
+                onClick={() => {
+                  setMissedSmokeConfirm(false);
+                  setSkipConfirmOpen(true);
+                }}
                 className="inline-flex items-center justify-center rounded-lg bg-ember px-4 py-2 font-body text-sm font-semibold text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-char focus:ring-offset-2"
+              >
+                Skip alert
+              </button>
+              <button
+                type="button"
+                onClick={handleSubmitAndClearFlag}
+                className="inline-flex items-center justify-center rounded-lg border border-line bg-paper px-4 py-2 font-body text-sm font-medium text-char hover:bg-ash"
               >
                 Submit & clear flag
               </button>
               <button
                 type="button"
                 onClick={handleSubmitAnyway}
-                className="inline-flex items-center justify-center rounded-lg border border-line bg-paper px-4 py-2 font-body text-sm font-medium text-char hover:bg-ash"
+                className="inline-flex items-center justify-center rounded-lg px-4 py-2 font-body text-sm font-medium text-char hover:bg-ash"
               >
                 Submit anyway
               </button>

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1762,6 +1762,7 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
                 onChange={handleMissedSmokeChange}
                 isSaving={setMissedSmokeFlag.isPending}
                 disabled={missedSmokeAnnotationId == null}
+                showSkipNudge={mode !== 'done'}
               />
             }
             footer={

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -864,10 +864,9 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   useEffect(() => {
     if (!alertDetail || sequenceIdNum == null || laneIdNum != null) return;
     if (selectLaneIdNum != null) {
-      // Not while a refetch is in flight: "+ Add object" activates its new
-      // lane the moment the server confirms it, which is necessarily before
-      // the invalidated alert-detail lands — judging the URL against the
-      // stale lane list would bounce the just-added object off selection.
+      // Not while a refetch is in flight: judging the URL against a stale
+      // lane list would bounce a lane that only the incoming alert-detail
+      // knows about off selection.
       if (alertFetching) return;
       const known = frameModel.objectStatus.some(o => o.laneSequenceId === selectLaneIdNum);
       if (!known) navigate(`${basePath}${location.search}`, { replace: true });

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1840,7 +1840,9 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
                             setSkipConfirmOpen(true);
                           }}
                           data-testid="skip-alert-button"
-                          className="inline-flex items-center rounded-lg border border-ember bg-paper px-3 py-2.5 font-body text-sm font-medium text-ember hover:bg-ember-soft"
+                          className={`inline-flex items-center rounded-lg border border-ember bg-paper px-3 py-2.5 font-body text-sm font-medium text-ember hover:bg-ember-soft${
+                            missedSmoke ? ' animate-skip-glow' : ''
+                          }`}
                         >
                           Skip alert
                         </button>

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -40,16 +40,17 @@
  * longer carry a hover preview popover (dropped — the selected rail row's
  * cropped loop replaces it).
  *
- * Task 9 retires the earlier ⚑ pseudo-object row (a carrier-lane box that
- * stood in for missed smoke) in favor of "+ Add object": a footer action
- * that spawns a brand-new sibling lane for a plume the AI missed entirely,
- * so it gets its own real object row like any other.
+ * Task 9 retired the earlier ⚑ pseudo-object row (a carrier-lane box that
+ * stood in for missed smoke). The "+ Add object" control that replaced it is
+ * itself retired for now — drawing a missed object isn't supported yet, so
+ * the missed-smoke Yes answer nudges toward the Skip alert escape hatch
+ * instead (see docs/specs/2026-08-06-missed-smoke-skip-nudge-design.md).
  *
  * Cockpit round: the page adopts ClassifyAlertPage's two-column shape —
  * a media column (the active object's frame grid) beside a sticky
  * `LocalizeRail` carrying the whole alert's
  * localization state. That collapses the three blocks the body used to
- * stack (workable timeline -> standalone "+ Add object" card -> a separate
+ * stack (workable timeline -> standalone add-object card -> a separate
  * dimmed "Already localized" timeline) into one rail: every object gets a
  * row in lane order, with already-localized lanes dimmed in place rather
  * than exiled to their own strip, and each row carries its own per-frame
@@ -92,11 +93,11 @@
  * no-box frame left at submit time. The missed-smoke soft-confirm is the
  * only gate left in front of it.
  *
- * The rail also owns the missed-smoke question, which guards "+ Add object":
- * it starts at No on every alert — deliberately NOT seeded from the lanes'
- * inherited `has_missed_smoke`, so arriving on an alert classify already
- * flagged never pre-authorizes adding — and answering writes the flag
- * through to the carrying lane.
+ * The rail also owns the missed-smoke question: it starts at No on every
+ * alert — deliberately NOT seeded from the lanes' inherited
+ * `has_missed_smoke`, so arriving on an alert classify already flagged never
+ * pre-answers it — and answering writes the flag through to the carrying
+ * lane.
  *
  * False-positive objects are hidden by default (the queue's own rule, via
  * `laneNeedsLocalization`) behind a rail toggle that surfaces them as a
@@ -113,7 +114,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useNavigate, useLocation, useSearchParams, useMatch } from 'react-router-dom';
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, Keyboard, PlayCircle, Plus, Upload, X } from 'lucide-react';
+import { ArrowLeft, Keyboard, PlayCircle, Upload, X } from 'lucide-react';
 import { apiClient } from '@/services/api';
 import { QUERY_KEYS } from '@/utils/constants';
 import {
@@ -259,18 +260,13 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   const [selectedSmokeType, setSelectedSmokeType] = useState<SmokeType>('wildfire');
   const smokeTypeInitFor = useRef<number | null>(null);
 
-  // The three-way "you flagged missed smoke but added no object" dialog and
-  // whether it's already been answered this submit round (so re-clicking
-  // Submit after "Submit anyway" goes straight through instead of re-asking
-  // the same question).
+  // The "you flagged missed smoke" dialog and whether it's already been
+  // answered this submit round (so re-clicking Submit after "Submit anyway"
+  // goes straight through instead of re-asking the same question).
   const [missedSmokeConfirm, setMissedSmokeConfirm] = useState(false);
   const [skipConfirmOpen, setSkipConfirmOpen] = useState(false);
   const [skipNote, setSkipNote] = useState('');
   const [softConfirmResolved, setSoftConfirmResolved] = useState(false);
-  // "+ Add object": lane ids spawned via the picker this session (feeds the
-  // soft-confirm gate below) and whether the picker is currently open.
-  const [sessionAddedObjects, setSessionAddedObjects] = useState<number[]>([]);
-  const [addObjectPickerOpen, setAddObjectPickerOpen] = useState(false);
 
   // The Accept boxes confirm popover — the editor's AcceptRemainingPopover,
   // anchored under the header button. Open/dismiss wiring mirrors the
@@ -279,11 +275,10 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   const [acceptPopoverOpen, setAcceptPopoverOpen] = useState(false);
   const acceptAnchorRef = useRef<HTMLDivElement | null>(null);
 
-  // The rail's missed-smoke answer, and the gate in front of "+ Add object".
-  // Deliberately NOT seeded from the lanes' inherited `has_missed_smoke`:
-  // adding an object has to be a decision made here, so arriving on an alert
-  // classify already flagged must not pre-authorize it. Answering writes the
-  // flag through to the carrier lane.
+  // The rail's missed-smoke answer. Deliberately NOT seeded from the lanes'
+  // inherited `has_missed_smoke`: flagging has to be a decision made here, so
+  // arriving on an alert classify already flagged must not pre-answer it.
+  // Answering writes the flag through to the carrier lane.
   const [missedSmoke, setMissedSmoke] = useState(false);
 
   // Object-focus mode: entering it (row/segment click activating an object)
@@ -351,8 +346,6 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     setHighlightedFrame(null);
     setMissedSmokeConfirm(false);
     setSoftConfirmResolved(false);
-    setSessionAddedObjects([]);
-    setAddObjectPickerOpen(false);
     setMissedSmoke(false);
     frameRefs.current = {};
   }, [sequenceIdNum]);
@@ -448,13 +441,10 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       })
     : { frames: [], objectStatus: [] };
 
-  // Soft-confirm gate for submit: `has_missed_smoke` is set on some lane,
-  // but no object was added this session to address it (`sessionAddedObjects`
-  // — see the "+ Add object" mutation below), and the question hasn't
-  // already been answered this submit round.
+  // Soft-confirm gate for submit: `has_missed_smoke` is set on some lane and
+  // the question hasn't already been answered this submit round.
   const anyLaneFlagged = alertDetail?.lanes.some(l => l.annotation?.has_missed_smoke) ?? false;
-  const softConfirmNeeded =
-    anyLaneFlagged && sessionAddedObjects.length === 0 && !softConfirmResolved;
+  const softConfirmNeeded = anyLaneFlagged && !softConfirmResolved;
 
   // The alert-level missed-smoke flag lives on ONE lane's annotation.
   // Whichever lane
@@ -722,9 +712,6 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
 
   const handleMissedSmokeChange = (value: boolean) => {
     setMissedSmoke(value);
-    // Answering No also closes a picker opened under a previous Yes, so the
-    // gate can't be walked around by leaving it open.
-    if (!value) setAddObjectPickerOpen(false);
     if (missedSmokeAnnotationId == null) return;
     setMissedSmokeFlag.mutate({ annotationId: missedSmokeAnnotationId, value });
   };
@@ -1312,34 +1299,6 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     });
   };
 
-  // "+ Add object": the ⚑ row's replacement for missed smoke — spawns a
-  // brand-new sibling lane server-side (empty algo_predictions, one-track
-  // smoke annotation born at seq_annotation_done; see the backend's
-  // `/alert/add-object`) rather than drawing an anonymous box on an
-  // existing lane. On success: invalidate alert-detail so the new Object
-  // N+1 row appears (its index/color fall out of its position in
-  // `alertDetail.lanes`, same as any other lane), record its lane id in
-  // `sessionAddedObjects` (feeds the soft-confirm gate above), close the
-  // picker, and auto-enter focus mode on it — a lens for immediately
-  // drawing its boxes. Repeatable: each success re-closes the picker so a
-  // further click reopens it for another add.
-  const addObject = useMutation({
-    mutationFn: (smokeType: SmokeType) => {
-      if (!sequence) throw new Error('Alert not loaded');
-      return apiClient.addObject(sequence.source_api, sequence.platform_alert_id, smokeType);
-    },
-    onSuccess: newLane => {
-      queryClient.invalidateQueries({ queryKey: alertDetailQueryKey });
-      setSessionAddedObjects(prev => [...prev, newLane.sequence.id]);
-      setAddObjectPickerOpen(false);
-      activateFocus(newLane.sequence.id);
-      showToastNotification('Object added', 'success');
-    },
-    onError: () => {
-      showToastNotification('Failed to add object — try again', 'error');
-    },
-  });
-
   const handleCellRef = (recordedAt: string, el: HTMLDivElement | null) => {
     frameRefs.current[recordedAt] = el;
   };
@@ -1406,11 +1365,10 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     const handleTab = (e: KeyboardEvent) => {
       if (e.key !== 'Tab') return;
       // Suspended whenever a surface with its own focusables is up — the
-      // per-frame editor, the (inline) add-object smoke-type picker, the
-      // missed-smoke submit dialog, the shortcuts sheet, the accept popover
-      // — so their controls stay keyboard-reachable (mirrors classify's
-      // modal guards).
-      if (detectionIdNum != null || addObjectPickerOpen || missedSmokeConfirm) return;
+      // per-frame editor, the missed-smoke submit dialog, the shortcuts
+      // sheet, the accept popover — so their controls stay
+      // keyboard-reachable (mirrors classify's modal guards).
+      if (detectionIdNum != null || missedSmokeConfirm) return;
       if (showShortcutsModal || acceptPopoverOpen) return;
       if (orderedObjectRows.length === 0) return;
       e.preventDefault();
@@ -1441,7 +1399,7 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // above: re-subscribing every render keeps the closure fresh.
   useEffect(() => {
     const handleShortcutKeys = (e: KeyboardEvent) => {
-      if (detectionIdNum != null || addObjectPickerOpen || missedSmokeConfirm) return;
+      if (detectionIdNum != null || missedSmokeConfirm) return;
       // Shift stays allowed: `?` requires it.
       if (e.ctrlKey || e.metaKey || e.altKey) return;
       const target = e.target;
@@ -1804,46 +1762,6 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
                 onChange={handleMissedSmokeChange}
                 isSaving={setMissedSmokeFlag.isPending}
                 disabled={missedSmokeAnnotationId == null}
-                addObject={
-                  /* "+ Add object" lives inside the question it answers, and
-                     only exists once that answer is Yes — a control that
-                     appears with the reason for it, rather than a dead button
-                     waiting on something above it. */
-                  addObjectPickerOpen ? (
-                    <>
-                      <span className="font-data text-eyebrow font-medium uppercase tracking-eyebrow text-haze">
-                        Smoke type
-                      </span>
-                      {(['wildfire', 'industrial', 'other'] as SmokeType[]).map(type => (
-                        <button
-                          key={type}
-                          type="button"
-                          onClick={() => addObject.mutate(type)}
-                          disabled={addObject.isPending}
-                          className="inline-flex items-center rounded-full bg-ash px-3 py-1 font-body text-xs font-medium capitalize text-haze transition-colors hover:bg-pine-soft hover:text-pine disabled:cursor-not-allowed disabled:opacity-50"
-                        >
-                          {type}
-                        </button>
-                      ))}
-                      <button
-                        type="button"
-                        onClick={() => setAddObjectPickerOpen(false)}
-                        className="font-body text-detail text-haze hover:text-char"
-                      >
-                        Cancel
-                      </button>
-                    </>
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => setAddObjectPickerOpen(true)}
-                      title="Add an object the AI missed entirely"
-                      className="inline-flex items-center gap-1.5 rounded-lg border border-line bg-paper px-3 py-2 font-body text-sm font-medium text-char hover:bg-ash"
-                    >
-                      <Plus className="w-3.5 h-3.5" /> Add object
-                    </button>
-                  )
-                }
               />
             }
             footer={

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1365,10 +1365,10 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     const handleTab = (e: KeyboardEvent) => {
       if (e.key !== 'Tab') return;
       // Suspended whenever a surface with its own focusables is up — the
-      // per-frame editor, the missed-smoke submit dialog, the shortcuts
-      // sheet, the accept popover — so their controls stay
+      // per-frame editor, the missed-smoke submit dialog, the skip confirm,
+      // the shortcuts sheet, the accept popover — so their controls stay
       // keyboard-reachable (mirrors classify's modal guards).
-      if (detectionIdNum != null || missedSmokeConfirm) return;
+      if (detectionIdNum != null || missedSmokeConfirm || skipConfirmOpen) return;
       if (showShortcutsModal || acceptPopoverOpen) return;
       if (orderedObjectRows.length === 0) return;
       e.preventDefault();
@@ -1399,7 +1399,7 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // above: re-subscribing every render keeps the closure fresh.
   useEffect(() => {
     const handleShortcutKeys = (e: KeyboardEvent) => {
-      if (detectionIdNum != null || missedSmokeConfirm) return;
+      if (detectionIdNum != null || missedSmokeConfirm || skipConfirmOpen) return;
       // Shift stays allowed: `?` requires it.
       if (e.ctrlKey || e.metaKey || e.altKey) return;
       const target = e.target;
@@ -1841,7 +1841,7 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
                           }}
                           data-testid="skip-alert-button"
                           className={`inline-flex items-center rounded-lg border border-ember bg-paper px-3 py-2.5 font-body text-sm font-medium text-ember hover:bg-ember-soft${
-                            missedSmoke ? ' animate-skip-glow' : ''
+                            missedSmoke ? ' animate-skip-glow motion-reduce:animate-none' : ''
                           }`}
                         >
                           Skip alert

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -46,6 +46,17 @@ export default {
       borderRadius: {
         card: '10px',
       },
+      keyframes: {
+        'skip-glow': {
+          '0%, 100%': { boxShadow: '0 0 0 0 rgba(217, 88, 30, 0)' },
+          '50%': { boxShadow: '0 0 0 5px rgba(217, 88, 30, 0.30)' },
+        },
+      },
+      animation: {
+        // Halo pulse, not `animate-pulse`: opacity flashing would make the
+        // button's own label unreadable.
+        'skip-glow': 'skip-glow 2s ease-in-out infinite',
+      },
     },
   },
   plugins: [],

--- a/frontend/tests/components/dashboard/GuidePage.test.tsx
+++ b/frontend/tests/components/dashboard/GuidePage.test.tsx
@@ -20,11 +20,11 @@ describe('GuidePage', () => {
     expect(screen.getByText('frames')).toBeInTheDocument();
   });
 
-  it('describes the collocated Pass 02 flow: timeline, focus, accept-all, and "+ Add object"', () => {
+  it('describes the collocated Pass 02 flow: timeline, focus, accept-all, and the skip escape hatch', () => {
     render(<GuidePage />, { wrapper: MemoryRouter });
     expect(screen.getByText(/object timeline/i)).toBeInTheDocument();
     expect(screen.getByText(/focus that object/i)).toBeInTheDocument();
-    expect(screen.getByText(/“\+ Add object” button/)).toBeInTheDocument();
+    expect(screen.getByText(/use “Skip alert” to park the whole alert/)).toBeInTheDocument();
     expect(screen.getByText(/“Accept all & submit alert”/)).toBeInTheDocument();
   });
 

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2233,7 +2233,7 @@ describe('LocalizeAlertPage', () => {
       });
     }
 
-    it('starts at No even on an alert classify already flagged — adding an object is a decision made here', async () => {
+    it('starts at No even on an alert classify already flagged — flagging is a decision made here', async () => {
       flaggedAlert();
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
@@ -2266,6 +2266,7 @@ describe('LocalizeAlertPage', () => {
       fireEvent.click(noRadio);
 
       expect(screen.queryByText(/Adding the missed object isn/)).not.toBeInTheDocument();
+      expect(screen.getByTestId('skip-alert-button').className).not.toContain('animate-skip-glow');
     });
 
     it('done mode: Yes shows no nudge — there is no Skip button to point at', async () => {
@@ -3071,6 +3072,32 @@ describe('LocalizeAlertPage', () => {
       answerMissedSmokeYes();
 
       expect(skipButton.className).toContain('animate-skip-glow');
+    });
+
+    it('Tab is inert while the skip confirm is open, so its controls stay reachable', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      // Arrival barrier: a Tab fired before the auto-select commits would
+      // itself land on lane 101 and pass vacuously.
+      await waitFor(() =>
+        expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101')
+      );
+      fireEvent.click(screen.getByRole('button', { name: /Skip alert/ }));
+
+      fireEvent.keyDown(document, { key: 'Tab' });
+
+      // No cycling happened behind the dialog: the URL still names the
+      // arrival object, and the dialog is still up.
+      expect(screen.getByTestId('location')).toHaveTextContent('/localize/101/object/101');
+      expect(screen.getByTestId('skip-alert-confirm')).toBeInTheDocument();
+    });
+
+    it("'?' is inert while the skip confirm is open", async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      fireEvent.click(screen.getByRole('button', { name: /Skip alert/ }));
+
+      fireEvent.keyDown(window, { key: '?' });
+
+      expect(screen.queryByRole('dialog', { name: 'Keyboard shortcuts' })).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -3041,6 +3041,17 @@ describe('LocalizeAlertPage', () => {
 
       expect(screen.queryByRole('button', { name: /Skip alert/ })).not.toBeInTheDocument();
     });
+
+    it('the Skip alert button glows while missed smoke is Yes', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      const skipButton = screen.getByTestId('skip-alert-button');
+      expect(skipButton.className).not.toContain('animate-skip-glow');
+
+      answerMissedSmokeYes();
+
+      expect(skipButton.className).toContain('animate-skip-glow');
+    });
   });
 
   describe('gap frames (issue #287)', () => {

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -341,6 +341,18 @@ function makeTwoLaneAlertDetail(): AlertDetail {
 
 const emptyAnnotationsPage = { items: [], page: 1, pages: 1, size: 100, total: 0 };
 
+/**
+ * The rail's missed-smoke question starts at No on every alert (deliberately
+ * NOT seeded from the flag classify set — flagging has to be a decision made
+ * on this screen). Answering Yes is what records `has_missed_smoke` and what
+ * reveals the skip-alert nudge — there is no add control behind it anymore.
+ */
+function answerMissedSmokeYes() {
+  fireEvent.click(
+    within(screen.getByTestId('localize-missed-smoke-row')).getByRole('radio', { name: 'Yes' })
+  );
+}
+
 function makeDetectionAnnotation(detectionId: number): DetectionAnnotation {
   return {
     id: 9200 + detectionId,
@@ -2230,6 +2242,40 @@ describe('LocalizeAlertPage', () => {
         'aria-checked',
         'true'
       );
+    });
+
+    it('answering Yes shows the skip-alert nudge — there is no add control anymore', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      answerMissedSmokeYes();
+
+      const row = screen.getByTestId('localize-missed-smoke-row');
+      expect(within(row).getByText(/Adding the missed object isn/)).toBeInTheDocument();
+      expect(within(row).getByText('Skip alert')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Add object' })).not.toBeInTheDocument();
+    });
+
+    it('answering No hides the nudge again', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      answerMissedSmokeYes();
+      const noRadio = within(screen.getByTestId('localize-missed-smoke-row')).getByRole('radio', {
+        name: 'No',
+      });
+      await waitFor(() => expect(noRadio).toBeEnabled());
+      fireEvent.click(noRadio);
+
+      expect(screen.queryByText(/Adding the missed object isn/)).not.toBeInTheDocument();
+    });
+
+    it('done mode: Yes shows no nudge — there is no Skip button to point at', async () => {
+      await renderAndSettle(<LocalizeAlertPage mode="done" />, { wrapper: doneWrapper });
+
+      fireEvent.click(
+        within(screen.getByTestId('localize-missed-smoke-row')).getByRole('radio', { name: 'Yes' })
+      );
+
+      expect(screen.queryByText(/Adding the missed object isn/)).not.toBeInTheDocument();
     });
 
     it('answering Yes PATCHes the flag onto the first annotated lane', async () => {

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -6,9 +6,9 @@
  * controls. Post-Task-5 feedback round adds the segment-click arrival
  * highlight + shareable `?frame=` deep link, and object-focus mode
  * (crop-on + small cards while an object is the timeline's selected row).
- * Task 9 retires the ⚑ pseudo-object row in favor of "+ Add object" (a new
- * sibling lane, its own object row) and reworks the soft-confirm gate
- * around whether an object was added this session.
+ * Task 9 retires the ⚑ pseudo-object row. The "+ Add object" control that
+ * replaced it is itself retired — drawing a missed object isn't supported
+ * yet, so the missed-smoke Yes answer nudges toward Skip alert instead.
  */
 
 import React from 'react';
@@ -25,7 +25,6 @@ import {
 } from 'react-router-dom';
 import type {
   AlertDetail,
-  AlertLane,
   Sequence,
   SequenceAnnotation,
   Detection,
@@ -342,18 +341,6 @@ function makeTwoLaneAlertDetail(): AlertDetail {
 
 const emptyAnnotationsPage = { items: [], page: 1, pages: 1, size: 100, total: 0 };
 
-/**
- * "+ Add object" is gated behind the rail's missed-smoke question, which
- * starts at No on every alert (deliberately NOT seeded from the flag classify
- * set — adding an object has to be a decision made on this screen). Any test
- * that adds an object has to open that gate first.
- */
-function answerMissedSmokeYes() {
-  fireEvent.click(
-    within(screen.getByTestId('localize-missed-smoke-row')).getByRole('radio', { name: 'Yes' })
-  );
-}
-
 function makeDetectionAnnotation(detectionId: number): DetectionAnnotation {
   return {
     id: 9200 + detectionId,
@@ -557,7 +544,7 @@ describe('LocalizeAlertPage', () => {
     expect(screen.getByText('0 of 1 object localized')).toBeInTheDocument();
   });
 
-  it('no ⚑ flag row renders (retired in favor of "+ Add object")', async () => {
+  it('no ⚑ flag row renders', async () => {
     await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
     expect(screen.queryByText('⚑ Missed')).not.toBeInTheDocument();
@@ -1369,238 +1356,6 @@ describe('LocalizeAlertPage', () => {
       // offering a dead button under "accept every object's boxes".
       await waitFor(() => expect(screen.getByTestId('all-objects-localized')).toBeInTheDocument());
       expect(screen.queryByRole('button', { name: /Submit/ })).not.toBeInTheDocument();
-    });
-  });
-
-  describe('"+ Add object"', () => {
-    // Both lanes seq_annotation_done, primary-first: lane 101 is Object 1,
-    // lane 102 is Object 2. `addObject` spawns a new lane appended after
-    // the existing ones — it becomes Object 3 (row index 2) once
-    // alert-detail refetches, mirroring the backend's real ordering
-    // (next synthetic object index, highest alert_api_id).
-    function mockAddObjectFlow() {
-      let alertLanes: AlertLane[] = makeTwoLaneAlertDetail().lanes;
-      vi.mocked(apiClient.getAlertDetail).mockImplementation(async () => ({
-        ...makeTwoLaneAlertDetail(),
-        lanes: alertLanes,
-      }));
-      vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
-        if (id === 101) return [makeDetection(1001, T1)];
-        if (id === 102) return [makeDetection(1002, T1), makeDetection(1003, T2)];
-        if (id === 103) return [makeDetection(1004, T1)];
-        if (id === 104) return [makeDetection(1005, T1)];
-        return [];
-      });
-      let nextId = 103;
-      vi.mocked(apiClient.addObject).mockImplementation(
-        async (_sourceApi, _platformAlertId, smokeType) => {
-          const id = nextId;
-          nextId += 1;
-          const newLane: AlertLane = {
-            sequence: makeSequence({ id, alert_api_id: 9000 + id }),
-            annotation: makeAnnotation({ id: id * 10, sequence_id: id, smoke_types: [smokeType] }),
-          };
-          alertLanes = [...alertLanes, newLane];
-          return newLane;
-        }
-      );
-    }
-
-    it('opens a smoke-type picker, and Cancel closes it without adding anything', async () => {
-      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-
-      answerMissedSmokeYes();
-      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
-      expect(screen.getByRole('button', { name: 'wildfire' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'industrial' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'other' })).toBeInTheDocument();
-
-      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-
-      expect(screen.queryByRole('button', { name: 'wildfire' })).not.toBeInTheDocument();
-      expect(apiClient.addObject).not.toHaveBeenCalled();
-    });
-
-    it('picking a smoke type calls addObject with the alert identity, refetches, and the new object row appears with focus auto-entered', async () => {
-      mockAddObjectFlow();
-      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-
-      answerMissedSmokeYes();
-      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
-      fireEvent.click(screen.getByRole('button', { name: 'industrial' }));
-
-      await waitFor(() => {
-        expect(apiClient.addObject).toHaveBeenCalledWith('pyronear_french', 500, 'industrial');
-      });
-
-      // The picker closes and the new row (Object 3) appears, focused.
-      await waitFor(() => {
-        expect(screen.getByTestId('localize-object-row-object-3')).toBeInTheDocument();
-      });
-      expect(
-        within(screen.getByTestId('localize-object-row-object-3')).getByText('Object 3')
-      ).toBeInTheDocument();
-      expect(screen.getByTestId('localize-object-row-object-3')).toHaveAttribute('data-active', 'true');
-      expect(screen.queryByRole('button', { name: 'industrial' })).not.toBeInTheDocument();
-
-      await expandCrop();
-      await waitFor(() => {
-        expect(screen.getByTestId('cropped-image-sequence')).toHaveAttribute(
-          'data-sequence-id',
-          '103'
-        );
-      });
-      expect(screen.getByText('Object added')).toBeInTheDocument();
-    });
-
-    it('is repeatable: a second add spawns its own further row', async () => {
-      mockAddObjectFlow();
-      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-
-      answerMissedSmokeYes();
-      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
-      fireEvent.click(screen.getByRole('button', { name: 'wildfire' }));
-      await waitFor(() => expect(screen.getByTestId('localize-object-row-object-3')).toBeInTheDocument());
-
-      answerMissedSmokeYes();
-      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
-      fireEvent.click(screen.getByRole('button', { name: 'other' }));
-      await waitFor(() => expect(screen.getByTestId('localize-object-row-object-4')).toBeInTheDocument());
-
-      expect(apiClient.addObject).toHaveBeenCalledTimes(2);
-      expect(
-        within(screen.getByTestId('localize-object-row-object-3')).getByText('Object 3')
-      ).toBeInTheDocument();
-      expect(
-        within(screen.getByTestId('localize-object-row-object-4')).getByText('Object 4')
-      ).toBeInTheDocument();
-    });
-
-    /**
-     * Faithful to the backend's `/alert/add-object`: the spawned lane's
-     * detections are cloned with `algo_predictions: []` and no
-     * auto_predictions (the AI never saw this object), and every frame gets
-     * a DetectionAnnotation at `bbox_annotation` stage — so every cell is
-     * `no-box`, with nothing to accept until the annotator draws.
-     * `mockAddObjectFlow` above is deliberately looser (its lanes carry
-     * model boxes); this is the shape the real endpoint produces.
-     */
-    function mockRealisticAddObjectFlow() {
-      let alertLanes: AlertLane[] = makeTwoLaneAlertDetail().lanes;
-      vi.mocked(apiClient.getAlertDetail).mockImplementation(async () => ({
-        ...makeTwoLaneAlertDetail(),
-        lanes: alertLanes,
-      }));
-      vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
-        if (id === 101) return [makeDetection(1001, T1)];
-        if (id === 102) return [makeDetection(1002, T1), makeDetection(1003, T2)];
-        if (id === 103) {
-          // Cloned frames: no predictions of any kind.
-          return [
-            {
-              ...makeDetection(1004, T1),
-              algo_predictions: { predictions: [] },
-              auto_predictions: undefined,
-            },
-            {
-              ...makeDetection(1005, T2),
-              algo_predictions: { predictions: [] },
-              auto_predictions: undefined,
-            },
-          ];
-        }
-        return [];
-      });
-      vi.mocked(apiClient.getDetectionAnnotations).mockImplementation(async filters => {
-        if (filters?.sequence_id !== 103) return emptyAnnotationsPage;
-        const items = [1004, 1005].map(detectionId => ({
-          ...makeDetectionAnnotation(detectionId),
-          annotation: { annotation: [] },
-          processing_stage: 'bbox_annotation' as const,
-        }));
-        return { ...emptyAnnotationsPage, items, total: items.length };
-      });
-      vi.mocked(apiClient.addObject).mockImplementation(async () => {
-        const newLane: AlertLane = {
-          sequence: makeSequence({ id: 103, alert_api_id: 9003 }),
-          annotation: makeAnnotation({ id: 203, sequence_id: 103 }),
-        };
-        alertLanes = [...alertLanes, newLane];
-        return newLane;
-      });
-    }
-
-    it('a just-added object reads as empty across its timeline — no fill implying boxes it does not have', async () => {
-      mockRealisticAddObjectFlow();
-      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-
-      answerMissedSmokeYes();
-      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
-      fireEvent.click(screen.getByRole('button', { name: 'wildfire' }));
-      await waitFor(() => expect(screen.getByTestId('localize-object-row-object-3')).toBeInTheDocument());
-
-      // Both of its frames are 'empty' (present, nothing on them), NOT
-      // 'pending' — which used to paint a filled bar across the whole row.
-      await waitFor(() => {
-        expect(screen.getByTestId('frame-segment-object-3-0')).toHaveAttribute(
-          'aria-label',
-          'Object 3, frame 1: empty'
-        );
-      });
-      expect(screen.getByTestId('frame-segment-object-3-1')).toHaveAttribute(
-        'aria-label',
-        'Object 3, frame 2: empty'
-      );
-
-      // And its rail row says 0 of 2 done rather than implying progress.
-      // Adding an object activates it, and a selected row shows its actions
-      // in the fraction's place — so deselect to read the progress off it.
-      fireEvent.click(screen.getByRole('button', { name: 'Object 3' }));
-      expect(
-        within(screen.getByTestId('localize-object-row-object-3')).getByText('0/2')
-      ).toBeInTheDocument();
-    });
-
-    it('clicking a just-added object activates it without hanging (no boxes to focus on)', async () => {
-      mockRealisticAddObjectFlow();
-      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-
-      answerMissedSmokeYes();
-      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
-      fireEvent.click(screen.getByRole('button', { name: 'wildfire' }));
-      await waitFor(() => expect(screen.getByTestId('localize-object-row-object-3')).toBeInTheDocument());
-
-      // Row click toggles focus off (add already focused it), then on again.
-      fireEvent.click(screen.getByRole('button', { name: 'Object 3' }));
-      fireEvent.click(screen.getByRole('button', { name: 'Object 3' }));
-
-      await waitFor(() => {
-        expect(screen.getByTestId('localize-object-row-object-3')).toHaveAttribute(
-          'data-active',
-          'true'
-        );
-      });
-      // A freshly added lane has no boxes yet, so the row must not even offer
-      // the disclosure — a chevron that opens onto an empty spinning square is
-      // worse than no chevron. Asserting on the CONTROL, not on the loop: the
-      // loop is collapsed by default, so its absence would prove nothing.
-      expect(screen.queryByRole('button', { name: /cropped view/i })).not.toBeInTheDocument();
-      expect(screen.queryByTestId('cropped-image-sequence')).not.toBeInTheDocument();
-    });
-
-    it('toasts on a failed add and keeps the picker usable for a retry', async () => {
-      vi.mocked(apiClient.addObject).mockRejectedValueOnce(new Error('Network error'));
-
-      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-
-      answerMissedSmokeYes();
-      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
-      fireEvent.click(screen.getByRole('button', { name: 'wildfire' }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Failed to add object — try again')).toBeInTheDocument();
-      });
-      expect(screen.queryByTestId('localize-object-row-object-3')).not.toBeInTheDocument();
     });
   });
 
@@ -2427,17 +2182,6 @@ describe('LocalizeAlertPage', () => {
       expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
     });
 
-    it('Enter is inert while the add-object picker is open', async () => {
-      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-      await awaitAutoSelect();
-
-      answerMissedSmokeYes();
-      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
-      fireEvent.keyDown(window, { key: 'Enter' });
-
-      expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
-    });
-
     it('Enter does nothing when the active object has nothing acceptable', async () => {
       vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
         if (id === 101)
@@ -2486,38 +2230,6 @@ describe('LocalizeAlertPage', () => {
         'aria-checked',
         'true'
       );
-      // And so the inherited flag alone never pre-authorizes adding.
-      expect(screen.queryByRole('button', { name: 'Add object' })).not.toBeInTheDocument();
-    });
-
-    it('gates "+ Add object" until answered Yes, and re-locks it on No', async () => {
-      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-
-      // The control does not exist at all until the question is answered Yes.
-      expect(screen.queryByRole('button', { name: 'Add object' })).not.toBeInTheDocument();
-
-      answerMissedSmokeYes();
-      expect(screen.getByRole('button', { name: 'Add object' })).toBeEnabled();
-      // It lives inside the question it answers, not beside it.
-      expect(
-        within(screen.getByTestId('localize-missed-smoke-row')).getByRole('button', {
-          name: 'Add object',
-        })
-      ).toBeInTheDocument();
-      expect(
-        within(screen.getByTestId('localize-missed-smoke-row')).getByText(
-          /Add the object the AI missed/
-        )
-      ).toBeInTheDocument();
-
-      // Both radios disable while the PATCH is in flight (no double-writes),
-      // so wait for it to settle before answering the other way.
-      const noRadio = within(screen.getByTestId('localize-missed-smoke-row')).getByRole('radio', {
-        name: 'No',
-      });
-      await waitFor(() => expect(noRadio).toBeEnabled());
-      fireEvent.click(noRadio);
-      expect(screen.queryByRole('button', { name: 'Add object' })).not.toBeInTheDocument();
     });
 
     it('answering Yes PATCHes the flag onto the first annotated lane', async () => {
@@ -2549,23 +2261,6 @@ describe('LocalizeAlertPage', () => {
       });
     });
 
-    it('answering Yes is what records the flag — the add itself no longer needs to', async () => {
-      vi.mocked(apiClient.addObject).mockResolvedValue({
-        sequence: makeSequence({ id: 103, alert_api_id: 9003 }),
-        annotation: makeAnnotation({ id: 203, sequence_id: 103 }),
-      });
-      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-
-      answerMissedSmokeYes();
-      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
-      fireEvent.click(screen.getByRole('button', { name: 'wildfire' }));
-
-      await waitFor(() => {
-        expect(apiClient.updateSequenceAnnotation).toHaveBeenCalledWith(201, {
-          has_missed_smoke: true,
-        });
-      });
-    });
   });
 
   describe('soft-confirm on submit (flagged, no object added this session)', () => {
@@ -2603,57 +2298,6 @@ describe('LocalizeAlertPage', () => {
         ).toBeInTheDocument();
       });
       expect(apiClient.localizeSubmit).not.toHaveBeenCalled();
-    });
-
-    it('adding an object this session satisfies the gate — no soft-confirm on submit', async () => {
-      let alertLanes: AlertLane[] = [
-        {
-          sequence: makeSequence({ id: 101, alert_api_id: 9001 }),
-          annotation: makeAnnotation({ id: 201, sequence_id: 101, has_missed_smoke: true }),
-        },
-        {
-          sequence: makeSequence({ id: 102, alert_api_id: 9002 }),
-          annotation: makeAnnotation({ id: 202, sequence_id: 102 }),
-        },
-      ];
-      vi.mocked(apiClient.getAlertDetail).mockImplementation(async () => ({
-        ...makeTwoLaneAlertDetail(),
-        lanes: alertLanes,
-      }));
-      vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
-        if (id === 101) return [makeDetection(1001, T1)];
-        if (id === 102) return [makeDetection(1002, T1), makeDetection(1003, T2)];
-        if (id === 103) return [makeDetection(1004, T1)];
-        return [];
-      });
-      // The spawned lane's own frame must be accepted too, or the submit
-      // gate (not the soft-confirm) would be what blocks the click.
-      vi.mocked(apiClient.getDetectionAnnotations).mockImplementation(async filters => {
-        const byLane: Record<number, number[]> = { 101: [1001], 102: [1002, 1003], 103: [1004] };
-        const items = (byLane[filters?.sequence_id ?? 0] ?? []).map(makeDetectionAnnotation);
-        return { ...emptyAnnotationsPage, items, total: items.length };
-      });
-      vi.mocked(apiClient.addObject).mockImplementation(async () => {
-        const newLane: AlertLane = {
-          sequence: makeSequence({ id: 103, alert_api_id: 9003 }),
-          annotation: makeAnnotation({ id: 203, sequence_id: 103 }),
-        };
-        alertLanes = [...alertLanes, newLane];
-        return newLane;
-      });
-
-      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
-
-      answerMissedSmokeYes();
-      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
-      fireEvent.click(screen.getByRole('button', { name: 'wildfire' }));
-      await waitFor(() => expect(screen.getByTestId('localize-object-row-object-3')).toBeInTheDocument());
-
-      fireEvent.click(screen.getByRole('button', { name: /Submit/ }));
-
-      expect(
-        screen.queryByText('You flagged missed smoke but added no object — submit anyway?')
-      ).not.toBeInTheDocument();
     });
 
     it('"Go back" cancels — nothing is submitted or patched', async () => {
@@ -3152,14 +2796,6 @@ describe('LocalizeAlertPage', () => {
       expect(screen.queryByRole('button', { name: 'Cropped view' })).not.toBeInTheDocument();
       fireEvent.keyDown(window, { key: 'p' });
       expect(screen.queryByTestId('cropped-image-sequence')).not.toBeInTheDocument();
-    });
-
-    it('size keys are inert while the add-object picker is open', async () => {
-      await arrive();
-      answerMissedSmokeYes();
-      fireEvent.click(screen.getByRole('button', { name: 'Add object' }));
-      fireEvent.keyDown(window, { key: 'l' });
-      expect(screen.getByTitle('Large cards')).toHaveAttribute('aria-pressed', 'false');
     });
 
     it('size keys are inert while the shortcuts sheet is open', async () => {

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -2309,7 +2309,7 @@ describe('LocalizeAlertPage', () => {
 
   });
 
-  describe('soft-confirm on submit (flagged, no object added this session)', () => {
+  describe('soft-confirm on submit (missed smoke flagged)', () => {
     // Every case here has to actually reach submit, which is gated on all
     // objects already being accepted.
     beforeEach(() => {
@@ -2332,7 +2332,7 @@ describe('LocalizeAlertPage', () => {
       });
     }
 
-    it('fires when a lane is flagged and no object was added this session', async () => {
+    it('fires when a lane is flagged', async () => {
       mockFlaggedAlert();
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
@@ -2340,9 +2340,29 @@ describe('LocalizeAlertPage', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('You flagged missed smoke but added no object — submit anyway?')
+          screen.getByText(/You flagged missed smoke, but adding the missed object isn/)
         ).toBeInTheDocument();
       });
+      expect(apiClient.localizeSubmit).not.toHaveBeenCalled();
+    });
+
+    it('Skip alert is the primary way out — it opens the skip confirm instead of submitting', async () => {
+      mockFlaggedAlert();
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: /Submit/ }));
+      await waitFor(() => {
+        expect(screen.getByTestId('missed-smoke-confirm')).toBeInTheDocument();
+      });
+
+      fireEvent.click(
+        within(screen.getByTestId('missed-smoke-confirm')).getByRole('button', {
+          name: 'Skip alert',
+        })
+      );
+
+      expect(screen.queryByTestId('missed-smoke-confirm')).not.toBeInTheDocument();
+      expect(screen.getByTestId('skip-alert-confirm')).toBeInTheDocument();
       expect(apiClient.localizeSubmit).not.toHaveBeenCalled();
     });
 
@@ -2354,14 +2374,14 @@ describe('LocalizeAlertPage', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('You flagged missed smoke but added no object — submit anyway?')
+          screen.getByText(/You flagged missed smoke, but adding the missed object isn/)
         ).toBeInTheDocument();
       });
 
       fireEvent.click(screen.getByRole('button', { name: 'Go back' }));
 
       expect(
-        screen.queryByText('You flagged missed smoke but added no object — submit anyway?')
+        screen.queryByText(/You flagged missed smoke, but adding the missed object isn/)
       ).not.toBeInTheDocument();
       expect(apiClient.localizeSubmit).not.toHaveBeenCalled();
       expect(apiClient.updateSequenceAnnotation).not.toHaveBeenCalled();


### PR DESCRIPTION
## What

On `/localize/:id`, drawing a brand-new object for missed smoke isn't developed enough to ship, so the page stops offering it and points annotators at the alert-skip escape hatch (#297) instead:

- **"+ Add object" is retired**: the smoke-type picker, mutation, and `sessionAddedObjects` plumbing are gone from `LocalizeAlertPage`; `LocalizeMissedSmokeRow` loses its `addObject` slot. The backend `/alert/add-object` endpoint and `apiClient.addObject` stay untouched so the feature can return by re-adding UI.
- **The missed-smoke Yes answer nudges toward skipping** (queue mode only): copy under the question — "Adding the missed object isn't supported yet. Use **Skip alert** below…" — and a pulsing ember halo (`animate-skip-glow`) on the footer's Skip alert button. Done mode shows the plain Yes/No row.
- **The submit soft-confirm leads with Skip alert**: reworded to "You flagged missed smoke, but adding the missed object isn't supported yet." with Skip alert as the filled-primary action (opens the existing skip confirm), then Submit & clear flag / Submit anyway / Go back. The gate itself simplifies to `anyLaneFlagged && !softConfirmResolved`.
- **Guide copy** (Pass 02) points at Skip alert instead of the removed button.

Spec: `docs/specs/2026-08-06-missed-smoke-skip-nudge-design.md`.

## Tests

- Deleted the add-object flow tests (spawn, retry toast, picker keyboard guards, add-satisfies-the-gate).
- Added: Yes → nudge copy + glow class, No → neither, done mode → no nudge; soft-confirm's Skip alert opens the skip confirm without submitting.
- Full suite: 1237 passed, `npm run quality` clean.