### PR TITLE
feat(frontend): autofocus the username field on the signin page

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -67,6 +67,7 @@ export default function LoginPage({ onLogin, isLoading = false, error }: LoginPa
                   name="username"
                   type="text"
                   autoComplete="username"
+                  autoFocus
                   required
                   value={username}
                   onChange={e => setUsername(e.target.value)}

--- a/frontend/tests/pages/LoginPage.test.tsx
+++ b/frontend/tests/pages/LoginPage.test.tsx
@@ -11,6 +11,11 @@ describe('LoginPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('focuses the username field on load', () => {
+    render(<LoginPage onLogin={vi.fn()} />);
+    expect(screen.getByLabelText('Username')).toHaveFocus();
+  });
+
   it('shows the error message when provided', () => {
     render(<LoginPage onLogin={vi.fn()} error="Invalid username or password" />);
     expect(screen.getByText('Invalid username or password')).toBeInTheDocument();


### PR DESCRIPTION
Focus the username input automatically when `/login` renders, so the sign-in form is ready to type into without a click or Tab.

## Change

- `frontend/src/pages/LoginPage.tsx`: added `autoFocus` to the username input.

## Test

- `frontend/tests/pages/LoginPage.test.tsx`: new `focuses the username field on load` case. Verified failing before the change, passing after.

Local checks: `vitest` (3 passed), `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check` on the source file — all clean.