### PR TITLE
fix(groups): drop hover underline on the camera cell

### DIFF
--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -357,7 +357,7 @@ export default function SequenceGroupsListPage({
                       <Link
                         to={classifyGroup(g.id)}
                         onClick={e => e.stopPropagation()}
-                        className={`${PRIMARY_CELL_TEXT} hover:underline`}
+                        className={PRIMARY_CELL_TEXT}
                       >
                         {g.camera_name}
                       </Link>


### PR DESCRIPTION
## What

Removes the `hover:underline` from the camera cell on `/classify/groups`.

```diff
-className={`${PRIMARY_CELL_TEXT} hover:underline`}
+className={PRIMARY_CELL_TEXT}
```

## Why

That cell was the only camera column in the app wrapped in a `<Link>` with a hover underline. The four other queue tables — `ClassifyAlertQueueTable`, `ClassifyDoneTable`, `LocalizeQueueTable`, `LocalizeDoneQueueTable` — all render the camera as plain `PRIMARY_CELL_TEXT`, so this also brings the groups list in line with them.

## Notes

The `<Link>` itself stays. The row's `onClick` deliberately bails on modified clicks and defers to that anchor for open-in-new-tab (see the comment above the handler), so dropping it would cost ctrl/cmd-click. The row also keeps its hover background from `ROW_CLASSES`, so the cell doesn't read as inert.

## Verification

- `npm run type-check`, `npm run lint`, `npm run format:check` — all clean
- `npx vitest run` — 1274 tests passed (98 files)