### PR TITLE
fix(sidebar): Recurring objects badge counts unlabeled, matching the page it opens

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -103,7 +103,7 @@ function SidebarContent({ currentPath }: { currentPath: string }) {
           name: 'Recurring objects',
           href: ROUTES.CLASSIFY_GROUPS,
           badgeCount: groupCount,
-          badgeTitle: `${groupCount} recurring objects need validation`,
+          badgeTitle: `${groupCount} recurring objects need a label`,
         },
         { name: 'Alerts', href: ROUTES.CLASSIFY, badgeCount: sequenceCount },
         { name: 'Done', href: ROUTES.CLASSIFY_DONE },

--- a/frontend/src/hooks/useAnnotationCounts.ts
+++ b/frontend/src/hooks/useAnnotationCounts.ts
@@ -25,7 +25,10 @@ export function useAnnotationCounts(): AnnotationCounts {
     error: detectionError,
   } = useLocalizeQueueTotal();
 
-  // Query for sequence groups awaiting validation
+  // Recurring objects still needing a label. Not `unvalidated`: the badge opens
+  // the recurring-objects list on its "To label" tab, which counts `unlabeled`,
+  // and label propagation is gated on is_validated — so a validated-but-
+  // unlabeled backlog always exists and the two numbers never converge.
   const {
     data: groupData,
     isLoading: groupLoading,
@@ -34,7 +37,7 @@ export function useAnnotationCounts(): AnnotationCounts {
     queryKey: ['annotation-counts', 'sequence-groups'],
     queryFn: async () => {
       const stats = await apiClient.getSequenceGroupStats();
-      return stats.unvalidated;
+      return stats.unlabeled;
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes

--- a/frontend/tests/components/layout/AppLayout.test.tsx
+++ b/frontend/tests/components/layout/AppLayout.test.tsx
@@ -100,7 +100,9 @@ describe('AppLayout sidebar navigation', () => {
     expect(objectsLink).toHaveAttribute('href', '/classify/groups');
 
     const badge = within(objectsLink).getByText('8');
-    expect(badge).toHaveAttribute('title', '8 recurring objects need validation');
+    // "a label", not "validation": the badge counts unlabeled groups, which is
+    // what the page it opens lands on.
+    expect(badge).toHaveAttribute('title', '8 recurring objects need a label');
   });
 
   it('places Objects first among the Classify sub-items, after the section header', () => {

--- a/frontend/tests/hooks/useAnnotationCounts.test.tsx
+++ b/frontend/tests/hooks/useAnnotationCounts.test.tsx
@@ -49,10 +49,14 @@ describe('useAnnotationCounts', () => {
     expect(result.current.detectionCount).toBe(9);
   });
 
-  it('counts unvalidated groups', async () => {
+  // The badge opens the recurring-objects list, which lands on its "To label"
+  // tab counting `unlabeled`. Counting `unvalidated` (15) here made the badge
+  // disagree with the page it opens — permanently, since label propagation is
+  // gated on is_validated, so validated-but-unlabeled groups always exist.
+  it('counts unlabeled groups, matching the page the badge opens', async () => {
     const { result } = renderHook(() => useAnnotationCounts(), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.groupCount).toBe(15);
+    expect(result.current.groupCount).toBe(12);
   });
 
   it('surfaces an error string when a count query fails', async () => {


### PR DESCRIPTION
Follow-up to #338, found while auditing the app for other count divergences of the same shape. **Stacked on #338** — retarget to `main` once that merges.

## Problem

The sidebar **Recurring objects** badge counted `unvalidated`. The page it links to (`/classify/groups`) defaults to its **"To label"** tab, whose count is `unlabeled`. So clicking a badge reading 15 landed on a list headed 12.

The dashboard's own entry point for that same destination ("Classify recurring objects", `PhaseCard`) already used `unlabeled` — the badge was the odd one out.

## Why it never self-corrects

`labeled` and `validated` are independent columns, not two names for one thing:

```python
func.count(...).filter(SequenceGroup.is_validated.is_(True)).label("validated"),
func.count(...).filter(
    (SequenceGroup.smoke_type.is_not(None)) | (SequenceGroup.false_positive_type.is_not(None))
).label("labeled"),
```

Validation confirms membership; labeling propagates a classification, and that propagation is *gated* on `is_validated`. Validation therefore strictly precedes labeling, guaranteeing a standing validated-but-unlabeled population. The two counts diverge permanently rather than converging after a refresh.

## Fix

`useAnnotationCounts` returns `stats.unlabeled`, and the tooltip becomes "N recurring objects need a label".

## Verification

1273 tests pass (98 files); `type-check`, `lint --max-warnings 0` clean. The hook fixture already carried distinct `unvalidated: 15` / `unlabeled: 12`, so the updated assertion discriminates — it fails with `expected 15 to be 12` against the old code.

## Note

This does not remove the validation backlog as a concept — nothing surfaced it except this badge, which was pointing at the wrong page for it. If the unvalidated count is worth watching, it wants its own indicator rather than borrowing this one.
