### PR TITLE
fix(api): harden the labeled-member fan-out after #258

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -929,6 +929,24 @@ _BULK_LOCKED_STAGES = {
 }
 
 
+def _labeled_member_stage(
+    smoke_type: Optional[SmokeType], is_unsure: bool
+) -> SequenceAnnotationProcessingStage:
+    """Stage a machine-written member annotation exits on when one label is
+    stamped across many sequences — the group fan-out and bulk-annotate.
+
+    Mirrors the two-lane exit a human classification takes (frontend:
+    `determineClassifySubmitStage`): a smoke label still owes localization
+    work, and an unsure write still gates its alert, so both park at
+    SEQ_ANNOTATION_DONE. An FP-only label owes nothing and exits at
+    ANNOTATED — `schedule_pending_auto_annotate` only advances lanes
+    matching the localization rule, so parking an FP member at
+    SEQ_ANNOTATION_DONE would strand it in no queue at all."""
+    if smoke_type is not None or is_unsure:
+        return SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE
+    return SequenceAnnotationProcessingStage.ANNOTATED
+
+
 def _is_classification_exit(annotation: SequenceAnnotation) -> bool:
     """Whether this save is the point where the lane's *classification*
     finishes — the one moment group propagation should fire.
@@ -1072,18 +1090,7 @@ async def _propagate_to_group_if_validated(
         min_cluster_size=1,
     )
 
-    # Members exit on the same two lanes a human classification does (mirrors
-    # `determineClassifySubmitStage` on the frontend): a smoke label still owes
-    # localization work, and an unsure fan-out still gates its alert, so both
-    # park at SEQ_ANNOTATION_DONE. An FP-only label owes nothing and goes
-    # straight out — `schedule_pending_auto_annotate` only advances lanes
-    # matching the localization rule, so parking an FP member at
-    # SEQ_ANNOTATION_DONE would strand it in no queue at all.
-    member_stage = (
-        SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE
-        if smoke_type is not None or group.is_unsure
-        else SequenceAnnotationProcessingStage.ANNOTATED
-    )
+    member_stage = _labeled_member_stage(smoke_type, group.is_unsure)
 
     for member_id in other_member_ids:
         existing = (
@@ -1128,8 +1135,11 @@ async def _propagate_to_group_if_validated(
             fanned_anno_id = existing.id
         # Fan-out carries the saving user's judgment onto the sibling
         # members; create/update only auto-record contributions at
-        # ANNOTATED, so attribute the write to them explicitly.
-        await annotations.record_contribution(fanned_anno_id, current_user_id)
+        # ANNOTATED, so attribute the write to them explicitly — but only
+        # when they didn't, or the member ends up with two rows for one
+        # gesture.
+        if member_stage != SequenceAnnotationProcessingStage.ANNOTATED:
+            await annotations.record_contribution(fanned_anno_id, current_user_id)
 
         # A member landing at ANNOTATED is finished, exactly as a hand-classified
         # FP lane is — give it the same detection annotations the classify
@@ -1511,6 +1521,8 @@ async def bulk_annotate_sequences(
     applied: List[SequenceAnnotationBulkResult] = []
     skipped: List[SequenceAnnotationBulkResult] = []
 
+    member_stage = _labeled_member_stage(payload.smoke_type, payload.is_unsure)
+
     for sid in payload.sequence_ids:
         seq = await session.get(Sequence, sid)
         if seq is None:
@@ -1560,12 +1572,13 @@ async def bulk_annotate_sequences(
                 has_missed_smoke=False,
                 is_unsure=payload.is_unsure,
                 annotation=generated,
-                processing_stage=SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE,
+                processing_stage=member_stage,
             )
             sequence_annotation = await annotations.create(create_data, current_user.id)
-            await annotations.record_contribution(
-                sequence_annotation.id, current_user.id
-            )
+            if member_stage != SequenceAnnotationProcessingStage.ANNOTATED:
+                await annotations.record_contribution(
+                    sequence_annotation.id, current_user.id
+                )
             applied.append(
                 SequenceAnnotationBulkResult(
                     sequence_id=sid,
@@ -1577,20 +1590,36 @@ async def bulk_annotate_sequences(
             update_data = SequenceAnnotationUpdate(
                 is_unsure=payload.is_unsure,
                 annotation=generated,
-                processing_stage=SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE,
+                processing_stage=member_stage,
             )
             sequence_annotation = await annotations.update(
                 existing.id, update_data, current_user.id
             )
-            await annotations.record_contribution(
-                sequence_annotation.id, current_user.id
-            )
+            if member_stage != SequenceAnnotationProcessingStage.ANNOTATED:
+                await annotations.record_contribution(
+                    sequence_annotation.id, current_user.id
+                )
             applied.append(
                 SequenceAnnotationBulkResult(
                     sequence_id=sid,
                     status="applied",
                     annotation_id=sequence_annotation.id,
                 )
+            )
+
+        # A sequence landing at ANNOTATED is finished, exactly as a
+        # hand-classified FP lane is — give it the same detection annotations
+        # the classify endpoints create on that transition. The flags are
+        # known by construction: member_stage is ANNOTATED only for an
+        # FP-only, not-unsure label.
+        if member_stage == SequenceAnnotationProcessingStage.ANNOTATED:
+            await auto_create_detection_annotations(
+                sequence_id=sid,
+                has_smoke=False,
+                has_missed_smoke=False,
+                has_false_positives=True,
+                session=session,
+                user_id=current_user.id,
             )
 
     # Write the label onto the group so future joiners inherit it. Only do

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -698,6 +698,53 @@ async def test_bulk_annotate_writes_label_on_group_and_seqs(
 
 
 @pytest.mark.asyncio
+async def test_bulk_annotate_fp_label_exits_at_annotated(
+    authenticated_client: AsyncClient,
+    sequence_session: AsyncSession,
+    detection_session: AsyncSession,
+    test_user: User,
+):
+    """An FP-only bulk label has no localization work left, so its sequences
+    exit at ANNOTATED rather than parking at SEQ_ANNOTATION_DONE, where
+    `schedule_pending_auto_annotate` would never pick them up. Same two-lane
+    rule the group fan-out uses (`_labeled_member_stage`)."""
+    await _set_seq_metadata(sequence_session, 1, camera_id=42, azimuth=90)
+    await _create_placeholder_annotation(authenticated_client, 1)
+    await assign_ungrouped_sequences(sequence_session, user_id=test_user.id)
+
+    group_id = (await authenticated_client.get("/sequences/1")).json()[
+        "sequence_group_id"
+    ]
+
+    bulk_resp = await authenticated_client.post(
+        "/annotations/sequences/bulk",
+        json={
+            "sequence_ids": [1],
+            "group_id": group_id,
+            "false_positive_type": "antenna",
+            "is_unsure": False,
+        },
+    )
+    assert bulk_resp.status_code == 200
+    assert len(bulk_resp.json()["applied"]) == 1
+
+    items = (
+        await authenticated_client.get("/annotations/sequences/?sequence_id=1")
+    ).json()["items"]
+    assert items[0]["processing_stage"] == "annotated"
+    assert items[0]["false_positive_types"] == ["antenna"]
+
+    group_payload = (
+        await authenticated_client.get(f"/sequence_groups/{group_id}")
+    ).json()
+    assert group_payload["false_positive_type"] == "antenna"
+    assert group_payload["smoke_type"] is None
+
+    # One row, not two: the CRUD already auto-records at ANNOTATED.
+    assert await _annotation_contributor_ids(sequence_session, 1) == [test_user.id]
+
+
+@pytest.mark.asyncio
 async def test_bulk_annotate_rejects_conflicting_label_without_force(
     authenticated_client: AsyncClient,
     sequence_session: AsyncSession,
@@ -818,6 +865,7 @@ async def test_propagation_fires_for_fp_only_lane_at_annotated(
     authenticated_client: AsyncClient,
     sequence_session: AsyncSession,
     detection_session: AsyncSession,
+    test_user: User,
 ):
     """Validated group, FP-only classification (issue #258). The lane exits
     straight to `annotated` — never visiting seq_annotation_done — so the
@@ -848,6 +896,10 @@ async def test_propagation_fires_for_fp_only_lane_at_annotated(
     assert items[0]["processing_stage"] == "annotated"
     assert items[0]["false_positive_types"] == ["antenna"]
     assert items[0]["has_smoke"] is False
+
+    # One gesture, one contribution row: the CRUD already auto-records at
+    # ANNOTATED, so the fan-out must not also record explicitly.
+    assert await _annotation_contributor_ids(sequence_session, 2) == [test_user.id]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #325. Two loose ends in the same code path — one found while verifying #325 on the live stack, one flagged as out-of-scope at the time.

## 1. Duplicate contribution rows on fanned members

The fan-out records a contribution explicitly, with the rationale *"create/update only auto-record contributions at ANNOTATED, so attribute the write to them explicitly."* That held while members always landed at `SEQ_ANNOTATION_DONE`. #325 made FP members land at `ANNOTATED`, so the CRUD auto-recorded **and** the explicit call fired — two rows per member for one gesture.

Caught by inspecting the live fan-out:

```
sequence_annotation_id | user_id | rows
                   383 |       1 |    2     ← seq 387, fanned
                   384 |       1 |    2     ← seq 390, fanned
```

Nothing was visibly broken — `get_annotation_contributors` uses `DISTINCT` and `merge_annotators` returns distinct usernames, so the Annotators column and the API both read correctly. But the contributions table is audit data, and it was recording a write that never happened. Now the explicit call only fires when the CRUD didn't.

## 2. Bulk-annotate had the same hardcoded member stage

`POST /annotations/sequences/bulk` still wrote every member at `SEQ_ANNOTATION_DONE`, exactly as the fan-out did before #325. An FP bulk label would strand its sequences at a stage `schedule_pending_auto_annotate` never advances (it only picks up lanes matching the localization rule) and neither queue displays. Nothing in the frontend calls this endpoint today, which is why it went unnoticed — I called it out as out-of-scope in #325 rather than leave it undocumented.

Fixed by extracting the two-lane rule as `_labeled_member_stage(smoke_type, is_unsure)` and using it in both writers, so the fan-out and bulk-annotate can no longer drift apart. Bulk also now creates the same detection annotations the fan-out does for members landing at `ANNOTATED` — without that, fixing the stage would have reproduced the exact gap #325 closed.

## Tests

- `test_bulk_annotate_fp_label_exits_at_annotated` — new; the FP path through bulk had no coverage at all, which is how the hardcoded stage survived. Asserts stage, label, group label, and the single contribution row.
- `test_propagation_fires_for_fp_only_lane_at_annotated` — extended to assert exactly one contribution row per fanned member.
- Full backend suite green (653 passed).

## Note on existing data

Not backfilled. Group 292's members (383, 384) keep their duplicate rows; they're harmless given the dedupe at every consumer. Any group labelled through the fan-out before this merges will have the same.