### PR TITLE
feat(api): enforce at most one box per detection within a sequence bbox

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
@@ -378,13 +378,24 @@ def build_single_track_annotation(
     auto-generation then runs as a harmless no-op on empty predictions).
     """
     ordered = sorted(detection_results, key=lambda r: _parse_dt(r["recorded_at"]))
+    # One object, one box per frame. split_sequence_records already unions an
+    # object's same-frame boxes, but its fallback path passes records through
+    # untouched, so a frame can still arrive with several boxes. This is one
+    # conservative track either way, so those boxes are already declared to be
+    # one object here — box them once.
+    by_detection: Dict[int, List[List[float]]] = {}
+    for r in ordered:
+        for xy in r.get("xyxyns", []):
+            if xy[0] < xy[2] and xy[1] < xy[3]:  # BoundingBox rejects zero-area boxes
+                by_detection.setdefault(r["annotation_detection_id"], []).append(
+                    [float(c) for c in xy[:4]]
+                )
     bboxes = [
         BoundingBox(
-            detection_id=r["annotation_detection_id"], xyxyn=[float(c) for c in xy[:4]]
+            detection_id=detection_id,
+            xyxyn=union_xyxyn(coords) if len(coords) > 1 else coords[0],
         )
-        for r in ordered
-        for xy in r.get("xyxyns", [])
-        if xy[0] < xy[2] and xy[1] < xy[3]  # BoundingBox rejects zero-area boxes
+        for detection_id, coords in by_detection.items()
     ]
     if not bboxes:
         return SequenceAnnotationData(sequences_bbox=[])

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
@@ -34,6 +34,7 @@ from app.schemas.annotation_validation import (
     SequenceAnnotationData,
     SequenceBBox,
 )
+from app.services.annotation_generation import union_xyxyn
 from .object_clustering import TrackedObject, cluster_objects, object_cone_azimuth
 from .shared import group_records_by_sequence
 
@@ -126,13 +127,7 @@ def union_boxes(boxes: List[List[float]]) -> List[float]:
     confidence 0.0, so any confidence-weighted rule is degenerate on a large
     slice of the data; max is the best-evidence reading and is stable.
     """
-    return [
-        min(b[0] for b in boxes),
-        min(b[1] for b in boxes),
-        max(b[2] for b in boxes),
-        max(b[3] for b in boxes),
-        max(b[4] for b in boxes),
-    ]
+    return [*union_xyxyn(boxes), max(b[4] for b in boxes)]
 
 
 @dataclass

--- a/annotation_api/src/app/schemas/annotation_validation.py
+++ b/annotation_api/src/app/schemas/annotation_validation.py
@@ -3,6 +3,7 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
+from collections import Counter
 from enum import Enum
 from typing import List, Optional
 
@@ -63,6 +64,27 @@ class SequenceBBox(BaseModel):
     smoke_type: Optional[SmokeType] = Field(default=None)
     false_positive_types: List[FalsePositiveType] = Field(default_factory=list)
     bboxes: List[BoundingBox]
+
+    @model_validator(mode="after")
+    def validate_one_box_per_detection(self) -> "SequenceBBox":
+        """One object, one box per frame.
+
+        A plume that visually forks into two strands and rejoins is still one
+        fire's smoke, boxed once — the same rule #286 enforces on detection
+        annotations. A persistent split is a second fire, so a second object
+        with its own annotation track.
+        """
+        counts = Counter(b.detection_id for b in self.bboxes)
+        repeated = sorted(d for d, n in counts.items() if n > 1)
+        if repeated:
+            raise ValueError(
+                f"At most one box is allowed per detection within a sequence "
+                f"bbox (detection_id repeated: {repeated}). A plume that forks "
+                "into two strands and rejoins is one object — box it once. A "
+                "persistent second plume is a separate object, with its own "
+                "annotation track."
+            )
+        return self
 
 
 class SequenceAnnotationData(BaseModel):

--- a/annotation_api/src/app/services/annotation_generation.py
+++ b/annotation_api/src/app/services/annotation_generation.py
@@ -86,6 +86,33 @@ def box_iou(box1: List[float], box2: List[float]) -> float:
     return intersection / union
 
 
+def union_xyxyn(boxes: List[List[float]]) -> List[float]:
+    """
+    Enclosing box of several bounding boxes, in normalized coordinates.
+
+    One object, one box per frame: a plume that visually forks into two strands
+    and rejoins is still one plume, boxed once (see #286).
+
+    Args:
+        boxes: Non-empty list of [x1, y1, x2, y2] in normalized coordinates (0-1).
+               Extra elements past index 3 are ignored, so the importer's
+               [x1, y1, x2, y2, confidence] boxes can be passed directly.
+
+    Returns:
+        The smallest box enclosing all of them, as [x1, y1, x2, y2]
+
+    Example:
+        >>> union_xyxyn([[0.1, 0.2, 0.3, 0.4], [0.2, 0.1, 0.5, 0.35]])
+        [0.1, 0.1, 0.5, 0.4]
+    """
+    return [
+        min(b[0] for b in boxes),
+        min(b[1] for b in boxes),
+        max(b[2] for b in boxes),
+        max(b[3] for b in boxes),
+    ]
+
+
 def filter_predictions_by_confidence(
     predictions: List[Dict[str, Any]], confidence_threshold: float
 ) -> List[Dict[str, Any]]:

--- a/annotation_api/src/app/services/annotation_generation.py
+++ b/annotation_api/src/app/services/annotation_generation.py
@@ -509,17 +509,31 @@ class AnnotationGenerationService:
         sequences_bbox = []
 
         for cluster in bbox_clusters:
-            bboxes = []
+            # One object, one box per frame. cluster_boxes_by_iou never consults
+            # detection_id, so two overlapping predictions on the same frame land
+            # in one cluster — a plume that forks and rejoins is still one plume,
+            # boxed once (#286). Validate before unioning: merging a null
+            # [0,0,0,0] box with a real one would anchor the result at the origin.
+            valid: Dict[int, List[List[float]]] = {}
 
             for bbox_coords, detection_id in cluster:
                 try:
                     bbox = BoundingBox(detection_id=detection_id, xyxyn=bbox_coords)
-                    bboxes.append(bbox)
                 except Exception as e:
                     self.logger.debug(
                         f"Skipping invalid coordinates for detection {detection_id}: {e}"
                     )
                     continue
+                valid.setdefault(bbox.detection_id, []).append(bbox.xyxyn)
+
+            # A union of valid boxes is itself valid, so this cannot raise.
+            bboxes = [
+                BoundingBox(
+                    detection_id=detection_id,
+                    xyxyn=union_xyxyn(coords) if len(coords) > 1 else coords[0],
+                )
+                for detection_id, coords in valid.items()
+            ]
 
             # Only create SequenceBBox if we have valid bboxes
             if not bboxes:

--- a/annotation_api/src/tests/endpoints/test_sequence_annotations_auto_generation.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_annotations_auto_generation.py
@@ -6,10 +6,11 @@ endpoints when processing_stage=READY_TO_ANNOTATE and annotation is empty.
 """
 
 import pytest
+from datetime import UTC, datetime
 from unittest.mock import patch
 from httpx import AsyncClient
 
-from app.models import SequenceAnnotationProcessingStage
+from app.models import Detection, SequenceAnnotationProcessingStage
 from app.schemas.annotation_validation import (
     SequenceAnnotationData,
     SequenceBBox,
@@ -265,3 +266,71 @@ async def test_should_trigger_auto_generation_logic():
         )
         is True
     )
+
+
+@pytest.mark.asyncio
+async def test_auto_generation_merges_same_frame_overlaps(
+    authenticated_client: AsyncClient, sequence_session, detection_session
+):
+    """Two overlapping predictions on one frame must not 422 the request.
+
+    cluster_boxes_by_iou puts them in one cluster because it never consults
+    detection_id; _create_sequence_bboxes collapses them to their union so the
+    SequenceBBox validator accepts the result. Detection 19167's real
+    coordinates (#324).
+    """
+    detection_session.add(
+        Detection(
+            id=4,
+            created_at=datetime.now(UTC),
+            sequence_id=2,
+            alert_api_id=99,
+            recorded_at=datetime.now(UTC),
+            bucket_key="seq2_img2.jpg",
+            algo_predictions={
+                "predictions": [
+                    {
+                        "xyxyn": [0.102, 0.565, 0.113, 0.586],
+                        "confidence": 0.5,
+                        "class_name": "smoke",
+                    },
+                    {
+                        "xyxyn": [0.107, 0.564, 0.119, 0.584],
+                        "confidence": 0.6,
+                        "class_name": "smoke",
+                    },
+                ]
+            },
+        )
+    )
+    await detection_session.commit()
+
+    response = await authenticated_client.post(
+        "/annotations/sequences/",
+        json={
+            "sequence_id": 2,
+            "has_missed_smoke": False,
+            "is_unsure": False,
+            "annotation": {"sequences_bbox": []},
+            "processing_stage": "ready_to_annotate",
+            "confidence_threshold": 0.0,
+            "iou_threshold": 0.0,
+            "min_cluster_size": 1,
+        },
+    )
+
+    assert response.status_code == 201, response.text
+
+    sequences_bbox = response.json()["annotation"]["sequences_bbox"]
+    for seq_bbox in sequences_bbox:
+        ids = [b["detection_id"] for b in seq_bbox["bboxes"]]
+        assert len(ids) == len(set(ids)), f"duplicate detection_id in {ids}"
+
+    merged = [
+        b
+        for seq_bbox in sequences_bbox
+        for b in seq_bbox["bboxes"]
+        if b["detection_id"] == 4
+    ]
+    assert len(merged) == 1
+    assert merged[0]["xyxyn"] == pytest.approx([0.102, 0.564, 0.119, 0.586])

--- a/annotation_api/src/tests/schemas/test_annotation_validation.py
+++ b/annotation_api/src/tests/schemas/test_annotation_validation.py
@@ -127,6 +127,23 @@ class TestSequenceBBox:
         )
         assert len(bbox.bboxes) == 2
 
+    def test_rejects_duplicate_detection_id(self):
+        """One object, one box per frame."""
+        with pytest.raises(ValidationError) as exc_info:
+            SequenceBBox(
+                is_smoke=True,
+                bboxes=[
+                    BoundingBox(detection_id=19167, xyxyn=[0.102, 0.565, 0.113, 0.586]),
+                    BoundingBox(detection_id=19167, xyxyn=[0.107, 0.564, 0.119, 0.584]),
+                ],
+            )
+        assert "At most one box is allowed per detection" in str(exc_info.value)
+
+    def test_allows_empty_bboxes(self):
+        """A track with no boxes on any frame is still a valid object."""
+        bbox = SequenceBBox(is_smoke=False, bboxes=[])
+        assert bbox.bboxes == []
+
 
 class TestSequenceAnnotationData:
     def test_valid_sequence_annotation_data(self):

--- a/annotation_api/src/tests/scripts/test_object_split.py
+++ b/annotation_api/src/tests/scripts/test_object_split.py
@@ -279,7 +279,10 @@ class TestBuildSingleTrackAnnotation:
         assert track.false_positive_types == []
         assert [b.detection_id for b in track.bboxes] == [11, 12]
 
-    def test_multiple_boxes_on_one_detection_become_multiple_track_entries(self):
+    def test_multiple_boxes_on_one_detection_become_one_union_box(self):
+        # One object, one box per frame (#315). Reachable via the fallback
+        # path, which passes records through without split_sequence_records'
+        # same-frame union.
         results = [
             {
                 "annotation_detection_id": 11,
@@ -288,7 +291,8 @@ class TestBuildSingleTrackAnnotation:
             }
         ]
         data = build_single_track_annotation(results)
-        assert len(data.sequences_bbox[0].bboxes) == 2
+        assert len(data.sequences_bbox[0].bboxes) == 1
+        assert data.sequences_bbox[0].bboxes[0].xyxyn == [0.1, 0.1, 0.4, 0.4]
 
     def test_zero_area_and_empty_results_yield_empty_sequences_bbox(self):
         # zero-area boxes would fail BoundingBox validation -> must be filtered

--- a/annotation_api/src/tests/services/test_annotation_generation.py
+++ b/annotation_api/src/tests/services/test_annotation_generation.py
@@ -210,6 +210,56 @@ class TestAnnotationGenerationService:
         assert all(seq_bbox.is_smoke is True for seq_bbox in result)
         assert all(len(seq_bbox.false_positive_types) == 0 for seq_bbox in result)
 
+    def test_create_sequence_bboxes_merges_same_detection_boxes(self):
+        """Two boxes from one frame collapse into the box enclosing both.
+
+        Detection 19167's real coordinates — the one same-frame overlap across
+        19,205 imported detections (#324).
+        """
+        bbox_clusters = [
+            [
+                ([0.102, 0.565, 0.113, 0.586], 19167),
+                ([0.107, 0.564, 0.119, 0.584], 19167),
+            ],
+        ]
+
+        result = self.service._create_sequence_bboxes(bbox_clusters)
+
+        assert len(result) == 1
+        assert len(result[0].bboxes) == 1
+        assert result[0].bboxes[0].detection_id == 19167
+        assert result[0].bboxes[0].xyxyn == pytest.approx([0.102, 0.564, 0.119, 0.586])
+
+    def test_create_sequence_bboxes_keeps_distinct_detections_apart(self):
+        """Boxes from different frames are not merged, and keep their order."""
+        bbox_clusters = [
+            [
+                ([0.1, 0.2, 0.3, 0.4], 123),
+                ([0.15, 0.25, 0.35, 0.45], 124),
+            ],
+        ]
+
+        result = self.service._create_sequence_bboxes(bbox_clusters)
+
+        assert len(result[0].bboxes) == 2
+        assert [b.detection_id for b in result[0].bboxes] == [123, 124]
+
+    def test_create_sequence_bboxes_null_box_does_not_poison_the_union(self):
+        """An invalid box is dropped before the union, not merged into it."""
+        bbox_clusters = [
+            [
+                ([0, 0, 0, 0], 200),
+                ([0.5, 0.5, 0.6, 0.6], 200),
+            ],
+        ]
+
+        with patch.object(self.service, "logger"):
+            result = self.service._create_sequence_bboxes(bbox_clusters)
+
+        assert len(result) == 1
+        assert len(result[0].bboxes) == 1
+        assert result[0].bboxes[0].xyxyn == [0.5, 0.5, 0.6, 0.6]
+
     def test_create_sequence_bboxes_mixed_valid_invalid(self):
         """Test sequence bbox creation with mixed valid/invalid coordinates in clusters."""
         bbox_clusters = [

--- a/annotation_api/src/tests/services/test_annotation_generation.py
+++ b/annotation_api/src/tests/services/test_annotation_generation.py
@@ -14,6 +14,7 @@ from app.services.annotation_generation import (
     box_iou,
     filter_predictions_by_confidence,
     cluster_boxes_by_iou,
+    union_xyxyn,
 )
 from app.schemas.annotation_validation import (
     BoundingBox,
@@ -425,6 +426,26 @@ class TestUtilityFunctions:
         iou = box_iou(box1, box2)
         expected_iou = 0.0625 / 0.4375
         assert abs(iou - expected_iou) < 1e-6
+
+    def test_union_xyxyn_single_box(self):
+        """A single box is its own union."""
+        assert union_xyxyn([[0.1, 0.2, 0.3, 0.4]]) == [0.1, 0.2, 0.3, 0.4]
+
+    def test_union_xyxyn_two_overlapping_boxes(self):
+        """The union encloses both boxes.
+
+        These are detection 19167's real coordinates, the one same-frame
+        overlap found across 19,205 imported detections (#324).
+        """
+        merged = union_xyxyn(
+            [[0.102, 0.565, 0.113, 0.586], [0.107, 0.564, 0.119, 0.584]]
+        )
+        assert merged == pytest.approx([0.102, 0.564, 0.119, 0.586])
+
+    def test_union_xyxyn_contained_box(self):
+        """A box fully inside another leaves the container unchanged."""
+        merged = union_xyxyn([[0.1, 0.1, 0.9, 0.9], [0.3, 0.3, 0.4, 0.4]])
+        assert merged == [0.1, 0.1, 0.9, 0.9]
 
     def test_filter_predictions_by_confidence(self):
         """Test prediction filtering by confidence threshold."""

--- a/docs/specs/2026-08-06-one-box-per-detection-in-sequence-bbox-design.md
+++ b/docs/specs/2026-08-06-one-box-per-detection-in-sequence-bbox-design.md
@@ -1,0 +1,220 @@
+# One box per detection within a sequence bbox
+
+Issue: [#315](https://github.com/pyronear/pyro-annotator/issues/315)
+Date: 2026-08-06
+
+## Problem
+
+A `SequenceBBox` is one object's track across a sequence: a list of
+`BoundingBox`, each carrying a `detection_id`. It should hold at most one box
+per `detection_id` — the same "one object, one box per frame" rule that #286
+enforces one layer down on detection annotations, and that #324 enforces one
+layer up in the importer.
+
+Nothing enforces it. `SequenceBBox`
+(`annotation_api/src/app/schemas/annotation_validation.py:60`) declares a bare
+`bboxes: List[BoundingBox]`.
+
+The validator cannot be added on its own, because the API can produce the
+violation itself. When a client POSTs or PATCHes a sequence annotation with an
+empty `sequences_bbox`, `AnnotationGenerationService` fills it in:
+
+- `cluster_boxes_by_iou` (`annotation_generation.py:175-230`) pops boxes off a
+  flat cross-frame list of `(bbox, detection_id)` pairs and merges any pair
+  whose IoU exceeds the threshold. It never consults `detection_id`.
+- `_create_sequence_bboxes` (`annotation_generation.py:472-509`) then emits one
+  `BoundingBox` per cluster member, with no per-detection cap.
+
+So two overlapping engine predictions on the same frame land in one cluster and
+become two boxes with the same `detection_id`. Adding the validator alone would
+turn a currently-succeeding request into a 422 for a case that genuinely
+occurs.
+
+## Measurement
+
+Dev database, 2026-08-06: **zero violations** — 9,987 boxes across 469 objects
+with boxes, over 475 sequence annotations. No `(annotation, object,
+detection_id)` triple appears twice.
+
+The underlying same-frame overlap is nonetheless real. #324 found **1 of 19,205
+detections** carrying two own boxes: detection `19167`, sequence 1018, alert
+`41386`, camera `brison-01`, 2026-05-11 05:09:57Z, two near-duplicate boxes of
+one small plume:
+
+```
+A = [0.102, 0.565, 0.113, 0.586]
+B = [0.107, 0.564, 0.119, 0.584]
+```
+
+An earlier 10,268-detection sample showed zero and was misleading. The dev-DB
+zero above is the same kind of evidence, so it is re-checked as a pre-merge gate
+rather than trusted (see Rollout).
+
+## The rule
+
+**Within one `SequenceBBox`, a `detection_id` appears at most once. When a frame
+contributes several boxes to one object, they collapse to the single box
+enclosing them.**
+
+This is #286's modelling rule at the sequence layer: a plume that forks into two
+strands and rejoins is one object, boxed once. A persistent second plume is a
+separate object with its own track.
+
+Confidence does not enter here. `_create_sequence_bboxes` receives only
+`(bbox, detection_id)` — `_cluster_temporal_bboxes` drops the prediction dict
+before clustering — and `BoundingBox` has no confidence field. The importer's
+`union_boxes` does carry confidence, as the group max, because 6,249 of 19,155
+real engine boxes have `confidence: 0.0` and any weighted rule is degenerate on
+a third of the data.
+
+## Design
+
+Three files. No new modules.
+
+### 1. Shared union geometry
+
+Add to `annotation_generation.py`, beside the existing `box_iou` (line 43):
+
+```python
+def union_xyxyn(boxes: List[List[float]]) -> List[float]:
+    """Enclosing box of several boxes, in normalized xyxy."""
+    return [
+        min(b[0] for b in boxes),
+        min(b[1] for b in boxes),
+        max(b[2] for b in boxes),
+        max(b[3] for b in boxes),
+    ]
+```
+
+`object_split.union_boxes` (`object_split.py:122`) delegates its four
+coordinates and keeps the confidence max:
+
+```python
+def union_boxes(boxes: List[List[float]]) -> List[float]:
+    return [*union_xyxyn(boxes), max(b[4] for b in boxes)]
+```
+
+The import direction is already established — `object_split.py:32` imports from
+`app.schemas.annotation_validation`. The docstring and the #331 rationale
+comment stay on `union_boxes`; behavior is unchanged, and its existing tests
+(`src/tests/scripts/test_object_split.py:104-118`) are the regression net.
+
+### 2. Collapse at emission
+
+In `_create_sequence_bboxes`, group each cluster's members by `detection_id`
+and emit one box per id:
+
+```python
+for cluster in bbox_clusters:
+    by_detection: Dict[int, List[List[float]]] = {}
+    for bbox_coords, detection_id in cluster:
+        by_detection.setdefault(detection_id, []).append(bbox_coords)
+
+    bboxes = []
+    for detection_id, coords_list in by_detection.items():
+        merged = union_xyxyn(coords_list) if len(coords_list) > 1 else coords_list[0]
+        try:
+            bboxes.append(BoundingBox(detection_id=detection_id, xyxyn=merged))
+        except Exception as e:
+            self.logger.debug(
+                f"Skipping invalid coordinates for detection {detection_id}: {e}"
+            )
+            continue
+```
+
+**Placement.** After clustering, not inside it. `cluster_boxes_by_iou` stays a
+pure geometric utility with its documented contract and doctests intact, and
+`_cluster_temporal_bboxes`'s `min_cluster_size` filter keeps counting pre-merge
+members — so a merge can never silently drop a cluster below the threshold.
+This mirrors #331's placement finding one layer up, where merging inside
+`cluster_objects` would have broken `select_primary_index`'s
+exact-coordinate matching.
+
+The existing per-box `try/except` that skips invalid coordinates is preserved,
+now wrapping the merged box.
+
+### 3. The validator
+
+```python
+    @model_validator(mode="after")
+    def validate_one_box_per_detection(self) -> "SequenceBBox":
+        """One object, one box per frame."""
+        counts = Counter(b.detection_id for b in self.bboxes)
+        repeated = sorted(d for d, n in counts.items() if n > 1)
+        if repeated:
+            raise ValueError(
+                f"At most one box is allowed per detection within a sequence "
+                f"bbox (detection_id repeated: {repeated}). A plume that forks "
+                "into two strands and rejoins is one object — box it once. A "
+                "persistent second plume is a separate object, with its own "
+                "annotation track."
+            )
+        return self
+```
+
+`Counter` needs importing into `annotation_validation.py`; the module currently
+imports only from `enum`, `typing`, `pydantic`, and `app.models`.
+
+Same shape as #318's `DetectionAnnotationData.validate_at_most_one_smoke_box`,
+and the message carries the same modelling explanation rather than a bare count.
+It raises rather than coercing: a silent merge is how #324 hid across 19,205
+detections.
+
+### Ordering
+
+The service fix (2) lands before the validator (3). Reversed, the generation
+service 422s on its own output for the case this spec documents.
+
+## Read-path exposure
+
+`SequenceAnnotationRead.annotation` is a `SequenceAnnotationData`
+(`sequence_annotations.py:197`), and `crud_sequence_annotation.py:127`
+reconstructs `SequenceAnnotationData(**annotation_data)` from stored JSON. So
+the validator runs on reads too: a pre-existing violating row would raise on GET
+(a 500) rather than only rejecting new writes.
+
+This is the same exposure #318 accepted for detection annotations, where
+`DetectionAnnotationData` is likewise the read model. It is acceptable here on
+the same terms, guarded by the pre-merge count below.
+
+## Testing
+
+- `union_xyxyn` unit tests: single box returns its own coordinates; two
+  overlapping boxes return the enclosing box; a box fully containing another
+  returns the container.
+- `_create_sequence_bboxes`: a cluster holding two boxes with the same
+  `detection_id` yields one `BoundingBox` whose `xyxyn` is the union; a cluster
+  with distinct ids is unchanged; the invalid-coordinate skip still applies to a
+  merged box.
+- `SequenceBBox` validator: a duplicate `detection_id` raises; distinct ids
+  pass; an empty `bboxes` list passes.
+- End-to-end: POST a sequence annotation with an empty `sequences_bbox` for a
+  sequence whose detections carry same-frame overlapping predictions, and assert
+  201 rather than 422.
+
+Detection 19167's coordinates are the shared fixture across the unit and
+validator tests:
+
+```
+[0.102, 0.565, 0.113, 0.586] ∪ [0.107, 0.564, 0.119, 0.584]
+                             = [0.102, 0.564, 0.119, 0.586]
+```
+
+## Rollout
+
+Before merging, re-run the violation count from the Measurement section against
+the target database. The 2026-08-06 zero is a point-in-time sample of the same
+kind that misled #324 at 10,268 detections.
+
+If it comes back non-zero, this branch does not merge as-is: repairing existing
+rows is its own ticket, not scope here.
+
+## Out of scope
+
+- **#319** — bulk accept can still send more than one smoke box per frame, and
+  `worker.py`'s `keep_boxes_overlapping` has the same missing per-frame cap on
+  the auto layer. Separate issue, unchanged by this work.
+- **Repair of existing rows.** No migration. See Rollout.
+- **`cluster_boxes_by_iou`'s IoU-blind clustering across frames.** Merging
+  distinct plumes into one cluster is a different problem from emitting two
+  boxes for one frame, and is not addressed here.

--- a/docs/specs/2026-08-06-one-box-per-detection-in-sequence-bbox-design.md
+++ b/docs/specs/2026-08-06-one-box-per-detection-in-sequence-bbox-design.md
@@ -106,21 +106,39 @@ and emit one box per id:
 
 ```python
 for cluster in bbox_clusters:
-    by_detection: Dict[int, List[List[float]]] = {}
+    valid: Dict[int, List[List[float]]] = {}
     for bbox_coords, detection_id in cluster:
-        by_detection.setdefault(detection_id, []).append(bbox_coords)
-
-    bboxes = []
-    for detection_id, coords_list in by_detection.items():
-        merged = union_xyxyn(coords_list) if len(coords_list) > 1 else coords_list[0]
         try:
-            bboxes.append(BoundingBox(detection_id=detection_id, xyxyn=merged))
+            box = BoundingBox(detection_id=detection_id, xyxyn=bbox_coords)
         except Exception as e:
             self.logger.debug(
                 f"Skipping invalid coordinates for detection {detection_id}: {e}"
             )
             continue
+        valid.setdefault(box.detection_id, []).append(box.xyxyn)
+
+    bboxes = [
+        BoundingBox(
+            detection_id=detection_id,
+            xyxyn=union_xyxyn(coords) if len(coords) > 1 else coords[0],
+        )
+        for detection_id, coords in valid.items()
+    ]
 ```
+
+**Validate before unioning, not after.** The obvious shape — group raw
+coordinates, union, then construct — is wrong: a frame carrying a valid box and
+a `[0, 0, 0, 0]` null box would union to a box anchored at the origin, silently
+inventing a huge plume out of a detection failure. Constructing each raw box
+first keeps the existing per-box rejection, and only survivors reach the union.
+
+The second construction cannot raise: a union of valid boxes lies within
+`[0, 1]`, has `x1 <= x2` and `y1 <= y2`, and encloses a non-zero-area box, so it
+is non-zero-area itself.
+
+Insertion order of `valid` preserves each `detection_id`'s first appearance, so
+clusters with no duplicates emit exactly the boxes they emit today, in the same
+order.
 
 **Placement.** After clustering, not inside it. `cluster_boxes_by_iou` stays a
 pure geometric utility with its documented contract and doctests intact, and
@@ -184,8 +202,15 @@ the same terms, guarded by the pre-merge count below.
   returns the container.
 - `_create_sequence_bboxes`: a cluster holding two boxes with the same
   `detection_id` yields one `BoundingBox` whose `xyxyn` is the union; a cluster
-  with distinct ids is unchanged; the invalid-coordinate skip still applies to a
-  merged box.
+  with distinct ids is unchanged; a null `[0, 0, 0, 0]` box sharing a
+  `detection_id` with a valid box is dropped before the union rather than
+  dragging it to the origin.
+
+  The six existing `_create_sequence_bboxes` tests
+  (`src/tests/services/test_annotation_generation.py:116-289`) all use distinct
+  `detection_id`s per cluster and must stay green unmodified — including their
+  exact `mock_logger.debug.call_count` assertions, which the validate-first
+  ordering preserves.
 - `SequenceBBox` validator: a duplicate `detection_id` raises; distinct ids
   pass; an empty `bboxes` list passes.
 - End-to-end: POST a sequence annotation with an empty `sequences_bbox` for a

--- a/docs/specs/2026-08-06-one-box-per-detection-in-sequence-bbox-design.md
+++ b/docs/specs/2026-08-06-one-box-per-detection-in-sequence-bbox-design.md
@@ -69,7 +69,8 @@ a third of the data.
 
 ## Design
 
-Three files. No new modules.
+Four files. No new modules. (The fourth, section 2b, was found during
+implementation — the original design said three.)
 
 ### 1. Shared union geometry
 
@@ -150,6 +151,32 @@ exact-coordinate matching.
 
 The existing per-box `try/except` that skips invalid coordinates is preserved,
 now wrapping the merged box.
+
+### 2b. The importer's annotation writer
+
+Found during implementation, not in the original design. `build_single_track_annotation`
+(`object_split.py:367`) is a **third** `SequenceBBox` producer — the importer's
+client-side annotation writer. It flattens each detection's `xyxyns` into one
+`BoundingBox` per box, so several boxes on one frame become several entries
+sharing a `detection_id`.
+
+Post-#331 the split path cannot feed it duplicates, but **#331 deliberately
+exempted the fallback path**: when `split_sequence_records` raises or finds no
+objects (`object_split.py:168,335`), records pass through untouched
+(`dict(r)`), so a raw multi-box frame reaches the writer. With the validator in
+place, that import raises rather than degrading.
+
+The same union applies here, grouping by `detection_id` before constructing.
+#331's reason for exempting fallback — that unioning could merge distinct
+plumes — does not carry over: `build_single_track_annotation` already places
+every box from every detection into a *single* `sequences_bbox` track, so it has
+already declared those boxes to be one object. Unioning them merges nothing the
+function kept apart.
+
+The existing test asserting the old flattening
+(`test_multiple_boxes_on_one_detection_become_multiple_track_entries`) is
+renamed and re-pointed at the union, since it encodes exactly the shape this
+issue outlaws.
 
 ### 3. The validator
 
@@ -233,6 +260,13 @@ kind that misled #324 at 10,268 detections.
 
 If it comes back non-zero, this branch does not merge as-is: repairing existing
 rows is its own ticket, not scope here.
+
+**A zero is only meaningful if the sample is non-empty.** Report the box,
+object and annotation counts alongside it. Run against the local dev stack on
+2026-08-06 the query returned zero rows — but that database held 518 sequences
+and 10,902 detections with **zero sequence annotations**, so the result proves
+nothing. The gate is therefore still outstanding and must run wherever this
+deploys.
 
 ## Out of scope
 


### PR DESCRIPTION
Closes #315.

A `SequenceBBox` is one object's track across a sequence, and it should hold at most one box per `detection_id` — the rule #286/#318 enforces one layer down on detection annotations and #324/#331 enforces one layer up in the importer. Nothing enforced it here.

The validator could not land alone, because the API produces the violation itself: `cluster_boxes_by_iou` (`annotation_generation.py:202`) pops boxes off a flat cross-frame list and never consults `detection_id`, so two overlapping engine predictions on one frame land in the same cluster, and `_create_sequence_bboxes` emitted one box per cluster member with no per-frame cap.

## The rule

**Within one `SequenceBBox`, a `detection_id` appears at most once. Several boxes on one frame collapse into the box enclosing them.** #286's modelling rule at the sequence layer: a plume that forks into two strands and rejoins is one object, boxed once. A persistent second plume is a separate object with its own track.

Confidence does not enter here — `_cluster_temporal_bboxes` drops the prediction dict before clustering and `BoundingBox` has no confidence field. The importer's `union_boxes` still carries the group max, because 6,249 of 19,155 real engine boxes have `confidence: 0.0`.

## What changed

1. **`union_xyxyn`** joins `box_iou` in `annotation_generation.py`. `object_split.union_boxes` keeps its 5-element signature and confidence-max, delegating the four coordinates — one definition of "enclosing box".
2. **`_create_sequence_bboxes`** groups each cluster's boxes by `detection_id` and unions duplicates. `cluster_boxes_by_iou` and `_cluster_temporal_bboxes` are deliberately untouched, so `min_cluster_size` still counts pre-merge members and a merge can never silently drop a cluster below the threshold.
3. **`build_single_track_annotation`** gets the same grouping — see below.
4. **`SequenceBBox`** gains a `model_validator` rejecting a repeated `detection_id`, in #318's voice.

**Order matters:** the service fix lands before the validator (`6f86a71` then `d35cbb3`). Reversed, generation 422s its own output.

### Validate before unioning

The obvious shape — group raw coordinates, union, construct — is wrong. A frame carrying a valid box plus a `[0,0,0,0]` null box would union to a box anchored at the origin, inventing an enormous plume out of a detection failure. Each raw box is constructed first, so only survivors reach the union, and the existing per-box rejection and its debug logging are preserved exactly. Regression test: `test_create_sequence_bboxes_null_box_does_not_poison_the_union`.

The second construction cannot raise: a union of valid boxes stays in `[0,1]`, satisfies `x1 <= x2` / `y1 <= y2`, and encloses a non-zero-area box.

### The third producer, found during implementation

The design assumed two `SequenceBBox` producers. There are three. `build_single_track_annotation` (`object_split.py:367`) is the importer's client-side annotation writer, and it flattened each detection's `xyxyns` into one box per entry.

Post-#331 the split path cannot feed it duplicates — but **#331 deliberately exempted the fallback path**: when `split_sequence_records` raises or finds no objects (`object_split.py:168,335`), records pass through untouched, so raw multi-box frames still reach the writer. With the validator in place that import would *raise* rather than degrade.

#331's reason for the exemption — unioning could merge distinct plumes — does not carry over here: `build_single_track_annotation` already places every box from every detection into a *single* track, so it has already declared those boxes to be one object. Unioning merges nothing it kept apart. The test asserting the old flattening is renamed and re-pointed at the union, since it encoded exactly the shape this issue outlaws.

## Failure mode without the fix

Not a client-visible 422. Verified against the pre-fix service: the request still returns **201**, but the offending sequence's annotation comes back **empty** — `auto_generate_annotation`'s failure handler swallows the ValidationError and saves nothing. The symptom is silent annotation loss.

## Read-path exposure — the one thing still owed

`SequenceAnnotationRead.annotation` is a `SequenceAnnotationData` (`sequence_annotations.py:197`) and `crud_sequence_annotation.py:127` rebuilds the model from stored JSON, so the validator runs on **reads**. A pre-existing violating row would raise on GET, not merely reject a write. This is the same exposure #318 accepted for detection annotations.

**The pre-merge gate has not been satisfied.** The violation query returns zero rows against the local dev stack — but that database holds 518 sequences and 10,902 detections with **zero sequence annotations**, so the zero is vacuous. The issue's 2026-08-06 figure (9,987 boxes / 469 objects / 475 annotations) was a DB state that no longer exists locally.

Before merging, run this wherever it deploys and report the counts alongside the result:

```sql
SELECT a.id, obj.ord, (bx.value ->> 'detection_id')::int AS detection_id, COUNT(*)
FROM sequences_annotations a
CROSS JOIN LATERAL jsonb_array_elements(a.annotation -> 'sequences_bbox')
     WITH ORDINALITY AS obj(val, ord)
CROSS JOIN LATERAL jsonb_array_elements(obj.val -> 'bboxes') AS bx(value)
GROUP BY 1, 2, 3 HAVING COUNT(*) > 1;
```

A non-zero result means this does not merge as-is; repairing rows is its own ticket.

## Verification

- **669 passed, 0 failed** (660 baseline + 9 new). `uv run ruff check .` — the CI gate — clean.
- The end-to-end test is negative-verified: it fails against the pre-fix service (`437d022`) and passes after.
- Every pre-existing `_create_sequence_bboxes` test passes **unmodified**, including exact `mock_logger.debug.call_count` assertions — the validate-first ordering preserves them.
- No other writer can produce duplicates: the backend only ever builds `bboxes=[]` (`sequences.py:796`); the frontend classify path spreads the server's array and changes only `is_smoke`/`smoke_type`/`false_positive_types`.
- Importer entry point imports cleanly and `union_boxes` output is unchanged.

## Not fixed here

- **#319** — bulk accept can still send more than one smoke box per frame, and `worker.py`'s `keep_boxes_overlapping` has the same missing per-frame cap on the auto layer. Untouched.
- **No repair migration** for existing rows.
- **`cluster_boxes_by_iou`'s cross-frame IoU-blind clustering** is a different problem and is not addressed.

Two pre-existing issues found while working, neither touched: `make lint`'s format check and `uv run mypy .` are already red on `main` (9 drifted files; a `shared.py` module-path collision), and `.pre-commit-config.yaml` pins ruff **v0.12.7** while `pyproject.toml` resolves **0.7.1** — running the hook reformats three files nobody edited. Both deserve their own tickets.

Design: `docs/specs/2026-08-06-one-box-per-detection-in-sequence-bbox-design.md`
