### PR TITLE
ci: stop running the frontend suite twice and cancel superseded runs

### DIFF
--- a/.github/workflows/annotation-api-ci.yml
+++ b/.github/workflows/annotation-api-ci.yml
@@ -7,6 +7,12 @@ on:
       - 'annotation_api/**'
       - '.github/workflows/annotation-api-ci.yml'
 
+# A new push to the same PR makes the in-flight run obsolete. This is the
+# most expensive workflow we have, so superseded runs are worth cancelling.
+concurrency:
+  group: annotation-api-ci-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: annotation_api

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -7,6 +7,11 @@ on:
       - 'frontend/**'
       - '.github/workflows/frontend-ci.yml'
 
+# A new push to the same PR makes the in-flight run obsolete.
+concurrency:
+  group: frontend-ci-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: frontend
@@ -51,25 +56,17 @@ jobs:
     - name: Install dependencies
       run: npm ci
     
-    - name: Run tests
-      run: npm test
-    
-    - name: Generate coverage report
+    # Runs the whole suite and fails the job on any test failure, so a
+    # separate `npm test` step would just run all 1260 tests a second time.
+    - name: Run tests with coverage
       run: npm run test:coverage
-      
+
     - name: Upload coverage reports
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: frontend/coverage/
         retention-days: 30
-    
-    - name: Display coverage summary
-      run: |
-        echo "## Test Coverage Summary"
-        echo "```"
-        npx vitest run --coverage --reporter=text-summary
-        echo "```"
 
   quality:
     name: Code Quality Checks

--- a/.github/workflows/ruff-check-annotation-api.yml
+++ b/.github/workflows/ruff-check-annotation-api.yml
@@ -7,6 +7,11 @@ on:
     branches:
       - '**'
 
+# A new push to the same PR makes the in-flight run obsolete.
+concurrency:
+  group: ruff-check-annotation-api-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ruff-check:
     name: Run ruff check on annotation_api


### PR DESCRIPTION
## Summary

Two independent sources of wasted CI time, found while investigating why CI has gotten slower (Frontend CI median went 0.5 min → 1.4 min → **3.4 min**; see also #320 for the backend half).

### 1. The frontend suite ran twice per job

`npm test` (74 s) followed by `npm run test:coverage` (92 s) — the same 96 files / 1260 tests, back to back. `vitest run --coverage` already runs the whole suite and exits non-zero on failure, so the first step bought nothing but latency.

### 2. "Display coverage summary" never ran

The triple-backtick fences inside its `run:` block opened a shell command substitution, so the step never invoked vitest:

```
line 6: $'\nnpx vitest run --coverage --reporter=text-summary\necho ': command not found
```

It failed silently without failing the job (0 s runtime, which is what gave it away). Dropped rather than repaired — the coverage table is already printed by the step above and uploaded as an artifact.

### 3. No workflow declared a `concurrency` group

Pushing to a PR left the previous run going to completion. Over the last 10 days that burned **145 minutes of Annotation API CI (19% of its total)** and 31 minutes of Frontend CI producing results nobody would read.

`push.yml` is deliberately left alone: cancelling a half-finished image push to DockerHub is worse than letting it finish.

## Expected effect

Frontend CI critical path ~4 min → **~2.8 min**, plus the superseded-run savings across all three PR workflows.

## Testing

- All three workflow files parse as valid YAML with the expected `concurrency` blocks.
- `npm ci && npm run test:coverage` in this branch: **96 files, 1260 tests passed**, exit 0.
- Verified the remaining step still gates CI — added a deliberately failing test, confirmed `npm run test:coverage` exits **1**, then removed it. This is the safety property that makes dropping `npm test` sound.
