### PR TITLE
fix(import): collapse an object's same-frame boxes into one union box

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
@@ -521,7 +521,8 @@ def main() -> None:
             f"{split_stats['objects']} object sequence(s) "
             f"({split_stats['sibling_objects']} sibling(s), "
             f"{split_stats['fallback_sequences']} fallback, "
-            f"{split_stats['cross_deduped_siblings']} cross-deduped)[/]"
+            f"{split_stats['cross_deduped_siblings']} cross-deduped, "
+            f"{split_stats['same_frame_merges']} same-frame merge(s))[/]"
         )
 
         if not records and not args.dry_run:

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
@@ -144,6 +144,8 @@ class ObjectGroup:
     is_primary: bool
     is_fallback: bool
     records: List[dict]
+    # Frames on which this object's boxes were collapsed into one union box.
+    same_frame_merges: int = 0
 
 
 def split_sequence_records(
@@ -254,6 +256,7 @@ def split_sequence_records(
                 is_primary=(pos == 0),
                 is_fallback=False,
                 records=member_records,
+                same_frame_merges=same_frame_merges,
             )
         )
     return groups
@@ -304,6 +307,7 @@ def split_all_records(
         "sibling_objects": 0,
         "fallback_sequences": 0,
         "cross_deduped_siblings": 0,
+        "same_frame_merges": 0,
     }
 
     grouped = group_records_by_sequence(records)
@@ -339,6 +343,7 @@ def split_all_records(
             ]
         stats["alert_api_sequences"] += 1
         stats["fallback_sequences"] += sum(1 for g in groups if g.is_fallback)
+        stats["same_frame_merges"] += sum(g.same_frame_merges for g in groups)
         for group in groups:
             if not group.is_primary:
                 matched_sid = None

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
@@ -195,6 +195,20 @@ def split_sequence_records(
         for member in obj.members:
             own_by_frame.setdefault(member.image_filename, []).append(member.box)
 
+        # One object, one box per frame. cluster_objects can attach two
+        # same-frame boxes to one object (it flattens to one item per box and
+        # never compares image_filename), but a plume the detector split into
+        # two overlapping boxes is still one plume — boxed as the box enclosing
+        # both, per the #286 modelling note. Deliberately here rather than in
+        # cluster_objects: select_primary_index has already run above and
+        # matches members by exact coordinates, so merging earlier would change
+        # which lane keeps the alert's real alert_api_id.
+        same_frame_merges = 0
+        for frame_key, frame_boxes in own_by_frame.items():
+            if len(frame_boxes) > 1:
+                own_by_frame[frame_key] = [union_boxes(frame_boxes)]
+                same_frame_merges += 1
+
         alert_id = (
             alert_api_sid
             if pos == 0

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
@@ -119,6 +119,22 @@ def synthetic_alert_api_id(
     return alert_id_base + alert_api_sequence_id * 1000 + object_index
 
 
+def union_boxes(boxes: List[List[float]]) -> List[float]:
+    """Enclosing box of several same-frame boxes of one object.
+
+    Carries the group's highest confidence. A third of real engine boxes have
+    confidence 0.0, so any confidence-weighted rule is degenerate on a large
+    slice of the data; max is the best-evidence reading and is stable.
+    """
+    return [
+        min(b[0] for b in boxes),
+        min(b[1] for b in boxes),
+        max(b[2] for b in boxes),
+        max(b[3] for b in boxes),
+        max(b[4] for b in boxes),
+    ]
+
+
 @dataclass
 class ObjectGroup:
     """One detected object, as rewritten alert-api records ready for posting."""

--- a/annotation_api/src/tests/scripts/test_object_split.py
+++ b/annotation_api/src/tests/scripts/test_object_split.py
@@ -138,6 +138,11 @@ class TestSplitSequenceRecords:
         assert groups[0].records[0]["detection_bboxes"] == [SPLIT_PLUME_A]
         assert groups[0].records[2]["detection_bboxes"] == [SPLIT_PLUME_A]
 
+    def test_group_reports_its_same_frame_merge_count(self):
+        groups = split_sequence_records(forked_plume_records())
+        assert groups[0].same_frame_merges == 1
+        assert split_sequence_records(two_object_records())[0].same_frame_merges == 0
+
     def test_two_objects_yield_two_groups_primary_first(self):
         groups = split_sequence_records(two_object_records())
         assert len(groups) == 2
@@ -217,12 +222,17 @@ class TestSplitAllRecords:
             "sibling_objects": 1,
             "fallback_sequences": 0,
             "cross_deduped_siblings": 0,
+            "same_frame_merges": 0,
         }
         assert {r["sequence_id"] for r in out} == {
             47105,
             DEFAULT_ALERT_ID_BASE + 47105 * 1000 + 1,
             200,
         }
+
+    def test_same_frame_merges_are_counted(self):
+        _out, stats = split_all_records(forked_plume_records())
+        assert stats["same_frame_merges"] == 1
 
     def test_broken_sequence_falls_back_others_still_split(self):
         # detection_created_at=None can't be parsed, so split_sequence_records

--- a/annotation_api/src/tests/scripts/test_object_split.py
+++ b/annotation_api/src/tests/scripts/test_object_split.py
@@ -31,6 +31,23 @@ def two_object_records():
     ]
 
 
+# Detection 19167 (alert 41386, camera brison-01, 2026-05-11): the detector
+# split one small plume into two overlapping boxes on a single frame, and
+# cluster_objects attached both to the same object. Both carry confidence 0.0,
+# as a third of real engine boxes do.
+SPLIT_PLUME_A = [0.102, 0.565, 0.113, 0.586, 0.0]
+SPLIT_PLUME_B = [0.107, 0.564, 0.119, 0.584, 0.0]
+
+
+def forked_plume_records():
+    """One object whose middle frame carries two overlapping boxes."""
+    return [
+        make_record(1, "2026-05-11T05:09:47", [SPLIT_PLUME_A]),
+        make_record(2, "2026-05-11T05:09:57", [SPLIT_PLUME_A, SPLIT_PLUME_B]),
+        make_record(3, "2026-05-11T05:10:07", [SPLIT_PLUME_A]),
+    ]
+
+
 class TestBuildFrames:
     def test_frames_merge_own_and_others_boxes(self):
         frames, primary_keys = build_frames(two_object_records())
@@ -108,6 +125,19 @@ class TestUnionBoxes:
 
 
 class TestSplitSequenceRecords:
+    def test_same_frame_boxes_of_one_object_collapse_to_their_union(self):
+        groups = split_sequence_records(forked_plume_records())
+        assert len(groups) == 1
+        for record in groups[0].records:
+            assert len(record["detection_bboxes"]) == 1
+        merged = groups[0].records[1]["detection_bboxes"][0]
+        assert merged == [0.102, 0.564, 0.119, 0.586, 0.0]
+
+    def test_single_box_frames_are_left_untouched(self):
+        groups = split_sequence_records(forked_plume_records())
+        assert groups[0].records[0]["detection_bboxes"] == [SPLIT_PLUME_A]
+        assert groups[0].records[2]["detection_bboxes"] == [SPLIT_PLUME_A]
+
     def test_two_objects_yield_two_groups_primary_first(self):
         groups = split_sequence_records(two_object_records())
         assert len(groups) == 2

--- a/annotation_api/src/tests/scripts/test_object_split.py
+++ b/annotation_api/src/tests/scripts/test_object_split.py
@@ -11,6 +11,7 @@ from scripts.data_transfer.ingestion.alert_api.object_split import (
     split_all_records,
     split_sequence_records,
     synthetic_alert_api_id,
+    union_boxes,
 )
 
 # No __init__.py convention in src/tests/ — pytest inserts the test dir on
@@ -79,6 +80,31 @@ class TestSyntheticAlertApiId:
         assert (
             synthetic_alert_api_id(5, 2, alert_id_base=2_000_000_000) == 2_000_005_002
         )
+
+
+class TestUnionBoxes:
+    def test_single_box_passes_through(self):
+        assert union_boxes([[0.1, 0.2, 0.3, 0.4, 0.7]]) == [0.1, 0.2, 0.3, 0.4, 0.7]
+
+    def test_two_overlapping_boxes_yield_enclosing_box(self):
+        merged = union_boxes(
+            [[0.102, 0.565, 0.113, 0.586, 0.0], [0.107, 0.564, 0.119, 0.584, 0.0]]
+        )
+        assert merged == [0.102, 0.564, 0.119, 0.586, 0.0]
+
+    def test_confidence_is_the_group_max(self):
+        merged = union_boxes([[0.1, 0.1, 0.2, 0.2, 0.3], [0.15, 0.15, 0.25, 0.25, 0.8]])
+        assert merged[4] == 0.8
+
+    def test_three_boxes_enclose_all_three(self):
+        merged = union_boxes(
+            [
+                [0.30, 0.30, 0.40, 0.40, 0.1],
+                [0.10, 0.35, 0.20, 0.45, 0.2],
+                [0.25, 0.05, 0.50, 0.15, 0.3],
+            ]
+        )
+        assert merged == [0.10, 0.05, 0.50, 0.45, 0.3]
 
 
 class TestSplitSequenceRecords:

--- a/docs/specs/2026-08-06-one-box-per-object-per-frame-union-design.md
+++ b/docs/specs/2026-08-06-one-box-per-object-per-frame-union-design.md
@@ -131,6 +131,22 @@ remaining leak is `boxes_by_frame`, which feeds `others_bboxes` — a duplicate
 member means another object's sibling list carries both boxes, a read-only
 display artifact.
 
+### The fallback path is deliberately exempt
+
+When `split_sequence_records` raises, `split_all_records` imports the sequence
+whole (`records=[dict(r) for r in seq_records]`), bypassing the merge. That is
+correct, not an oversight: a fallback sequence was never split into objects, so
+the several boxes on one of its frames may belong to *different* plumes. Unioning
+them there would merge distinct objects into one box — strictly worse than
+leaving them alone.
+
+So the guarantee this design establishes is scoped: **every successfully split
+object holds at most one box per frame**. A fallback sequence can still carry a
+frame with several boxes, and downstream that still means a detection with
+several `algo_predictions`. Fallbacks are already counted in
+`split_stats['fallback_sequences']` and were 0 across the 352-sequence
+verification window.
+
 ### Box shape
 
 `build_frames` filters boxes at `len(b) >= 5`, so a box is at least

--- a/docs/specs/2026-08-06-one-box-per-object-per-frame-union-design.md
+++ b/docs/specs/2026-08-06-one-box-per-object-per-frame-union-design.md
@@ -1,0 +1,188 @@
+# One box per object per frame
+
+Issue: [#324](https://github.com/pyronear/pyro-annotator/issues/324)
+Date: 2026-08-06
+
+## Problem
+
+`cluster_objects` can attach two boxes from the same frame to one object. Nothing
+forbids it, in either path that adds members:
+
+- **Attach** (`object_clustering.py:178-186`) — box A on frame F joins object O,
+  which makes `O.last_box` A's box. Box B on the same frame is then tested
+  against A, and if they overlap it joins O too. Nothing compares
+  `image_filename`.
+- **Spawn** (`object_clustering.py:188-200`) — `window` gathers pending
+  detections overlapping `det.box`, so two same-frame boxes both pending and
+  overlapping spawn an object holding both.
+
+Both are made likelier by `bboxes_overlap` (`object_clustering.py:80`) being a
+bare strictly-positive-intersection test ported from pyro-api, with no IoU
+threshold: boxes that merely graze count as overlapping.
+
+Everything downstream assumes one object holds at most one box per frame.
+`own_by_frame[key]` becomes `detection_bboxes` becomes the detection's
+`algo_predictions`, and the localize accept path turns every one of those into a
+committed smoke box. Since #286, a second smoke box on a detection annotation is
+a 422.
+
+## Measurement
+
+Local DB, 2026-08-06, after importing three windows of production alert-API
+data: **19,205 detections across 984 sequences**.
+
+| metric | value |
+| --- | --- |
+| detections with ≥2 own boxes (`algo_predictions`) | **1** (0.005%) |
+| max own boxes | 2 |
+| frames carrying sibling boxes (`others_bboxes`) | 2,793 |
+| frames with 2+ siblings | 408 |
+| max boxes on a single frame | 4 |
+
+The one occurrence is **detection 19167** — sequence 1018, alert `41386`, camera
+`brison-01`, recorded 2026-05-11 05:09:57Z:
+
+```
+A = [0.102, 0.565, 0.113, 0.586]
+B = [0.107, 0.564, 0.119, 0.584]
+```
+
+They overlap in both axes and are near-duplicates of one small plume.
+`others_bboxes` is null, so both are the object's own boxes. The lane sits at
+`READY_TO_ANNOTATE` with `has_smoke = true` and an empty `auto_predictions`, so
+the engine layer wins and bulk-accepting it will 422.
+
+Note that an earlier 10,268-detection sample showed **zero** occurrences. The
+counterexample only appeared after widening to 19,205 — a reminder that one
+import window is not enough to conclude an invariant holds.
+
+## The rule
+
+Within one object, all boxes on the same frame collapse to the single box
+enclosing them, carrying the highest confidence of the group.
+
+This is #286's modelling rule applied one layer up: a plume that visually forks
+into two strands and rejoins is still one fire's smoke, boxed as one box
+enclosing both strands. A *persistent* split is a second fire, which the
+clustering already separates into its own object.
+
+Confidence is taken as the max rather than the mean or the first: a third of
+engine boxes (6,249 of 19,155) carry `confidence: 0.0`, including both boxes on
+detection 19167, so any confidence-weighted rule is degenerate on a large slice
+of real data. Max is the "best evidence available" reading and is stable.
+
+## Where it lives
+
+In `object_split.py`, immediately after `own_by_frame` is built
+(`object_split.py:178-180`):
+
+```python
+own_by_frame: Dict[str, List[List[float]]] = {}
+for member in obj.members:
+    own_by_frame.setdefault(member.image_filename, []).append(member.box)
+
+# One object, one box per frame. A plume the detector split into two
+# overlapping boxes on one frame is still one plume, boxed as the box
+# enclosing both (see the #286 modelling note).
+for key, boxes in own_by_frame.items():
+    if len(boxes) > 1:
+        own_by_frame[key] = [union_boxes(boxes)]
+```
+
+with:
+
+```python
+def union_boxes(boxes: List[List[float]]) -> List[float]:
+    """Enclosing box of several same-frame boxes of one object, carrying the
+    highest confidence of the group."""
+    return [
+        min(b[0] for b in boxes),
+        min(b[1] for b in boxes),
+        max(b[2] for b in boxes),
+        max(b[3] for b in boxes),
+        max(b[4] for b in boxes),
+    ]
+```
+
+### Why not in `cluster_objects`
+
+The ticket points at `cluster_objects`, and the invariant is arguably a property
+of the object model. But `select_primary_index` (`object_split.py:96-111`)
+identifies bbox-sourced members by exact coordinates:
+
+```python
+if (m.image_filename, tuple(m.box[:4])) in primary_keys
+```
+
+`primary_keys` holds the original coordinates from `detection_bboxes`. A unioned
+box matches **neither** original, so merging inside `cluster_objects` would drop
+that frame's bbox-sourced count and could flip which object is selected as
+primary — which decides which lane keeps the alert's real `alert_api_id` and
+which gets a synthetic one. That trades a rare box bug for a rarer identity bug
+that is harder to notice.
+
+Collapsing in `own_by_frame` runs *after* `select_primary_index` (called at
+`object_split.py:162`), so lane identity is untouched.
+
+The cost is that `TrackedObject.members` can still hold two members for one
+frame. Consequences are contained: `member_keys` is `sorted(own_by_frame)`, so
+frame keys are already unique; `object_cone_azimuth` uses `members[0]`. The
+remaining leak is `boxes_by_frame`, which feeds `others_bboxes` — a duplicate
+member means another object's sibling list carries both boxes, a read-only
+display artifact.
+
+### Box shape
+
+`build_frames` filters boxes at `len(b) >= 5`, so a box is at least
+`[x1, y1, x2, y2, conf]`. `union_boxes` returns exactly 5 elements, dropping
+anything beyond index 4. That is safe: `parse_alert_api_bboxes`
+(`shared.py:238-243`) is the only consumer of `detection_bboxes` and reads
+`bbox[:4]` as coordinates and `bbox[4]` as confidence, ignoring the rest.
+
+## Visibility
+
+A silent merge is how this stayed invisible across 19,205 detections. Add a
+`same_frame_merges` counter to the `split_stats` dict returned by
+`split_all_records`, and surface it in the existing import summary line
+(`import.py:520-524`) next to the sibling and cross-dedup counts.
+
+## Tests
+
+In `src/tests/scripts/test_object_clustering.py`, which already provides
+`make_frames`, `BOX_A`, and `BOX_B`:
+
+1. **Real-data regression** — detection 19167's two boxes verbatim as a fixture;
+   assert the object yields one box on that frame equal to
+   `[0.102, 0.564, 0.119, 0.586]`. This is the shape production actually
+   produced, not an invented one.
+2. **Union helper** — a single box passes through unchanged; confidence is the
+   max of the group; three boxes enclose all three.
+3. **Unchanged behavior** — the existing
+   `test_two_disjoint_box_groups_form_two_objects` must stay green. The union
+   applies only within one object, so two disjoint boxes still form two objects.
+
+## End-to-end verification
+
+Re-running the May import alone will *not* exercise the fix: sequence 1018 is
+already imported and would be skipped. Verification needs the alert re-ingested
+— either delete the sequences for alert `41386` and re-import
+`2026-05-10..2026-05-24`, or import that window into a fresh database. Then:
+
+```sql
+SELECT count(*) FROM detections
+WHERE jsonb_array_length(algo_predictions->'predictions') >= 2;
+```
+
+This currently returns 1 and must return 0.
+
+## Out of scope
+
+Detection 19167 is already written and this change does not repair it, so
+bulk-accepting sequence 1018 still 422s. That is left to #319, which caps the
+accept payload and handles any pre-existing row generically rather than
+special-casing one.
+
+The auto layer has the same absence of a per-frame cap —
+`worker.py`'s `keep_boxes_overlapping` retains every sensitive-model box
+overlapping the anchor. It measures max 1 today, but across only 312 frames.
+Also #319.


### PR DESCRIPTION
Closes #324.

`cluster_objects` can attach two boxes from the same frame to one object — it flattens frames to one item per box and never compares `image_filename`, in either its attach or spawn path, and `bboxes_overlap` is a bare positive-intersection test with no IoU threshold. Everything downstream assumes one box per object per frame: `own_by_frame` becomes `detection_bboxes` becomes `algo_predictions`, and the localize accept path commits every one of those as a smoke box, which #318 now rejects with a 422.

This collapses an object's same-frame boxes into the single box enclosing them, carrying the group max confidence — #286's modelling rule applied one layer up: a plume that forks into two strands and rejoins is one object, boxed once.

**Placement.** The merge runs in `split_sequence_records`'s `own_by_frame`, *after* `select_primary_index`. That function matches members by exact coordinates against `primary_keys`, so merging inside `cluster_objects` would make a unioned box match neither original, dropping that frame's bbox-sourced count and potentially flipping which lane keeps the alert's real `alert_api_id`. `cluster_objects` is deliberately untouched.

**Confidence is the group max** rather than mean or first: 6,249 of 19,155 real engine boxes carry `confidence: 0.0`, including both boxes on the case below, so any confidence-weighted rule is degenerate on a third of the data.

**Visibility.** A silent merge is how this hid across 19,205 detections, so `same_frame_merges` is threaded through `ObjectGroup` into the `split_all_records` stats and printed in the import summary line.

## The real occurrence

One in 19,205 imported detections. Detection `19167` — sequence 1018, alert `41386`, camera `brison-01`, 2026-05-11 05:09:57Z — held two overlapping near-duplicate boxes of one small plume, `others_bboxes` null:

```
[0.102, 0.565, 0.113, 0.586]
[0.107, 0.564, 0.119, 0.584]
```

Its lane sat at `READY_TO_ANNOTATE` with `has_smoke` and an empty `auto_predictions`, so the engine layer wins and bulk-accepting it would 422. Those exact coordinates are the regression-test fixture.

## End-to-end verification

The alert's lanes were deleted from a local stack and re-imported through the patched splitter:

```
🔀 Object split: 352 alert sequence(s) → 367 object sequence(s)
   (15 sibling(s), 0 fallback, 14 cross-deduped, 1 same-frame merge(s))
```

| check | before | after |
| --- | --- | --- |
| detections | 19,205 | 19,205 |
| detections with ≥2 own boxes | 1 | **0** |
| max own boxes | 2 | **1** |
| that frame's boxes | the two above | **`[0.102, 0.564, 0.119, 0.586]`** |

The recreated detection (19252) exists and holds a single box that is exactly the union, so the zero is real rather than an artifact of the row being absent.

Finally, the payload `buildQuickSubmitPlan` builds for that lane — one smoke box — now **POSTs 201** against a live API. The bulk accept that would have failed succeeds.

Tests: 660 passed, 0 failed. `ruff check` clean on all changed files.

## Scope of the guarantee

**Every successfully split object holds at most one box per frame.** The fallback path — when `split_sequence_records` raises and the sequence is imported whole — is deliberately exempt: that sequence was never split into objects, so several boxes on one frame may belong to *different* plumes, and unioning them would merge distinct objects into one box. Fallbacks are counted in `split_stats['fallback_sequences']` and were 0 across the 352-sequence verification window.

Two smaller interactions, both checked and neither worth code:

- `boxes_by_frame` (which feeds a neighbouring lane's read-only `others_bboxes`) is built from the original member boxes, so a sibling lane displays both pre-merge boxes for an object that now holds one. Display-only, no data impact.
- Cross-sequence dedup calls `_own_box_keys` on the rewritten records, so a merged frame's key no longer matches the raw index. It does not break dedup: the check iterates a key *set* and breaks on the first match, and a sibling group needs at least `min_dets` frames to spawn, so dedup would only degrade if every one of its frames merged.

## Not fixed here

Detection 19167's original row is superseded by the re-import above, but this change does not repair pre-existing bad rows in general, so any that exist still 422 on bulk accept until #319 caps the accept payload. The auto layer has the same missing per-frame cap (`worker.py`'s `keep_boxes_overlapping`) — also #319.

Design: `docs/specs/2026-08-06-one-box-per-object-per-frame-union-design.md`
