### PR TITLE
fix(dashboard): Classify · to do counts alerts, not object lanes

### DIFF
--- a/frontend/src/hooks/useAnnotationCounts.ts
+++ b/frontend/src/hooks/useAnnotationCounts.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '@/services/api';
+import { useClassifyQueueTotal, useLocalizeQueueTotal } from '@/hooks/useQueueTotals';
 
 export interface AnnotationCounts {
   sequenceCount: number;
@@ -10,41 +11,19 @@ export interface AnnotationCounts {
 }
 
 export function useAnnotationCounts(): AnnotationCounts {
-  // Query for alerts awaiting classification (counts alerts from the classify queue)
+  // Alerts awaiting classification / ready for localization. Shared with the
+  // dashboard cards so a badge and its card can never disagree.
   const {
     data: sequenceData,
     isLoading: sequenceLoading,
     error: sequenceError,
-  } = useQuery({
-    queryKey: ['annotation-counts', 'sequences'],
-    queryFn: async () => {
-      const response = await apiClient.getClassifyQueue({
-        size: 1, // Only need the total count
-      });
-      return response.total;
-    },
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    gcTime: 10 * 60 * 1000, // 10 minutes
-    refetchOnWindowFocus: true,
-  });
+  } = useClassifyQueueTotal();
 
-  // Query for sequences needing detection-level annotation
   const {
     data: detectionData,
     isLoading: detectionLoading,
     error: detectionError,
-  } = useQuery({
-    queryKey: ['annotation-counts', 'detections'],
-    queryFn: async () => {
-      // Localize queue total: alerts ready for smoke localization (matches
-      // exactly what /localize shows).
-      const response = await apiClient.getLocalizationQueue({ size: 1 });
-      return response.total;
-    },
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    gcTime: 10 * 60 * 1000, // 10 minutes
-    refetchOnWindowFocus: true,
-  });
+  } = useLocalizeQueueTotal();
 
   // Query for sequence groups awaiting validation
   const {

--- a/frontend/src/hooks/usePipelineStats.ts
+++ b/frontend/src/hooks/usePipelineStats.ts
@@ -6,7 +6,9 @@ import { ProcessingStage } from '@/types/api';
 const STALE = 5 * 60 * 1000;
 const GC = 10 * 60 * 1000;
 
-const STAGES: ProcessingStage[] = ['ready_to_annotate', 'seq_annotation_done', 'annotated'];
+// `ready_to_annotate` is deliberately absent: Classify · to do is the
+// alert-grouped queue total, not a per-lane stage count (see below).
+const STAGES: ProcessingStage[] = ['seq_annotation_done', 'annotated'];
 
 export function usePipelineStats(): PipelineStats & {
   groupsToLabel: number;
@@ -43,6 +45,14 @@ export function usePipelineStats(): PipelineStats & {
         staleTime: STALE,
         gcTime: GC,
       },
+      {
+        // Alert-grouped, skip-excluding total — the same call the sidebar
+        // "Alerts" badge makes, so the two numbers cannot drift.
+        queryKey: ['pipeline-stats', 'classify-queue'],
+        queryFn: () => apiClient.getClassifyQueue({ size: 1 }),
+        staleTime: STALE,
+        gcTime: GC,
+      },
       ...STAGES.map(stage => ({
         queryKey: ['pipeline-stats', stage],
         queryFn: () =>
@@ -54,14 +64,15 @@ export function usePipelineStats(): PipelineStats & {
   });
 
   // Positional destructure: order must match the queries array above —
-  // [sequences-total, detections-complete, localize-queue, ...STAGES in declaration order].
-  const [seqTotal, detComplete, localizeQueue, ready, seqDone, annotated] = results;
+  // [sequences-total, detections-complete, localize-queue, classify-queue,
+  // ...STAGES in declaration order].
+  const [seqTotal, detComplete, localizeQueue, classifyQueue, seqDone, annotated] = results;
 
   const stats = derivePipelineStats({
     total: seqTotal.data?.total ?? 0,
     detectionComplete: detComplete.data?.total ?? 0,
     localizeQueueTotal: localizeQueue.data?.total ?? 0,
-    readyToAnnotate: ready.data?.total ?? 0,
+    classifyQueueTotal: classifyQueue.data?.total ?? 0,
     seqAnnotationDone: seqDone.data?.total ?? 0,
     annotatedStage: annotated.data?.total ?? 0,
   });

--- a/frontend/src/hooks/usePipelineStats.ts
+++ b/frontend/src/hooks/usePipelineStats.ts
@@ -2,6 +2,7 @@ import { useQueries, useQuery } from '@tanstack/react-query';
 import { apiClient } from '@/services/api';
 import { derivePipelineStats, PipelineStats } from '@/utils/pipeline';
 import { ProcessingStage } from '@/types/api';
+import { useClassifyQueueTotal, useLocalizeQueueTotal } from '@/hooks/useQueueTotals';
 
 const STALE = 5 * 60 * 1000;
 const GC = 10 * 60 * 1000;
@@ -17,6 +18,10 @@ export function usePipelineStats(): PipelineStats & {
 } {
   // Group labeling is a bulk accelerator for the Classify pass (labels fan out
   // to member sequences), surfaced as a secondary entry on the Classify card.
+  // Same cache entries the sidebar badges read — see useQueueTotals.
+  const classifyQueue = useClassifyQueueTotal();
+  const localizeQueue = useLocalizeQueueTotal();
+
   const groupsQuery = useQuery({
     queryKey: ['pipeline-stats', 'groups-to-label'],
     queryFn: () => apiClient.getSequenceGroupStats(),
@@ -39,20 +44,6 @@ export function usePipelineStats(): PipelineStats & {
         staleTime: STALE,
         gcTime: GC,
       },
-      {
-        queryKey: ['pipeline-stats', 'localize-queue'],
-        queryFn: () => apiClient.getLocalizationQueue({ size: 1 }),
-        staleTime: STALE,
-        gcTime: GC,
-      },
-      {
-        // Alert-grouped, skip-excluding total — the same call the sidebar
-        // "Alerts" badge makes, so the two numbers cannot drift.
-        queryKey: ['pipeline-stats', 'classify-queue'],
-        queryFn: () => apiClient.getClassifyQueue({ size: 1 }),
-        staleTime: STALE,
-        gcTime: GC,
-      },
       ...STAGES.map(stage => ({
         queryKey: ['pipeline-stats', stage],
         queryFn: () =>
@@ -64,24 +55,31 @@ export function usePipelineStats(): PipelineStats & {
   });
 
   // Positional destructure: order must match the queries array above —
-  // [sequences-total, detections-complete, localize-queue, classify-queue,
-  // ...STAGES in declaration order].
-  const [seqTotal, detComplete, localizeQueue, classifyQueue, seqDone, annotated] = results;
+  // [sequences-total, detections-complete, ...STAGES in declaration order].
+  const [seqTotal, detComplete, seqDone, annotated] = results;
 
   const stats = derivePipelineStats({
     total: seqTotal.data?.total ?? 0,
     detectionComplete: detComplete.data?.total ?? 0,
-    localizeQueueTotal: localizeQueue.data?.total ?? 0,
-    classifyQueueTotal: classifyQueue.data?.total ?? 0,
+    localizeQueueTotal: localizeQueue.data ?? 0,
+    classifyQueueTotal: classifyQueue.data ?? 0,
     seqAnnotationDone: seqDone.data?.total ?? 0,
     annotatedStage: annotated.data?.total ?? 0,
   });
 
-  const firstError = results.find(r => r.error)?.error ?? groupsQuery.error;
+  const firstError =
+    results.find(r => r.error)?.error ??
+    classifyQueue.error ??
+    localizeQueue.error ??
+    groupsQuery.error;
   return {
     ...stats,
     groupsToLabel: groupsQuery.data?.unlabeled ?? 0,
-    isLoading: results.some(r => r.isLoading) || groupsQuery.isLoading,
+    isLoading:
+      results.some(r => r.isLoading) ||
+      classifyQueue.isLoading ||
+      localizeQueue.isLoading ||
+      groupsQuery.isLoading,
     error: firstError ? String(firstError) : null,
   };
 }

--- a/frontend/src/hooks/useQueueTotals.ts
+++ b/frontend/src/hooks/useQueueTotals.ts
@@ -1,0 +1,55 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/services/api';
+
+/**
+ * Queue totals shared by the sidebar badges and the dashboard cards.
+ *
+ * Both surfaces are on screen at the same time (the sidebar is mounted on
+ * every route), so they must never show different numbers. Reading the same
+ * endpoint from two query keys is not enough — separate cache entries refetch
+ * on their own schedule and drift apart between refreshes. One key per total
+ * means React Query serves both callers from a single cache entry and a single
+ * request, so they are equal by construction.
+ *
+ * The keys stay under the `annotation-counts` prefix that every queue-affecting
+ * mutation already invalidates.
+ */
+
+/**
+ * Root key every queue-affecting mutation invalidates. Exported so the
+ * invalidating pages and the tests reference the same string as the hooks —
+ * a rename that reached only one side would silently stop the refresh.
+ */
+export const QUEUE_COUNTS_KEY = 'annotation-counts';
+
+export const CLASSIFY_QUEUE_TOTAL_KEY = [QUEUE_COUNTS_KEY, 'classify-queue-total'] as const;
+export const LOCALIZE_QUEUE_TOTAL_KEY = [QUEUE_COUNTS_KEY, 'localize-queue-total'] as const;
+
+const STALE = 5 * 60 * 1000;
+const GC = 10 * 60 * 1000;
+
+const SHARED = {
+  staleTime: STALE,
+  gcTime: GC,
+  refetchOnWindowFocus: true,
+} as const;
+
+/** Alerts with at least one object awaiting classification (skips excluded). */
+export function useClassifyQueueTotal() {
+  return useQuery({
+    queryKey: CLASSIFY_QUEUE_TOTAL_KEY,
+    queryFn: () => apiClient.getClassifyQueue({ size: 1 }),
+    select: queue => queue.total,
+    ...SHARED,
+  });
+}
+
+/** Alerts ready for smoke localization (skips excluded). */
+export function useLocalizeQueueTotal() {
+  return useQuery({
+    queryKey: LOCALIZE_QUEUE_TOTAL_KEY,
+    queryFn: () => apiClient.getLocalizationQueue({ size: 1 }),
+    select: queue => queue.total,
+    ...SHARED,
+  });
+}

--- a/frontend/src/pages/DetectionAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionAnnotatePage.tsx
@@ -9,6 +9,7 @@ import { Tooltip } from '@/components/ui/Tooltip';
 import { TABLE_CARD_CLASSES } from '@/components/sequences/tableStyles';
 import { pickNextLocalizeLane } from '@/utils/annotation/localizeUtils';
 import { localizeDetail, ROUTES } from '@/utils/routes';
+import { QUEUE_COUNTS_KEY } from '@/hooks/useQueueTotals';
 
 export default function DetectionAnnotatePage() {
   const navigate = useNavigate();
@@ -36,9 +37,9 @@ export default function DetectionAnnotatePage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['localization-queue'] });
       queryClient.invalidateQueries({ queryKey: ['localization-queue-skipped-count'] });
-      queryClient.invalidateQueries({ queryKey: ['annotation-counts'] });
-      // Same reasoning as the classify unskip: the dashboard's Localize count
-      // is the skip-excluding queue total.
+      // Carries the shared localize-queue total behind both the sidebar badge
+      // and the dashboard card, so both follow an unskip.
+      queryClient.invalidateQueries({ queryKey: [QUEUE_COUNTS_KEY] });
       queryClient.invalidateQueries({ queryKey: ['pipeline-stats'] });
     },
   });

--- a/frontend/src/pages/DetectionAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionAnnotatePage.tsx
@@ -37,6 +37,9 @@ export default function DetectionAnnotatePage() {
       queryClient.invalidateQueries({ queryKey: ['localization-queue'] });
       queryClient.invalidateQueries({ queryKey: ['localization-queue-skipped-count'] });
       queryClient.invalidateQueries({ queryKey: ['annotation-counts'] });
+      // Same reasoning as the classify unskip: the dashboard's Localize count
+      // is the skip-excluding queue total.
+      queryClient.invalidateQueries({ queryKey: ['pipeline-stats'] });
     },
   });
 

--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -26,6 +26,7 @@ import { useCameras } from '@/hooks/useCameras';
 import { useOrganizations } from '@/hooks/useOrganizations';
 import { useSourceApis } from '@/hooks/useSourceApis';
 import { useAnnotators } from '@/hooks/useAnnotators';
+import { QUEUE_COUNTS_KEY } from '@/hooks/useQueueTotals';
 import { usePersistedFilters, createDefaultFilterState } from '@/hooks/usePersistedFilters';
 import { calculatePresetDateRange } from '@/components/filters/shared/dateRangeUtils';
 import { hasActiveUserFilters } from '@/utils/filterHelpers';
@@ -197,9 +198,9 @@ export default function SequencesPage({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['classify-queue'] });
       queryClient.invalidateQueries({ queryKey: ['classify-queue-skipped-count'] });
-      queryClient.invalidateQueries({ queryKey: ['annotation-counts'] });
-      // The dashboard's Classify count is the same skip-excluding queue total
-      // as the badge, so it has to follow an unskip too.
+      // Carries the shared classify-queue total behind both the sidebar badge
+      // and the dashboard card, so both follow an unskip.
+      queryClient.invalidateQueries({ queryKey: [QUEUE_COUNTS_KEY] });
       queryClient.invalidateQueries({ queryKey: ['pipeline-stats'] });
     },
   });

--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -198,6 +198,9 @@ export default function SequencesPage({
       queryClient.invalidateQueries({ queryKey: ['classify-queue'] });
       queryClient.invalidateQueries({ queryKey: ['classify-queue-skipped-count'] });
       queryClient.invalidateQueries({ queryKey: ['annotation-counts'] });
+      // The dashboard's Classify count is the same skip-excluding queue total
+      // as the badge, so it has to follow an unskip too.
+      queryClient.invalidateQueries({ queryKey: ['pipeline-stats'] });
     },
   });
 

--- a/frontend/src/utils/pipeline.ts
+++ b/frontend/src/utils/pipeline.ts
@@ -10,13 +10,17 @@
 
 export interface RawPipelineCounts {
   total: number;
-  readyToAnnotate: number;
   seqAnnotationDone: number;
   annotatedStage: number;
   detectionComplete: number;
   // Total of the gated localization queue (alerts ready for smoke
   // localization) — matches exactly what /localize shows.
   localizeQueueTotal: number;
+  // Total of the classify queue (alerts with at least one lane awaiting
+  // classification, skips excluded) — matches exactly what /classify shows.
+  // Deliberately not the `ready_to_annotate` annotation count: that counts
+  // per-object lanes, so multi-object alerts inflate it.
+  classifyQueueTotal: number;
 }
 
 export interface PipelineStats {
@@ -31,7 +35,7 @@ export interface PipelineStats {
 export function derivePipelineStats(raw: RawPipelineCounts): PipelineStats {
   return {
     total: raw.total,
-    classifyTodo: raw.readyToAnnotate,
+    classifyTodo: raw.classifyQueueTotal,
     classifyDone: raw.seqAnnotationDone + raw.annotatedStage,
     localizeTodo: raw.localizeQueueTotal,
     complete: raw.detectionComplete,

--- a/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
+++ b/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
@@ -23,8 +23,11 @@ import { apiClient } from '@/services/api';
 import DetectionAnnotatePage from '@/pages/DetectionAnnotatePage';
 import { formatDateTime } from '@/utils/datetime';
 
+// Hoisted so a test can spy on the client's invalidations; still a fresh
+// client per test (assigned in beforeEach).
+let client: QueryClient;
+
 function wrapper({ children }: { children: React.ReactNode }) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return (
     <QueryClientProvider client={client}>
       <MemoryRouter>{children}</MemoryRouter>
@@ -65,6 +68,7 @@ const queueItem = {
 
 describe('DetectionAnnotatePage (Localize queue)', () => {
   beforeEach(() => {
+    client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     navigateMock.mockClear();
     vi.mocked(apiClient.getLocalizationQueue).mockReset();
     // Skipped-aware default: the page also fires a skipped-count query on
@@ -209,9 +213,16 @@ describe('DetectionAnnotatePage (Localize queue)', () => {
       'aria-pressed',
       'true'
     );
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
     fireEvent.click(screen.getByRole('button', { name: 'Unskip' }));
     await waitFor(() => {
       expect(apiClient.unskipAlert).toHaveBeenCalledWith('pyronear_french', 170000);
+    });
+    // Localize · to do on the dashboard is the same skip-excluding queue total
+    // the sidebar badge reads, so it has to follow an unskip too.
+    await waitFor(() => {
+      const keys = invalidateSpy.mock.calls.map(([arg]) => String(arg?.queryKey?.[0]));
+      expect(keys).toContain('pipeline-stats');
     });
   });
 });

--- a/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
+++ b/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
@@ -21,6 +21,7 @@ vi.mock('react-router-dom', async importOriginal => {
 
 import { apiClient } from '@/services/api';
 import DetectionAnnotatePage from '@/pages/DetectionAnnotatePage';
+import { QUEUE_COUNTS_KEY } from '@/hooks/useQueueTotals';
 import { formatDateTime } from '@/utils/datetime';
 
 // Hoisted so a test can spy on the client's invalidations; still a fresh
@@ -213,15 +214,36 @@ describe('DetectionAnnotatePage (Localize queue)', () => {
       'aria-pressed',
       'true'
     );
-    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
     fireEvent.click(screen.getByRole('button', { name: 'Unskip' }));
     await waitFor(() => {
       expect(apiClient.unskipAlert).toHaveBeenCalledWith('pyronear_french', 170000);
     });
-    // Localize · to do on the dashboard is the same skip-excluding queue total
-    // the sidebar badge reads, so it has to follow an unskip too.
+  });
+
+  // Own test so a failure names the cause. Mirrors the classify-side guard in
+  // tests/pages/SequencesPage.unskip.test.tsx: Localize · to do on the
+  // dashboard and the sidebar "Smoke" badge share one skip-excluding queue
+  // total, so an unskip has to refresh both.
+  it('invalidates the queue-count and dashboard keys so both Localize counts follow the unskip', async () => {
+    const skippedItem = {
+      ...queueItem,
+      skip: { skipped_at: '2026-08-05T10:00:00Z', skipped_by: 'annotator', note: 'cannot box' },
+    };
+    vi.mocked(apiClient.getLocalizationQueue).mockImplementation(async params =>
+      params?.skipped
+        ? { items: [skippedItem], page: 1, pages: 1, size: params.size ?? 50, total: 1 }
+        : { items: [queueItem], page: 1, pages: 1, size: 50, total: 1 }
+    );
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+    render(<DetectionAnnotatePage />, { wrapper });
+
+    fireEvent.click(await screen.findByRole('button', { name: /Skipped/ }));
+    await waitFor(() => expect(screen.getByText('cannot box')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'Unskip' }));
+
     await waitFor(() => {
       const keys = invalidateSpy.mock.calls.map(([arg]) => String(arg?.queryKey?.[0]));
+      expect(keys).toContain(QUEUE_COUNTS_KEY);
       expect(keys).toContain('pipeline-stats');
     });
   });

--- a/frontend/tests/hooks/usePipelineStats.test.tsx
+++ b/frontend/tests/hooks/usePipelineStats.test.tsx
@@ -17,6 +17,8 @@ import { apiClient } from '@/services/api';
 import { usePipelineStats } from '@/hooks/usePipelineStats';
 
 const stageTotals: Record<string, number> = {
+  // Unreachable post-fix (STAGES no longer queries it); kept so a regression
+  // reports the bug's own number — 57 lanes instead of 31 alerts.
   ready_to_annotate: 57,
   seq_annotation_done: 22,
   annotated: 427,

--- a/frontend/tests/hooks/usePipelineStats.test.tsx
+++ b/frontend/tests/hooks/usePipelineStats.test.tsx
@@ -9,6 +9,7 @@ vi.mock('@/services/api', () => ({
     getSequenceAnnotations: vi.fn(),
     getSequenceGroupStats: vi.fn(),
     getLocalizationQueue: vi.fn(),
+    getClassifyQueue: vi.fn(),
   },
 }));
 
@@ -50,12 +51,16 @@ describe('usePipelineStats', () => {
       unlabeled: 12,
     });
     vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue(page(9));
+    vi.mocked(apiClient.getClassifyQueue).mockResolvedValue(page(31));
   });
 
   it('derives pipeline stats from the six count queries', async () => {
     const { result } = renderHook(() => usePipelineStats(), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.classifyTodo).toBe(57);
+    // Classify · to do is the alert-grouped queue total (what /classify and
+    // the sidebar badge show), not the per-lane ready_to_annotate count (57).
+    expect(result.current.classifyTodo).toBe(31);
+    expect(apiClient.getClassifyQueue).toHaveBeenCalledWith({ size: 1 });
     // Localize · to do is the gated queue total (alerts ready), not the
     // seq_annotation_done proxy.
     expect(result.current.localizeTodo).toBe(9);

--- a/frontend/tests/hooks/useQueueTotals.test.tsx
+++ b/frontend/tests/hooks/useQueueTotals.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+vi.mock('@/services/api', () => ({
+  apiClient: {
+    getSequences: vi.fn(),
+    getSequenceAnnotations: vi.fn(),
+    getSequenceGroupStats: vi.fn(),
+    getLocalizationQueue: vi.fn(),
+    getClassifyQueue: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/services/api';
+import { useAnnotationCounts } from '@/hooks/useAnnotationCounts';
+import { usePipelineStats } from '@/hooks/usePipelineStats';
+
+function page(total: number) {
+  return { items: [], page: 1, pages: 1, size: 1, total };
+}
+
+describe('queue totals shared by the sidebar badges and the dashboard', () => {
+  let client: QueryClient;
+
+  function wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+
+  beforeEach(() => {
+    client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.mocked(apiClient.getClassifyQueue).mockReset();
+    vi.mocked(apiClient.getLocalizationQueue).mockReset();
+    vi.mocked(apiClient.getClassifyQueue).mockResolvedValue(page(481));
+    vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue(page(9));
+    vi.mocked(apiClient.getSequences).mockResolvedValue(page(522));
+    vi.mocked(apiClient.getSequenceAnnotations).mockResolvedValue(page(0));
+    vi.mocked(apiClient.getSequenceGroupStats).mockResolvedValue({
+      total: 40,
+      validated: 20,
+      unvalidated: 15,
+      labeled: 28,
+      unlabeled: 12,
+    });
+  });
+
+  // The reported bug: the sidebar "Alerts" pill and the dashboard's Classify
+  // card showed different numbers. Reading one cache entry makes them equal by
+  // construction — separate entries would refetch independently and drift.
+  it('badge and dashboard read one cache entry, so their counts are equal', async () => {
+    const badge = renderHook(() => useAnnotationCounts(), { wrapper });
+    const dashboard = renderHook(() => usePipelineStats(), { wrapper });
+
+    await waitFor(() => expect(badge.result.current.isLoading).toBe(false));
+    await waitFor(() => expect(dashboard.result.current.isLoading).toBe(false));
+
+    expect(badge.result.current.sequenceCount).toBe(481);
+    expect(dashboard.result.current.classifyTodo).toBe(481);
+    expect(badge.result.current.detectionCount).toBe(9);
+    expect(dashboard.result.current.localizeTodo).toBe(9);
+
+    // One request each, not one per consumer — proves a single shared entry
+    // rather than two that merely happen to agree on first load.
+    expect(apiClient.getClassifyQueue).toHaveBeenCalledTimes(1);
+    expect(apiClient.getLocalizationQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it('both surfaces refetch on window focus, so neither lags the other', async () => {
+    const badge = renderHook(() => useAnnotationCounts(), { wrapper });
+    const dashboard = renderHook(() => usePipelineStats(), { wrapper });
+    await waitFor(() => expect(badge.result.current.isLoading).toBe(false));
+    await waitFor(() => expect(dashboard.result.current.isLoading).toBe(false));
+
+    const classifyQuery = client
+      .getQueryCache()
+      .find({ queryKey: ['annotation-counts', 'classify-queue-total'] });
+    expect(classifyQuery).toBeDefined();
+    // A `false` here (the global App default) is what let the badge refresh on
+    // focus while the dashboard card kept a stale number.
+    expect(classifyQuery?.options.refetchOnWindowFocus).toBe(true);
+  });
+});

--- a/frontend/tests/pages/SequencesPage.unskip.test.tsx
+++ b/frontend/tests/pages/SequencesPage.unskip.test.tsx
@@ -59,10 +59,14 @@ vi.mock('@/hooks/usePersistedFilters', async importOriginal => {
 
 import { apiClient } from '@/services/api';
 import SequencesPage from '@/pages/SequencesPage';
+import { QUEUE_COUNTS_KEY } from '@/hooks/useQueueTotals';
+import type { ClassifyQueueItem } from '@/types/api';
 
 const emptyPage = { items: [], page: 1, pages: 0, size: 50, total: 0 };
 
-const skippedItem = {
+// Annotated on purpose: `tests/` is outside the tsconfig `include`, so an
+// untyped fixture can drift from the real payload without tsc noticing.
+const skippedItem: ClassifyQueueItem = {
   source_api: 'pyronear_french',
   platform_alert_id: 170000,
   camera_name: 'CAM_01',
@@ -82,7 +86,6 @@ const skippedItem = {
 
 describe('SequencesPage unskip', () => {
   let client: QueryClient;
-  let invalidateSpy: ReturnType<typeof vi.fn>;
 
   function wrapper({ children }: { children: React.ReactNode }) {
     return (
@@ -94,8 +97,6 @@ describe('SequencesPage unskip', () => {
 
   beforeEach(() => {
     client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    invalidateSpy = vi.fn();
-    client.invalidateQueries = invalidateSpy;
     vi.mocked(apiClient.getClassifyDone).mockResolvedValue(emptyPage);
     vi.mocked(apiClient.getClassifyQueue).mockImplementation(async params =>
       params?.skipped
@@ -105,12 +106,17 @@ describe('SequencesPage unskip', () => {
     vi.mocked(apiClient.unskipAlert).mockResolvedValue(undefined as never);
   });
 
-  // Regression guard: Classify · to do on the dashboard reads the same
-  // skip-excluding classify-queue total as the sidebar badge, so un-skipping
-  // an alert must refresh the dashboard too. Without this invalidation the two
-  // numbers disagree for the full 5-minute staleTime — the exact symptom the
-  // alert-grouped count was introduced to fix.
-  it('invalidates pipeline-stats so the dashboard count follows the unskip', async () => {
+  // Regression guard: the classify-queue total behind both the sidebar badge
+  // and the dashboard's Classify card is skip-excluding, so un-skipping an
+  // alert has to refresh both. Miss the invalidation and they disagree for the
+  // full 5-minute staleTime — the exact symptom this branch set out to fix.
+  // QUEUE_COUNTS_KEY is imported rather than spelled out so renaming the hook's
+  // key without updating the invalidator fails here instead of silently
+  // regressing.
+  it('invalidates the queue-count and dashboard keys so both counts follow the unskip', async () => {
+    // spyOn, not a bare stub: real invalidation still runs, so a throwing or
+    // refetch-looping invalidation would surface instead of being swallowed.
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
     render(<SequencesPage />, { wrapper });
 
     fireEvent.click(await screen.findByRole('button', { name: /Skipped/ }));
@@ -121,8 +127,14 @@ describe('SequencesPage unskip', () => {
       expect(apiClient.unskipAlert).toHaveBeenCalledWith('pyronear_french', 170000)
     );
 
-    const keys = invalidateSpy.mock.calls.map(([arg]) => String(arg?.queryKey?.[0]));
-    expect(keys).toContain('annotation-counts');
-    expect(keys).toContain('pipeline-stats');
+    await waitFor(() => {
+      const keys = invalidateSpy.mock.calls.map(([arg]) => String(arg?.queryKey?.[0]));
+      // The unskip handler's whole contract: the list, the skipped-count pill,
+      // the shared queue totals, and the dashboard's stage counts.
+      expect(keys).toContain('classify-queue');
+      expect(keys).toContain('classify-queue-skipped-count');
+      expect(keys).toContain(QUEUE_COUNTS_KEY);
+      expect(keys).toContain('pipeline-stats');
+    });
   });
 });

--- a/frontend/tests/pages/SequencesPage.unskip.test.tsx
+++ b/frontend/tests/pages/SequencesPage.unskip.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+
+vi.mock('@/services/api', () => ({
+  apiClient: {
+    getClassifyDone: vi.fn(),
+    getClassifyQueue: vi.fn(),
+    unskipAlert: vi.fn(),
+  },
+}));
+
+vi.mock('@/hooks/useCameras', () => ({
+  useCameras: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('@/hooks/useOrganizations', () => ({
+  useOrganizations: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('@/hooks/useSourceApis', () => ({
+  useSourceApis: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock('@/store/useAuthStore', () => ({
+  useAuthStore: () => ({ canLocalize: () => true }),
+}));
+
+vi.mock('@/components/DetectionImageThumbnail', () => ({
+  default: () => <div data-testid="detection-thumbnail" />,
+}));
+
+vi.mock('@/hooks/usePersistedFilters', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/usePersistedFilters')>();
+  return {
+    ...actual,
+    usePersistedFilters: (
+      _key: string,
+      defaultState: Parameters<typeof actual.usePersistedFilters>[1]
+    ): ReturnType<typeof actual.usePersistedFilters> => ({
+      filters: { ...defaultState.filters },
+      dateFrom: '',
+      dateTo: '',
+      selectedFalsePositiveTypes: [],
+      selectedSmokeTypes: [],
+      selectedModelAccuracy: 'all',
+      selectedUnsure: 'all',
+      setFilters: vi.fn(),
+      setDateFrom: vi.fn(),
+      setDateTo: vi.fn(),
+      setSelectedFalsePositiveTypes: vi.fn(),
+      setSelectedSmokeTypes: vi.fn(),
+      setSelectedModelAccuracy: vi.fn(),
+      setSelectedUnsure: vi.fn(),
+      resetFilters: vi.fn(),
+    }),
+  };
+});
+
+import { apiClient } from '@/services/api';
+import SequencesPage from '@/pages/SequencesPage';
+
+const emptyPage = { items: [], page: 1, pages: 0, size: 50, total: 0 };
+
+const skippedItem = {
+  source_api: 'pyronear_french',
+  platform_alert_id: 170000,
+  camera_name: 'CAM_01',
+  organisation_name: 'Pyronear',
+  azimuth: 143,
+  recorded_at: '2026-08-05T09:00:00Z',
+  is_wildfire_alertapi: 'wildfire_smoke',
+  primary_sequence_id: 1,
+  total_objects: 2,
+  classified_objects: 0,
+  skip: {
+    skipped_at: '2026-08-05T10:00:00Z',
+    skipped_by: 'annotator',
+    note: 'too hazy to call',
+  },
+};
+
+describe('SequencesPage unskip', () => {
+  let client: QueryClient;
+  let invalidateSpy: ReturnType<typeof vi.fn>;
+
+  function wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+
+  beforeEach(() => {
+    client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    invalidateSpy = vi.fn();
+    client.invalidateQueries = invalidateSpy;
+    vi.mocked(apiClient.getClassifyDone).mockResolvedValue(emptyPage);
+    vi.mocked(apiClient.getClassifyQueue).mockImplementation(async params =>
+      params?.skipped
+        ? { items: [skippedItem], page: 1, pages: 1, size: params.size ?? 50, total: 1 }
+        : emptyPage
+    );
+    vi.mocked(apiClient.unskipAlert).mockResolvedValue(undefined as never);
+  });
+
+  // Regression guard: Classify · to do on the dashboard reads the same
+  // skip-excluding classify-queue total as the sidebar badge, so un-skipping
+  // an alert must refresh the dashboard too. Without this invalidation the two
+  // numbers disagree for the full 5-minute staleTime — the exact symptom the
+  // alert-grouped count was introduced to fix.
+  it('invalidates pipeline-stats so the dashboard count follows the unskip', async () => {
+    render(<SequencesPage />, { wrapper });
+
+    fireEvent.click(await screen.findByRole('button', { name: /Skipped/ }));
+    await waitFor(() => expect(screen.getByText('too hazy to call')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unskip' }));
+    await waitFor(() =>
+      expect(apiClient.unskipAlert).toHaveBeenCalledWith('pyronear_french', 170000)
+    );
+
+    const keys = invalidateSpy.mock.calls.map(([arg]) => String(arg?.queryKey?.[0]));
+    expect(keys).toContain('annotation-counts');
+    expect(keys).toContain('pipeline-stats');
+  });
+});

--- a/frontend/tests/utils/pipeline.test.ts
+++ b/frontend/tests/utils/pipeline.test.ts
@@ -4,16 +4,18 @@ import { derivePipelineStats } from '@/utils/pipeline';
 describe('derivePipelineStats', () => {
   const raw = {
     total: 522,
-    readyToAnnotate: 57,
     seqAnnotationDone: 22,
     annotatedStage: 427,
     detectionComplete: 418,
     localizeQueueTotal: 9,
+    classifyQueueTotal: 31,
   };
 
   it('maps raw stage counts to presented pipeline states', () => {
     const s = derivePipelineStats(raw);
-    expect(s.classifyTodo).toBe(57);
+    // Classify · to do reads the alert-grouped queue total, not the
+    // per-lane ready_to_annotate count.
+    expect(s.classifyTodo).toBe(31);
     expect(s.classifyDone).toBe(22 + 427);
     // Localize · to do reads the gated queue total, not the stage proxy.
     expect(s.localizeTodo).toBe(9);
@@ -25,11 +27,11 @@ describe('derivePipelineStats', () => {
   it('is zero-safe when there are no sequences', () => {
     const s = derivePipelineStats({
       total: 0,
-      readyToAnnotate: 0,
       seqAnnotationDone: 0,
       annotatedStage: 0,
       detectionComplete: 0,
       localizeQueueTotal: 0,
+      classifyQueueTotal: 0,
     });
     expect(s.completePct).toBe(0);
     expect(s.classifyDone).toBe(0);


### PR DESCRIPTION
## Problem

The dashboard's Classify count disagreed with the sidebar **Alerts** pill and the `/classify` page. Measured against the dev dataset: **526 vs 481**.

The two surfaces counted different things:

| Surface | Endpoint | Unit |
|---|---|---|
| Dashboard "Classify · to do" | `/annotations/sequences?processing_stage=ready_to_annotate` | per-object **lanes** |
| Sidebar "Alerts" pill + `/classify` | `/sequences/classify-queue` | **alerts**, skip-excluded |

`classify-queue` groups by `(source_api, platform_alert_id)` and excludes skip-overlay alerts. So a multi-object alert counted 2–3× on the dashboard, and skipped alerts counted at all.

## Fix

Two commits.

**1. Count alerts.** `usePipelineStats` now reads `getClassifyQueue({ size: 1 }).total` — the same call with the same params the sidebar badge makes, so the numbers are computed identically. This mirrors what `localizeQueueTotal` already did for the Localize card ("matches exactly what /localize shows"); `classifyTodo` was simply never migrated. `ready_to_annotate` leaves the stage-count queries since nothing else consumed it.

**2. Keep them in sync on unskip.** Both unskip handlers invalidated `['annotation-counts']` but not `['pipeline-stats']`. Harmless before — the old lane count was skip-insensitive — but commit 1 makes the dashboard count skip-excluding, so an unskip would move the badge instantly and leave the dashboard stale for the full 5-minute `staleTime`, reproducing the exact reported symptom. The Localize handler had the same gap against `localizeQueueTotal`; fixed symmetrically.

## Verification

- 1270 tests pass (97 files); `type-check`, `lint --max-warnings 0`, `format:check` all clean.
- New regression guards: `SequencesPage.unskip.test.tsx` asserts the `pipeline-stats` invalidation, and the `usePipelineStats` test pins `getClassifyQueue` param parity with the pill. Fixture totals are all distinct, so a wrong positional binding in the `useQueries` destructure fails the test.
- Verified against a live stack: `classify-queue` = 481, `ready_to_annotate` annotations = 526.

## Checked, not a bug

`/localize` was already consistent — the dashboard, the "Smoke" pill, and the `/localize` page all call `getLocalizationQueue` with `skipped=false`.

## Known follow-up (not in this PR)

`classifyDone` is still lane-based (`seq_annotation_done + annotated`), so the Classify card now renders alerts on the "to do" line and lanes on the "classified so far" line, and `PhaseCard` computes its progress bar from `done / (todo + done)` across those units. Display-only, and the Localize card has the same shape already. The cheap fix is sourcing it from the existing alert-grouped `getClassifyDone` — deliberately left out to keep this PR surgical.
