### PR TITLE
feat(import): auto-skip boxless alerts instead of leaving zero-object lanes

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
@@ -264,6 +264,44 @@ def test_annotation_credentials(
         return False
 
 
+def auto_skip_boxless(
+    annotation_api_url: str,
+    login: str,
+    password: str,
+    source_api: str,
+    boxless_alert_ids: List[int],
+    console: Console,
+    error_collector: ErrorCollector,
+) -> dict:
+    """
+    Best-effort auto-skip of boxless alerts (#333): park their zero-object
+    lanes via the skip overlay. Never raises — a skip failure must not fail
+    an otherwise successful import.
+    """
+    counts = {"skipped": 0, "already_skipped": 0, "failed": 0}
+    try:
+        auth_token = annotation_api.get_auth_token(
+            annotation_api_url, username=login, password=password
+        )
+        counts = shared.skip_boxless_alerts(
+            annotation_api_url, auth_token, source_api, boxless_alert_ids
+        )
+    except Exception as exc:
+        counts["failed"] = len(boxless_alert_ids)
+        logging.warning("boxless auto-skip aborted: %s", exc)
+    console.print(
+        f"[blue]⏭️  Auto-skipped {counts['skipped']} boxless alert(s) "
+        f"({counts['already_skipped']} already skipped, "
+        f"{counts['failed']} failed): {boxless_alert_ids}[/]"
+    )
+    if counts["failed"] > 0:
+        error_collector.add_warning(
+            f"{counts['failed']} boxless alert(s) could not be auto-skipped; "
+            "their zero-object lanes remain in the queue."
+        )
+    return counts
+
+
 def parse_sequence_selection(sequence_arg: str) -> List[int]:
     """
     Parse a comma/whitespace-separated sequence list from CLI or a file.
@@ -415,7 +453,9 @@ def main() -> None:
     )
 
     if args.loglevel == "debug":
-        console.print(f"[blue]ℹ️  Date range: {args.date_from} to {args.date_end}[/]")
+        console.print(
+            f"[blue]ℹ️  Date range: {args.date_from} to {args.date_end}[/]"
+        )
         console.print(
             f"[blue]ℹ️  Alert API: {args.alert_api_url} (source_api: {source_api})[/]"
         )
@@ -525,7 +565,7 @@ def main() -> None:
 
         # Boxless alerts import as zero-object lanes the classify page cannot
         # act on (#333); they are auto-skipped after annotation creation below.
-        boxless_alert_ids = shared.boxless_platform_alert_ids(records)
+        boxless_alert_ids = sorted(shared.boxless_platform_alert_ids(records))
 
         if not records and not args.dry_run:
             step_manager.complete_step(False, "No records fetched from alert API")
@@ -614,6 +654,20 @@ def main() -> None:
         if not sequence_ids:
             step_message = "No sequences successfully imported - nothing to process for annotation generation"
             step_manager.complete_step(True, step_message)
+
+            # Boxless alerts from a previous run over this range may still
+            # need parking (an earlier skip failed, or the range predates the
+            # auto-skip feature); their lanes already exist, so skip works.
+            if boxless_alert_ids and not args.dry_run:
+                auto_skip_boxless(
+                    args.annotation_api_url,
+                    target_login,
+                    target_password,
+                    source_api,
+                    boxless_alert_ids,
+                    console,
+                    error_collector,
+                )
 
             # Show final summary with zero processing and exit gracefully
             console.print()
@@ -735,27 +789,15 @@ def main() -> None:
         # instead of leaving dead lanes in the classify queue.
         skip_counts = {"skipped": 0, "already_skipped": 0, "failed": 0}
         if boxless_alert_ids and not args.dry_run:
-            skip_counts = shared.skip_boxless_alerts(
+            skip_counts = auto_skip_boxless(
                 args.annotation_api_url,
-                annotation_api.get_auth_token(
-                    args.annotation_api_url,
-                    username=target_login,
-                    password=target_password,
-                ),
+                target_login,
+                target_password,
                 source_api,
-                sorted(boxless_alert_ids),
+                boxless_alert_ids,
+                console,
+                error_collector,
             )
-            console.print(
-                f"[blue]⏭️  Auto-skipped {skip_counts['skipped']} boxless alert(s) "
-                f"({skip_counts['already_skipped']} already skipped, "
-                f"{skip_counts['failed']} failed): "
-                f"{sorted(boxless_alert_ids)}[/]"
-            )
-            if skip_counts["failed"] > 0:
-                error_collector.add_warning(
-                    f"{skip_counts['failed']} boxless alert(s) could not be "
-                    "auto-skipped; their zero-object lanes remain in the queue."
-                )
 
         # Show any accumulated errors/warnings
         if error_collector.has_issues():
@@ -798,7 +840,7 @@ def main() -> None:
             annotation_section += (
                 f"\n• Boxless alerts auto-skipped: {skip_counts['skipped']} "
                 f"(+{skip_counts['already_skipped']} already skipped, "
-                f"{skip_counts['failed']} failed): {sorted(boxless_alert_ids)}"
+                f"{skip_counts['failed']} failed): {boxless_alert_ids}"
             )
         summary_parts.append(annotation_section)
 

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
@@ -415,9 +415,7 @@ def main() -> None:
     )
 
     if args.loglevel == "debug":
-        console.print(
-            f"[blue]ℹ️  Date range: {args.date_from} to {args.date_end}[/]"
-        )
+        console.print(f"[blue]ℹ️  Date range: {args.date_from} to {args.date_end}[/]")
         console.print(
             f"[blue]ℹ️  Alert API: {args.alert_api_url} (source_api: {source_api})[/]"
         )
@@ -524,6 +522,10 @@ def main() -> None:
             f"{split_stats['cross_deduped_siblings']} cross-deduped, "
             f"{split_stats['same_frame_merges']} same-frame merge(s))[/]"
         )
+
+        # Boxless alerts import as zero-object lanes the classify page cannot
+        # act on (#333); they are auto-skipped after annotation creation below.
+        boxless_alert_ids = shared.boxless_platform_alert_ids(records)
 
         if not records and not args.dry_run:
             step_manager.complete_step(False, "No records fetched from alert API")
@@ -728,6 +730,33 @@ def main() -> None:
 
         step_manager.complete_step(step_3_success, step_3_message, final_stats)
 
+        # Auto-skip boxless alerts (#333): their lanes exist now (sequence +
+        # annotation) but have zero objects, so park them via the skip overlay
+        # instead of leaving dead lanes in the classify queue.
+        skip_counts = {"skipped": 0, "already_skipped": 0, "failed": 0}
+        if boxless_alert_ids and not args.dry_run:
+            skip_counts = shared.skip_boxless_alerts(
+                args.annotation_api_url,
+                annotation_api.get_auth_token(
+                    args.annotation_api_url,
+                    username=target_login,
+                    password=target_password,
+                ),
+                source_api,
+                sorted(boxless_alert_ids),
+            )
+            console.print(
+                f"[blue]⏭️  Auto-skipped {skip_counts['skipped']} boxless alert(s) "
+                f"({skip_counts['already_skipped']} already skipped, "
+                f"{skip_counts['failed']} failed): "
+                f"{sorted(boxless_alert_ids)}[/]"
+            )
+            if skip_counts["failed"] > 0:
+                error_collector.add_warning(
+                    f"{skip_counts['failed']} boxless alert(s) could not be "
+                    "auto-skipped; their zero-object lanes remain in the queue."
+                )
+
         # Show any accumulated errors/warnings
         if error_collector.has_issues():
             error_collector.print_summary(console, "Processing Summary")
@@ -765,6 +794,12 @@ def main() -> None:
 • Annotations successful: {stats['annotations_successful']}
 • Annotations failed: {stats['annotations_failed']}
 • Annotations created: {stats['annotations_created']}"""
+        if boxless_alert_ids:
+            annotation_section += (
+                f"\n• Boxless alerts auto-skipped: {skip_counts['skipped']} "
+                f"(+{skip_counts['already_skipped']} already skipped, "
+                f"{skip_counts['failed']} failed): {sorted(boxless_alert_ids)}"
+            )
         summary_parts.append(annotation_section)
 
         # Join sections

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
@@ -32,6 +32,7 @@ from app.clients.annotation_api import (
     create_detection_from_bucket_key,
     create_detection_from_url,
     list_detections,
+    skip_alert,
     AnnotationAPIError,
     ValidationError,
 )
@@ -303,6 +304,67 @@ def transform_detection_data(record: dict, annotation_sequence_id: int) -> dict:
     if others_payload is not None:
         payload["others_bboxes"] = others_payload
     return payload
+
+
+AUTO_SKIP_BOXLESS_NOTE = "auto-skip at import: boxless alert (no engine boxes)"
+
+
+def boxless_platform_alert_ids(records: List[dict]) -> set:
+    """
+    Platform alert ids whose records carry no usable engine box.
+
+    "Usable" mirrors `transform_detection_data` (parse + sanitize), so this
+    flags exactly the alerts that would import as zero-object lanes the
+    classify page cannot act on (#333).
+    """
+    has_usable_box: Dict[int, bool] = {}
+    for record in records:
+        platform_alert_id = record["platform_alert_id"]
+        if has_usable_box.get(platform_alert_id):
+            continue
+        parsed = parse_alert_api_bboxes(record["detection_bboxes"])
+        has_usable_box[platform_alert_id] = bool(
+            _sanitize_predictions(parsed.get("predictions", []))
+        )
+    return {pid for pid, usable in has_usable_box.items() if not usable}
+
+
+def skip_boxless_alerts(
+    base_url: str,
+    auth_token: str,
+    source_api: str,
+    platform_alert_ids: List[int],
+) -> Dict[str, int]:
+    """
+    Park each boxless alert via the alert-skip overlay.
+
+    409 (already skipped) counts separately so re-imports stay idempotent;
+    other errors are logged and counted but never raised — auto-skip is
+    best-effort queue hygiene, not import-critical.
+    """
+    counts = {"skipped": 0, "already_skipped": 0, "failed": 0}
+    for platform_alert_id in platform_alert_ids:
+        try:
+            skip_alert(
+                base_url,
+                auth_token,
+                source_api,
+                platform_alert_id,
+                note=AUTO_SKIP_BOXLESS_NOTE,
+            )
+            counts["skipped"] += 1
+        except AnnotationAPIError as exc:
+            if exc.status_code == 409:
+                counts["already_skipped"] += 1
+            else:
+                logging.warning(
+                    "auto-skip failed for alert %s/%s: %s",
+                    source_api,
+                    platform_alert_id,
+                    exc,
+                )
+                counts["failed"] += 1
+    return counts
 
 
 def download_image(url: str, timeout: int = 30) -> bytes:

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
@@ -11,7 +11,7 @@ import logging
 import os
 import time
 from collections import defaultdict
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, Set
 from urllib.parse import urlparse
 
 import requests
@@ -309,22 +309,27 @@ def transform_detection_data(record: dict, annotation_sequence_id: int) -> dict:
 AUTO_SKIP_BOXLESS_NOTE = "auto-skip at import: boxless alert (no engine boxes)"
 
 
-def boxless_platform_alert_ids(records: List[dict]) -> set:
+def boxless_platform_alert_ids(records: List[dict]) -> Set[int]:
     """
     Platform alert ids whose records carry no usable engine box.
 
-    "Usable" mirrors `transform_detection_data` (parse + sanitize), so this
-    flags exactly the alerts that would import as zero-object lanes the
-    classify page cannot act on (#333).
+    "Usable" means the box survives `transform_detection_data`'s parse +
+    sanitize AND `build_single_track_annotation`'s zero-area filter
+    (x1 < x2, y1 < y2) — i.e. it could become an annotation track. This flags
+    exactly the alerts that would import as zero-object lanes the classify
+    page cannot act on (#333). Records without a `platform_alert_id` (the
+    object-split exception fallback emits those) cannot be alert-skipped and
+    are ignored.
     """
     has_usable_box: Dict[int, bool] = {}
     for record in records:
-        platform_alert_id = record["platform_alert_id"]
-        if has_usable_box.get(platform_alert_id):
+        platform_alert_id = record.get("platform_alert_id")
+        if platform_alert_id is None or has_usable_box.get(platform_alert_id):
             continue
         parsed = parse_alert_api_bboxes(record["detection_bboxes"])
-        has_usable_box[platform_alert_id] = bool(
-            _sanitize_predictions(parsed.get("predictions", []))
+        has_usable_box[platform_alert_id] = any(
+            pred["xyxyn"][0] < pred["xyxyn"][2] and pred["xyxyn"][1] < pred["xyxyn"][3]
+            for pred in _sanitize_predictions(parsed.get("predictions", []))
         )
     return {pid for pid, usable in has_usable_box.items() if not usable}
 
@@ -355,6 +360,8 @@ def skip_boxless_alerts(
             counts["skipped"] += 1
         except AnnotationAPIError as exc:
             if exc.status_code == 409:
+                # Covers both endpoint 409 flavors — "already skipped" and
+                # "fully annotated, nothing to skip" — each a benign no-op.
                 counts["already_skipped"] += 1
             else:
                 logging.warning(

--- a/annotation_api/src/app/clients/annotation_api.py
+++ b/annotation_api/src/app/clients/annotation_api.py
@@ -71,6 +71,7 @@ __all__ = [
     "get_sequence",
     "list_sequences",
     "delete_sequence",
+    "skip_alert",
     "create_detection",
     "get_detection",
     "list_detections",
@@ -367,6 +368,46 @@ def delete_sequence(base_url: str, auth_token: str, sequence_id: int) -> None:
     operation = f"delete sequence {sequence_id}"
     response = _make_request("DELETE", url, auth_token, operation=operation)
     _handle_response(response, operation=operation)
+
+
+def skip_alert(
+    base_url: str,
+    auth_token: str,
+    source_api: str,
+    platform_alert_id: int,
+    note: Optional[str] = None,
+) -> Dict:
+    """
+    Park a whole alert in the recoverable skipped state (alert-skip overlay).
+
+    Args:
+        base_url: Base URL of the annotation API
+        auth_token: JWT authentication token
+        source_api: Source API of the alert (e.g., "pyronear_french")
+        platform_alert_id: Platform alert grouping id
+        note: Optional free-text reason shown in the skipped list
+
+    Returns:
+        Dictionary containing the created skip info
+
+    Raises:
+        AnnotationAPIError: For API errors; status_code 409 when the alert
+            is already skipped or has fully exited the pipeline
+    """
+    url = f"{base_url.rstrip('/')}/api/v1/sequences/alert/skip"
+    operation = f"skip alert {source_api}/{platform_alert_id}"
+    response = _make_request(
+        "POST",
+        url,
+        auth_token,
+        operation=operation,
+        json={
+            "source_api": source_api,
+            "platform_alert_id": platform_alert_id,
+            "note": note,
+        },
+    )
+    return _handle_response(response, operation=operation)
 
 
 # -------------------- DETECTION OPERATIONS --------------------

--- a/annotation_api/src/tests/scripts/test_boxless_skip.py
+++ b/annotation_api/src/tests/scripts/test_boxless_skip.py
@@ -1,0 +1,105 @@
+"""Auto-skip of boxless alerts at import time (#333).
+
+An alert whose records carry no usable engine box produces a zero-object
+lane that the classify page cannot act on. The import detects those alerts
+(`boxless_platform_alert_ids`) and parks them via the alert-skip overlay
+(`skip_boxless_alerts`).
+"""
+
+import requests_mock as requests_mock_lib
+
+from scripts.data_transfer.ingestion.alert_api.shared import (
+    boxless_platform_alert_ids,
+    skip_boxless_alerts,
+)
+
+# No __init__.py convention in src/tests/ — pytest inserts the test dir on
+# sys.path, so sibling helpers are imported as top-level modules.
+from factories import make_record
+
+GOOD_BOX = [0.10, 0.10, 0.20, 0.20, 0.9]
+ZERO_BOX = [0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+def alert_records(platform_alert_id, bboxes_per_record):
+    return [
+        make_record(
+            det_id=platform_alert_id * 100 + i,
+            created_at=f"2026-08-04T13:0{i}:00",
+            bboxes=bboxes,
+            sid=platform_alert_id,
+            platform_alert_id=platform_alert_id,
+        )
+        for i, bboxes in enumerate(bboxes_per_record)
+    ]
+
+
+class TestBoxlessPlatformAlertIds:
+    def test_all_records_boxless_flags_alert(self):
+        records = alert_records(56861, [None, None, None])
+        assert boxless_platform_alert_ids(records) == {56861}
+
+    def test_empty_box_lists_flag_alert(self):
+        records = alert_records(56861, [[], [], []])
+        assert boxless_platform_alert_ids(records) == {56861}
+
+    def test_all_zero_boxes_flag_alert(self):
+        # _sanitize_predictions drops all-zero boxes, same as posting does.
+        records = alert_records(56861, [[ZERO_BOX], [ZERO_BOX]])
+        assert boxless_platform_alert_ids(records) == {56861}
+
+    def test_one_usable_box_clears_alert(self):
+        records = alert_records(56861, [None, [GOOD_BOX], None])
+        assert boxless_platform_alert_ids(records) == set()
+
+    def test_mixed_alerts_only_boxless_flagged(self):
+        records = alert_records(1111, [[GOOD_BOX], [GOOD_BOX]]) + alert_records(
+            2222, [None, []]
+        )
+        assert boxless_platform_alert_ids(records) == {2222}
+
+    def test_no_records(self):
+        assert boxless_platform_alert_ids([]) == set()
+
+
+class TestSkipBoxlessAlerts:
+    BASE = "http://localhost:5050"
+
+    def test_skips_each_alert_with_note(self):
+        with requests_mock_lib.Mocker() as m:
+            m.post(f"{self.BASE}/api/v1/sequences/alert/skip", json={}, status_code=201)
+            counts = skip_boxless_alerts(
+                self.BASE, "token", "pyronear_french", [56861, 56999]
+            )
+        assert counts == {"skipped": 2, "already_skipped": 0, "failed": 0}
+        assert m.call_count == 2
+        payload = m.request_history[0].json()
+        assert payload["source_api"] == "pyronear_french"
+        assert payload["platform_alert_id"] == 56861
+        assert "boxless" in payload["note"]
+
+    def test_409_counts_as_already_skipped(self):
+        with requests_mock_lib.Mocker() as m:
+            m.post(
+                f"{self.BASE}/api/v1/sequences/alert/skip",
+                json={"detail": "Alert is already skipped"},
+                status_code=409,
+            )
+            counts = skip_boxless_alerts(self.BASE, "token", "pyronear_french", [56861])
+        assert counts == {"skipped": 0, "already_skipped": 1, "failed": 0}
+
+    def test_other_errors_count_as_failed_and_do_not_raise(self):
+        with requests_mock_lib.Mocker() as m:
+            m.post(
+                f"{self.BASE}/api/v1/sequences/alert/skip",
+                json={"detail": "No sequences for alert"},
+                status_code=404,
+            )
+            counts = skip_boxless_alerts(self.BASE, "token", "pyronear_french", [56861])
+        assert counts == {"skipped": 0, "already_skipped": 0, "failed": 1}
+
+    def test_no_alerts_no_requests(self):
+        with requests_mock_lib.Mocker() as m:
+            counts = skip_boxless_alerts(self.BASE, "token", "pyronear_french", [])
+        assert counts == {"skipped": 0, "already_skipped": 0, "failed": 0}
+        assert m.call_count == 0

--- a/annotation_api/src/tests/scripts/test_boxless_skip.py
+++ b/annotation_api/src/tests/scripts/test_boxless_skip.py
@@ -19,6 +19,8 @@ from factories import make_record
 
 GOOD_BOX = [0.10, 0.10, 0.20, 0.20, 0.9]
 ZERO_BOX = [0.0, 0.0, 0.0, 0.0, 0.0]
+POINT_BOX = [0.5, 0.5, 0.5, 0.5, 0.9]  # non-zero but zero-area
+INVERTED_BOX = [0.6, 0.6, 0.4, 0.4, 0.9]  # x1 > x2, y1 > y2
 
 
 def alert_records(platform_alert_id, bboxes_per_record):
@@ -57,6 +59,19 @@ class TestBoxlessPlatformAlertIds:
             2222, [None, []]
         )
         assert boxless_platform_alert_ids(records) == {2222}
+
+    def test_degenerate_boxes_flag_alert(self):
+        # Non-zero but zero-area/inverted boxes are dropped by
+        # build_single_track_annotation, so the lane would have no tracks.
+        records = alert_records(56861, [[POINT_BOX], [INVERTED_BOX]])
+        assert boxless_platform_alert_ids(records) == {56861}
+
+    def test_records_without_platform_alert_id_are_ignored(self):
+        # The object-split exception fallback emits records without the key;
+        # they cannot be alert-skipped and must not crash the decision.
+        records = alert_records(2222, [None])
+        no_pid = make_record(1, "2026-08-04T13:00:00", None, sid=999)
+        assert boxless_platform_alert_ids([no_pid] + records) == {2222}
 
     def test_no_records(self):
         assert boxless_platform_alert_ids([]) == set()


### PR DESCRIPTION
Fixes #333.

## Problem

An alert whose records carry no usable engine box (e.g. alert 56861: every detection has `bboxes: null`) goes through the object-split fallback and imports as a lane whose annotation has an empty `sequences_bbox`. The classify page builds its object list from those tracks, so the lane renders **"No objects to review yet"** with nothing to classify and no way to progress — a dead lane in the queue.

## Approach

Skip, don't drop (as discussed on #333): the alert-skip overlay already models "parked, out of the queue, recoverable", so the import now uses it for boxless alerts instead of leaving dead lanes or silently dropping data.

- `shared.boxless_platform_alert_ids(records)`: flags alerts where **no** record survives the same parse + sanitize rule the posting path uses — exactly the alerts that would import with zero objects.
- After Step 3 (annotations exist, so the skip row is visible in a queue), the import posts `/sequences/alert/skip` for each with the note `auto-skip at import: boxless alert (no engine boxes)`, so machine skips are distinguishable from human skips in the skipped list.
- **Idempotent re-imports**: 409 (already skipped) counts as `already_skipped`, other failures are warned + counted, never fatal — auto-skip is queue hygiene, not import-critical.
- The final summary reports `Boxless alerts auto-skipped: N (...): [ids]` so nothing is silently parked.
- New client function `skip_alert` in `app/clients/annotation_api.py`.

## Testing

- 10 new tests in `src/tests/scripts/test_boxless_skip.py` covering the boxless decision (null / empty / all-zero boxes, mixed alerts) and the skip loop (payload + note, 409 handling, failure counting, no-op).
- Full backend suite: 670 passed.
- `ruff format` + `ruff check` clean on touched files.

Observed in the wild: 1 of 27 sequences in an August 1–6 sdis-07 import (alert 56861, brison-02).