### PR TITLE
ci: drop the docker base-image cache that never hits

### DIFF
--- a/.github/workflows/annotation-api-ci.yml
+++ b/.github/workflows/annotation-api-ci.yml
@@ -40,34 +40,14 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
     
-    - name: Cache Docker images
-      uses: actions/cache@v3
-      with:
-        path: /tmp/docker-images
-        key: docker-images-${{ runner.os }}-${{ hashFiles('annotation_api/docker-compose-dev.yml') }}
-        restore-keys: |
-          docker-images-${{ runner.os }}-
-    
-    - name: Load cached Docker images
-      run: |
-        if [ -d /tmp/docker-images ]; then
-          for img in /tmp/docker-images/*.tar; do
-            [ -f "$img" ] && docker load -i "$img" || true
-          done
-        fi
-    
-    - name: Pull and save base images
-      run: |
-        mkdir -p /tmp/docker-images
-        
-        # Pull images if not already present
-        docker pull postgres:15-alpine || true
-        docker pull localstack/localstack:1.4.0 || true
-        
-        # Save images for next run
-        docker save postgres:15-alpine -o /tmp/docker-images/postgres.tar || true
-        docker save localstack/localstack:1.4.0 -o /tmp/docker-images/localstack.tar || true
-    
+    # postgres and localstack are pulled by `docker compose up` in `make test`.
+    # We used to tarball them into an actions/cache here, but this workflow only
+    # runs on pull_request, so every cache it wrote was scoped to that PR's merge
+    # ref and no other PR could read it - main never populated the key. It cost
+    # ~70s of pull/save/upload on every run and restored only on a repeat run of
+    # the same PR. Measured back-to-back from one base commit: 8m05s with these
+    # steps, 6m38s without.
+
     - name: Run tests using make
       run: |
         # Use the pre-built image by tagging it appropriately


### PR DESCRIPTION
## Summary

Removes the three docker base-image cache steps from `annotation-api-ci.yml`. They tarballed `postgres:15-alpine` and `localstack:1.4.0` into an `actions/cache` to avoid pulling them.

**They cannot work as intended.** This workflow only triggers on `pull_request`, so every cache it writes is scoped to that PR's merge ref — and Actions cache scoping stops one PR from reading another's. `main` never populates the key, because nothing runs this workflow on `main`. Every `docker-images-*` cache currently in the repo is owned by a `refs/pull/*/merge` ref:

```
refs/pull/327/merge  docker-images-Linux-4620034...
refs/pull/323/merge  docker-images-Linux-4620034...
refs/pull/320/merge  docker-images-Linux-4620034...
refs/pull/316/merge  docker-images-Linux-4620034...
refs/pull/318/merge  docker-images-Linux-4620034...
```

Not one owned by `refs/heads/main`. So the steps paid ~70 s of pull + save + upload on every run and restored only on a *repeat* run of the same PR.

## Measurement

The reliable number is the **direct cost of the steps themselves**, taken from their own step durations in the control run (#327):

| Step | Duration |
|---|---|
| `Pull and save base images` | 60 s |
| `Post Cache Docker images` (upload) | 9 s |
| `Load cached Docker images` (the payoff) | **0 s — miss** |
| **Net cost per run** | **~69 s for nothing** |

Replacing them costs an image pull inside `docker compose up`, and that is measured at **~38-39 s and stable** across runs (39 s on #328, 38 s on this PR's run).

Paired control/treatment from the same base commit, launched within 10 s of each other (#327 and #328, both now closed), came out 8 m 05 s vs 6 m 38 s. **Treat that 1 m 27 s as indicative, not exact** — pytest alone varies by ~60 s run to run on GitHub's runners (161 s on #328, 221 s on this PR's run, 216 s on #320, all on identical code and the same 639 tests), so whole-job totals carry that noise. The step-level numbers above don't.

`make test` does not get slower for pulling the images itself: the pull is ~38 s either way, and the control paid it too — its `docker pull` ran inside the "Pull and save" step rather than inside compose.

## Not touched

The `type=gha` **layer** cache on the "Pre-build backend image" step is a different mechanism, it does hit, and it stays. This PR only removes the base-image tarball cache.

The vestigial `docker tag pyronear/annotation-api:test …:latest` line in the test step is also left alone — compose builds its own image and never references those tags, but that's unrelated cleanup and doesn't cost measurable time.
