### PR TITLE
fix(api): propagate group labels from FP-only classifications (#258)

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -929,25 +929,52 @@ _BULK_LOCKED_STAGES = {
 }
 
 
+def _is_classification_exit(annotation: SequenceAnnotation) -> bool:
+    """Whether this save is the point where the lane's *classification*
+    finishes — the one moment group propagation should fire.
+
+    A classification lands on one of two stages (spec: smoke-localization
+    entry point): a lane needing localization parks at SEQ_ANNOTATION_DONE
+    and finishes classifying there, while an FP-only or deferred-unsure lane
+    exits straight to ANNOTATED without ever visiting that stage.
+
+    Keying propagation on SEQ_ANNOTATION_DONE alone made every FP-only
+    classification a silent no-op (#258). Since
+    `derive_group_label_from_annotation` lets smoke outrank FP, a lane can
+    only derive an FP label when it has no smoke — precisely the lanes that
+    exit at ANNOTATED — so group FP labelling was unreachable end to end.
+
+    A lane that reaches ANNOTATED *after* localization is excluded: it
+    already propagated on the way through SEQ_ANNOTATION_DONE, and firing
+    again at the localization exit would re-derive the group label from work
+    that changed nothing about the classification."""
+    stage = annotation.processing_stage
+    if stage == SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE:
+        return True
+    if stage != SequenceAnnotationProcessingStage.ANNOTATED:
+        return False
+    return not needs_localization(
+        annotation.has_smoke, annotation.has_missed_smoke, annotation.is_unsure
+    )
+
+
 async def _propagate_to_group_if_validated(
     sequence_annotation: SequenceAnnotation,
     annotations: SequenceAnnotationCRUD,
     session: AsyncSession,
     current_user_id: int,
 ) -> Optional[str]:
-    """If the source annotation has just reached SEQ_ANNOTATION_DONE and
-    the underlying sequence belongs to a validated group, derive a single
-    label from the annotation and fan it out to other group members that
-    aren't locked. Group's own label is updated accordingly.
+    """If the source annotation has just finished classifying (see
+    `_is_classification_exit`) and the underlying sequence belongs to a
+    validated group, derive a single label from the annotation and fan it out to
+    other group members that aren't locked. Group's own label is updated
+    accordingly.
 
     Returns a warning string when propagation was *attempted but skipped*
     so the caller can surface it back to the annotator. Returns None when
     propagation either succeeded or was simply not applicable (no group,
     group not validated, no label to derive)."""
-    if (
-        sequence_annotation.processing_stage
-        != SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE
-    ):
+    if not _is_classification_exit(sequence_annotation):
         return None
 
     seq = await session.get(Sequence, sequence_annotation.sequence_id)
@@ -1045,6 +1072,19 @@ async def _propagate_to_group_if_validated(
         min_cluster_size=1,
     )
 
+    # Members exit on the same two lanes a human classification does (mirrors
+    # `determineClassifySubmitStage` on the frontend): a smoke label still owes
+    # localization work, and an unsure fan-out still gates its alert, so both
+    # park at SEQ_ANNOTATION_DONE. An FP-only label owes nothing and goes
+    # straight out — `schedule_pending_auto_annotate` only advances lanes
+    # matching the localization rule, so parking an FP member at
+    # SEQ_ANNOTATION_DONE would strand it in no queue at all.
+    member_stage = (
+        SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE
+        if smoke_type is not None or group.is_unsure
+        else SequenceAnnotationProcessingStage.ANNOTATED
+    )
+
     for member_id in other_member_ids:
         existing = (
             await session.execute(
@@ -1070,7 +1110,7 @@ async def _propagate_to_group_if_validated(
                     has_missed_smoke=False,
                     is_unsure=group.is_unsure,
                     annotation=generated,
-                    processing_stage=SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE,
+                    processing_stage=member_stage,
                 ),
                 current_user_id,
             )
@@ -1081,7 +1121,7 @@ async def _propagate_to_group_if_validated(
                 SequenceAnnotationUpdate(
                     is_unsure=group.is_unsure,
                     annotation=generated,
-                    processing_stage=SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE,
+                    processing_stage=member_stage,
                 ),
                 current_user_id,
             )
@@ -1090,6 +1130,22 @@ async def _propagate_to_group_if_validated(
         # members; create/update only auto-record contributions at
         # ANNOTATED, so attribute the write to them explicitly.
         await annotations.record_contribution(fanned_anno_id, current_user_id)
+
+        # A member landing at ANNOTATED is finished, exactly as a hand-classified
+        # FP lane is — give it the same detection annotations the classify
+        # endpoints create on that transition. Smoke members don't need this:
+        # they get theirs from `auto_annotate_sequence` once their alert
+        # completes. The flags are known by construction here: member_stage is
+        # ANNOTATED only for an FP-only, not-unsure fan-out.
+        if member_stage == SequenceAnnotationProcessingStage.ANNOTATED:
+            await auto_create_detection_annotations(
+                sequence_id=member_id,
+                has_smoke=False,
+                has_missed_smoke=False,
+                has_false_positives=True,
+                session=session,
+                user_id=current_user_id,
+            )
 
     # The fan-out is the human's one gesture writing the whole group — credit
     # the source annotation too, so the sequence they actually annotated isn't

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -25,7 +25,15 @@ from httpx import AsyncClient
 from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.models import AlertSkip, Detection, Sequence, User
+from app.api.api_v1.endpoints.sequence_annotations import _is_classification_exit
+from app.models import (
+    AlertSkip,
+    Detection,
+    Sequence,
+    SequenceAnnotation,
+    SequenceAnnotationProcessingStage,
+    User,
+)
 from app.services.group_assignment import assign_ungrouped_sequences
 
 
@@ -328,6 +336,61 @@ def _annotation_payload(*, stage: str, smoke_type: str) -> dict:
     }
 
 
+@pytest.mark.parametrize(
+    ("stage", "has_smoke", "has_missed_smoke", "is_unsure", "expected"),
+    [
+        # Classification finishes here for anything that owes localization.
+        ("SEQ_ANNOTATION_DONE", True, False, False, True),
+        ("SEQ_ANNOTATION_DONE", False, False, True, True),  # unsure, parked
+        # Two-lane exit: these never visit SEQ_ANNOTATION_DONE, so ANNOTATED
+        # is their only chance to propagate (#258).
+        ("ANNOTATED", False, False, False, True),  # FP-only exit
+        ("ANNOTATED", False, False, True, True),  # deferred-unsure exit
+        # Reached ANNOTATED through localization — already propagated on the
+        # way past SEQ_ANNOTATION_DONE, must not fire twice.
+        ("ANNOTATED", True, False, False, False),
+        ("ANNOTATED", False, True, False, False),
+        # Not a classification exit at all.
+        ("READY_TO_ANNOTATE", False, False, False, False),
+        ("IMPORTED", True, False, False, False),
+    ],
+)
+def test_is_classification_exit(
+    stage, has_smoke, has_missed_smoke, is_unsure, expected
+):
+    annotation = SequenceAnnotation(
+        sequence_id=1,
+        has_smoke=has_smoke,
+        has_missed_smoke=has_missed_smoke,
+        has_false_positives=not has_smoke,
+        is_unsure=is_unsure,
+        annotation={"sequences_bbox": []},
+        processing_stage=SequenceAnnotationProcessingStage[stage],
+    )
+    assert _is_classification_exit(annotation) is expected
+
+
+def _fp_annotation_payload(*, stage: str, false_positive_type: str) -> dict:
+    """An FP-only submission. The classify UI writes these straight to
+    `annotated` — the two-lane exit means they never visit
+    seq_annotation_done (spec: smoke-localization entry point)."""
+    return {
+        "sequence_id": 1,  # overwritten per call
+        "has_missed_smoke": False,
+        "is_unsure": False,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": False,
+                    "false_positive_types": [false_positive_type],
+                    "bboxes": [{"detection_id": 1, "xyxyn": [0.1, 0.1, 0.4, 0.4]}],
+                }
+            ]
+        },
+        "processing_stage": stage,
+    }
+
+
 def _unsure_payload(*, stage: str) -> dict:
     """An unsure submission carries no label (empty sequences_bbox)."""
     return {
@@ -592,6 +655,43 @@ async def test_propagation_writes_label_and_fans_out(
     # and so is the source annotation (one gesture writes the whole group).
     assert await _annotation_contributor_ids(sequence_session, 2) == [test_user.id]
     assert await _annotation_contributor_ids(sequence_session, 1) == [test_user.id]
+
+
+@pytest.mark.asyncio
+async def test_propagation_fires_for_fp_only_lane_at_annotated(
+    authenticated_client: AsyncClient,
+    sequence_session: AsyncSession,
+    detection_session: AsyncSession,
+):
+    """Validated group, FP-only classification (issue #258). The lane exits
+    straight to `annotated` — never visiting seq_annotation_done — so the
+    fan-out must key on "landed at a done stage", not on that one stage.
+
+    The fanned-out member gets `annotated` too: an FP member has no
+    localization work left, and `schedule_pending_auto_annotate` only
+    advances lanes matching the localization rule, so parking it at
+    seq_annotation_done would strand it in no queue at all."""
+    group_id = await _seed_two_member_group(sequence_session, [1, 2], is_validated=True)
+
+    payload = _fp_annotation_payload(stage="annotated", false_positive_type="antenna")
+    payload["sequence_id"] = 1
+    resp = await authenticated_client.post("/annotations/sequences/", json=payload)
+    assert resp.status_code == 201
+    assert resp.json().get("group_propagation_warning") is None
+
+    group_payload = (
+        await authenticated_client.get(f"/sequence_groups/{group_id}")
+    ).json()
+    assert group_payload["false_positive_type"] == "antenna"
+    assert group_payload["smoke_type"] is None
+    assert group_payload["labeled_at"] is not None
+
+    other = await authenticated_client.get("/annotations/sequences/?sequence_id=2")
+    items = other.json()["items"]
+    assert len(items) == 1
+    assert items[0]["processing_stage"] == "annotated"
+    assert items[0]["false_positive_types"] == ["antenna"]
+    assert items[0]["has_smoke"] is False
 
 
 @pytest.mark.asyncio

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -814,6 +814,14 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
       // server-side (#275); without this the localize page redraws the lane
       // against the cached ones and shows every frame as already confirmed.
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.DETECTION_ANNOTATIONS });
+      // Classifying a member of a validated group labels the group and fans
+      // out to its other members (#258). With the 5-minute global staleTime,
+      // walking back to the group page would otherwise show the pre-propagation
+      // state. Same keys SequenceGroupAnnotatePage invalidates after its own
+      // mutations.
+      queryClient.invalidateQueries({ queryKey: ['sequenceGroup'] });
+      queryClient.invalidateQueries({ queryKey: ['sequenceGroupsList'] });
+      queryClient.invalidateQueries({ queryKey: ['sequenceGroupStats'] });
 
       const warnings = response.results
         .filter(r => r.group_propagation_warning)


### PR DESCRIPTION
Closes #258.

## Problem

Classifying a member of a **validated** group as a false positive never labels the group and never fans out to the other members. Reproduced twice on the live stack today:

| Group | Validated | Member classified | Result |
| --- | --- | --- | --- |
| 2 | 2026-08-03 | seq 458 → FP·cliff | `false_positive_type = NULL`, 23 members still `READY_TO_ANNOTATE` |
| 292 | 2026-08-06 13:13:51 | seq 397 → FP·antenna, 8s later | `false_positive_type = NULL`, 2 members still `READY_TO_ANNOTATE` |

Both used the validate-then-classify ordering the group-freeze spec recommends, so #253 is not the cause.

## Root cause

`_propagate_to_group_if_validated` was gated on the annotation landing at *exactly* `SEQ_ANNOTATION_DONE`. Since the two-lane exit (`4624cfe`, 2026-07-28, "FP fast-path at classify submit"), `determineClassifySubmitStage` sends FP-only lanes straight to `annotated` — they never visit that stage, so the hook returned on its first line. No warning surfaced, because that early return is indistinguishable from "not applicable".

This is a regression: when propagation shipped (`5a01716`, 2026-05-10), `AnnotationInterface` wrote `seq_annotation_done` for every classification, smoke and FP alike.

Worth noting how total the breakage was: `derive_group_label_from_annotation` lets smoke outrank FP, so a lane can only derive an FP label when it has no smoke — precisely the lanes that exit at `ANNOTATED`. Group FP labelling, the recurring-false-positive case groups exist for, was unreachable end to end.

## Fix

**1. Trigger on the classification exit, not on one stage.** New `_is_classification_exit`: a lane finishes classifying at `SEQ_ANNOTATION_DONE`, or at `ANNOTATED` when it never owed localization (FP-only and deferred-unsure exits).

A lane that reaches `ANNOTATED` *through* localization is deliberately excluded — it already propagated on the way past `SEQ_ANNOTATION_DONE`, and re-firing at the localization exit would re-derive the group label from work that changed nothing about the classification. (Widening to "either done stage" unconditionally breaks `test_propagation_skips_locked_members`, which is what surfaced this boundary.)

**2. Fanned-out members exit on the same two lanes.** Previously hardcoded to `SEQ_ANNOTATION_DONE`. `schedule_pending_auto_annotate` only advances lanes matching the localization rule, so an FP member parked there would strand at a stage neither queue shows. Members landing at `ANNOTATED` also get the detection annotations the classify endpoints create on that same transition; smoke members still get theirs from `auto_annotate_sequence` once their alert completes.

**3. Frontend: refresh group queries after a classify submit.** The submit invalidated only alert-level queries. With the global 5-minute `staleTime`, walking back to the group page after classifying showed the pre-propagation state — indistinguishable from the propagation not having happened. Now invalidates the same three group keys `SequenceGroupAnnotatePage` already invalidates after its own mutations.

## Tests

- `test_propagation_fires_for_fp_only_lane_at_annotated` — the reported bug, end to end.
- `test_is_classification_exit` — 8-case truth table over the trigger rule, including the excluded post-localization case.
- Full backend suite green (648 passed); frontend suite green (1260 passed).

## Not in scope

- **#253** (group PATCH validate doesn't re-derive from already-done members) stays open — classify-then-validate is still broken.
- `POST /annotations/sequences/bulk` has the same hardcoded `SEQ_ANNOTATION_DONE` target, but nothing in the frontend calls it, so it is left alone.

## Recovering the stranded groups

Once deployed, re-saving the classification on the affected member fires the fan-out. Note done-mode only PATCHes lanes the annotator actually changed, so the label has to be touched, not just re-submitted.