### PR TITLE
ci: cache node_modules across frontend jobs

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -32,9 +32,19 @@ jobs:
         cache: 'npm'
         cache-dependency-path: 'frontend/package-lock.json'
     
+    # setup-node's `cache: npm` only caches the download tarballs; npm ci still
+    # rebuilds node_modules from scratch (~70s). Cache the tree itself.
+    - name: Cache node_modules
+      id: node-modules
+      uses: actions/cache@v4
+      with:
+        path: frontend/node_modules
+        key: node-modules-${{ runner.os }}-node18-${{ hashFiles('frontend/package-lock.json') }}
+
     - name: Install dependencies
+      if: steps.node-modules.outputs.cache-hit != 'true'
       run: npm ci
-    
+
     - name: Build application
       run: npm run build
 
@@ -53,9 +63,17 @@ jobs:
         cache: 'npm'
         cache-dependency-path: 'frontend/package-lock.json'
     
+    - name: Cache node_modules
+      id: node-modules
+      uses: actions/cache@v4
+      with:
+        path: frontend/node_modules
+        key: node-modules-${{ runner.os }}-node18-${{ hashFiles('frontend/package-lock.json') }}
+
     - name: Install dependencies
+      if: steps.node-modules.outputs.cache-hit != 'true'
       run: npm ci
-    
+
     # Runs the whole suite and fails the job on any test failure, so a
     # separate `npm test` step would just run all 1260 tests a second time.
     - name: Run tests with coverage
@@ -86,8 +104,16 @@ jobs:
         cache: 'npm'
         cache-dependency-path: 'frontend/package-lock.json'
     
+    - name: Cache node_modules
+      id: node-modules
+      uses: actions/cache@v4
+      with:
+        path: frontend/node_modules
+        key: node-modules-${{ runner.os }}-node18-${{ hashFiles('frontend/package-lock.json') }}
+
     - name: Install dependencies
+      if: steps.node-modules.outputs.cache-hit != 'true'
       run: npm ci
-    
+
     - name: Run quality checks
       run: npm run quality:ci


### PR DESCRIPTION
## Summary

`setup-node`'s `cache: 'npm'` only caches the downloaded tarballs. `npm ci` still deletes and rebuilds `node_modules` from scratch on every job, ~72 s each time. All three frontend jobs pay it, and after #323 removed the duplicate test run it became the single largest remaining chunk of Frontend CI.

This caches the tree itself, keyed on `hashFiles('frontend/package-lock.json')` plus OS and node major, and skips `npm ci` on a hit. A lock file change misses the key and reinstalls, so the cache can't drift from the manifest.

## Measured on this PR's own CI

Cache restore takes ~4 s against ~72 s for `npm ci`:

| Job | Before (#323 baseline) | Cache hit | Saved |
|---|---|---|---|
| Build Frontend | 1 m 39 s | **26 s** | 73 s |
| Code Quality Checks | 1 m 40 s | **33 s** | 67 s |
| Run Tests (critical path) | 2 m 57 s | **1 m 40 s** | 77 s |

**Frontend CI critical path 2 m 57 s → 1 m 40 s.** Together with #323, the workflow has gone from 4 m 11 s to 1 m 40 s — about 2.5×.

The cache-miss run costs essentially nothing extra (Build 1 m 35 s, Quality 1 m 40 s — within noise of baseline), so a lock file bump doesn't regress anything.

## Testing

All checks green on both the cache-miss and cache-hit runs. The cache-hit path was also verified locally against a pre-existing `node_modules` tree, exercising all three jobs' commands: `npm run build` (built), `npm run quality:ci` (clean), `npm run test:coverage` (96 files, 1260 tests passed).

## Two notes for reviewers

1. **Expect two scary log lines on a cache miss.** All three jobs race to write the same key, so two of them log `Failed to save: Unable to reserve cache with key … another job may be creating this cache`. This is benign — exactly one job saves it (confirmed in the Quality job log and against the repo's cache list, 35.5 MB stored). Avoiding it entirely would mean serialising the jobs behind a shared install job, which costs more wall-clock than it saves.
2. **Full benefit arrives only after this is on main.** Actions cache scoping means a cache written on a feature branch isn't readable from other PRs' branches, while caches on the default branch are. Other open PRs keep paying the 72 s until `main` has populated the cache once.
