### PR TITLE
perf(tests): build the schema once per session instead of per test

### DIFF
--- a/annotation_api/src/tests/conftest.py
+++ b/annotation_api/src/tests/conftest.py
@@ -33,16 +33,6 @@ def _alembic_config() -> Config:
     return cfg
 
 
-async def _run_alembic_upgrade() -> None:
-    """Run ``alembic upgrade head`` from inside a running event loop.
-
-    ``env.py`` calls ``asyncio.run`` which cannot nest, so we offload the
-    command to a worker thread that owns its own event loop.
-    """
-    cfg = _alembic_config()
-    await asyncio.to_thread(command.upgrade, cfg, "head")
-
-
 dt_format = "%Y-%m-%dT%H:%M:%S.%f"
 now = datetime.now(UTC)
 
@@ -165,18 +155,26 @@ async def async_client(
     app.dependency_overrides.clear()
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _schema() -> None:
+    # Build the schema ONCE per session using Alembic so tests still exercise
+    # the same migration path as production startup. Replaying the migration
+    # chain per test costs ~1.1s and dominates the suite runtime; the
+    # per-test DELETE loop below is enough to isolate tests from each other.
+    # Sync fixture on purpose: pytest-asyncio's event_loop is function-scoped,
+    # so this owns a throwaway loop rather than requesting one.
+    async def _reset() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.drop_all)
+            await conn.exec_driver_sql("DROP TABLE IF EXISTS alembic_version")
+        await engine.dispose()
+
+    asyncio.run(_reset())
+    command.upgrade(_alembic_config(), "head")
+
+
 @pytest_asyncio.fixture(scope="function")
 async def async_session() -> AsyncSession:
-    # Reset schema using Alembic so tests exercise the same migration path
-    # as production startup. We drop everything first to guarantee a clean
-    # slate (including the alembic_version table) and then upgrade to head.
-    async with engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.drop_all)
-        await conn.exec_driver_sql("DROP TABLE IF EXISTS alembic_version")
-    await engine.dispose()
-
-    await _run_alembic_upgrade()
-
     async_session_maker = sessionmaker(
         engine, class_=AsyncSession, expire_on_commit=False
     )


### PR DESCRIPTION
## Summary

Backend CI has grown from ~3 min to ~11 min over the project's life. The dominant cost is not the tests — it's the fixture.

`async_session` was function-scoped and replayed the entire Alembic migration chain **once per test**. Measured inside the test container:

| | |
|---|---|
| `alembic upgrade head` | **1093 ms** |
| `drop_all` + drop `alembic_version` | 49 ms |
| per-table `DELETE` + `ALTER SEQUENCE` loop | 28 ms |

Per-test `setup` was **1.23s** against test bodies of **0.01–0.07s** — roughly 95% of the suite was fixture overhead. Worse, it scaled with the number of *migrations*, so the suite got slower every time we added one, regardless of how many tests we wrote.

## Change

Move the drop + `alembic upgrade head` into a session-scoped autouse fixture. Tests still exercise the real migration path on the way in; the existing per-table `DELETE` loop (28 ms) still isolates them from each other's data.

The new fixture is deliberately **synchronous** — pytest-asyncio's `event_loop` is function-scoped, so a session-scoped async fixture raises `ScopeMismatch`. It owns a throwaway loop via `asyncio.run` instead.

## Results

**Measured on this PR's own CI run** (the number that matters):

| | pytest | whole job |
|---|---|---|
| previous run on main | 452 s (629 passed) | 11 min 27 s |
| this PR | **216 s (635 passed)** | **7 min 31 s** |

**~2.1× faster on pytest, ~4 min off every backend CI run.** No test files changed.

Locally the same change measures 683 s → 118 s (5.8×); GitHub's runners see a smaller multiple, presumably because local disk fsync makes the repeated DDL disproportionately expensive. The CI figures above are the honest ones.

## Testing

- Full suite green locally both before and after (629 passed each way), and green on CI here (635 passed).
- This weakens per-test isolation from "pristine schema" to "pristine data", so order-independence was verified explicitly: `tests/endpoints` (384) and the remaining directories (240) each pass standalone.
- `ruff format --check` and `ruff check` clean. (`mypy` reports 17 errors in this file, all pre-existing and untouched by this change; it isn't run in CI.)

## Note for reviewers

The tradeoff worth a second opinion: a future test that performs DDL would now leak schema changes into later tests. Nothing in the current suite does.

## Follow-ups (not in this PR)

- The remaining job time is mostly image work: "Pre-build backend image" (~1 m 54 s) and the docker save/load cache (~57 s this run, which missed).
- `detection_session` fetches an image from githubusercontent.com **per test** — network in the hot path and a flakiness source.
