### PR TITLE
[BENCH - do not merge] treatment: docker image cache steps removed

### DIFF
--- a/.github/workflows/annotation-api-ci.yml
+++ b/.github/workflows/annotation-api-ci.yml
@@ -34,34 +34,10 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
     
-    - name: Cache Docker images
-      uses: actions/cache@v3
-      with:
-        path: /tmp/docker-images
-        key: docker-images-${{ runner.os }}-${{ hashFiles('annotation_api/docker-compose-dev.yml') }}
-        restore-keys: |
-          docker-images-${{ runner.os }}-
-    
-    - name: Load cached Docker images
-      run: |
-        if [ -d /tmp/docker-images ]; then
-          for img in /tmp/docker-images/*.tar; do
-            [ -f "$img" ] && docker load -i "$img" || true
-          done
-        fi
-    
-    - name: Pull and save base images
-      run: |
-        mkdir -p /tmp/docker-images
-        
-        # Pull images if not already present
-        docker pull postgres:15-alpine || true
-        docker pull localstack/localstack:1.4.0 || true
-        
-        # Save images for next run
-        docker save postgres:15-alpine -o /tmp/docker-images/postgres.tar || true
-        docker save localstack/localstack:1.4.0 -o /tmp/docker-images/localstack.tar || true
-    
+    # BENCHMARK TREATMENT - do not merge. The docker image save/load cache
+    # steps are removed here; `docker compose up` pulls postgres and
+    # localstack itself. Paired with the docker-cache-control branch.
+
     - name: Run tests using make
       run: |
         # Use the pre-built image by tagging it appropriately


### PR DESCRIPTION
Benchmark treatment. **Do not merge.**

Paired with #327 (control) from the same base commit. Removes the three docker image cache steps (`actions/cache` restore, the `docker load` loop, and the pull-and-save step), letting `docker compose up` pull postgres and localstack itself.

Hypothesis: the cache dance costs ~57-79s per run (13s restore + 42s load + 24s save) to avoid pulling two base images, and is a net loss.

Compare total `Run Tests` job duration against #327. Will be closed once measured; if removal wins, a clean PR follows.