### PR TITLE
fix(frontend): suspend page shortcuts while the skip confirm is open

### DIFF
--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -1427,6 +1427,11 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
               </label>
               <textarea
                 id="skip-note"
+                // Without this the caret stays on the rail's Skip trigger, so
+                // a user who clicks and types straight away types into
+                // nothing — the page shortcuts are suspended, but the
+                // characters have nowhere to land either.
+                autoFocus
                 value={skipNote}
                 onChange={e => setSkipNote(e.target.value)}
                 rows={3}

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -1018,8 +1018,17 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
       },
     });
 
-    document.addEventListener('keydown', handleKeyDown, true);
-    return () => document.removeEventListener('keydown', handleKeyDown, true);
+    // The skip confirm owns the keyboard while it is up. Its note is a free
+    // text field, and these shortcuts are registered capture-phase on
+    // document: unguarded, every letter typed there classifies the object
+    // behind the dialog and Enter submits the whole alert.
+    const handleGuarded = (e: KeyboardEvent) => {
+      if (skipConfirmOpen) return;
+      handleKeyDown(e);
+    };
+
+    document.addEventListener('keydown', handleGuarded, true);
+    return () => document.removeEventListener('keydown', handleGuarded, true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     activeIndex,
@@ -1031,6 +1040,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     missedSmokeReview,
     primaryClassification,
     canSubmit,
+    skipConfirmOpen,
   ]);
 
   // Focus cycle: Tab / Shift+Tab move strictly between the rail's stops —
@@ -1040,11 +1050,17 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
   // shortcuts modal is open so its close button stays reachable.
   useEffect(() => {
     const handleTab = (e: KeyboardEvent) => {
-      // Suspended while the shortcuts modal or the group-propagation
-      // warning banner is up — both carry focusables (close button, "Open
-      // group" link, Dismiss) that the trap would otherwise make
-      // keyboard-unreachable.
-      if (e.key !== 'Tab' || showKeyboardModal || groupConflictWarnings.length > 0) return;
+      // Suspended while the shortcuts modal, the group-propagation warning
+      // banner or the skip confirm is up — each carries focusables (close
+      // button, "Open group" link, Dismiss, the skip note and its confirm)
+      // that the trap would otherwise make keyboard-unreachable.
+      if (
+        e.key !== 'Tab' ||
+        showKeyboardModal ||
+        skipConfirmOpen ||
+        groupConflictWarnings.length > 0
+      )
+        return;
       const stops = (
         [
           ...cards.map(c => cardRefs.current[c.cardKey]),
@@ -1061,7 +1077,7 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
     };
     document.addEventListener('keydown', handleTab, true);
     return () => document.removeEventListener('keydown', handleTab, true);
-  }, [cards, showKeyboardModal, groupConflictWarnings]);
+  }, [cards, showKeyboardModal, skipConfirmOpen, groupConflictWarnings]);
 
   const handlePreviousAlert = () => {
     const prev = navigateToPreviousInWorkflow();

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1969,6 +1969,10 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
             </label>
             <textarea
               id="skip-note"
+              // Without this the caret stays on whatever opened the dialog —
+              // the rail's Skip trigger or the missed-smoke nudge — so a user
+              // who types straight away types into nothing.
+              autoFocus
               value={skipNote}
               onChange={e => setSkipNote(e.target.value)}
               rows={3}

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1328,18 +1328,24 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   };
 
   // 'c' toggles crop mode, matching the legacy grid — inert while the modal
-  // is open (mirrors the legacy page's showModal guard) and while the
-  // shortcuts sheet is up (only `?`/Escape act there).
+  // is open (mirrors the legacy page's showModal guard), while the shortcuts
+  // sheet is up (only `?`/Escape act there), and while the skip confirm is
+  // up (its note is a free text field, so a typed "c" is a letter).
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.key === 'c' || e.key === 'C') && detectionIdNum == null && !showShortcutsModal) {
+      if (
+        (e.key === 'c' || e.key === 'C') &&
+        detectionIdNum == null &&
+        !showShortcutsModal &&
+        !skipConfirmOpen
+      ) {
         setCropMode(prev => !prev);
         e.preventDefault();
       }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [detectionIdNum, showShortcutsModal]);
+  }, [detectionIdNum, showShortcutsModal, skipConfirmOpen]);
 
   // Tab / Shift+Tab step the objects exactly as the rail displays them —
   // smoke first, false positives only while shown — wrapping at the ends

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -1191,6 +1191,33 @@ describe('ClassifyAlertPage', () => {
       expect(screen.getByTestId('skip-alert-confirm')).toBeInTheDocument();
     });
 
+    it('Ctrl+Z in the note does not discard the work on the alert', async () => {
+      await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+      const card = openRow('101:0');
+      fireEvent.click(card.getByRole('radio', { name: 'Smoke' }));
+      fireEvent.click(card.getByRole('radio', { name: 'Wildfire' }));
+
+      fireEvent.click(screen.getByRole('button', { name: /Skip alert/ }));
+      fireEvent.keyDown(screen.getByLabelText(/optional/i), { key: 'z', ctrlKey: true });
+
+      // Ctrl+Z used to reach handleReset, re-initializing every lane from the
+      // server and throwing away the classification above.
+      const row = within(screen.getByTestId('object-card-101:0'));
+      expect(row.getByRole('radio', { name: 'Smoke' })).toBeChecked();
+      expect(row.getByRole('radio', { name: 'Wildfire' })).toBeChecked();
+    });
+
+    it('opening the confirm puts the caret in the note', async () => {
+      await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: /Skip alert/ }));
+
+      // Without this the caret stays on the trigger button, so a user who
+      // clicks and types straight away types into nothing.
+      expect(document.activeElement).toBe(screen.getByLabelText(/optional/i));
+    });
+
     it('Tab is inert while the confirm is open, so its controls stay reachable', async () => {
       await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import type { AlertDetail, Sequence, SequenceAnnotation, ClassifySubmitRequest } from '@/types/api';
@@ -1140,6 +1140,69 @@ describe('ClassifyAlertPage', () => {
     const row = within(screen.getByTestId('object-card-101:0'));
     expect(row.getByRole('radio', { name: 'False positive' })).not.toBeChecked();
     expect(row.getByText('Pending')).toBeInTheDocument();
+  });
+
+  describe('skip confirm keyboard guards', () => {
+    it('page shortcuts are inert while the confirm is open, so the note is typable', async () => {
+      await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: /Skip alert/ }));
+      const note = screen.getByLabelText(/optional/i);
+
+      // Letters a note actually contains: 's' and 'u' classify the active
+      // object, 'a' toggles a false-positive type, '?' opens the shortcuts
+      // sheet on top of the dialog.
+      fireEvent.keyDown(note, { key: 's' });
+      fireEvent.keyDown(note, { key: 'u' });
+      fireEvent.keyDown(note, { key: 'a' });
+      fireEvent.keyDown(note, { key: '?' });
+
+      expect(screen.queryByRole('dialog', { name: 'Keyboard shortcuts' })).not.toBeInTheDocument();
+      expect(screen.getByTestId('skip-alert-confirm')).toBeInTheDocument();
+
+      fireEvent.click(
+        within(screen.getByTestId('skip-alert-confirm')).getByRole('button', { name: 'Close' })
+      );
+      const row = within(screen.getByTestId('object-card-101:0'));
+      expect(row.getByRole('radio', { name: 'Smoke' })).not.toBeChecked();
+      expect(row.getByRole('radio', { name: 'Unsure' })).not.toBeChecked();
+      expect(row.getByText('Pending')).toBeInTheDocument();
+    });
+
+    it('Enter in the note does not submit the alert behind the confirm', async () => {
+      await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+      // Make the alert submittable, so only the guard can stop Enter.
+      const cardA = openRow('101:0');
+      fireEvent.click(cardA.getByRole('radio', { name: 'Smoke' }));
+      fireEvent.click(cardA.getByRole('radio', { name: 'Wildfire' }));
+      const cardB = openRow('102:0');
+      fireEvent.click(cardB.getByRole('radio', { name: 'False positive' }));
+      fireEvent.click(cardB.getByRole('checkbox', { name: 'Antenna' }));
+      fireEvent.click(missedSmokeChip('No'));
+
+      fireEvent.click(screen.getByRole('button', { name: /Skip alert/ }));
+      fireEvent.keyDown(screen.getByLabelText(/optional/i), { key: 'Enter' });
+      // The submit runs through a mutation: without a flush the negative
+      // assertion below would pass even when the shortcut did fire.
+      await act(async () => {});
+
+      expect(apiClient.classifySubmit).not.toHaveBeenCalled();
+      expect(screen.getByTestId('skip-alert-confirm')).toBeInTheDocument();
+    });
+
+    it('Tab is inert while the confirm is open, so its controls stay reachable', async () => {
+      await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: /Skip alert/ }));
+      const note = screen.getByLabelText(/optional/i);
+      note.focus();
+
+      fireEvent.keyDown(note, { key: 'Tab' });
+
+      // The rail's focus trap did not yank focus back to an object row.
+      expect(document.activeElement).toBe(note);
+    });
   });
 
   it('blocks re-submission during the post-submit window and invalidates the cached alert detail', async () => {

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -3091,6 +3091,21 @@ describe('LocalizeAlertPage', () => {
       expect(screen.getByTestId('skip-alert-confirm')).toBeInTheDocument();
     });
 
+    it("'c' is inert while the skip confirm is open, so the note is typable", async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      // Arrival auto-focus turns crop on; typing a "c" must not toggle it.
+      await waitFor(() => {
+        const img = within(screen.getByTestId(`alert-frame-cell-${T1}`)).getByRole('img');
+        expect(img.style.transform).toContain('scale(');
+      });
+      fireEvent.click(screen.getByRole('button', { name: /Skip alert/ }));
+
+      fireEvent.keyDown(screen.getByLabelText(/optional/i), { key: 'c' });
+
+      const img = within(screen.getByTestId(`alert-frame-cell-${T1}`)).getByRole('img');
+      expect(img.style.transform).toContain('scale(');
+    });
+
     it("'?' is inert while the skip confirm is open", async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
       fireEvent.click(screen.getByRole('button', { name: /Skip alert/ }));

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -3091,6 +3091,14 @@ describe('LocalizeAlertPage', () => {
       expect(screen.getByTestId('skip-alert-confirm')).toBeInTheDocument();
     });
 
+    it('opening the confirm puts the caret in the note', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: /Skip alert/ }));
+
+      expect(document.activeElement).toBe(screen.getByLabelText(/optional/i));
+    });
+
     it("'c' is inert while the skip confirm is open, so the note is typable", async () => {
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
       // Arrival auto-focus turns crop on; typing a "c" must not toggle it.


### PR DESCRIPTION
## Problem

Typing a note in the **Skip alert** confirm dialog drove the page behind it, making the note almost impossible to fill in.

Both classify keyboard effects are registered **capture-phase on `document`**, and `createKeyboardHandler` has no `INPUT`/`TEXTAREA`/`contentEditable` guard, so keys reached the page before the textarea and `preventDefault()` swallowed the character:

| Key typed in the note | What actually happened |
| --- | --- |
| `s` / `f` / `u` / `1`–`3` / FP letters | classified the object behind the dialog |
| `?` | opened the shortcuts sheet on top of the dialog |
| `Enter` | **submitted the whole alert** |
| `Ctrl+Z` | **reset the alert**, discarding every unsaved classification on it |
| `Tab` | stolen by the rail focus trap — the note's Close and Skip buttons became keyboard-unreachable |

Localize was already fixed for this in `d038c04`, except one leftover handler: `c` still toggled crop mode from inside the note.

On top of that, nothing ever put the caret **in** the note: clicking "Skip alert" leaves focus on the trigger button, so suspending the shortcuts alone would have turned "typing classifies objects" into "typing does nothing".

## Fix

1. **Suspend the page shortcuts** — the same flag-guard pattern localize already established, `skipConfirmOpen` in the guard plus the dependency array:
   - `ClassifyAlertPage` — the shortcuts effect returns early while the confirm is open
   - `ClassifyAlertPage` — the Tab focus trap is suspended alongside the existing shortcuts-modal / group-warning cases
   - `LocalizeAlertPage` — `c` no longer toggles crop mode from inside the note
2. **Focus the note on open** — `autoFocus` on both dialogs' textareas, so the caret is where the user is already typing.

No behaviour changes while the dialog is closed.

## Out of scope (follow-ups)

- `createKeyboardHandler` still has no target guard of its own. Worth adding as defense in depth for the next text field, but it would **not** have fixed this bug: with focus on the trigger button the event target isn't the textarea, so only the flag guard covers it.
- `SequencePlayer` / `PlayerControls` guard on target type but on no page flag, so with focus outside the note the media keys (`space`, `k`, arrows, …) still drive the sequence behind the dialog. `autoFocus` removes the common path; the residue is pre-existing.
- The dialog has no Escape-to-close and no focus trap of its own.
- The two dialogs are byte-identical duplicated markup across the two pages — which is exactly why the `d038c04` fix never reached classify. A shared `SkipAlertDialog` owning focus, Escape and the trap would retire this bug class.

## Tests

Six regression tests, each **verified failing against the pre-fix sources** (not just reasoned about):

- classify: page shortcuts inert while the confirm is open (`s`/`u`/`a`/`?`, object behind stays `Pending`)
- classify: `Enter` in the note does not submit the alert
- classify: `Ctrl+Z` in the note does not discard the alert's classifications
- classify: `Tab` does not yank focus out of the note
- classify + localize: opening the confirm puts the caret in the note
- localize: `c` does not toggle crop mode from the note

The `Enter` test needs an `await act(async () => {})` flush — the submit runs through a mutation, so a synchronous negative assertion passes even when the shortcut fires.

Full frontend suite: 1269 passed / 96 files. `type-check`, `lint`, `format:check` clean.
