### PR TITLE
fix(import): keep union_xyxyn off the app.services import path

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
@@ -33,8 +33,8 @@ from app.schemas.annotation_validation import (
     BoundingBox,
     SequenceAnnotationData,
     SequenceBBox,
+    union_xyxyn,
 )
-from app.services.annotation_generation import union_xyxyn
 from .object_clustering import TrackedObject, cluster_objects, object_cone_azimuth
 from .shared import group_records_by_sequence
 

--- a/annotation_api/src/app/schemas/annotation_validation.py
+++ b/annotation_api/src/app/schemas/annotation_validation.py
@@ -20,7 +20,39 @@ __all__ = [
     "AnnotationOrigin",
     "DetectionAnnotationItem",
     "DetectionAnnotationData",
+    "union_xyxyn",
 ]
+
+
+def union_xyxyn(boxes: List[List[float]]) -> List[float]:
+    """
+    Enclosing box of several bounding boxes, in normalized coordinates.
+
+    One object, one box per frame: a plume that visually forks into two strands
+    and rejoins is still one plume, boxed once (see #286).
+
+    Lives here rather than beside its callers in ``app.services`` so the
+    importer can share it: importing anything under ``app.services`` pulls
+    ``storage``, which probes S3 at module scope (see #336).
+
+    Args:
+        boxes: Non-empty list of [x1, y1, x2, y2] in normalized coordinates (0-1).
+               Extra elements past index 3 are ignored, so the importer's
+               [x1, y1, x2, y2, confidence] boxes can be passed directly.
+
+    Returns:
+        The smallest box enclosing all of them, as [x1, y1, x2, y2]
+
+    Example:
+        >>> union_xyxyn([[0.1, 0.2, 0.3, 0.4], [0.2, 0.1, 0.5, 0.35]])
+        [0.1, 0.1, 0.5, 0.4]
+    """
+    return [
+        min(b[0] for b in boxes),
+        min(b[1] for b in boxes),
+        max(b[2] for b in boxes),
+        max(b[3] for b in boxes),
+    ]
 
 
 class BoundingBox(BaseModel):

--- a/annotation_api/src/app/services/annotation_generation.py
+++ b/annotation_api/src/app/services/annotation_generation.py
@@ -37,6 +37,7 @@ from app.schemas.annotation_validation import (
     BoundingBox,
     SequenceBBox,
     SequenceAnnotationData,
+    union_xyxyn,
 )
 
 
@@ -84,33 +85,6 @@ def box_iou(box1: List[float], box2: List[float]) -> float:
         return 0.0
 
     return intersection / union
-
-
-def union_xyxyn(boxes: List[List[float]]) -> List[float]:
-    """
-    Enclosing box of several bounding boxes, in normalized coordinates.
-
-    One object, one box per frame: a plume that visually forks into two strands
-    and rejoins is still one plume, boxed once (see #286).
-
-    Args:
-        boxes: Non-empty list of [x1, y1, x2, y2] in normalized coordinates (0-1).
-               Extra elements past index 3 are ignored, so the importer's
-               [x1, y1, x2, y2, confidence] boxes can be passed directly.
-
-    Returns:
-        The smallest box enclosing all of them, as [x1, y1, x2, y2]
-
-    Example:
-        >>> union_xyxyn([[0.1, 0.2, 0.3, 0.4], [0.2, 0.1, 0.5, 0.35]])
-        [0.1, 0.1, 0.5, 0.4]
-    """
-    return [
-        min(b[0] for b in boxes),
-        min(b[1] for b in boxes),
-        max(b[2] for b in boxes),
-        max(b[3] for b in boxes),
-    ]
 
 
 def filter_predictions_by_confidence(

--- a/annotation_api/src/tests/scripts/test_import_boundaries.py
+++ b/annotation_api/src/tests/scripts/test_import_boundaries.py
@@ -1,0 +1,49 @@
+"""The importer must not reach `app.services` (#336).
+
+`app/services/__init__.py` imports `storage`, which builds `S3Service` at
+module scope and probes the configured bucket with a live `head_bucket` call.
+Anything that imports `app.services` therefore needs reachable S3 credentials
+just to *load*. When `object_split` started importing
+`app.services.annotation_generation`, local imports died on the production
+bucket before doing any work -- even with `--image-transfer url`, because the
+failure is an import-time side effect rather than part of the transfer.
+
+Every other script import stays inside `app.clients` / `app.schemas` /
+`app.models`, none of which touch S3. This pins that boundary.
+"""
+
+import os
+import subprocess
+import sys
+
+# Run in a clean interpreter: the pytest session has already imported
+# `app.services` itself, so an in-process check could never observe the
+# boundary holding.
+PROBE = """
+import sys
+
+import scripts.data_transfer.ingestion.alert_api.object_split  # noqa: F401
+
+print(
+    "\\n".join(
+        sorted(m for m in sys.modules if m == "app.services" or m.startswith("app.services."))
+    )
+)
+"""
+
+
+def test_object_split_does_not_import_app_services() -> None:
+    env = dict(os.environ, PYTHONPATH=os.pathsep.join(p for p in sys.path if p))
+
+    result = subprocess.run(
+        [sys.executable, "-c", PROBE],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, f"importing object_split failed:\n{result.stderr}"
+    assert result.stdout.strip() == "", (
+        "object_split reached app.services, which does live S3 I/O at import time: "
+        f"{result.stdout.split()}"
+    )

--- a/annotation_api/src/tests/scripts/test_import_boundaries.py
+++ b/annotation_api/src/tests/scripts/test_import_boundaries.py
@@ -16,13 +16,16 @@ import os
 import subprocess
 import sys
 
+import pytest
+
 # Run in a clean interpreter: the pytest session has already imported
 # `app.services` itself, so an in-process check could never observe the
 # boundary holding.
 PROBE = """
+import importlib
 import sys
 
-import scripts.data_transfer.ingestion.alert_api.object_split  # noqa: F401
+importlib.import_module({module!r})
 
 print(
     "\\n".join(
@@ -31,19 +34,28 @@ print(
 )
 """
 
+# The entry point is what `make import-alert-api` runs, so it is the boundary
+# that actually breaks users; `object_split` is pinned separately to keep the
+# failure precise when the regression comes back through that module.
+IMPORTER_MODULES = [
+    "scripts.data_transfer.ingestion.alert_api.import",
+    "scripts.data_transfer.ingestion.alert_api.object_split",
+]
 
-def test_object_split_does_not_import_app_services() -> None:
+
+@pytest.mark.parametrize("module", IMPORTER_MODULES)
+def test_importer_does_not_import_app_services(module: str) -> None:
     env = dict(os.environ, PYTHONPATH=os.pathsep.join(p for p in sys.path if p))
 
     result = subprocess.run(
-        [sys.executable, "-c", PROBE],
+        [sys.executable, "-c", PROBE.format(module=module)],
         capture_output=True,
         text=True,
         env=env,
     )
 
-    assert result.returncode == 0, f"importing object_split failed:\n{result.stderr}"
+    assert result.returncode == 0, f"importing {module} failed:\n{result.stderr}"
     assert result.stdout.strip() == "", (
-        "object_split reached app.services, which does live S3 I/O at import time: "
+        f"{module} reached app.services, which does live S3 I/O at import time: "
         f"{result.stdout.split()}"
     )


### PR DESCRIPTION
## Problem

#336 shared `union_xyxyn` with the importer by having `object_split` import it from `app.services.annotation_generation`:

```python
from app.services.annotation_generation import union_xyxyn
```

Importing anything under `app.services` executes `app/services/__init__.py`, which imports `storage.py`, which constructs `S3Service` **at module scope** (`storage.py:504`). That constructor issues a live `head_bucket` against the configured bucket. The importer therefore needs reachable S3 credentials just to *load*, and dies before doing any work:

```
ValueError: unable to access bucket ovh-annotation-api-prod on S3
```

`--image-transfer url` does not avoid this — the failure is an import-time side effect, not part of the transfer. Production likely masks it because the credentials resolve there; locally the importer is simply broken.

Found while running a July + August import against `269a071`: the July import (pre-#336) succeeded, the August one aborted immediately.

## Fix

Move `union_xyxyn` to `app/schemas/annotation_validation.py`, beside `BoundingBox` and the xyxyn coordinate rules it operates on. Both callers already import that module and it pulls no S3, so the helper stays shared. **The function body is unchanged.**

This restores a boundary the rest of the codebase already respects — every other script import stays inside `app.clients` / `app.schemas` / `app.models`. #336's was the only one reaching into `app.services`.

## Test plan

`tests/scripts/test_import_boundaries.py` asserts, in a clean interpreter, that importing the importer leaves nothing under `app.services` in `sys.modules`. The subprocess is required: the pytest session imports `app.services` itself, so an in-process check could never observe the boundary.

Parametrized over two modules:
- `...alert_api.import` — the entry point `make import-alert-api` actually runs, which also covers `shared`, `annotation_management`, etc.
- `...alert_api.object_split` — keeps the failure precise if the regression returns through that module.

Both verified to catch the regression by probing the unfixed `269a071` checkout, which reports `['app.services.storage', 'app.services', 'app.services.annotation_generation']` for each.

Also verified:
- Full backend suite: **683 passed, 0 failed**.
- The importer entry point loads with `S3_BUCKET_NAME=ovh-annotation-api-prod` (the exact config that raised the `ValueError`), with `app.services imported: []`.
- A real `make import-alert-api` run with **no S3 overrides** reaches the alert API and completes its fetch/object-split steps — the local workaround of pointing `S3_*` at MinIO is no longer needed.

## Not addressed

The underlying landmine stays: `storage.py` still builds `s3_service` at module scope, so any future import of `app.services` from a script hits the same wall. It is also why host-side `pytest` cannot collect in this repo. Making it lazy changes the API's fail-fast-on-bad-S3-config startup behavior, so it belongs in its own PR.

`union_xyxyn`'s unit tests still live in `tests/services/test_annotation_generation.py` and resolve the name through that module's import. They pass unchanged; moving them alongside the function would be unrelated churn here.

`make lint` is red on `main` independently of this change (9 files with format drift, 7 mypy errors) — identical output on a pristine `269a071` checkout. None are files touched here, so they are left alone.