### PR TITLE
feat: preview thumbnails column on the groups list

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
@@ -51,6 +51,29 @@ class OrderDirection(str, Enum):
     desc = "desc"
 
 
+def _crop_bbox(algo_predictions: Optional[dict]) -> Optional[list[float]]:
+    """Union of a frame's valid prediction boxes, as a crop target for the
+    list page's thumbnails. Mirrors the frontend's cropBox math on the
+    group annotate page (union of valid boxes, else fall back)."""
+    predictions = (algo_predictions or {}).get("predictions") or []
+    boxes = [
+        p["xyxyn"]
+        for p in predictions
+        if isinstance(p.get("xyxyn"), list)
+        and len(p["xyxyn"]) == 4
+        and p["xyxyn"][2] > p["xyxyn"][0]
+        and p["xyxyn"][3] > p["xyxyn"][1]
+    ]
+    if not boxes:
+        return None
+    return [
+        min(b[0] for b in boxes),
+        min(b[1] for b in boxes),
+        max(b[2] for b in boxes),
+        max(b[3] for b in boxes),
+    ]
+
+
 @router.get(
     "/",
     response_model=Page[SequenceGroupListItem],

--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
@@ -29,8 +29,10 @@ from app.schemas.sequence_group import (
     SequenceGroupRead,
     SequenceGroupReadWithMembers,
     SequenceGroupStats,
+    SequenceGroupThumbnail,
     SequenceGroupUpdate,
 )
+from app.services.storage import s3_service
 
 router = APIRouter()
 
@@ -72,6 +74,98 @@ def _crop_bbox(algo_predictions: Optional[dict]) -> Optional[list[float]]:
         max(b[2] for b in boxes),
         max(b[3] for b in boxes),
     ]
+
+
+async def _thumbnails_for_groups(
+    session: AsyncSession, group_ids: list[int]
+) -> dict[int, list[SequenceGroupThumbnail]]:
+    """Up to 3 member previews per group: first / middle / last member by
+    (recorded_at, id), among members that have at least one detection.
+    One query for the whole page; presigning is a local computation."""
+    if not group_ids:
+        return {}
+
+    # First detection per member sequence (lowest recorded_at, id as
+    # tie-breaker) — same definition as the group detail endpoint.
+    detection_rownum = (
+        select(
+            Detection.id.label("det_id"),
+            Detection.sequence_id.label("seq_id"),
+            Detection.bucket_key.label("bucket_key"),
+            Detection.algo_predictions.label("det_algo"),
+            func.row_number()
+            .over(
+                partition_by=Detection.sequence_id,
+                order_by=(Detection.recorded_at.asc(), Detection.id.asc()),
+            )
+            .label("rn"),
+        )
+        .join(Sequence, Sequence.id == Detection.sequence_id)
+        .where(Sequence.sequence_group_id.in_(group_ids))
+        .subquery()
+    )
+    first_det = (
+        select(
+            detection_rownum.c.seq_id,
+            detection_rownum.c.det_id,
+            detection_rownum.c.bucket_key,
+            detection_rownum.c.det_algo,
+        )
+        .where(detection_rownum.c.rn == 1)
+        .subquery()
+    )
+
+    # Rank eligible members (inner join drops detection-less ones) per
+    # group along the timeline.
+    member_rank = (
+        select(
+            Sequence.sequence_group_id.label("group_id"),
+            first_det.c.det_id,
+            first_det.c.bucket_key,
+            first_det.c.det_algo,
+            func.row_number()
+            .over(
+                partition_by=Sequence.sequence_group_id,
+                order_by=(Sequence.recorded_at.asc(), Sequence.id.asc()),
+            )
+            .label("rn"),
+            func.count().over(partition_by=Sequence.sequence_group_id).label("cnt"),
+        )
+        .join(first_det, first_det.c.seq_id == Sequence.id)
+        .where(Sequence.sequence_group_id.in_(group_ids))
+        .subquery()
+    )
+    # First / middle / last ranks. `//` is floor division (SQLAlchemy 2.0
+    # renders `/` on integers as TRUE division): cnt=5 → middle rank 3.
+    # Overlapping ranks (cnt < 3) match a single row once — no duplicates.
+    rows = await session.execute(
+        select(
+            member_rank.c.group_id,
+            member_rank.c.det_id,
+            member_rank.c.bucket_key,
+            member_rank.c.det_algo,
+        )
+        .where(
+            (member_rank.c.rn == 1)
+            | (member_rank.c.rn == member_rank.c.cnt // 2 + 1)
+            | (member_rank.c.rn == member_rank.c.cnt)
+        )
+        .order_by(member_rank.c.group_id, member_rank.c.rn)
+    )
+
+    bucket = s3_service.get_bucket(s3_service.resolve_bucket_name())
+    thumbnails: dict[int, list[SequenceGroupThumbnail]] = {}
+    for group_id, det_id, bucket_key, det_algo in rows.all():
+        thumbnails.setdefault(group_id, []).append(
+            SequenceGroupThumbnail(
+                detection_id=det_id,
+                # generate_presigned_url, not get_public_url: presigning is
+                # offline; get_public_url HEAD-checks S3 per key and 404s.
+                url=bucket.generate_presigned_url(bucket_key),
+                bbox_xyxyn=_crop_bbox(det_algo),
+            )
+        )
+    return thumbnails
 
 
 @router.get(
@@ -160,9 +254,20 @@ async def list_sequence_groups(
             & SequenceGroup.false_positive_type.is_(None)
         )
 
+    async def _attach_thumbnails(rows: list) -> list[SequenceGroupListItem]:
+        thumbnails = await _thumbnails_for_groups(session, [r.id for r in rows])
+        return [
+            SequenceGroupListItem(
+                **dict(r._mapping), thumbnails=thumbnails.get(r.id, [])
+            )
+            for r in rows
+        ]
+
     # `unique=False` is required because the row tuple includes the JSONB
     # `representative_bbox`, which is a dict and therefore not hashable.
-    return await apaginate(session, query, params, unique=False)
+    return await apaginate(
+        session, query, params, unique=False, transformer=_attach_thumbnails
+    )
 
 
 @router.get(

--- a/annotation_api/src/app/schemas/sequence_group.py
+++ b/annotation_api/src/app/schemas/sequence_group.py
@@ -16,6 +16,7 @@ __all__ = [
     "SequenceGroupRead",
     "SequenceGroupListItem",
     "SequenceGroupMember",
+    "SequenceGroupThumbnail",
     "SequenceGroupReadWithMembers",
     "SequenceGroupUpdate",
 ]
@@ -75,6 +76,17 @@ class SequenceGroupMember(BaseModel):
     first_detection_algo_predictions: Optional[dict] = None
 
 
+class SequenceGroupThumbnail(BaseModel):
+    """One member-sequence preview for the groups list: the member's first
+    detection, presigned for direct <img> use, plus the union of that
+    frame's valid prediction boxes as a crop target (None when the frame
+    has no valid boxes — the UI falls back to representative_bbox)."""
+
+    detection_id: int
+    url: str
+    bbox_xyxyn: Optional[List[float]] = None
+
+
 class SequenceGroupListItem(BaseModel):
     """Lightweight row for the groups list page; includes member_count to
     avoid an N+1 in the UI."""
@@ -95,6 +107,9 @@ class SequenceGroupListItem(BaseModel):
     labeled_at: Optional[datetime]
     created_at: datetime
     member_count: int
+    # Up to 3 member previews (first/middle/last member by recorded_at,
+    # among members that have a detection).
+    thumbnails: List[SequenceGroupThumbnail] = []
 
 
 class SequenceGroupStats(BaseModel):

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -952,3 +952,43 @@ async def test_list_legacy_validated_group_has_null_reviewer(
     assert row["is_validated"] is True
     assert row["validated_by_username"] is None
     assert row["validated_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# Thumbnails on the list endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_crop_bbox_unions_valid_prediction_boxes():
+    from app.api.api_v1.endpoints.sequence_groups import _crop_bbox
+
+    algo = {
+        "predictions": [
+            {"xyxyn": [0.1, 0.2, 0.2, 0.3], "confidence": 0.8, "class_name": "smoke"},
+            {"xyxyn": [0.15, 0.1, 0.3, 0.25], "confidence": 0.7, "class_name": "smoke"},
+        ]
+    }
+    assert _crop_bbox(algo) == [0.1, 0.1, 0.3, 0.3]
+
+
+def test_crop_bbox_none_when_no_valid_boxes():
+    from app.api.api_v1.endpoints.sequence_groups import _crop_bbox
+
+    assert _crop_bbox(None) is None
+    assert _crop_bbox({}) is None
+    assert _crop_bbox({"predictions": []}) is None
+    # Degenerate box (zero width) is not a valid crop target.
+    assert (
+        _crop_bbox(
+            {
+                "predictions": [
+                    {
+                        "xyxyn": [0.5, 0.5, 0.5, 0.9],
+                        "confidence": 0.9,
+                        "class_name": "smoke",
+                    }
+                ]
+            }
+        )
+        is None
+    )

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -25,7 +25,7 @@ from httpx import AsyncClient
 from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.models import AlertSkip, Sequence, User
+from app.models import AlertSkip, Detection, Sequence, User
 from app.services.group_assignment import assign_ungrouped_sequences
 
 
@@ -957,6 +957,187 @@ async def test_list_legacy_validated_group_has_null_reviewer(
 # ---------------------------------------------------------------------------
 # Thumbnails on the list endpoint
 # ---------------------------------------------------------------------------
+
+
+async def _group_member_ids(session: AsyncSession, group_id: int) -> list[int]:
+    """Member sequence ids ordered by (recorded_at, id) — the thumbnail
+    picking order."""
+    result = await session.exec(
+        text(
+            "SELECT id FROM sequences WHERE sequence_group_id = :gid "
+            "ORDER BY recorded_at, id"
+        ).bindparams(gid=group_id)
+    )
+    return [row[0] for row in result.all()]
+
+
+async def _add_first_detection(
+    session: AsyncSession,
+    sequence_id: int,
+    *,
+    bucket_key: str,
+    algo_predictions: dict | None = None,
+) -> int:
+    """Give a member sequence one detection (its 'first detection')."""
+    det = Detection(
+        alert_api_id=1,
+        sequence_id=sequence_id,
+        recorded_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        bucket_key=bucket_key,
+        algo_predictions=algo_predictions,
+    )
+    session.add(det)
+    await session.commit()
+    await session.refresh(det)
+    return det.id
+
+
+async def _stagger_member_recorded_at(session: AsyncSession, group_id: int) -> None:
+    """_seed_group_with_members gives every member the same recorded_at;
+    spread them one day apart so first/middle/last picking is deterministic."""
+    member_ids = await _group_member_ids(session, group_id)
+    for i, sid in enumerate(member_ids):
+        await session.exec(
+            text("UPDATE sequences SET recorded_at = :ts WHERE id = :sid").bindparams(
+                ts=datetime(2026, 1, 1 + i, tzinfo=timezone.utc), sid=sid
+            )
+        )
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_list_thumbnails_pick_first_middle_last_members(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    gid = await _seed_group_with_members(
+        async_session,
+        n_members=5,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        alert_api_id_start=500,
+    )
+    await _stagger_member_recorded_at(async_session, gid)
+    member_ids = await _group_member_ids(async_session, gid)
+    det_ids = {}
+    for i, sid in enumerate(member_ids):
+        det_ids[sid] = await _add_first_detection(
+            async_session, sid, bucket_key=f"thumb-key-{i}.jpg"
+        )
+
+    resp = await authenticated_client.get("/sequence_groups/")
+    assert resp.status_code == 200
+    row = next(i for i in resp.json()["items"] if i["id"] == gid)
+    thumbs = row["thumbnails"]
+    # 5 members → picks index 0, 2 (middle), 4 (last), in timeline order.
+    assert [t["detection_id"] for t in thumbs] == [
+        det_ids[member_ids[0]],
+        det_ids[member_ids[2]],
+        det_ids[member_ids[4]],
+    ]
+    assert "thumb-key-0.jpg" in thumbs[0]["url"]
+    assert "thumb-key-2.jpg" in thumbs[1]["url"]
+    assert "thumb-key-4.jpg" in thumbs[2]["url"]
+
+
+@pytest.mark.asyncio
+async def test_list_thumbnails_three_members_no_duplicates(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    gid = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        alert_api_id_start=600,
+    )
+    await _stagger_member_recorded_at(async_session, gid)
+    member_ids = await _group_member_ids(async_session, gid)
+    for i, sid in enumerate(member_ids):
+        await _add_first_detection(async_session, sid, bucket_key=f"trio-{i}.jpg")
+
+    resp = await authenticated_client.get("/sequence_groups/")
+    row = next(i for i in resp.json()["items"] if i["id"] == gid)
+    det_ids = [t["detection_id"] for t in row["thumbnails"]]
+    assert len(det_ids) == 3
+    assert len(set(det_ids)) == 3
+
+
+@pytest.mark.asyncio
+async def test_list_thumbnails_skip_detectionless_members(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    gid = await _seed_group_with_members(
+        async_session,
+        n_members=4,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        alert_api_id_start=700,
+    )
+    await _stagger_member_recorded_at(async_session, gid)
+    member_ids = await _group_member_ids(async_session, gid)
+    # Member at index 1 gets no detection → ineligible; picks come from
+    # the remaining 3 (indices 0, 2, 3).
+    expected = []
+    for i, sid in enumerate(member_ids):
+        if i == 1:
+            continue
+        expected.append(
+            await _add_first_detection(async_session, sid, bucket_key=f"skip-{i}.jpg")
+        )
+
+    resp = await authenticated_client.get("/sequence_groups/")
+    row = next(i for i in resp.json()["items"] if i["id"] == gid)
+    assert [t["detection_id"] for t in row["thumbnails"]] == expected
+
+
+@pytest.mark.asyncio
+async def test_list_thumbnails_bbox_union_and_null(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    gid = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        alert_api_id_start=800,
+    )
+    await _stagger_member_recorded_at(async_session, gid)
+    member_ids = await _group_member_ids(async_session, gid)
+    await _add_first_detection(
+        async_session,
+        member_ids[0],
+        bucket_key="bbox-0.jpg",
+        algo_predictions={
+            "predictions": [
+                {
+                    "xyxyn": [0.1, 0.2, 0.2, 0.3],
+                    "confidence": 0.8,
+                    "class_name": "smoke",
+                },
+                {
+                    "xyxyn": [0.15, 0.1, 0.3, 0.25],
+                    "confidence": 0.7,
+                    "class_name": "smoke",
+                },
+            ]
+        },
+    )
+    # No predictions at all → bbox_xyxyn null.
+    await _add_first_detection(async_session, member_ids[1], bucket_key="bbox-1.jpg")
+    await _add_first_detection(
+        async_session,
+        member_ids[2],
+        bucket_key="bbox-2.jpg",
+        algo_predictions={"predictions": []},
+    )
+
+    resp = await authenticated_client.get("/sequence_groups/")
+    row = next(i for i in resp.json()["items"] if i["id"] == gid)
+    thumbs = row["thumbnails"]
+    assert thumbs[0]["bbox_xyxyn"] == [0.1, 0.1, 0.3, 0.3]
+    assert thumbs[1]["bbox_xyxyn"] is None
+    assert thumbs[2]["bbox_xyxyn"] is None
 
 
 def test_crop_bbox_unions_valid_prediction_boxes():

--- a/docs/specs/2026-08-06-groups-thumbnails-column-design.md
+++ b/docs/specs/2026-08-06-groups-thumbnails-column-design.md
@@ -55,8 +55,9 @@ paginated query resolves the page's group IDs (≤ page size):
 3. `bbox_xyxyn` = union of the first detection's *valid* algo-prediction boxes
    (same math as the detail page's `cropBox`); `None` when the frame has no
    valid prediction boxes.
-4. Presign each `bucket_key` via `bucket.get_public_url` and attach the
-   thumbnail lists to the page items in member-`recorded_at` order.
+4. Presign each `bucket_key` via `bucket.generate_presigned_url` (offline,
+   bulk-safe — `get_public_url` HEAD-checks S3 per key and raises 404) and
+   attach the thumbnail lists to the page items in member-`recorded_at` order.
 
 ### Tests
 
@@ -68,7 +69,7 @@ paginated query resolves the page's group IDs (≤ page size):
 
 ## Frontend
 
-- Extract the private `ZoomedCrop` component from
+- Extract the private `BboxCrop` component from
   `SequenceGroupAnnotatePage.tsx` (~25 lines: 3× bbox region, 8× zoom cap)
   into a shared component and reuse it in both places — pure move, no behavior
   change.

--- a/docs/specs/2026-08-06-groups-thumbnails-column-design.md
+++ b/docs/specs/2026-08-06-groups-thumbnails-column-design.md
@@ -1,0 +1,96 @@
+# Groups list thumbnails column
+
+**Date:** 2026-08-06
+**Status:** Approved
+
+## Goal
+
+On `/classify/groups` (the recurring-objects table), add a far-left column
+showing 3 small image crops of the potentially-same object, so a reviewer can
+judge at a glance — without opening the group — whether the grouped sequences
+really show one recurring object.
+
+## Decisions
+
+- **Thumbnail content:** zoomed crop of the object, reusing the crop technique
+  of the group annotate page's member cards (region = 3× the bbox, zoom capped
+  at 8×). Not the full frame — at thumbnail size the object would be invisible.
+- **Member picking:** first, middle, last member by `recorded_at` — spread
+  across the group's timeline, the best evidence that the object recurs.
+- **Data flow:** the list endpoint embeds everything (presigned image URL +
+  crop bbox) directly in each `SequenceGroupListItem`. Presigning is a local
+  boto3 computation, so this costs no extra latency and avoids ~150 extra
+  frontend round trips per 50-row page.
+
+## Backend (`annotation_api`)
+
+### Schema
+
+```python
+class SequenceGroupThumbnail(BaseModel):
+    detection_id: int
+    url: str                                   # presigned image URL
+    bbox_xyxyn: list[float] | None             # crop box; None → frontend falls
+                                               # back to representative_bbox
+
+class SequenceGroupListItem(...):
+    ...existing fields...
+    thumbnails: list[SequenceGroupThumbnail]   # 0–3 entries
+```
+
+### Implementation
+
+In `list_sequence_groups` (`endpoints/sequence_groups.py`), after the existing
+paginated query resolves the page's group IDs (≤ page size):
+
+1. One query ranks each group's members by `recorded_at` with a window
+   function, restricted to members that have a first detection (a
+   detection-less member is skipped, so a group can yield fewer than 3
+   thumbnails). Per group keep ranks first / middle / last (middle =
+   `count // 2` 0-indexed); when the eligible member count is < 3 the picks
+   deduplicate naturally.
+2. Join each picked member's first detection — same "first detection of the
+   sequence" logic the group detail endpoint already uses — for `id`,
+   `bucket_key`, and `algo_predictions`.
+3. `bbox_xyxyn` = union of the first detection's *valid* algo-prediction boxes
+   (same math as the detail page's `cropBox`); `None` when the frame has no
+   valid prediction boxes.
+4. Presign each `bucket_key` via `bucket.get_public_url` and attach the
+   thumbnail lists to the page items in member-`recorded_at` order.
+
+### Tests
+
+- 3 thumbnails picked in first/middle/last `recorded_at` order.
+- Group with exactly 3 members → the 3 members, no duplicates.
+- Detection-less member skipped (fewer thumbnails returned).
+- Payload carries `url` and `bbox_xyxyn`; `bbox_xyxyn` is `None` when the
+  detection has no valid prediction boxes.
+
+## Frontend
+
+- Extract the private `ZoomedCrop` component from
+  `SequenceGroupAnnotatePage.tsx` (~25 lines: 3× bbox region, 8× zoom cap)
+  into a shared component and reuse it in both places — pure move, no behavior
+  change.
+- `types/api.ts`: mirror `SequenceGroupThumbnail`; add `thumbnails` to
+  `SequenceGroupListItem`.
+- `SequenceGroupsListPage.tsx`: new far-left column, header "Preview" (not
+  sortable). Cell = `flex gap-1` row of up to 3 fixed-size crops (~56×42px,
+  `aspect-video`, `bg-ash` placeholder). Each `<img>` uses `loading="lazy"`
+  so only visible rows download images. Crop box:
+  `thumbnail.bbox_xyxyn ?? group.representative_bbox`.
+- Thumbnails are not links; clicks bubble to the existing row navigation.
+- **Error handling:** a failed image load shows the `bg-ash` placeholder
+  (hide the broken img via `onError`); no retry logic.
+
+### Tests
+
+- Cell renders one img per thumbnail with the returned URL.
+- Crop falls back to `representative_bbox` when `bbox_xyxyn` is null.
+- Empty `thumbnails` renders placeholders, not a crash.
+
+## Out of scope
+
+- No new endpoint; no change to the group detail page.
+- No re-picking controls, hover previews, or click-to-open on thumbnails.
+- No caching/CDN work for presigned URLs.

--- a/frontend/src/components/annotation/BboxCrop.tsx
+++ b/frontend/src/components/annotation/BboxCrop.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+
+export type Bbox = [number, number, number, number];
+
+// Zoomed view of a single image centered on `box`. The same (already cached)
+// detection image is reused and magnified with a CSS transform — no second
+// fetch, no canvas — so small objects are legible next to the full frame.
+export function BboxCrop({ url, box, loading }: { url: string; box: Bbox; loading?: 'lazy' }) {
+  const [failed, setFailed] = useState(false);
+  const [x1, y1, x2, y2] = box;
+  const cx = (x1 + x2) / 2;
+  const cy = (y1 + y2) / 2;
+  // Show the box plus a margin of one box-size on each side (region ≈ 3×),
+  // then zoom so the whole region fits the cell; cap at 8× for tiny boxes.
+  const regionW = Math.min(1, Math.max(x2 - x1, 0.001) * 3);
+  const regionH = Math.min(1, Math.max(y2 - y1, 0.001) * 3);
+  const zoom = Math.min(1 / regionW, 1 / regionH, 8);
+
+  if (failed) return null;
+  return (
+    <img
+      src={url}
+      alt=""
+      loading={loading}
+      onError={() => setFailed(true)}
+      className="absolute inset-0 w-full h-full object-cover"
+      style={{
+        transformOrigin: `${cx * 100}% ${cy * 100}%`,
+        transform: `translate(${(0.5 - cx) * 100}%, ${(0.5 - cy) * 100}%) scale(${zoom})`,
+      }}
+    />
+  );
+}

--- a/frontend/src/components/annotation/BboxCrop.tsx
+++ b/frontend/src/components/annotation/BboxCrop.tsx
@@ -6,7 +6,9 @@ export type Bbox = [number, number, number, number];
 // detection image is reused and magnified with a CSS transform — no second
 // fetch, no canvas — so small objects are legible next to the full frame.
 export function BboxCrop({ url, box, loading }: { url: string; box: Bbox; loading?: 'lazy' }) {
-  const [failed, setFailed] = useState(false);
+  // Track WHICH url failed, not a boolean: presigned urls rotate on refetch,
+  // and a fresh url must clear a stale failure on the same mounted instance.
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
   const [x1, y1, x2, y2] = box;
   const cx = (x1 + x2) / 2;
   const cy = (y1 + y2) / 2;
@@ -16,13 +18,13 @@ export function BboxCrop({ url, box, loading }: { url: string; box: Bbox; loadin
   const regionH = Math.min(1, Math.max(y2 - y1, 0.001) * 3);
   const zoom = Math.min(1 / regionW, 1 / regionH, 8);
 
-  if (failed) return null;
+  if (failedUrl === url) return null;
   return (
     <img
       src={url}
       alt=""
       loading={loading}
-      onError={() => setFailed(true)}
+      onError={() => setFailedUrl(url)}
       className="absolute inset-0 w-full h-full object-cover"
       style={{
         transformOrigin: `${cx * 100}% ${cy * 100}%`,

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -13,6 +13,7 @@ import {
   X,
 } from 'lucide-react';
 import { apiClient } from '@/services/api';
+import { Bbox, BboxCrop } from '@/components/annotation/BboxCrop';
 import { useDetectionImage } from '@/hooks/useDetectionImage';
 import { usePersistedTabState } from '@/hooks/usePersistedTabState';
 import { useState } from 'react';
@@ -43,36 +44,8 @@ function memberIsAnnotated(m: SequenceGroupMember): boolean {
   );
 }
 
-type Bbox = [number, number, number, number];
-
 function isValidBox([x1, y1, x2, y2]: Bbox): boolean {
   return x2 > x1 && y2 > y1;
-}
-
-// Zoomed view of a single image centered on `box`. The same (already cached)
-// detection image is reused and magnified with a CSS transform — no second
-// fetch, no canvas — so small objects are legible next to the full frame.
-function BboxCrop({ url, box }: { url: string; box: Bbox }) {
-  const [x1, y1, x2, y2] = box;
-  const cx = (x1 + x2) / 2;
-  const cy = (y1 + y2) / 2;
-  // Show the box plus a margin of one box-size on each side (region ≈ 3×),
-  // then zoom so the whole region fits the cell; cap at 8× for tiny boxes.
-  const regionW = Math.min(1, Math.max(x2 - x1, 0.001) * 3);
-  const regionH = Math.min(1, Math.max(y2 - y1, 0.001) * 3);
-  const zoom = Math.min(1 / regionW, 1 / regionH, 8);
-
-  return (
-    <img
-      src={url}
-      alt=""
-      className="absolute inset-0 w-full h-full object-cover"
-      style={{
-        transformOrigin: `${cx * 100}% ${cy * 100}%`,
-        transform: `translate(${(0.5 - cx) * 100}%, ${(0.5 - cy) * 100}%) scale(${zoom})`,
-      }}
-    />
-  );
 }
 
 function MemberCard({

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -342,7 +342,7 @@ export default function SequenceGroupsListPage({
                           return (
                             <div
                               key={i}
-                              className="relative w-14 shrink-0 aspect-video overflow-hidden rounded bg-ash"
+                              className="relative w-14 shrink-0 aspect-video overflow-hidden bg-ash"
                             >
                               {t && (
                                 <BboxCrop

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Popover } from '@headlessui/react';
 import { Loader2, AlertCircle, Check, Info, Layers, ShieldCheck, ChevronRight } from 'lucide-react';
 import { apiClient } from '@/services/api';
+import { BboxCrop } from '@/components/annotation/BboxCrop';
 import { SequenceGroupStats } from '@/types/api';
 import { classifyGroup, classifyGroups, ROUTES, SequenceGroupsFilter } from '@/utils/routes';
 import { ColumnHeader } from '@/components/sequences/ColumnHeader';
@@ -269,6 +270,10 @@ export default function SequenceGroupsListPage({
               <thead className={THEAD_CLASSES}>
                 <tr>
                   <ColumnHeader
+                    label="Preview"
+                    tip="Crops of the object from three of its sequences — first, middle, and last sighting"
+                  />
+                  <ColumnHeader
                     label="Camera"
                     tip="Camera that recorded the object's sequences"
                     sort={{
@@ -330,6 +335,27 @@ export default function SequenceGroupsListPage({
                     }}
                     className={ROW_CLASSES}
                   >
+                    <td className={CELL_CLASSES}>
+                      <div className="flex gap-1">
+                        {[0, 1, 2].map(i => {
+                          const t = g.thumbnails[i];
+                          return (
+                            <div
+                              key={i}
+                              className="relative w-14 shrink-0 aspect-video overflow-hidden rounded bg-ash"
+                            >
+                              {t && (
+                                <BboxCrop
+                                  url={t.url}
+                                  box={t.bbox_xyxyn ?? g.representative_bbox.xyxyn}
+                                  loading="lazy"
+                                />
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </td>
                     <td className={CELL_CLASSES}>
                       <Link
                         to={classifyGroup(g.id)}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -288,6 +288,14 @@ export interface SequenceGroupMember {
   first_detection_algo_predictions: AlgoPredictions | null;
 }
 
+export interface SequenceGroupThumbnail {
+  detection_id: number;
+  url: string;
+  // Crop box for the thumbnail; null when the frame has no valid
+  // prediction boxes — fall back to the group's representative_bbox.
+  bbox_xyxyn: [number, number, number, number] | null;
+}
+
 export interface SequenceGroupListItem {
   id: number;
   camera_id: number;
@@ -305,6 +313,8 @@ export interface SequenceGroupListItem {
   labeled_at: string | null;
   created_at: string;
   member_count: number;
+  // Up to 3 member previews (first/middle/last member by recorded_at).
+  thumbnails: SequenceGroupThumbnail[];
 }
 
 export interface SequenceGroupStats {

--- a/frontend/tests/components/annotation/BboxCrop.test.tsx
+++ b/frontend/tests/components/annotation/BboxCrop.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { BboxCrop } from '@/components/annotation/BboxCrop';
+
+describe('BboxCrop', () => {
+  it('hides itself after a load error', () => {
+    const { container } = render(
+      <BboxCrop url="http://s3/broken.jpg" box={[0.1, 0.1, 0.4, 0.4]} />
+    );
+    fireEvent.error(container.querySelector('img')!);
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('recovers when the url changes after an error', () => {
+    // Presigned URLs expire; a refetch hands the same mounted component a
+    // fresh url — the old failure must not keep the new image hidden.
+    const { container, rerender } = render(
+      <BboxCrop url="http://s3/expired.jpg" box={[0.1, 0.1, 0.4, 0.4]} />
+    );
+    fireEvent.error(container.querySelector('img')!);
+    expect(container.querySelector('img')).toBeNull();
+
+    rerender(<BboxCrop url="http://s3/fresh.jpg" box={[0.1, 0.1, 0.4, 0.4]} />);
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute('src')).toBe('http://s3/fresh.jpg');
+  });
+});

--- a/frontend/tests/pages/SequenceGroupsListPage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupsListPage.test.tsx
@@ -45,6 +45,8 @@ const group = {
   false_positive_type: null,
   is_validated: false,
   created_at: '2026-08-01T10:00:00Z',
+  representative_bbox: { xyxyn: [0.1, 0.1, 0.4, 0.4], confidence: 0.9 },
+  thumbnails: [],
 };
 
 describe('SequenceGroupsListPage', () => {
@@ -143,7 +145,15 @@ describe('SequenceGroupsListPage', () => {
     expect(row?.className).toContain('hover:bg-ash');
     expect(row?.className).not.toContain('hover:bg-blue-50');
 
-    const headerLabels = ['Camera', 'Created', 'Azimuth', 'Sequences', 'Label', 'Reviewed'];
+    const headerLabels = [
+      'Preview',
+      'Camera',
+      'Created',
+      'Azimuth',
+      'Sequences',
+      'Label',
+      'Reviewed',
+    ];
     const positions = headerLabels.map(l => {
       const el = screen.getByText(l);
       return Array.from(document.querySelectorAll('th')).findIndex(th => th.contains(el));
@@ -214,9 +224,9 @@ describe('SequenceGroupsListPage', () => {
     });
     renderAt('/classify/groups');
     await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
-    // One tooltip per labeled column (Camera, Azimuth, Sequences, Label,
-    // Reviewed, Created) plus one on the row's "to label" badge.
-    expect(within(screen.getByRole('table')).getAllByRole('tooltip')).toHaveLength(7);
+    // One tooltip per labeled column (Preview, Camera, Azimuth, Sequences,
+    // Label, Reviewed, Created) plus one on the row's "to label" badge.
+    expect(within(screen.getByRole('table')).getAllByRole('tooltip')).toHaveLength(8);
     expect(screen.getByText('Number of sequences showing this object')).toBeTruthy();
     expect(screen.getByText(/propagates to every sequence/)).toBeTruthy();
     expect(screen.getByText('Camera viewing direction, in degrees')).toBeTruthy();
@@ -239,5 +249,74 @@ describe('SequenceGroupsListPage', () => {
     await waitFor(() => expect(screen.getAllByText('to label')).toHaveLength(2));
     expect(screen.getByText(/^Classify any of this object's sequences/)).toBeTruthy();
     expect(screen.getByText(/^Validate the group first, then classify/)).toBeTruthy();
+  });
+
+  it('renders one crop img per thumbnail, zoomed to its own bbox', async () => {
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
+      items: [
+        {
+          ...group,
+          thumbnails: [
+            { detection_id: 11, url: 'http://s3/a.jpg', bbox_xyxyn: [0.5, 0.5, 0.9, 0.9] },
+            { detection_id: 12, url: 'http://s3/b.jpg', bbox_xyxyn: [0.2, 0.2, 0.4, 0.4] },
+            { detection_id: 13, url: 'http://s3/c.jpg', bbox_xyxyn: [0.1, 0.1, 0.2, 0.2] },
+          ],
+        },
+      ],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 1,
+    });
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
+
+    const imgs = Array.from(document.querySelectorAll('tbody img'));
+    expect(imgs.map(img => img.getAttribute('src'))).toEqual([
+      'http://s3/a.jpg',
+      'http://s3/b.jpg',
+      'http://s3/c.jpg',
+    ]);
+    // Lazy so only visible rows download images.
+    expect(imgs.every(img => img.getAttribute('loading') === 'lazy')).toBe(true);
+    // Zoom centers on the thumbnail's own bbox center (70% for [0.5,...,0.9]).
+    expect((imgs[0] as HTMLElement).style.transformOrigin).toBe('70% 70%');
+  });
+
+  it('falls back to the representative bbox when a thumbnail has no bbox', async () => {
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
+      items: [
+        {
+          ...group,
+          thumbnails: [{ detection_id: 11, url: 'http://s3/a.jpg', bbox_xyxyn: null }],
+        },
+      ],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 1,
+    });
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
+
+    // representative_bbox [0.1,0.1,0.4,0.4] centers at 25%.
+    const img = document.querySelector('tbody img') as HTMLElement;
+    expect(img.style.transformOrigin).toBe('25% 25%');
+  });
+
+  it('renders three empty placeholders when a group has no thumbnails', async () => {
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
+      items: [group],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 1,
+    });
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
+
+    expect(document.querySelectorAll('tbody img')).toHaveLength(0);
+    const row = screen.getByText('CAM_07').closest('tr')!;
+    expect(row.querySelectorAll('td:first-child .bg-ash')).toHaveLength(3);
   });
 });


### PR DESCRIPTION
## Summary

Adds a far-left **Preview** column to `/classify/groups`: three zoomed crops of the group's recurring object (first / middle / last member by `recorded_at`), so the grouping can be judged at a glance without opening the group.

Spec: `docs/specs/2026-08-06-groups-thumbnails-column-design.md` (committed on this branch).

### Backend
- `SequenceGroupListItem` gains `thumbnails: list[SequenceGroupThumbnail]` (0–3 entries: `detection_id`, presigned `url`, `bbox_xyxyn`).
- One window-function query per page picks first/middle/last member **among members that have a detection** (ties broken by id; `//` floor division for the middle rank — SQLAlchemy 2.0 renders `/` on integers as true division), joins each member's first detection, and attaches results via an `apaginate` async transformer.
- `bbox_xyxyn` = union of the frame's valid algo-prediction boxes; `null` when none (frontend falls back to the group's `representative_bbox`).
- Presigning uses `generate_presigned_url` (offline, bulk-safe) — not `get_public_url`, which HEAD-checks S3 per key.
- Additive API change, no migration.

### Frontend
- Extracted the private `BboxCrop` from `SequenceGroupAnnotatePage` into shared `components/annotation/BboxCrop.tsx` (same 3×-region / 8×-cap zoom math), with `loading="lazy"` support and per-url error hiding that resets when presigned urls rotate.
- New non-sortable Preview column: three fixed-size square-cornered crops, `bg-ash` placeholders, clicks bubble to the existing row navigation.

## Test plan
- Backend: 6 new tests (picking order, exactly-3 dedupe, detection-less member skip, bbox union/null, crop-box unit tests) — full suite 627 passed in an isolated Docker stack.
- Frontend: 5 new/updated page tests (imgs per thumbnail, lazy attr, crop centering, representative-bbox fallback, empty placeholders) + 2 `BboxCrop` tests (error hide, url-rotation recovery) — full suite 1259 passed, `npm run quality` clean.
- Eyeballed against real data (worktree API + shared-stack DB/MinIO).