### PR TITLE
fix(filters): make the Alert API annotation filter work everywhere it is shown

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -107,6 +107,27 @@ def build_detection_stats_subquery():
     )
 
 
+PLATFORM_ANNOTATION_FILTER_DESC = (
+    "Filter by the alert platform's own annotation: 'wildfire_smoke', "
+    "'other_smoke', 'other', or 'null' for unclassified"
+)
+
+
+def platform_annotation_clause(seq, value: Optional[str]):
+    """WHERE clause for the alert platform's annotation filter, or None when
+    the filter doesn't apply. The literal string "null" selects unclassified
+    alerts (a bare null can't survive query-string encoding); an unparseable
+    value disables the filter rather than 422-ing the caller."""
+    if value is None:
+        return None
+    if value == "null":
+        return seq.is_wildfire_alertapi.is_(None)
+    try:
+        return seq.is_wildfire_alertapi == AnnotationType(value)
+    except ValueError:
+        return None
+
+
 class SequenceOrderByField(str, Enum):
     """Valid fields for ordering sequences."""
 
@@ -328,18 +349,9 @@ async def list_sequences(
     if organisation_name is not None:
         query = query.where(Sequence.organisation_name == organisation_name)
 
-    if is_wildfire_alertapi is not None:
-        # Special handling for filtering null values (sent as "null" string from frontend)
-        if is_wildfire_alertapi == "null":
-            query = query.where(Sequence.is_wildfire_alertapi.is_(None))
-        else:
-            # Validate that the value is a valid AnnotationType
-            try:
-                enum_value = AnnotationType(is_wildfire_alertapi)
-                query = query.where(Sequence.is_wildfire_alertapi == enum_value)
-            except ValueError:
-                # Invalid enum value, ignore filter (could also raise an error)
-                pass
+    wildfire_clause = platform_annotation_clause(Sequence, is_wildfire_alertapi)
+    if wildfire_clause is not None:
+        query = query.where(wildfire_clause)
 
     if has_annotation is not None:
         if has_annotation:
@@ -1328,6 +1340,9 @@ async def classify_queue(
     source_api: Optional[SourceApi] = Query(None),
     recorded_at_gte: Optional[datetime] = Query(None),
     recorded_at_lte: Optional[datetime] = Query(None),
+    is_wildfire_alertapi: Optional[str] = Query(
+        None, description=PLATFORM_ANNOTATION_FILTER_DESC
+    ),
     skipped: bool = Query(False),
     session: AsyncSession = Depends(get_session),
     params: Params = Depends(),
@@ -1359,6 +1374,9 @@ async def classify_queue(
         candidates = candidates.where(cand_seq.recorded_at >= recorded_at_gte)
     if recorded_at_lte is not None:
         candidates = candidates.where(cand_seq.recorded_at <= recorded_at_lte)
+    wildfire_clause = platform_annotation_clause(cand_seq, is_wildfire_alertapi)
+    if wildfire_clause is not None:
+        candidates = candidates.where(wildfire_clause)
 
     alerts = (
         select(
@@ -1435,6 +1453,9 @@ async def localize_done_queue(
     source_api: Optional[SourceApi] = Query(None),
     recorded_at_gte: Optional[datetime] = Query(None),
     recorded_at_lte: Optional[datetime] = Query(None),
+    is_wildfire_alertapi: Optional[str] = Query(
+        None, description=PLATFORM_ANNOTATION_FILTER_DESC
+    ),
     annotator_id: Optional[int] = Query(
         None, description="Alerts with any lane contributed to by this user"
     ),
@@ -1470,6 +1491,9 @@ async def localize_done_queue(
         candidates = candidates.where(cand_seq.recorded_at >= recorded_at_gte)
     if recorded_at_lte is not None:
         candidates = candidates.where(cand_seq.recorded_at <= recorded_at_lte)
+    wildfire_clause = platform_annotation_clause(cand_seq, is_wildfire_alertapi)
+    if wildfire_clause is not None:
+        candidates = candidates.where(wildfire_clause)
 
     alerts_query = (
         select(
@@ -1531,9 +1555,7 @@ async def classify_done(
     recorded_at_gte: Optional[datetime] = Query(None),
     recorded_at_lte: Optional[datetime] = Query(None),
     is_wildfire_alertapi: Optional[str] = Query(
-        None,
-        description="Filter by the alert platform's annotation: "
-        "'wildfire_smoke', 'other_smoke', 'other', or 'null' for unclassified",
+        None, description=PLATFORM_ANNOTATION_FILTER_DESC
     ),
     false_positive_types: Optional[List[FalsePositiveType]] = Query(
         None, description="Alerts with any lane matching one of these FP types"
@@ -1577,19 +1599,9 @@ async def classify_done(
         candidates = candidates.where(cand_seq.recorded_at >= recorded_at_gte)
     if recorded_at_lte is not None:
         candidates = candidates.where(cand_seq.recorded_at <= recorded_at_lte)
-    if is_wildfire_alertapi is not None:
-        # "null" selects unclassified alerts; invalid values disable the
-        # filter (same contract as the list-sequences endpoint).
-        if is_wildfire_alertapi == "null":
-            candidates = candidates.where(cand_seq.is_wildfire_alertapi.is_(None))
-        else:
-            try:
-                enum_value = AnnotationType(is_wildfire_alertapi)
-                candidates = candidates.where(
-                    cand_seq.is_wildfire_alertapi == enum_value
-                )
-            except ValueError:
-                pass
+    wildfire_clause = platform_annotation_clause(cand_seq, is_wildfire_alertapi)
+    if wildfire_clause is not None:
+        candidates = candidates.where(wildfire_clause)
 
     lane_done = case((SequenceAnnotation.processing_stage.in_(DONE_STAGES), 1), else_=0)
     alerts = (

--- a/annotation_api/src/tests/endpoints/test_classify_queue.py
+++ b/annotation_api/src/tests/endpoints/test_classify_queue.py
@@ -160,6 +160,73 @@ async def test_filters(authenticated_client: AsyncClient, async_session):
 
 
 @pytest.mark.asyncio
+async def test_is_wildfire_alertapi_filter(
+    authenticated_client: AsyncClient, async_session
+):
+    wildfire = await _lane(
+        async_session,
+        alert_api_id=822,
+        platform_alert_id=822,
+        stage=Stage.READY_TO_ANNOTATE,
+    )
+    wildfire.is_wildfire_alertapi = "wildfire_smoke"
+    async_session.add(wildfire)
+    await async_session.commit()
+    await _lane(
+        async_session,
+        alert_api_id=823,
+        platform_alert_id=823,
+        stage=Stage.READY_TO_ANNOTATE,
+    )
+
+    resp = await authenticated_client.get(
+        "/sequences/classify-queue", params={"is_wildfire_alertapi": "wildfire_smoke"}
+    )
+    assert [it["platform_alert_id"] for it in resp.json()["items"]] == [822]
+    assert resp.json()["total"] == 1
+
+    # "null" selects the alerts the platform left unclassified.
+    null_resp = await authenticated_client.get(
+        "/sequences/classify-queue", params={"is_wildfire_alertapi": "null"}
+    )
+    assert [it["platform_alert_id"] for it in null_resp.json()["items"]] == [823]
+    assert null_resp.json()["total"] == 1
+
+    # An unparseable value disables the filter rather than 422-ing.
+    junk_resp = await authenticated_client.get(
+        "/sequences/classify-queue", params={"is_wildfire_alertapi": "bogus"}
+    )
+    assert junk_resp.status_code == 200
+    assert junk_resp.json()["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_is_wildfire_alertapi_filter_keeps_sibling_lane_counts(
+    authenticated_client: AsyncClient, async_session
+):
+    # Two lanes of one alert, both carrying the platform's annotation (the
+    # importer copies it onto every object-split lane). The filter must not
+    # narrow the grouped row to the matching lanes only.
+    for alert_api_id in (824, 825):
+        lane = await _lane(
+            async_session,
+            alert_api_id=alert_api_id,
+            platform_alert_id=824,
+            stage=Stage.READY_TO_ANNOTATE,
+        )
+        lane.is_wildfire_alertapi = "other_smoke"
+        async_session.add(lane)
+    await async_session.commit()
+
+    resp = await authenticated_client.get(
+        "/sequences/classify-queue", params={"is_wildfire_alertapi": "other_smoke"}
+    )
+    items = resp.json()["items"]
+    assert len(items) == 1
+    assert items[0]["total_objects"] == 2
+
+
+@pytest.mark.asyncio
 async def test_empty_queue(authenticated_client: AsyncClient, async_session):
     resp = await authenticated_client.get("/sequences/classify-queue")
     assert resp.status_code == 200

--- a/annotation_api/src/tests/endpoints/test_classify_queue.py
+++ b/annotation_api/src/tests/endpoints/test_classify_queue.py
@@ -204,18 +204,26 @@ async def test_is_wildfire_alertapi_filter(
 async def test_is_wildfire_alertapi_filter_keeps_sibling_lane_counts(
     authenticated_client: AsyncClient, async_session
 ):
-    # Two lanes of one alert, both carrying the platform's annotation (the
-    # importer copies it onto every object-split lane). The filter must not
-    # narrow the grouped row to the matching lanes only.
-    for alert_api_id in (824, 825):
-        lane = await _lane(
-            async_session,
-            alert_api_id=alert_api_id,
-            platform_alert_id=824,
-            stage=Stage.READY_TO_ANNOTATE,
-        )
-        lane.is_wildfire_alertapi = "other_smoke"
-        async_session.add(lane)
+    # One alert, two lanes, deliberately disagreeing on the platform
+    # annotation. Real data can't produce this — both the importer and
+    # add_object copy the value onto every lane — but it's the only shape that
+    # tells candidate-level filtering apart from lane-level filtering: the
+    # filter selects the *alert*, so the row must still roll up both lanes.
+    # Filtering lanes directly would report total_objects == 1.
+    matching = await _lane(
+        async_session,
+        alert_api_id=824,
+        platform_alert_id=824,
+        stage=Stage.READY_TO_ANNOTATE,
+    )
+    matching.is_wildfire_alertapi = "other_smoke"
+    async_session.add(matching)
+    await _lane(
+        async_session,
+        alert_api_id=825,
+        platform_alert_id=824,
+        stage=Stage.READY_TO_ANNOTATE,
+    )
     await async_session.commit()
 
     resp = await authenticated_client.get(

--- a/annotation_api/src/tests/endpoints/test_localize_done_queue.py
+++ b/annotation_api/src/tests/endpoints/test_localize_done_queue.py
@@ -333,6 +333,46 @@ async def test_filters(authenticated_client: AsyncClient, async_session):
 
 
 @pytest.mark.asyncio
+async def test_is_wildfire_alertapi_filter(
+    authenticated_client: AsyncClient, async_session
+):
+    wildfire = await _lane(
+        async_session,
+        alert_api_id=912,
+        platform_alert_id=912,
+        stage=Stage.ANNOTATED,
+        has_smoke=True,
+    )
+    wildfire.is_wildfire_alertapi = "wildfire_smoke"
+    async_session.add(wildfire)
+    await async_session.commit()
+    await _lane(
+        async_session,
+        alert_api_id=913,
+        platform_alert_id=913,
+        stage=Stage.ANNOTATED,
+        has_smoke=True,
+    )
+
+    resp = await authenticated_client.get(
+        "/sequences/localize-done-queue",
+        params={"is_wildfire_alertapi": "wildfire_smoke"},
+    )
+    assert [it["platform_alert_id"] for it in resp.json()["items"]] == [912]
+
+    null_resp = await authenticated_client.get(
+        "/sequences/localize-done-queue", params={"is_wildfire_alertapi": "null"}
+    )
+    assert [it["platform_alert_id"] for it in null_resp.json()["items"]] == [913]
+
+    junk_resp = await authenticated_client.get(
+        "/sequences/localize-done-queue", params={"is_wildfire_alertapi": "bogus"}
+    )
+    assert junk_resp.status_code == 200
+    assert junk_resp.json()["total"] == 2
+
+
+@pytest.mark.asyncio
 async def test_recorded_at_filters(authenticated_client: AsyncClient, async_session):
     await _lane(
         async_session,

--- a/frontend/src/pages/DetectionReviewPage.tsx
+++ b/frontend/src/pages/DetectionReviewPage.tsx
@@ -101,6 +101,7 @@ export default function DetectionReviewPage() {
         source_api: filters.source_api,
         recorded_at_gte: filters.recorded_at_gte,
         recorded_at_lte: filters.recorded_at_lte,
+        is_wildfire_alertapi: filters.is_wildfire_alertapi,
         annotator_id: filters.annotator_id,
       }),
   });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -41,6 +41,20 @@ import {
 } from '@/types/api';
 import { API_ENDPOINTS } from '@/utils/constants';
 
+/**
+ * The "Unclassified" choice of the alert-platform annotation filter is JS
+ * `null`, but the params serializer drops nulls, so it would never reach the
+ * server. Encode it as the literal "null" string the API expects for that
+ * case. Applied by every endpoint that accepts the filter.
+ */
+function encodePlatformAnnotationFilter<
+  T extends { is_wildfire_alertapi?: AnnotationType | 'null' | null },
+>(params: T): T {
+  return params.is_wildfire_alertapi === null
+    ? { ...params, is_wildfire_alertapi: 'null' as const }
+    : params;
+}
+
 class ApiClient {
   private client: AxiosInstance;
 
@@ -258,12 +272,13 @@ class ApiClient {
       source_api?: string;
       recorded_at_gte?: string;
       recorded_at_lte?: string;
+      is_wildfire_alertapi?: AnnotationType | 'null' | null;
       skipped?: boolean;
     } = {}
   ): Promise<PaginatedResponse<ClassifyQueueItem>> {
     const response: AxiosResponse<PaginatedResponse<ClassifyQueueItem>> = await this.client.get(
       `${API_ENDPOINTS.SEQUENCES}classify-queue`,
-      { params }
+      { params: encodePlatformAnnotationFilter(params) }
     );
     return response.data;
   }
@@ -278,12 +293,13 @@ class ApiClient {
       source_api?: string;
       recorded_at_gte?: string;
       recorded_at_lte?: string;
+      is_wildfire_alertapi?: AnnotationType | 'null' | null;
       annotator_id?: number;
     } = {}
   ): Promise<PaginatedResponse<LocalizeDoneQueueItem>> {
     const response: AxiosResponse<PaginatedResponse<LocalizeDoneQueueItem>> = await this.client.get(
       `${API_ENDPOINTS.SEQUENCES}localize-done-queue`,
-      { params }
+      { params: encodePlatformAnnotationFilter(params) }
     );
     return response.data;
   }
@@ -308,7 +324,7 @@ class ApiClient {
   ): Promise<PaginatedResponse<ClassifyDoneItem>> {
     const response: AxiosResponse<PaginatedResponse<ClassifyDoneItem>> = await this.client.get(
       `${API_ENDPOINTS.SEQUENCES}classify-done`,
-      { params }
+      { params: encodePlatformAnnotationFilter(params) }
     );
     return response.data;
   }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -49,7 +49,7 @@ import { API_ENDPOINTS } from '@/utils/constants';
  */
 function encodePlatformAnnotationFilter<
   T extends { is_wildfire_alertapi?: AnnotationType | 'null' | null },
->(params: T): T {
+>(params: T): T | (Omit<T, 'is_wildfire_alertapi'> & { is_wildfire_alertapi: 'null' }) {
   return params.is_wildfire_alertapi === null
     ? { ...params, is_wildfire_alertapi: 'null' as const }
     : params;
@@ -119,7 +119,7 @@ class ApiClient {
     const response: AxiosResponse<PaginatedResponse<Sequence>> = await this.client.get(
       API_ENDPOINTS.SEQUENCES,
       {
-        params: filters,
+        params: encodePlatformAnnotationFilter(filters),
       }
     );
     return response.data;
@@ -174,7 +174,7 @@ class ApiClient {
     filters: ExtendedSequenceFilters = {}
   ): Promise<PaginatedResponse<SequenceWithAnnotation>> {
     const enhancedFilters = {
-      ...filters,
+      ...encodePlatformAnnotationFilter(filters),
       include_annotation: true, // Always include annotation data
     };
 

--- a/frontend/src/utils/filterHelpers.ts
+++ b/frontend/src/utils/filterHelpers.ts
@@ -41,6 +41,16 @@ export function hasActiveUserFilters(
     return true;
   }
 
+  if (filters.source_api) {
+    return true;
+  }
+
+  // The alert-platform annotation filter is set whenever the key is present:
+  // its "Unclassified" choice is null, which is a selection, not an absence.
+  if (filters.is_wildfire_alertapi !== undefined) {
+    return true;
+  }
+
   // Check review-specific filters (only relevant on review pages)
   if (showModelAccuracy && selectedModelAccuracy !== 'all') {
     return true;

--- a/frontend/tests/pages/DetectionReviewPage.test.tsx
+++ b/frontend/tests/pages/DetectionReviewPage.test.tsx
@@ -156,6 +156,24 @@ describe('DetectionReviewPage (/localize/done)', () => {
     );
   });
 
+  it('wires the Alert API annotation filter through to the endpoint', async () => {
+    mockedFilters = { is_wildfire_alertapi: 'other_smoke' };
+    render(<DetectionReviewPage />, { wrapper });
+    await waitFor(() => expect(apiClient.getLocalizeDoneQueue).toHaveBeenCalled());
+    expect(apiClient.getLocalizeDoneQueue).toHaveBeenCalledWith(
+      expect.objectContaining({ is_wildfire_alertapi: 'other_smoke' })
+    );
+  });
+
+  it('wires the Unclassified choice of the Alert API annotation filter through', async () => {
+    mockedFilters = { is_wildfire_alertapi: null };
+    render(<DetectionReviewPage />, { wrapper });
+    await waitFor(() => expect(apiClient.getLocalizeDoneQueue).toHaveBeenCalled());
+    expect(apiClient.getLocalizeDoneQueue).toHaveBeenCalledWith(
+      expect.objectContaining({ is_wildfire_alertapi: null })
+    );
+  });
+
   it('does not show the model-accuracy or annotation-type filter controls', async () => {
     render(<DetectionReviewPage />, { wrapper });
     await waitFor(() => expect(screen.getByText('CAM_01')).toBeTruthy());

--- a/frontend/tests/pages/SequencesPage.platformAnnotationFilter.test.tsx
+++ b/frontend/tests/pages/SequencesPage.platformAnnotationFilter.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+
+vi.mock('@/services/api', () => ({
+  apiClient: {
+    getClassifyDone: vi.fn(),
+    getClassifyQueue: vi.fn(),
+  },
+}));
+
+vi.mock('@/hooks/useCameras', () => ({
+  useCameras: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('@/hooks/useOrganizations', () => ({
+  useOrganizations: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('@/hooks/useSourceApis', () => ({
+  useSourceApis: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('@/hooks/useAnnotators', () => ({
+  useAnnotators: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock('@/store/useAuthStore', () => ({
+  useAuthStore: () => ({ canLocalize: () => true }),
+}));
+
+let mockedFilters: Record<string, unknown> = {};
+
+vi.mock('@/hooks/usePersistedFilters', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/hooks/usePersistedFilters')>();
+  return {
+    ...actual,
+    usePersistedFilters: (
+      _key: string,
+      defaultState: Parameters<typeof actual.usePersistedFilters>[1]
+    ): ReturnType<typeof actual.usePersistedFilters> => ({
+      filters: { ...defaultState.filters, ...mockedFilters },
+      dateFrom: '',
+      dateTo: '',
+      selectedFalsePositiveTypes: [],
+      selectedSmokeTypes: [],
+      selectedModelAccuracy: 'all',
+      selectedUnsure: 'all',
+      setFilters: vi.fn(),
+      setDateFrom: vi.fn(),
+      setDateTo: vi.fn(),
+      setSelectedFalsePositiveTypes: vi.fn(),
+      setSelectedSmokeTypes: vi.fn(),
+      setSelectedModelAccuracy: vi.fn(),
+      setSelectedUnsure: vi.fn(),
+      resetFilters: vi.fn(),
+    }),
+  };
+});
+
+import { apiClient } from '@/services/api';
+import SequencesPage from '@/pages/SequencesPage';
+import { ALL_CLASSIFIED_STAGES } from '@/utils/processingStage';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const emptyPage = { items: [], page: 1, pages: 0, size: 50, total: 0 };
+
+describe('SequencesPage passes the Alert API annotation filter to the endpoint', () => {
+  beforeEach(() => {
+    mockedFilters = {};
+    vi.mocked(apiClient.getClassifyQueue).mockResolvedValue(emptyPage);
+    vi.mocked(apiClient.getClassifyDone).mockResolvedValue(emptyPage);
+  });
+
+  it('sends it from the /classify queue', async () => {
+    mockedFilters = { is_wildfire_alertapi: 'wildfire_smoke' };
+    render(<SequencesPage />, { wrapper });
+    await waitFor(() => expect(apiClient.getClassifyQueue).toHaveBeenCalled());
+    expect(apiClient.getClassifyQueue).toHaveBeenCalledWith(
+      expect.objectContaining({ is_wildfire_alertapi: 'wildfire_smoke' })
+    );
+  });
+
+  it('sends the Unclassified choice from the /classify queue', async () => {
+    mockedFilters = { is_wildfire_alertapi: null };
+    render(<SequencesPage />, { wrapper });
+    await waitFor(() => expect(apiClient.getClassifyQueue).toHaveBeenCalled());
+    expect(apiClient.getClassifyQueue).toHaveBeenCalledWith(
+      expect.objectContaining({ is_wildfire_alertapi: null })
+    );
+  });
+
+  it('sends it from /classify/done', async () => {
+    mockedFilters = { is_wildfire_alertapi: 'other' };
+    render(<SequencesPage defaultProcessingStage={ALL_CLASSIFIED_STAGES} isReviewPage />, {
+      wrapper,
+    });
+    await waitFor(() => expect(apiClient.getClassifyDone).toHaveBeenCalled());
+    expect(apiClient.getClassifyDone).toHaveBeenCalledWith(
+      expect.objectContaining({ is_wildfire_alertapi: 'other' })
+    );
+  });
+});

--- a/frontend/tests/pages/SequencesPage.platformAnnotationFilter.test.tsx
+++ b/frontend/tests/pages/SequencesPage.platformAnnotationFilter.test.tsx
@@ -72,6 +72,11 @@ function wrapper({ children }: { children: React.ReactNode }) {
 
 const emptyPage = { items: [], page: 1, pages: 0, size: 50, total: 0 };
 
+// These are regression guards, not reproductions: SequencesPage already spread
+// the filter into both calls, and the mock bypasses serialization, so they would
+// have passed while the filter was broken. They exist because the sibling page
+// (DetectionReviewPage) enumerated its params and silently dropped this one —
+// the same mistake is easy to make here.
 describe('SequencesPage passes the Alert API annotation filter to the endpoint', () => {
   beforeEach(() => {
     mockedFilters = {};

--- a/frontend/tests/services/api.platformAnnotationFilter.test.ts
+++ b/frontend/tests/services/api.platformAnnotationFilter.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
+import { apiClient } from '@/services/api';
+
+// The alert-platform annotation filter is the one filter whose "no value from
+// the platform" choice is a real value (Unclassified). It has to survive
+// query-string encoding, where the client's paramsSerializer drops nulls — so
+// these tests assert on the serialized URL, not on the params object.
+
+// The axios instance is private to ApiClient; reach it to swap in a capturing
+// adapter, which is the only way to see the post-serialization URL.
+const axiosInstance = (apiClient as unknown as { client: AxiosInstance }).client;
+
+let requestedUrls: string[] = [];
+
+beforeEach(() => {
+  requestedUrls = [];
+  axiosInstance.defaults.adapter = async (config: InternalAxiosRequestConfig) => {
+    requestedUrls.push(axiosInstance.getUri(config));
+    return {
+      data: { items: [], page: 1, pages: 0, size: 50, total: 0 },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+    };
+  };
+});
+
+const lastUrl = () => requestedUrls[requestedUrls.length - 1];
+
+describe('is_wildfire_alertapi on the wire', () => {
+  it('sends the Unclassified choice as the literal "null" the API expects', async () => {
+    await apiClient.getClassifyDone({ is_wildfire_alertapi: null });
+    expect(lastUrl()).toContain('is_wildfire_alertapi=null');
+  });
+
+  it('sends a concrete platform annotation unchanged', async () => {
+    await apiClient.getClassifyDone({ is_wildfire_alertapi: 'wildfire_smoke' });
+    expect(lastUrl()).toContain('is_wildfire_alertapi=wildfire_smoke');
+  });
+
+  it('omits the param entirely when the filter is unset', async () => {
+    await apiClient.getClassifyDone({ camera_name: 'CAM_01' });
+    expect(lastUrl()).not.toContain('is_wildfire_alertapi');
+  });
+
+  it('sends the filter on the classify queue', async () => {
+    await apiClient.getClassifyQueue({ is_wildfire_alertapi: 'other' });
+    expect(lastUrl()).toContain('is_wildfire_alertapi=other');
+    await apiClient.getClassifyQueue({ is_wildfire_alertapi: null });
+    expect(lastUrl()).toContain('is_wildfire_alertapi=null');
+  });
+
+  it('sends the filter on the localize-done queue', async () => {
+    await apiClient.getLocalizeDoneQueue({ is_wildfire_alertapi: 'other_smoke' });
+    expect(lastUrl()).toContain('is_wildfire_alertapi=other_smoke');
+    await apiClient.getLocalizeDoneQueue({ is_wildfire_alertapi: null });
+    expect(lastUrl()).toContain('is_wildfire_alertapi=null');
+  });
+});

--- a/frontend/tests/services/api.platformAnnotationFilter.test.ts
+++ b/frontend/tests/services/api.platformAnnotationFilter.test.ts
@@ -59,6 +59,22 @@ describe('is_wildfire_alertapi on the wire', () => {
     expect(lastUrl()).toContain('is_wildfire_alertapi=null');
   });
 
+  // GET /sequences honors the same "null" contract, and SequenceFilters lets
+  // callers pass null — so the encoding has to reach these two as well, even
+  // though no current caller sets the filter here.
+  it('sends the filter on the plain sequences list', async () => {
+    await apiClient.getSequences({ is_wildfire_alertapi: null });
+    expect(lastUrl()).toContain('is_wildfire_alertapi=null');
+    await apiClient.getSequences({ is_wildfire_alertapi: 'other' });
+    expect(lastUrl()).toContain('is_wildfire_alertapi=other');
+  });
+
+  it('sends the filter on the sequences-with-annotations list', async () => {
+    await apiClient.getSequencesWithAnnotations({ is_wildfire_alertapi: null });
+    expect(lastUrl()).toContain('is_wildfire_alertapi=null');
+    expect(lastUrl()).toContain('include_annotation=true');
+  });
+
   it('sends the filter on the localize-done queue', async () => {
     await apiClient.getLocalizeDoneQueue({ is_wildfire_alertapi: 'other_smoke' });
     expect(lastUrl()).toContain('is_wildfire_alertapi=other_smoke');

--- a/frontend/tests/services/api.platformAnnotationFilter.test.ts
+++ b/frontend/tests/services/api.platformAnnotationFilter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 import { apiClient } from '@/services/api';
 
@@ -12,6 +12,13 @@ import { apiClient } from '@/services/api';
 const axiosInstance = (apiClient as unknown as { client: AxiosInstance }).client;
 
 let requestedUrls: string[] = [];
+const realAdapter = axiosInstance.defaults.adapter;
+
+// apiClient is a module singleton; put the real adapter back so swapping it
+// can't leak into another test file if module isolation is ever turned off.
+afterEach(() => {
+  axiosInstance.defaults.adapter = realAdapter;
+});
 
 beforeEach(() => {
   requestedUrls = [];

--- a/frontend/tests/utils/filterHelpers.test.ts
+++ b/frontend/tests/utils/filterHelpers.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { hasActiveUserFilters } from '@/utils/filterHelpers';
+import { ExtendedSequenceFilters } from '@/types/api';
+
+// Only the filters argument varies here; everything else stays at its
+// "nothing selected" value so a true result can only come from `filters`.
+const check = (filters: ExtendedSequenceFilters) =>
+  hasActiveUserFilters(filters, '', '', [], [], 'all', 'all');
+
+describe('hasActiveUserFilters', () => {
+  it('is false with no filters applied', () => {
+    expect(check({})).toBe(false);
+  });
+
+  it('counts the filters shown on every page', () => {
+    expect(check({ camera_name: 'CAM_01' })).toBe(true);
+    expect(check({ organisation_name: 'Pyronear' })).toBe(true);
+    expect(check({ source_api: 'pyronear_french' })).toBe(true);
+    expect(check({ recorded_at_gte: '2026-01-01T00:00:00' })).toBe(true);
+  });
+
+  it('counts the Alert API annotation filter, including Unclassified', () => {
+    expect(check({ is_wildfire_alertapi: 'wildfire_smoke' })).toBe(true);
+    // null is the Unclassified choice — a selection, not an absent filter.
+    expect(check({ is_wildfire_alertapi: null })).toBe(true);
+  });
+});


### PR DESCRIPTION
## The bug

`FilterPopover` renders the **Alert API annotation** select (`is_wildfire_alertapi`) unconditionally — unlike every other optional filter, which is gated behind a `show*` prop. Three pages render it, and only one endpoint accepted it:

| Page | Endpoint | Before |
|---|---|---|
| `/classify` | `GET /sequences/classify-queue` | **Dead.** The value was spread into the request, but `classify_queue` declared no such param, so FastAPI dropped it. The pill rendered; the rows never changed. |
| `/localize/done` | `GET /sequences/localize-done-queue` | **Dead.** `DetectionReviewPage` enumerates its params explicitly and never passed it; the endpoint wouldn't have accepted it either. |
| `/classify/done` | `GET /sequences/classify-done` | Worked for the three concrete values. **"Unclassified" was broken:** the popover sets JS `null`, the axios `paramsSerializer` uses `skipNulls: true`, so the param never left the browser — while the backend expects the literal string `"null"`. It returned *all* classified alerts. |

Two independent defects: a filter shown on pages whose endpoints don't support it, and a `null` → `"null"` wire encoding lost by the serializer.

## The fix

Make it work on all three pages, rather than hiding the control where it wasn't supported.

**Backend** (`annotation_api/.../endpoints/sequences.py`)
- `is_wildfire_alertapi` added to `classify_queue` and `localize_done_queue`, applied to the **candidate pre-filter** (matching what `classify_done` already did) so a grouped alert row keeps all of its sibling lanes instead of being narrowed to the matching ones.
- The `"null"` / invalid-value contract was inline in two endpoints and this would have made four. It is now one function, `platform_annotation_clause`, used by all four sites including `list_sequences`.

The any-lane semantics are safe because the importer copies the platform record's `sequence_is_wildfire` onto every object-split lane, so all siblings of an alert share the value — no disagreement with the value the row displays (taken from the lowest-`alert_api_id` lane).

**Frontend**
- `encodePlatformAnnotationFilter` in `api.ts` maps `null` → `"null"`, applied by classify-queue, classify-done and localize-done-queue.
- `DetectionReviewPage` passes the filter through.
- `hasActiveUserFilters` now counts `source_api` and `is_wildfire_alertapi`, so an empty result caused only by those shows "No matching alerts" instead of "queue is clear" / "nothing classified yet".

## Verification

- Backend: **686 passed**. The new tests were red first for the right reason (`assert [822, 823] == [822]` — filter ignored).
- Frontend: **1287 passed**; `npm run quality` clean.
- `tests/services/api.platformAnnotationFilter.test.ts` asserts on the **serialized URL** via a capturing axios adapter — that is the test that actually reproduces the "Unclassified" bug. The page-level tests are regression guards, not reproductions.
- mypy on `sequences.py`: 117 errors on `main`, 115 after. No new errors (that file is pre-existing red).
- Checked against the real local dataset through this branch's API. The four choices partition the row set exactly:
  - classify-queue: 479 unfiltered = 14 wildfire_smoke + 15 other_smoke + 38 other + 412 unclassified
  - classify-done: 25 unfiltered = 0 + 0 + 6 other + 19 unclassified

  Before the fix, every choice on `/classify` returned all 479.

`/localize/done` has zero qualifying alerts in that dataset, so its filter is covered by the backend test and an endpoint-level check only, not by eyeballing.

## Deliberately out of scope

- `frontend/src/utils/filter-state.ts` has zero importers — dead code with its own `wildfire` URL serialization. Left alone.
- `SequencesPage` still spreads `processing_stage` into the classify-queue call, which that endpoint ignores harmlessly.
- `/localize` (`DetectionAnnotatePage`) has no filter UI at all.
