### PR TITLE
fix(tests): drop the removed user_id arg from the bulk FP test

### DIFF
--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -657,7 +657,7 @@ async def test_bulk_annotate_fp_label_exits_at_annotated(
     rule the group fan-out uses (`_labeled_member_stage`)."""
     await _set_seq_metadata(sequence_session, 1, camera_id=42, azimuth=90)
     await _create_placeholder_annotation(authenticated_client, 1)
-    await assign_ungrouped_sequences(sequence_session, user_id=test_user.id)
+    await assign_ungrouped_sequences(sequence_session)
 
     group_id = (await authenticated_client.get("/sequences/1")).json()[
         "sequence_group_id"


### PR DESCRIPTION
**main is currently red.** One test fails on `ccc5fde`:

```
tests/endpoints/test_sequence_groups.py:660
    await assign_ungrouped_sequences(sequence_session, user_id=test_user.id)
TypeError
```

## How it got in

A semantic conflict between two PRs that never touched the same lines:

- **#330** added `test_bulk_annotate_fp_label_exits_at_annotated`, calling `assign_ungrouped_sequences(session, user_id=...)` — correct against main at the time.
- **#294** removed the `user_id` parameter, since the sweep no longer writes annotations.

Git had no conflict to report, and neither CI run could have caught it: each PR was verified against a main that lacked the other. #330 merged at 17:28 and went green; #294 merged at 17:34 and broke it.

Caught by running the full suite against merged main rather than trusting the two green PR runs.

## Fix

Drop the argument. The `test_user` fixture stays — it's still used for the contribution assertion at the end of the test.

## Verification

Full backend suite against merged main + this commit: **660 passed, 0 failed** (was 659 passed / 1 failed). Ruff clean.