### PR TITLE
fix(dashboard): count each phase card's done half in alerts, not objects

### DIFF
--- a/frontend/src/hooks/usePipelineStats.ts
+++ b/frontend/src/hooks/usePipelineStats.ts
@@ -1,27 +1,22 @@
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { apiClient } from '@/services/api';
 import { derivePipelineStats, PipelineStats } from '@/utils/pipeline';
-import { ProcessingStage } from '@/types/api';
 import { useClassifyQueueTotal, useLocalizeQueueTotal } from '@/hooks/useQueueTotals';
 
 const STALE = 5 * 60 * 1000;
 const GC = 10 * 60 * 1000;
-
-// `ready_to_annotate` is deliberately absent: Classify · to do is the
-// alert-grouped queue total, not a per-lane stage count (see below).
-const STAGES: ProcessingStage[] = ['seq_annotation_done', 'annotated'];
 
 export function usePipelineStats(): PipelineStats & {
   groupsToLabel: number;
   isLoading: boolean;
   error: string | null;
 } {
-  // Group labeling is a bulk accelerator for the Classify pass (labels fan out
-  // to member sequences), surfaced as a secondary entry on the Classify card.
   // Same cache entries the sidebar badges read — see useQueueTotals.
   const classifyQueue = useClassifyQueueTotal();
   const localizeQueue = useLocalizeQueueTotal();
 
+  // Group labeling is a bulk accelerator for the Classify pass (labels fan out
+  // to member sequences), surfaced as a secondary entry on the Classify card.
   const groupsQuery = useQuery({
     queryKey: ['pipeline-stats', 'groups-to-label'],
     queryFn: () => apiClient.getSequenceGroupStats(),
@@ -44,27 +39,36 @@ export function usePipelineStats(): PipelineStats & {
         staleTime: STALE,
         gcTime: GC,
       },
-      ...STAGES.map(stage => ({
-        queryKey: ['pipeline-stats', stage],
-        queryFn: () =>
-          apiClient.getSequenceAnnotations({ processing_stage: stage, size: 1, page: 1 }),
+      {
+        // Done totals come from the alert-grouped done queues — the same pages
+        // the cards' "Review …" links open — so each card's to-do and done
+        // halves are both alert counts. Summing the `seq_annotation_done` and
+        // `annotated` annotation stages instead counted objects, which made
+        // the progress bar divide objects by (alerts + objects).
+        queryKey: ['pipeline-stats', 'classify-done'],
+        queryFn: () => apiClient.getClassifyDone({ size: 1, page: 1 }),
         staleTime: STALE,
         gcTime: GC,
-      })),
+      },
+      {
+        queryKey: ['pipeline-stats', 'localize-done'],
+        queryFn: () => apiClient.getLocalizeDoneQueue({ size: 1, page: 1 }),
+        staleTime: STALE,
+        gcTime: GC,
+      },
     ],
   });
 
-  // Positional destructure: order must match the queries array above —
-  // [sequences-total, detections-complete, ...STAGES in declaration order].
-  const [seqTotal, detComplete, seqDone, annotated] = results;
+  // Positional destructure: order must match the queries array above.
+  const [seqTotal, detComplete, classifyDone, localizeDone] = results;
 
   const stats = derivePipelineStats({
     total: seqTotal.data?.total ?? 0,
     detectionComplete: detComplete.data?.total ?? 0,
     localizeQueueTotal: localizeQueue.data ?? 0,
     classifyQueueTotal: classifyQueue.data ?? 0,
-    seqAnnotationDone: seqDone.data?.total ?? 0,
-    annotatedStage: annotated.data?.total ?? 0,
+    classifyDoneTotal: classifyDone.data?.total ?? 0,
+    localizeDoneTotal: localizeDone.data?.total ?? 0,
   });
 
   const firstError =

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -61,7 +61,7 @@ export default function DashboardPage() {
             title="Localize smoke"
             description="Draw a tight box around the smoke in every image. Unlocked by Pass 01."
             todo={stats.localizeTodo}
-            done={stats.complete}
+            done={stats.localizeDone}
             doneNoun="localized"
             ctaLabel="Start localizing"
             ctaTo={ROUTES.LOCALIZE}

--- a/frontend/src/utils/pipeline.ts
+++ b/frontend/src/utils/pipeline.ts
@@ -1,26 +1,30 @@
 /**
  * Presentation-layer pipeline taxonomy.
  *
- * Maps raw processing-stage counts onto the two-pass pipeline shown on the
- * dashboard (Classify → Localize → Complete). See
+ * Maps raw counts onto the two-pass pipeline shown on the dashboard
+ * (Classify → Localize → Complete). See
  * docs/specs/2026-07-28-dashboard-taxonomy-redesign-design.md for the mapping
  * rationale. `imported` and `no_annotation` are deliberate omissions: import
  * plumbing, never shown.
+ *
+ * Unit discipline: every per-pass number is an ALERT count, taken from the
+ * alert-grouped queue endpoints that back the pages those numbers link to. The
+ * one exception is `complete`/`completePct`, which is object-grained on
+ * purpose and labelled as such in the UI. Mixing the two inside a single card
+ * made its progress bar divide objects by (alerts + objects).
  */
 
 export interface RawPipelineCounts {
+  /** All sequences (objects) — denominator of the object-grained Complete %. */
   total: number;
-  seqAnnotationDone: number;
-  annotatedStage: number;
+  /** Objects whose detection-level annotation is finished. */
   detectionComplete: number;
-  // Total of the gated localization queue (alerts ready for smoke
-  // localization) — matches exactly what /localize shows.
+  // Totals of the alert-grouped queues — each matches exactly what the page it
+  // links to shows.
   localizeQueueTotal: number;
-  // Total of the classify queue (alerts with at least one lane awaiting
-  // classification, skips excluded) — matches exactly what /classify shows.
-  // Deliberately not the `ready_to_annotate` annotation count: that counts
-  // per-object lanes, so multi-object alerts inflate it.
   classifyQueueTotal: number;
+  classifyDoneTotal: number;
+  localizeDoneTotal: number;
 }
 
 export interface PipelineStats {
@@ -28,6 +32,7 @@ export interface PipelineStats {
   classifyTodo: number;
   classifyDone: number;
   localizeTodo: number;
+  localizeDone: number;
   complete: number;
   completePct: number;
 }
@@ -36,8 +41,9 @@ export function derivePipelineStats(raw: RawPipelineCounts): PipelineStats {
   return {
     total: raw.total,
     classifyTodo: raw.classifyQueueTotal,
-    classifyDone: raw.seqAnnotationDone + raw.annotatedStage,
+    classifyDone: raw.classifyDoneTotal,
     localizeTodo: raw.localizeQueueTotal,
+    localizeDone: raw.localizeDoneTotal,
     complete: raw.detectionComplete,
     completePct: raw.total > 0 ? Math.round((raw.detectionComplete / raw.total) * 100) : 0,
   };

--- a/frontend/tests/components/dashboard/DashboardPage.test.tsx
+++ b/frontend/tests/components/dashboard/DashboardPage.test.tsx
@@ -20,6 +20,9 @@ vi.mock('@/hooks/usePipelineStats', () => ({
     classifyTodo: 57,
     classifyDone: 453,
     localizeTodo: 31,
+    // Distinct from `complete` on purpose: the Localize card shows alerts
+    // localized, while the Complete strip segment shows objects.
+    localizeDone: 402,
     complete: 418,
     completePct: 80,
     groupsToLabel: 12,
@@ -57,5 +60,14 @@ describe('DashboardPage', () => {
   it('shows the Localize phase card when the user can localize', () => {
     render(<DashboardPage />, { wrapper: MemoryRouter });
     expect(screen.getByText('Localize smoke')).toBeInTheDocument();
+  });
+
+  // The card's two halves have to be the same unit for its progress bar to
+  // mean anything: "localized so far" is alerts (localizeDone), not the
+  // object-grained `complete` the Complete strip segment shows.
+  it('counts the Localize card done half in alerts, not objects', () => {
+    render(<DashboardPage />, { wrapper: MemoryRouter });
+    expect(screen.getByText(/402 localized so far/)).toBeInTheDocument();
+    expect(screen.queryByText(/418 localized so far/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/hooks/usePipelineStats.test.tsx
+++ b/frontend/tests/hooks/usePipelineStats.test.tsx
@@ -6,23 +6,16 @@ import React from 'react';
 vi.mock('@/services/api', () => ({
   apiClient: {
     getSequences: vi.fn(),
-    getSequenceAnnotations: vi.fn(),
     getSequenceGroupStats: vi.fn(),
     getLocalizationQueue: vi.fn(),
     getClassifyQueue: vi.fn(),
+    getClassifyDone: vi.fn(),
+    getLocalizeDoneQueue: vi.fn(),
   },
 }));
 
 import { apiClient } from '@/services/api';
 import { usePipelineStats } from '@/hooks/usePipelineStats';
-
-const stageTotals: Record<string, number> = {
-  // Unreachable post-fix (STAGES no longer queries it); kept so a regression
-  // reports the bug's own number — 57 lanes instead of 31 alerts.
-  ready_to_annotate: 57,
-  seq_annotation_done: 22,
-  annotated: 427,
-};
 
 function wrapper({ children }: { children: React.ReactNode }) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -39,12 +32,8 @@ describe('usePipelineStats', () => {
       Promise.resolve(
         page(params?.detection_annotation_completion === 'complete' ? 418 : 522)
       )) as unknown as typeof apiClient.getSequences);
-    vi.mocked(apiClient.getSequenceAnnotations).mockImplementation(((
-      params?: Record<string, unknown>
-    ) =>
-      Promise.resolve(
-        page(stageTotals[String(params?.processing_stage)] ?? 0)
-      )) as unknown as typeof apiClient.getSequenceAnnotations);
+    vi.mocked(apiClient.getClassifyDone).mockResolvedValue(page(449));
+    vi.mocked(apiClient.getLocalizeDoneQueue).mockResolvedValue(page(402));
     vi.mocked(apiClient.getSequenceGroupStats).mockResolvedValue({
       total: 40,
       validated: 20,
@@ -56,13 +45,14 @@ describe('usePipelineStats', () => {
     vi.mocked(apiClient.getClassifyQueue).mockResolvedValue(page(31));
   });
 
-  it('derives pipeline stats from the six count queries', async () => {
+  it('derives pipeline stats from the alert-grouped queues', async () => {
     const { result } = renderHook(() => usePipelineStats(), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    // Classify · to do is the alert-grouped queue total (what /classify and
-    // the sidebar badge show), not the per-lane ready_to_annotate count (57).
+    // Every pass number is alert-grained, matching the page it links to.
     expect(result.current.classifyTodo).toBe(31);
     expect(apiClient.getClassifyQueue).toHaveBeenCalledWith({ size: 1 });
+    expect(result.current.classifyDone).toBe(449);
+    expect(result.current.localizeDone).toBe(402);
     // Localize · to do is the gated queue total (alerts ready), not the
     // seq_annotation_done proxy.
     expect(result.current.localizeTodo).toBe(9);

--- a/frontend/tests/utils/pipeline.test.ts
+++ b/frontend/tests/utils/pipeline.test.ts
@@ -4,21 +4,24 @@ import { derivePipelineStats } from '@/utils/pipeline';
 describe('derivePipelineStats', () => {
   const raw = {
     total: 522,
-    seqAnnotationDone: 22,
-    annotatedStage: 427,
     detectionComplete: 418,
     localizeQueueTotal: 9,
     classifyQueueTotal: 31,
+    classifyDoneTotal: 449,
+    localizeDoneTotal: 402,
   };
 
-  it('maps raw stage counts to presented pipeline states', () => {
+  it('maps raw counts to presented pipeline states', () => {
     const s = derivePipelineStats(raw);
-    // Classify · to do reads the alert-grouped queue total, not the
-    // per-lane ready_to_annotate count.
+    // Every card number is alert-grained: to do and done both come from the
+    // alert-grouped queues, so a card's two halves are the same unit and its
+    // progress bar is a real ratio.
     expect(s.classifyTodo).toBe(31);
-    expect(s.classifyDone).toBe(22 + 427);
-    // Localize · to do reads the gated queue total, not the stage proxy.
+    expect(s.classifyDone).toBe(449);
     expect(s.localizeTodo).toBe(9);
+    expect(s.localizeDone).toBe(402);
+    // The Complete strip segment stays object-grained — it is labelled
+    // "% of all objects" and its denominator is all sequences.
     expect(s.complete).toBe(418);
     expect(s.completePct).toBe(80);
     expect(s.total).toBe(522);
@@ -27,13 +30,14 @@ describe('derivePipelineStats', () => {
   it('is zero-safe when there are no sequences', () => {
     const s = derivePipelineStats({
       total: 0,
-      seqAnnotationDone: 0,
-      annotatedStage: 0,
       detectionComplete: 0,
       localizeQueueTotal: 0,
       classifyQueueTotal: 0,
+      classifyDoneTotal: 0,
+      localizeDoneTotal: 0,
     });
     expect(s.completePct).toBe(0);
     expect(s.classifyDone).toBe(0);
+    expect(s.localizeDone).toBe(0);
   });
 });


### PR DESCRIPTION
Follow-up to #338, and the second half of the unit fix that PR started. **Stacked on #338** — retarget to `main` once that merges.

## Problem

`PhaseCard` computes its progress bar as `pct = done / (todo + done)`. #338 moved the `todo` halves to alert counts but left both `done` halves object-grained:

| Card | `todo` | `done` (before) |
|---|---|---|
| Classify | classify-queue alerts | `seq_annotation_done + annotated` annotation rows — **objects** |
| Localize | localize-queue alerts | `detectionComplete` sequences — **objects** |

So the bar divided objects by (alerts + objects), and "N classified so far" sat directly above a "Review classified" link to a page reporting a different number for the same thing.

Worse, the two terms **double-count**. Classify-queue membership needs only ≥1 lane at `ready_to_annotate` and has no `HAVING` — partially-classified alerts are a designed state, which is why the queue row renders "3 · 2 classified". Such an alert adds 1 to `todo` *and* its finished lanes to `done`. Localize is the same by construction: an alert is queued while one lane still needs boxes, while its already-`annotated` siblings are counted in `complete`.

## Fix

Both `done` halves now read the alert-grouped done queues — `getClassifyDone` and `getLocalizeDoneQueue` — which are exactly the pages each card's "Review …" link opens. Each card's two numbers are now the same unit and agree with their destination.

The stage-count queries (`seq_annotation_done`, `annotated`) had no other consumer and are removed, which also shrinks the fragile positional `useQueries` destructure from six entries to four.

**The Complete strip segment is deliberately unchanged.** It stays object-grained — its denominator is all sequences and it is already labelled "% of all objects".

## Verification

1274 tests pass (98 files); `type-check`, `lint --max-warnings 0`, `format:check` clean.

New guard in `DashboardPage.test.tsx` asserts the Localize card shows `402 localized so far` (alerts) and *not* `418` (objects) — the mock carries both values distinctly, so it fails if `done` regresses to `complete`.

Note: the untyped `usePipelineStats` mock in that test silently lacked the new field and crashed on render — the same untyped-fixture hazard flagged in #338's review. Worth putting `tests/` inside a type-checked project at some point; out of scope here.

## Not addressed

- The `/sequences` denominator behind `completePct` includes skipped alerts and annotation-less import debris, which can never reach `complete`, so the percentage has a ceiling below 100%.
- `setMissedSmokeFlag` changes localize-queue membership but invalidates no counts key (pre-existing).
