### PR TITLE
fix(classify): keep the annotated-only filter controls on the empty done page

### DIFF
--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -358,10 +358,10 @@ export default function SequencesPage({
               organizationsLoading={organizationsLoading}
               sourceApisLoading={sourceApisLoading}
               annotatorsLoading={annotatorsLoading}
-              showModelAccuracy={defaultProcessingStage === 'annotated'}
-              showFalsePositiveTypes={defaultProcessingStage === 'annotated'}
-              showSmokeTypes={defaultProcessingStage === 'annotated'}
-              showUnsureFilter={defaultProcessingStage === 'annotated'}
+              showModelAccuracy={isAnnotatedView}
+              showFalsePositiveTypes={isAnnotatedView}
+              showSmokeTypes={isAnnotatedView}
+              showUnsureFilter={isAnnotatedView}
               showAnnotatorFilter={isReviewPage}
             />
           </div>

--- a/frontend/tests/pages/DetectionReviewPage.test.tsx
+++ b/frontend/tests/pages/DetectionReviewPage.test.tsx
@@ -179,9 +179,13 @@ describe('DetectionReviewPage (/localize/done)', () => {
     await waitFor(() => expect(screen.getByText('CAM_01')).toBeTruthy());
     fireEvent.click(screen.getByRole('button', { name: /Filters/ }));
     fireEvent.click(screen.getByText(/More filters/));
-    expect(screen.queryByText('Model Accuracy')).toBeNull();
+    // The control is labelled "Result", not "Model Accuracy" — asserting on
+    // the latter could never fail. "Result" also names a table column here, so
+    // match the radiogroup rather than the text.
+    expect(screen.queryByRole('radiogroup', { name: 'Result' })).toBeNull();
     expect(screen.queryByText('False Positive Types')).toBeNull();
     expect(screen.queryByText('Smoke Types')).toBeNull();
+    expect(screen.queryByText('Certainty')).toBeNull();
   });
 
   it('shows an all-caught-up empty state when the queue is empty', async () => {

--- a/frontend/tests/pages/SequencesPage.empty.test.tsx
+++ b/frontend/tests/pages/SequencesPage.empty.test.tsx
@@ -132,6 +132,24 @@ describe('SequencesPage empty states', () => {
     expect(screen.getByRole('button', { name: 'Clear filters' })).toBeTruthy();
   });
 
+  it('empty done page keeps the annotated-only filter controls available', async () => {
+    // Regression: the empty state gated these on `defaultProcessingStage ===
+    // 'annotated'`, but /classify/done arrives with ALL_CLASSIFIED_STAGES (an
+    // array), so the condition was never true and the controls vanished
+    // exactly when a user needed them to widen a search that returned nothing.
+    render(<SequencesPage defaultProcessingStage={ALL_CLASSIFIED_STAGES} isReviewPage />, {
+      wrapper,
+    });
+    await waitFor(() => expect(screen.getByText('No classified alerts yet')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: /Filters/ }));
+    fireEvent.click(screen.getByText(/More filters/));
+    // "Result" also names a table column, so match the radiogroup, not text.
+    expect(screen.getByRole('radiogroup', { name: 'Result' })).toBeTruthy();
+    expect(screen.getByText('Certainty')).toBeTruthy();
+    expect(screen.getByText('False Positive Types')).toBeTruthy();
+    expect(screen.getByText('Smoke Types')).toBeTruthy();
+  });
+
   it('review page on a specific stage scopes the headline to that stage', async () => {
     render(<SequencesPage defaultProcessingStage="seq_annotation_done" isReviewPage />, {
       wrapper,


### PR DESCRIPTION
## The bug

On `/classify/done`, filter down to zero results and the **Result**, **Certainty**, **False Positive Types** and **Smoke Types** controls disappear from the filter popover — the very controls you'd need to widen a search that returned nothing. All that's left is a blunt "Clear filters".

The empty state gated those four on `defaultProcessingStage === 'annotated'`:

```tsx
showModelAccuracy={defaultProcessingStage === 'annotated'}
```

But `/classify/done` reaches `SequencesPage` through `SequencesPageWrapper`, which passes `ALL_CLASSIFIED_STAGES` — an **array** — so the comparison is never true. It's the only caller, which makes that condition dead code: the four props were permanently `false` in the empty branch.

The non-empty branch of the same page already used `isAnnotatedView` and showed the controls, so the page contradicted itself depending on whether rows came back.

## The fix

Use `isAnnotatedView` in both branches. `defaultProcessingStage` is a `ProcessingStageFilter` — a string **or** an array — so it has to be compared with `stageFilterIncludes`, which is exactly what `isAnnotatedView` already does.

Only `/classify/done`'s empty state changes behaviour. `/classify` evaluated both expressions to `false` before and still does.

## A test that could never fail

While pinning the fix I found `DetectionReviewPage.test.tsx` asserting:

```ts
expect(screen.queryByText('Model Accuracy')).toBeNull();
```

The control is labelled **`Result`**, so that text never appears whether or not the control renders — the assertion gave false confidence that `/localize/done` hides it. It now matches the radiogroup by accessible name (plain text would hit the identically named *table column* on that page), and also covers `Certainty`, which wasn't asserted at all. Verified by mutation: passing `showModelAccuracy` to that page now reddens the test, where before it stayed green.

## Verification

- New regression test fails before the fix (`Unable to find an accessible element with the role "radiogroup" and name "Result"`) and passes after.
- Full frontend suite: **1290 passed**; `npm run quality` clean.
- No backend change.
