### PR TITLE
[BENCH - do not merge] control: docker image cache steps kept

### DIFF
--- a/.github/workflows/annotation-api-ci.yml
+++ b/.github/workflows/annotation-api-ci.yml
@@ -1,5 +1,9 @@
 name: Annotation API CI
 
+# BENCHMARK CONTROL - do not merge. Paired with the docker-cache-removed
+# branch to measure whether the image save/load cache steps pay for
+# themselves. This comment exists only to trigger a run.
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Benchmark control. **Do not merge.**

Paired with #(treatment) to measure whether the docker image save/load cache steps in `annotation-api-ci.yml` pay for themselves. Identical base commit, identical code; the only difference is a no-op comment to trigger the run.

Compare total `Run Tests` job duration against the treatment branch. Will be closed once measured.