### PR TITLE
feat(localize): send a localized alert back to the queue

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -40,6 +40,9 @@ from app.schemas.sequence_annotations import (
     ClassifySubmitRequest,
     ClassifySubmitResponse,
     ClassifySubmitResult,
+    LocalizeRevertRequest,
+    LocalizeRevertResponse,
+    LocalizeRevertResult,
     LocalizeSubmitRequest,
     LocalizeSubmitResponse,
     LocalizeSubmitResult,
@@ -1446,6 +1449,141 @@ async def localize_submit(
         )
 
     return LocalizeSubmitResponse(results=results)
+
+
+@router.post(
+    "/localize-revert",
+    status_code=status.HTTP_200_OK,
+    response_model=LocalizeRevertResponse,
+    summary="Send a localized alert back to the localize queue",
+)
+async def localize_revert(
+    payload: LocalizeRevertRequest = Body(...),
+    annotations: SequenceAnnotationCRUD = Depends(get_sequence_annotation_crud),
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> LocalizeRevertResponse:
+    """Atomically move every annotated smoke lane of one alert back to
+    seq_annotation_done (spec: 2026-08-07-localize-revert-to-queue). The alert
+    leaves /localize/done, re-enters /localize, and — because /export/alerts
+    admits an alert only when EVERY lane is annotated — drops out of the
+    export. Withdrawing bad data from the export is the point of the feature.
+
+    Deliberately does NOT route through `apply_annotation_update`: this exact
+    stage move on a lane needing localization is the FP->smoke promotion
+    predicate (`:742-753`), whose effects block 422s on any committed
+    detection annotation and otherwise DELETES every DetectionAnnotation of
+    the sequence. Here the boxes must survive — the annotator is fixing one
+    frame, not starting over. Writing through the CRUD also keeps three other
+    hooks from firing: auto_create_detection_annotations (only for lanes newly
+    reaching annotated), `_propagate_to_group_if_validated` (a revert is not a
+    new label and must not fan out to a validated group), and the contribution
+    insert (reverting is a correction, not authorship).
+    """
+    annotation_ids = payload.annotation_ids
+    rows = (
+        await session.execute(
+            select(SequenceAnnotation, Sequence)
+            .join(Sequence, Sequence.id == SequenceAnnotation.sequence_id)
+            .where(SequenceAnnotation.id.in_(annotation_ids))
+        )
+    ).all()
+    by_id = {ann.id: (ann, seq) for ann, seq in rows}
+
+    missing_ids = [aid for aid in annotation_ids if aid not in by_id]
+    if missing_ids:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Sequence annotation(s) {missing_ids} not found",
+        )
+
+    alert_keys = {(seq.source_api, seq.platform_alert_id) for _, seq in by_id.values()}
+    if len(alert_keys) > 1:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="All annotations must belong to sequences of the same alert",
+        )
+
+    wrong_stage_ids = [
+        aid
+        for aid, (ann, _seq) in by_id.items()
+        if ann.processing_stage != SequenceAnnotationProcessingStage.ANNOTATED
+    ]
+    if wrong_stage_ids:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Annotation(s) {sorted(wrong_stage_ids)} are not at annotated; "
+                "refresh the list and retry"
+            ),
+        )
+
+    # FP-only and deferred-unsure lanes exited the pipeline at classify and
+    # never carried localization work; demoting one would park it in a stage
+    # it never occupied.
+    not_localized_ids = [
+        aid
+        for aid, (ann, _seq) in by_id.items()
+        if not needs_localization(ann.has_smoke, ann.has_missed_smoke, ann.is_unsure)
+    ]
+    if not_localized_ids:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Annotation(s) {sorted(not_localized_ids)} does not need "
+                "localization; only localized smoke lanes can be sent back"
+            ),
+        )
+
+    # Sequences whose reference layer never landed: after the revert they
+    # would fail the queue's `_ready_smoke_lane` check (which requires
+    # auto_annotated_at) and sit in NEITHER queue. Read before the commit,
+    # deferred after it.
+    unreferenced_sequence_ids = [
+        seq.id for _, seq in by_id.values() if seq.auto_annotated_at is None
+    ]
+
+    updated: List[SequenceAnnotation] = []
+    try:
+        for annotation_id in annotation_ids:
+            updated_annotation = await annotations.update(
+                annotation_id,
+                SequenceAnnotationUpdate(
+                    processing_stage=(
+                        SequenceAnnotationProcessingStage.SEQ_ANNOTATION_DONE
+                    )
+                ),
+                current_user.id,
+                commit=False,
+            )
+            if updated_annotation is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Sequence annotation with id {annotation_id} not found",
+                )
+            updated.append(updated_annotation)
+    except HTTPException:
+        await session.rollback()
+        raise
+
+    # The one atomic point: every lane's write lands together.
+    await session.commit()
+
+    # Post-commit so a lost defer can't strand the transaction; the periodic
+    # schedule_auto_annotate sweep re-enqueues stale lanes anyway.
+    for sequence_id in unreferenced_sequence_ids:
+        await auto_annotate_sequence.defer_async(sequence_id=sequence_id)
+
+    return LocalizeRevertResponse(
+        results=[
+            LocalizeRevertResult(
+                annotation_id=ann.id,
+                sequence_id=ann.sequence_id,
+                processing_stage=ann.processing_stage,
+            )
+            for ann in updated
+        ]
+    )
 
 
 @router.post(

--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py
@@ -59,6 +59,7 @@ from app.services.annotation_generation import (
     derive_group_label_from_annotation,
 )
 from app.services.alert_skip import alert_skip_exists_clause
+from app.services.auto_annotate_scheduling import DONE_STAGES
 from app.services.localization_rule import (
     needs_localization,
     unsettled_unsure_clause,
@@ -1535,6 +1536,43 @@ async def localize_revert(
             ),
         )
 
+    # The two lists disagree about alerts, and the gap can strand one. The
+    # done list admits an alert as soon as ONE lane is annotated and needs
+    # localization; the localize queue demands EVERY sibling sit at a done
+    # stage with none left undecided. So an alert can be listed as done while
+    # a sibling is still unfinished or unsure — and reverting it there would
+    # drop it from the done list without letting it into the queue, leaving
+    # the work unreachable from both. Mirror the queue's admission rule and
+    # refuse instead. (Such an alert is not in the export either — that needs
+    # every lane annotated — so nothing is being withheld by refusing.)
+    alert_source_api, alert_platform_id = next(iter(alert_keys))
+    blocking_siblings = (
+        await session.execute(
+            select(func.count(Sequence.id))
+            .outerjoin(
+                SequenceAnnotation, SequenceAnnotation.sequence_id == Sequence.id
+            )
+            .where(
+                Sequence.source_api == alert_source_api,
+                Sequence.platform_alert_id == alert_platform_id,
+                or_(
+                    SequenceAnnotation.id.is_(None),
+                    SequenceAnnotation.processing_stage.notin_(DONE_STAGES),
+                    unsettled_unsure_clause(SequenceAnnotation),
+                ),
+            )
+        )
+    ).scalar_one()
+    if blocking_siblings > 0:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Cannot send back: {blocking_siblings} object(s) of this alert "
+                "are still unfinished or undecided, so the alert would not "
+                "re-enter the localize queue. Settle them in Classify first."
+            ),
+        )
+
     # Sequences whose reference layer never landed: after the revert they
     # would fail the queue's `_ready_smoke_lane` check (which requires
     # auto_annotated_at) and sit in NEITHER queue. Read before the commit,
@@ -1569,10 +1607,20 @@ async def localize_revert(
     # The one atomic point: every lane's write lands together.
     await session.commit()
 
-    # Post-commit so a lost defer can't strand the transaction; the periodic
-    # schedule_auto_annotate sweep re-enqueues stale lanes anyway.
+    # Post-commit so a lost defer can't strand the transaction. Failures are
+    # swallowed on purpose: the revert has already landed, and raising here
+    # would report failure for work that succeeded — the caller would retry
+    # and get a 409 "not at annotated", which reads as a contradiction. The
+    # periodic schedule_auto_annotate sweep re-enqueues stale lanes anyway,
+    # so a lost defer costs latency, not correctness.
     for sequence_id in unreferenced_sequence_ids:
-        await auto_annotate_sequence.defer_async(sequence_id=sequence_id)
+        try:
+            await auto_annotate_sequence.defer_async(sequence_id=sequence_id)
+        except Exception:
+            logger.exception(
+                "localize-revert: failed to re-arm auto-annotate for sequence "
+                f"{sequence_id}; the periodic sweep will pick it up"
+            )
 
     return LocalizeRevertResponse(
         results=[

--- a/annotation_api/src/app/schemas/sequence_annotations.py
+++ b/annotation_api/src/app/schemas/sequence_annotations.py
@@ -31,6 +31,9 @@ __all__ = [
     "LocalizeSubmitRequest",
     "LocalizeSubmitResult",
     "LocalizeSubmitResponse",
+    "LocalizeRevertRequest",
+    "LocalizeRevertResult",
+    "LocalizeRevertResponse",
 ]
 
 
@@ -113,6 +116,24 @@ class LocalizeSubmitResult(BaseModel):
 
 class LocalizeSubmitResponse(BaseModel):
     results: List[LocalizeSubmitResult]
+
+
+class LocalizeRevertRequest(BaseModel):
+    """Send a localized alert back to the localize queue (spec:
+    2026-08-07-localize-revert-to-queue): every annotated lane of one alert
+    that needs localization returns to seq_annotation_done together."""
+
+    annotation_ids: List[int] = Field(..., min_length=1)
+
+
+class LocalizeRevertResult(BaseModel):
+    annotation_id: int
+    sequence_id: int
+    processing_stage: SequenceAnnotationProcessingStage
+
+
+class LocalizeRevertResponse(BaseModel):
+    results: List[LocalizeRevertResult]
 
 
 class SequenceAnnotationCreate(BaseModel):

--- a/annotation_api/src/tests/endpoints/test_localize_revert.py
+++ b/annotation_api/src/tests/endpoints/test_localize_revert.py
@@ -1,0 +1,347 @@
+"""Send a localized alert back to the localize queue (spec:
+2026-08-07-localize-revert-to-queue-design): annotated smoke lanes of one
+alert return to seq_annotation_done, keeping every box they carry."""
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+
+from app import models
+from app.api.api_v1.endpoints import sequence_annotations as ep
+
+now = datetime.now(UTC)
+
+
+@pytest.fixture(autouse=True)
+def deferred_auto_annotate(monkeypatch):
+    """Stub the auto-annotate defer, and record what it was asked to enqueue.
+
+    The revert re-arms auto-annotation for any lane whose reference layer
+    never landed (`auto_annotated_at IS NULL`), which would otherwise leave it
+    in NEITHER queue. No worker runs in tests, so that column is always NULL
+    here and the defer fires on every successful revert — and procrastinate's
+    App is not open, so an unstubbed defer raises AppNotOpen.
+    """
+    calls: list[dict] = []
+
+    async def fake_defer(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(ep.auto_annotate_sequence, "defer_async", fake_defer)
+    return calls
+
+
+async def _create_sequence(
+    client: AsyncClient, *, alert_api_id: int, platform_alert_id: int
+) -> int:
+    payload = {
+        "source_api": "pyronear_french",
+        "alert_api_id": str(alert_api_id),
+        "platform_alert_id": str(platform_alert_id),
+        "camera_name": "Revert Cam",
+        "camera_id": "800",
+        "organisation_name": "Revert Org",
+        "organisation_id": "80",
+        "lat": "43.0",
+        "lon": "1.0",
+        "recorded_at": now.isoformat(),
+        "last_seen_at": now.isoformat(),
+    }
+    resp = await client.post("/sequences", data=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _create_detection(
+    client: AsyncClient, mock_img: bytes, *, sequence_id: int, alert_api_id: int
+) -> int:
+    payload = {
+        "sequence_id": str(sequence_id),
+        "alert_api_id": str(alert_api_id),
+        "recorded_at": now.isoformat(),
+        "algo_predictions": json.dumps({"predictions": []}),
+    }
+    resp = await client.post(
+        "/detections",
+        data=payload,
+        files={"file": ("image.jpg", mock_img, "image/jpeg")},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _annotate_lane(
+    client: AsyncClient,
+    *,
+    sequence_id: int,
+    detection_id: int,
+    is_smoke: bool = True,
+    is_unsure: bool = False,
+    stage: str = "seq_annotation_done",
+) -> int:
+    """Create the lane's sequence annotation, returns its id."""
+    payload = {
+        "sequence_id": sequence_id,
+        "has_missed_smoke": False,
+        "is_unsure": is_unsure,
+        "annotation": {
+            "sequences_bbox": [
+                {
+                    "is_smoke": is_smoke,
+                    "false_positive_types": [] if is_smoke else ["antenna"],
+                    "bboxes": [
+                        {"detection_id": detection_id, "xyxyn": [0.1, 0.1, 0.2, 0.2]}
+                    ],
+                }
+            ]
+        },
+        "processing_stage": stage,
+    }
+    resp = await client.post("/annotations/sequences/", json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _localize_frame(client: AsyncClient, *, detection_id: int) -> int:
+    """Commit a box on one frame, as the localize editor does.
+
+    Deliberately a CREATE, not a PATCH: the auto-create fan-out only fires for
+    lanes newly reaching ANNOTATED, so a lane parked at seq_annotation_done
+    (the state localization actually works from) has no detection annotation
+    rows yet. The endpoint takes form data, not JSON.
+    """
+    resp = await client.post(
+        "/annotations/detections/",
+        data={
+            "detection_id": str(detection_id),
+            "annotation": json.dumps(
+                {
+                    "annotation": [
+                        {
+                            "xyxyn": [0.4, 0.3, 0.5, 0.4],
+                            "class_name": "smoke",
+                            "smoke_type": "wildfire",
+                        }
+                    ]
+                }
+            ),
+            "processing_stage": "annotated",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _seed_submitted_alert(
+    client: AsyncClient, mock_img: bytes, *, platform_alert_id: int
+):
+    """Two smoke lanes of one alert, localized and submitted to `annotated`.
+
+    Returns (annotation_ids, sequence_ids, detection_ids).
+    """
+    ann_ids, seq_ids, det_ids = [], [], []
+    for offset in (1, 2):
+        seq = await _create_sequence(
+            client,
+            alert_api_id=platform_alert_id * 10 + offset,
+            platform_alert_id=platform_alert_id,
+        )
+        det = await _create_detection(
+            client, mock_img, sequence_id=seq, alert_api_id=offset
+        )
+        ann = await _annotate_lane(client, sequence_id=seq, detection_id=det)
+        await _localize_frame(client, detection_id=det)
+        ann_ids.append(ann)
+        seq_ids.append(seq)
+        det_ids.append(det)
+
+    resp = await client.post(
+        "/annotations/sequences/localize-submit", json={"annotation_ids": ann_ids}
+    )
+    assert resp.status_code == 200, resp.text
+    return ann_ids, seq_ids, det_ids
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_moves_lanes_back_to_seq_annotation_done(
+    authenticated_client: AsyncClient, mock_img: bytes
+):
+    ann_ids, _, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8801
+    )
+
+    resp = await authenticated_client.post(
+        "/annotations/sequences/localize-revert", json={"annotation_ids": ann_ids}
+    )
+    assert resp.status_code == 200, resp.text
+    results = resp.json()["results"]
+    assert {r["annotation_id"] for r in results} == set(ann_ids)
+    assert all(r["processing_stage"] == "seq_annotation_done" for r in results)
+
+    for ann_id in ann_ids:
+        got = await authenticated_client.get(f"/annotations/sequences/{ann_id}")
+        assert got.json()["processing_stage"] == "seq_annotation_done"
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_rearms_auto_annotate_for_unreferenced_lanes(
+    authenticated_client: AsyncClient, mock_img: bytes, deferred_auto_annotate
+):
+    """A lane reverted without an `auto_annotated_at` fails the queue's
+    `_ready_smoke_lane` check and would sit in NEITHER queue; the revert
+    re-arms auto-annotation for it rather than waiting up to an hour for the
+    stale-reconciliation sweep."""
+    ann_ids, seq_ids, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8808
+    )
+
+    resp = await authenticated_client.post(
+        "/annotations/sequences/localize-revert", json={"annotation_ids": ann_ids}
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert [c["sequence_id"] for c in deferred_auto_annotate] == seq_ids
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_does_not_rearm_when_reference_layer_landed(
+    authenticated_client: AsyncClient,
+    mock_img: bytes,
+    sequence_session,
+    deferred_auto_annotate,
+):
+    """The common case: `auto_annotated_at` is already stamped, so the lane
+    re-qualifies for the queue immediately and nothing is re-enqueued."""
+    ann_ids, seq_ids, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8809
+    )
+    for sequence_id in seq_ids:
+        sequence = await sequence_session.get(models.Sequence, sequence_id)
+        sequence.auto_annotated_at = now
+        sequence_session.add(sequence)
+    await sequence_session.commit()
+
+    resp = await authenticated_client.post(
+        "/annotations/sequences/localize-revert", json={"annotation_ids": ann_ids}
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert deferred_auto_annotate == []
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_404_on_unknown_annotation(
+    authenticated_client: AsyncClient, mock_img: bytes
+):
+    ann_ids, _, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8802
+    )
+    resp = await authenticated_client.post(
+        "/annotations/sequences/localize-revert",
+        json={"annotation_ids": [*ann_ids, 999999]},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_422_across_two_alerts(
+    authenticated_client: AsyncClient, mock_img: bytes
+):
+    a_ids, _, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8803
+    )
+    b_ids, _, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8804
+    )
+    resp = await authenticated_client.post(
+        "/annotations/sequences/localize-revert",
+        json={"annotation_ids": [a_ids[0], b_ids[0]]},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "same alert" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_409_when_lane_not_annotated(
+    authenticated_client: AsyncClient, mock_img: bytes
+):
+    """A lane still at seq_annotation_done has nothing to revert."""
+    seq = await _create_sequence(
+        authenticated_client, alert_api_id=88050, platform_alert_id=8805
+    )
+    det = await _create_detection(
+        authenticated_client, mock_img, sequence_id=seq, alert_api_id=1
+    )
+    ann = await _annotate_lane(authenticated_client, sequence_id=seq, detection_id=det)
+
+    resp = await authenticated_client.post(
+        "/annotations/sequences/localize-revert", json={"annotation_ids": [ann]}
+    )
+    assert resp.status_code == 409, resp.text
+    assert "not at annotated" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_422_when_lane_does_not_need_localization(
+    authenticated_client: AsyncClient, mock_img: bytes
+):
+    """An FP lane exits at annotated without ever being localized; knocking it
+    back to seq_annotation_done would park it in a stage it never occupied."""
+    seq = await _create_sequence(
+        authenticated_client, alert_api_id=88060, platform_alert_id=8806
+    )
+    det = await _create_detection(
+        authenticated_client, mock_img, sequence_id=seq, alert_api_id=1
+    )
+    ann = await _annotate_lane(
+        authenticated_client,
+        sequence_id=seq,
+        detection_id=det,
+        is_smoke=False,
+        stage="annotated",
+    )
+
+    resp = await authenticated_client.post(
+        "/annotations/sequences/localize-revert", json={"annotation_ids": [ann]}
+    )
+    assert resp.status_code == 422, resp.text
+    assert "does not need localization" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_is_atomic(
+    authenticated_client: AsyncClient, mock_img: bytes
+):
+    """One bad lane rejects the batch; the good lane must not have moved."""
+    ann_ids, _, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8807
+    )
+    # A third lane of the same alert, still at seq_annotation_done.
+    seq3 = await _create_sequence(
+        authenticated_client, alert_api_id=88073, platform_alert_id=8807
+    )
+    det3 = await _create_detection(
+        authenticated_client, mock_img, sequence_id=seq3, alert_api_id=3
+    )
+    ann3 = await _annotate_lane(
+        authenticated_client, sequence_id=seq3, detection_id=det3
+    )
+
+    resp = await authenticated_client.post(
+        "/annotations/sequences/localize-revert",
+        json={"annotation_ids": [ann_ids[0], ann3]},
+    )
+    assert resp.status_code == 409, resp.text
+
+    got = await authenticated_client.get(f"/annotations/sequences/{ann_ids[0]}")
+    assert got.json()["processing_stage"] == "annotated"
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_requires_auth(async_client: AsyncClient):
+    resp = await async_client.post(
+        "/annotations/sequences/localize-revert", json={"annotation_ids": [1]}
+    )
+    assert resp.status_code in (401, 403)

--- a/annotation_api/src/tests/endpoints/test_localize_revert.py
+++ b/annotation_api/src/tests/endpoints/test_localize_revert.py
@@ -342,6 +342,100 @@ async def test_localize_revert_is_atomic(
 
 
 @pytest.mark.asyncio
+async def test_localize_revert_422_when_a_sibling_is_unfinished(
+    authenticated_client: AsyncClient, mock_img: bytes
+):
+    """The done list admits an alert on ONE annotated lane, but the localize
+    queue demands every sibling be done. Reverting past that mismatch would
+    strand the alert in NEITHER list, so the mismatch is refused."""
+    ann_ids, _, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8816
+    )
+    unfinished_seq = await _create_sequence(
+        authenticated_client, alert_api_id=88169, platform_alert_id=8816
+    )
+    unfinished_det = await _create_detection(
+        authenticated_client, mock_img, sequence_id=unfinished_seq, alert_api_id=9
+    )
+    await _annotate_lane(
+        authenticated_client,
+        sequence_id=unfinished_seq,
+        detection_id=unfinished_det,
+        stage="ready_to_annotate",
+    )
+
+    resp = await authenticated_client.post(
+        "/annotations/sequences/localize-revert", json={"annotation_ids": ann_ids}
+    )
+    assert resp.status_code == 422, resp.text
+    assert "would not re-enter" in resp.json()["detail"]
+
+    # ...and nothing moved.
+    got = await authenticated_client.get(f"/annotations/sequences/{ann_ids[0]}")
+    assert got.json()["processing_stage"] == "annotated"
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_422_when_a_sibling_is_undecided(
+    authenticated_client: AsyncClient, mock_img: bytes
+):
+    """Same stranding, via the other arm of the queue's rule: an unsure lane
+    parked at seq_annotation_done withholds the whole alert from localization.
+    localize-submit already guards this; so must revert."""
+    ann_ids, _, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8817
+    )
+    unsure_seq = await _create_sequence(
+        authenticated_client, alert_api_id=88179, platform_alert_id=8817
+    )
+    unsure_det = await _create_detection(
+        authenticated_client, mock_img, sequence_id=unsure_seq, alert_api_id=9
+    )
+    await _annotate_lane(
+        authenticated_client,
+        sequence_id=unsure_seq,
+        detection_id=unsure_det,
+        is_unsure=True,
+        stage="seq_annotation_done",
+    )
+
+    resp = await authenticated_client.post(
+        "/annotations/sequences/localize-revert", json={"annotation_ids": ann_ids}
+    )
+    assert resp.status_code == 422, resp.text
+    assert "would not re-enter" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_allows_a_deferred_unsure_sibling(
+    authenticated_client: AsyncClient, mock_img: bytes
+):
+    """A DEFERRED unsure lane settles at annotated, which is a done stage and
+    is not 'unsettled' — it must not block the revert."""
+    ann_ids, _, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8818
+    )
+    deferred_seq = await _create_sequence(
+        authenticated_client, alert_api_id=88189, platform_alert_id=8818
+    )
+    deferred_det = await _create_detection(
+        authenticated_client, mock_img, sequence_id=deferred_seq, alert_api_id=9
+    )
+    await _annotate_lane(
+        authenticated_client,
+        sequence_id=deferred_seq,
+        detection_id=deferred_det,
+        is_unsure=True,
+        stage="annotated",
+    )
+
+    resp = await authenticated_client.post(
+        "/annotations/sequences/localize-revert", json={"annotation_ids": ann_ids}
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
 async def test_localize_revert_requires_auth(async_client: AsyncClient):
     resp = await async_client.post(
         "/annotations/sequences/localize-revert", json={"annotation_ids": [1]}

--- a/annotation_api/src/tests/endpoints/test_localize_revert.py
+++ b/annotation_api/src/tests/endpoints/test_localize_revert.py
@@ -4,9 +4,11 @@ alert return to seq_annotation_done, keeping every box they carry."""
 
 import json
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import func, select
 
 from app import models
 from app.api.api_v1.endpoints import sequence_annotations as ep
@@ -345,3 +347,205 @@ async def test_localize_revert_requires_auth(async_client: AsyncClient):
         "/annotations/sequences/localize-revert", json={"annotation_ids": [1]}
     )
     assert resp.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_withdraws_alert_from_export(
+    authenticated_client: AsyncClient, mock_img: bytes
+):
+    """The point of the feature: a reverted alert stops exporting, and the
+    corrected version re-exports with an advanced watermark."""
+    ann_ids, _, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8810
+    )
+
+    def alert_ids(resp):
+        return [i["platform_alert_id"] for i in resp.json()["items"]]
+
+    resp = await authenticated_client.get("/export/alerts")
+    assert 8810 in alert_ids(resp), alert_ids(resp)
+    before = next(
+        i["last_annotated_at"]
+        for i in resp.json()["items"]
+        if i["platform_alert_id"] == 8810
+    )
+
+    revert = await authenticated_client.post(
+        "/annotations/sequences/localize-revert", json={"annotation_ids": ann_ids}
+    )
+    assert revert.status_code == 200, revert.text
+
+    resp = await authenticated_client.get("/export/alerts")
+    assert 8810 not in alert_ids(resp), f"still exported: {alert_ids(resp)}"
+
+    # Re-submitting the corrected alert puts it back, with a later watermark
+    # so an incremental consumer picks the correction up.
+    resubmit = await authenticated_client.post(
+        "/annotations/sequences/localize-submit", json={"annotation_ids": ann_ids}
+    )
+    assert resubmit.status_code == 200, resubmit.text
+
+    resp = await authenticated_client.get("/export/alerts")
+    assert 8810 in alert_ids(resp)
+    after = next(
+        i["last_annotated_at"]
+        for i in resp.json()["items"]
+        if i["platform_alert_id"] == 8810
+    )
+    assert after >= before
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_moves_alert_between_the_two_queues(
+    authenticated_client: AsyncClient, mock_img: bytes, sequence_session
+):
+    ann_ids, seq_ids, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8811
+    )
+    # The localize queue only offers a lane whose auto-annotate reference pass
+    # landed; no worker runs here, so stamp it as the worker would.
+    for sequence_id in seq_ids:
+        sequence = await sequence_session.get(models.Sequence, sequence_id)
+        sequence.auto_annotated_at = now
+        sequence_session.add(sequence)
+    await sequence_session.commit()
+
+    async def in_queue(path: str) -> bool:
+        resp = await authenticated_client.get(path)
+        assert resp.status_code == 200, resp.text
+        return any(i["platform_alert_id"] == 8811 for i in resp.json()["items"])
+
+    assert await in_queue("/sequences/localize-done-queue")
+    assert not await in_queue("/sequences/localization-queue")
+
+    revert = await authenticated_client.post(
+        "/annotations/sequences/localize-revert", json={"annotation_ids": ann_ids}
+    )
+    assert revert.status_code == 200, revert.text
+
+    assert not await in_queue("/sequences/localize-done-queue")
+    assert await in_queue("/sequences/localization-queue")
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_preserves_the_localization_work(
+    authenticated_client: AsyncClient, mock_img: bytes
+):
+    """Boxes and per-frame acceptance survive — the annotator fixes one frame
+    and resubmits rather than redoing the alert. This is what separates the
+    revert from the FP-promote demotion, which deletes them."""
+    ann_ids, _, det_ids = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8812
+    )
+
+    async def frame_annotations():
+        out = []
+        for det_id in det_ids:
+            resp = await authenticated_client.get(
+                "/annotations/detections/", params={"detection_id": det_id}
+            )
+            out.extend(resp.json()["items"])
+        return out
+
+    before = await frame_annotations()
+    assert before and all(a["annotation"]["annotation"] for a in before)
+
+    revert = await authenticated_client.post(
+        "/annotations/sequences/localize-revert", json={"annotation_ids": ann_ids}
+    )
+    assert revert.status_code == 200, revert.text
+
+    after = await frame_annotations()
+    assert len(after) == len(before)
+    assert [a["annotation"] for a in after] == [a["annotation"] for a in before]
+    assert all(a["processing_stage"] == "annotated" for a in after)
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_records_no_contribution(
+    authenticated_client: AsyncClient, mock_img: bytes, sequence_session
+):
+    """Reverting is a correction, not authorship: the reverter must not land
+    in the Annotators column. Contributions are append-only, so this can only
+    be prevented, never undone."""
+    ann_ids, _, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8813
+    )
+
+    async def contribution_count() -> int:
+        return (
+            await sequence_session.execute(
+                select(func.count(models.SequenceAnnotationContribution.id)).where(
+                    models.SequenceAnnotationContribution.sequence_annotation_id.in_(
+                        ann_ids
+                    )
+                )
+            )
+        ).scalar_one()
+
+    before = await contribution_count()
+    # Non-vacuous: the submit that seeded this alert DID credit its annotator,
+    # so "unchanged" is a real constraint rather than 0 == 0.
+    assert before > 0
+
+    revert = await authenticated_client.post(
+        "/annotations/sequences/localize-revert", json={"annotation_ids": ann_ids}
+    )
+    assert revert.status_code == 200, revert.text
+
+    assert await contribution_count() == before
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_leaves_fp_siblings_annotated(
+    authenticated_client: AsyncClient, mock_img: bytes
+):
+    ann_ids, _, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8814
+    )
+    fp_seq = await _create_sequence(
+        authenticated_client, alert_api_id=88149, platform_alert_id=8814
+    )
+    fp_det = await _create_detection(
+        authenticated_client, mock_img, sequence_id=fp_seq, alert_api_id=9
+    )
+    fp_ann = await _annotate_lane(
+        authenticated_client,
+        sequence_id=fp_seq,
+        detection_id=fp_det,
+        is_smoke=False,
+        stage="annotated",
+    )
+
+    revert = await authenticated_client.post(
+        "/annotations/sequences/localize-revert", json={"annotation_ids": ann_ids}
+    )
+    assert revert.status_code == 200, revert.text
+
+    got = await authenticated_client.get(f"/annotations/sequences/{fp_ann}")
+    assert got.json()["processing_stage"] == "annotated"
+
+
+@pytest.mark.asyncio
+async def test_localize_revert_never_propagates_to_a_group(
+    authenticated_client: AsyncClient, mock_img: bytes
+):
+    """A revert reaches seq_annotation_done, which is exactly the stage the
+    group fan-out hooks on — but a revert is a correction, not a new label,
+    and must never rewrite a validated group's other members. Patching the
+    hook pins the intent directly, without seeding a whole group."""
+    ann_ids, _, _ = await _seed_submitted_alert(
+        authenticated_client, mock_img, platform_alert_id=8815
+    )
+
+    with patch(
+        "app.api.api_v1.endpoints.sequence_annotations."
+        "_propagate_to_group_if_validated",
+        new=AsyncMock(return_value=None),
+    ) as propagate:
+        resp = await authenticated_client.post(
+            "/annotations/sequences/localize-revert", json={"annotation_ids": ann_ids}
+        )
+        assert resp.status_code == 200, resp.text
+
+    propagate.assert_not_awaited()

--- a/docs/specs/2026-08-07-localize-revert-to-queue-design.md
+++ b/docs/specs/2026-08-07-localize-revert-to-queue-design.md
@@ -1,0 +1,200 @@
+# Send a localized alert back to the Localize queue
+
+**Date**: 2026-08-07
+**Status**: Approved
+**Base**: `main` (the alert-skip escape hatch #297, the collocated localize
+cockpit #274/#278, and the `/export/alerts` endpoint #310 all merged).
+
+## Problem
+
+Once an alert is submitted from `/localize`, it lands at `/localize/done` and
+its lanes sit at `annotated` forever. There is no way back. Two things follow:
+
+1. **A mistake is unfixable in place.** Spotting a bad box on a done alert
+   leaves the annotator with nothing to click.
+2. **Bad data cannot be withheld from the export.** `/export/alerts` ships an
+   alert only when *every* lane of it is `annotated`
+   (`export.py:225`, `.having(annotated_lanes == total_lanes)`). An alert with
+   a known-wrong localization keeps flowing into the training set.
+
+The second is the driving motivation: we want a way to pull an alert back out
+of the export. Reverting it to the queue does exactly that, and re-opening it
+for correction is the same action.
+
+## Decision
+
+Add a **Send back to queue** action to the done-mode localize cockpit
+(`/localize/done/:sequenceId`). It flips every `annotated` lane of the alert
+that needs localization back to `seq_annotation_done` — and does nothing else.
+
+That single bit is the entire difference between the two queues
+(`sequences.py:1113-1197` for `/localize`, `:1431-1521` for `/localize/done`),
+and the same bit is the export's admission gate. So one stage write covers
+both goals: the alert leaves Done, re-enters the queue, and drops out of the
+export.
+
+## Design
+
+### 1. Scope of the flip
+
+Reverted: lanes at `annotated` whose flags match the localization rule
+(`localization_rule.py:29-54` — `(has_smoke OR has_missed_smoke) AND NOT
+is_unsure`).
+
+Not reverted, deliberately:
+
+- **FP lanes and deferred-unsure lanes.** They exited the pipeline at classify
+  and never had localization work; demoting them would park them in a stage
+  they never occupied.
+- **Lanes already at `seq_annotation_done`.** Nothing to do.
+- **`DetectionAnnotation` rows.** Boxes and per-frame acceptance survive
+  untouched, so the reopened alert looks exactly as it was left and Submit is
+  immediately re-armed. The annotator fixes the one bad frame and resubmits
+  rather than redoing the alert.
+- **`auto_annotated_at` / `auto_annotate_enqueued_at`.** Both stay set, so the
+  auto-annotate sweep does not re-fire (`_pending_ready_lane`'s two arms both
+  fail, `auto_annotate_scheduling.py:68-84`) and the lane instantly
+  re-qualifies as a `_ready_smoke_lane` (`sequences.py:580-591`).
+
+`DONE_STAGES` covers both `seq_annotation_done` and `annotated`
+(`auto_annotate_scheduling.py:28-31`), so every sibling "all lanes done" check
+keeps passing across the revert — the alert is never in a half-visible state.
+
+### 2. Backend — `POST /api/v1/annotations/sequences/localize-revert`
+
+Mirrors `localize-submit`'s shape and validation spine
+(`sequence_annotations.py:1316-1448`): request `{annotation_ids: [...]}`,
+response a list of `{annotation_id, sequence_id, processing_stage}`.
+
+**It must not route through `apply_annotation_update`.** A stage write of
+`annotated → seq_annotation_done` on a lane needing localization is exactly
+the FP→smoke promotion predicate (`sequence_annotations.py:739-750`), whose
+effects block (`:780-815`) 422s on any committed detection annotation and
+otherwise *deletes* every `DetectionAnnotation` of the sequence. That is the
+opposite of this feature. The endpoint therefore writes through
+`SequenceAnnotationCRUD.update()` directly.
+
+Writing through the CRUD also keeps us clear of three other hooks that must
+not fire on a revert:
+
+- `auto_create_detection_annotations` — only runs on lanes newly reaching
+  `annotated`.
+- `_propagate_to_group_if_validated` — fans a label out to a validated group
+  when a lane newly reaches `seq_annotation_done`. A revert is not a new
+  label; it must not touch the group.
+- The contribution insert (see §4).
+
+Guards, all inside one transaction with a single commit — either every lane
+flips or none does:
+
+| Condition | Status |
+| --- | --- |
+| Unknown annotation id | 404 |
+| Ids spanning more than one alert | 422 |
+| Any target lane not at `annotated` | 409 — "refresh and retry" |
+| Any target lane that does not need localization | 422 |
+
+**Post-commit safety net.** If a reverted lane's sequence has
+`auto_annotated_at IS NULL`, defer `auto_annotate_sequence` for it (the same
+post-commit `defer_async` the FP-promote path uses,
+`sequence_annotations.py:888-890`). Without it, such a lane fails
+`_ready_smoke_lane` and sits in neither queue until the stale-reconciliation
+arm rescues it up to an hour later.
+
+### 3. Frontend
+
+**Where.** The rail footer's secondary-action slot — the position the **Skip
+alert** button occupies in queue mode (`LocalizeAlertPage.tsx:1826-1845`),
+gated `mode !== 'done'`. Done mode gets **Send back to queue** in that same
+slot, with the same outlined-ember treatment.
+
+The footer has two branches (`:1763-1846`) and only the
+`workableObjects.length > 0` one currently renders the action row. The slot
+goes into both, so a partially-reverted alert opened from Done shows Submit
+*and* the revert button.
+
+**When.** Rendered only when at least one lane is `annotated` and passes
+`laneNeedsLocalization` — the client-side mirror of the endpoint's guards, so
+a deep link to a non-done alert never offers an action that would 409. Derived
+from `alertDetail.lanes` alongside the existing `workableLanes` memo
+(`:1000-1008`); call it `revertableLanes`.
+
+**Interaction.** Confirmation dialog, no note field (see Out of scope), then:
+
+- `apiClient.localizeRevert(annotationIds)` → `POST .../localize-revert`
+- invalidate `localization-queue`, `localize-done-queue`, `annotation-counts`,
+  `pipeline-stats`, `SEQUENCE_ANNOTATIONS`
+- toast, then navigate to `/localize/done` — the alert is gone from the list it
+  came from, and whoever picks it up does so from the queue.
+
+### 4. Attribution
+
+Contributions are append-only and nothing ever removes them, so a revert must
+not credit the reverter as an annotator — it would pollute the Annotators
+column on `/localize/done` and its `annotator_id` filter. Precedent: group
+unvalidate deliberately clears attribution rather than carrying it stale
+(`sequence_groups.py:441-445`).
+
+No code is needed for this: `crud_sequence_annotation.py:144-157` reads
+`annotation.processing_stage` *after* the `setattr` loop has already applied
+the new stage, so its "old stage was annotated" arm is dead and only the new
+stage counts. A demotion writes no contribution row today. Because that
+behavior rests on a subtlety rather than an intention, it gets a test of its
+own (see Testing) so a later fix to that condition cannot silently change it.
+
+## Export behavior
+
+This is the point of the feature, so it is specified rather than merely noted.
+
+- `/export/alerts` groups by `(source_api, platform_alert_id)` and requires
+  every lane annotated (`export.py:225`). Reverting any one lane drops the
+  **whole alert** from the export.
+- The round-trip re-admits the corrected version. `updated_at` bumps on the
+  revert and again on the re-submit, and `last_annotated_at` is
+  `max(sequence annotation write, detection annotation write)`
+  (`export.py:173-204`) — so the fixed alert returns with a watermark later
+  than its original export and an incremental consumer picks the correction
+  up.
+- **Removal carries no signal.** The export only ever emits present alerts;
+  there is no tombstone. A consumer that pulled the alert and then synced
+  incrementally would silently retain the bad copy. Withdrawal is therefore
+  only real for consumers doing a full pull, or one that diffs against the
+  full set of alert keys. No pull script exists in the repo yet
+  (`annotation_api/scripts/data_transfer/` is ingestion-only); this is a
+  constraint on whoever writes it.
+
+## Out of scope
+
+- **A reason note.** Skip captures an optional note; this does not. There is
+  no field on `SequenceAnnotation` to hold one, and adding one means a column,
+  a migration, and queue/serializer plumbing. Accepted cost: whoever picks the
+  reverted alert up from `/localize` does not learn why it came back.
+- **A revert entry point on the `/localize/done` list rows.** The action lives
+  where you can see the work you are judging.
+- **Any per-lane granularity.** Revert is alert-shaped, like the queues and
+  like the export.
+- **An audit trail of reverts.** Only `updated_at` records that anything
+  happened.
+
+## Testing
+
+**Backend** — `annotation_api/src/tests/endpoints/test_localize_revert.py`:
+
+- Round-trip through the real queue endpoints: an alert present in
+  `/localize/done` and absent from `/localize`, reverted, is then absent from
+  Done and present in the queue.
+- The alert is absent from `/export/alerts` after the revert, and present
+  again after a re-submit — the feature's actual purpose, pinned end to end.
+- Detection annotations are unchanged after the revert (count and content).
+- Zero new `SequenceAnnotationContribution` rows.
+- An FP sibling lane of the same alert stays at `annotated`.
+- Each guard's status code: 404, 422 (cross-alert), 409 (wrong stage), 422
+  (lane does not need localization).
+- A lane in a validated group leaves the group's members unchanged.
+
+**Frontend** — `frontend/tests/pages/`:
+
+- The button is absent in queue mode and present in done mode.
+- It is absent when no lane is annotated-and-needs-localization.
+- Confirm posts the expected `annotation_ids` and navigates to
+  `/localize/done`.

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1106,6 +1106,33 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     },
   });
 
+  // Send back to queue (spec: 2026-08-07-localize-revert-to-queue): the
+  // alert's annotated smoke lanes return to seq_annotation_done, which pulls
+  // the alert out of /export/alerts until it is submitted again. Done mode
+  // only. Boxes are untouched — the next annotator fixes a frame, not the
+  // whole alert.
+  const revertAlertMutation = useMutation({
+    mutationFn: async () => apiClient.localizeRevert(revertableLanes.map(l => l.annotationId)),
+    onSuccess: () => {
+      setRevertConfirmOpen(false);
+      queryClient.invalidateQueries({ queryKey: ['localization-queue'] });
+      queryClient.invalidateQueries({ queryKey: ['localize-done-queue'] });
+      queryClient.invalidateQueries({ queryKey: ['annotation-counts'] });
+      queryClient.invalidateQueries({ queryKey: ['pipeline-stats'] });
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.SEQUENCE_ANNOTATIONS });
+      queryClient.invalidateQueries({ queryKey: alertDetailQueryKey });
+      showToastNotification('Alert sent back to the queue', 'success');
+      navigate(listPath);
+    },
+    onError: err => {
+      const detail = (err as { detail?: string })?.detail || (err as Error)?.message || '';
+      showToastNotification(
+        detail ? `Send back failed: ${detail}` : 'Send back failed — try again',
+        'error'
+      );
+    },
+  });
+
   // The missed-smoke soft-confirm is the only gate left in front of submit:
   // flagged missed smoke can't be annotated yet, so it leads with Skip alert
   // before offering to submit anyway. The old two-step no-box warning went
@@ -1377,7 +1404,8 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
         (e.key === 'c' || e.key === 'C') &&
         detectionIdNum == null &&
         !showShortcutsModal &&
-        !skipConfirmOpen
+        !skipConfirmOpen &&
+        !revertConfirmOpen
       ) {
         setCropMode(prev => !prev);
         e.preventDefault();
@@ -1385,7 +1413,7 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [detectionIdNum, showShortcutsModal, skipConfirmOpen]);
+  }, [detectionIdNum, showShortcutsModal, skipConfirmOpen, revertConfirmOpen]);
 
   // Tab / Shift+Tab step the objects exactly as the rail displays them —
   // smoke first, false positives only while shown — wrapping at the ends
@@ -1403,7 +1431,8 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       // per-frame editor, the missed-smoke submit dialog, the skip confirm,
       // the shortcuts sheet, the accept popover — so their controls stay
       // keyboard-reachable (mirrors classify's modal guards).
-      if (detectionIdNum != null || missedSmokeConfirm || skipConfirmOpen) return;
+      if (detectionIdNum != null || missedSmokeConfirm || skipConfirmOpen || revertConfirmOpen)
+        return;
       if (showShortcutsModal || acceptPopoverOpen) return;
       if (orderedObjectRows.length === 0) return;
       e.preventDefault();
@@ -1434,7 +1463,8 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // above: re-subscribing every render keeps the closure fresh.
   useEffect(() => {
     const handleShortcutKeys = (e: KeyboardEvent) => {
-      if (detectionIdNum != null || missedSmokeConfirm || skipConfirmOpen) return;
+      if (detectionIdNum != null || missedSmokeConfirm || skipConfirmOpen || revertConfirmOpen)
+        return;
       // Shift stays allowed: `?` requires it.
       if (e.ctrlKey || e.metaKey || e.altKey) return;
       const target = e.target;
@@ -2030,6 +2060,50 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
                 className="inline-flex items-center rounded-lg bg-pine px-3 py-2 font-body text-sm font-semibold text-white hover:brightness-95 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Skip alert
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {revertConfirmOpen && (
+        <div
+          data-testid="revert-to-queue-confirm"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-char/40 px-4"
+        >
+          <div className="w-full max-w-sm rounded-lg border border-line bg-paper p-5">
+            <div className="flex items-start justify-between">
+              <h2 className="font-body text-sm font-semibold text-char">
+                Send this alert back to the queue?
+              </h2>
+              <button
+                type="button"
+                onClick={() => setRevertConfirmOpen(false)}
+                aria-label="Close"
+                className="-mr-1.5 -mt-1.5 rounded-md p-1.5 hover:bg-ash"
+              >
+                <X className="h-4 w-4 text-haze" />
+              </button>
+            </div>
+            <p className="mt-1 font-body text-xs text-haze">
+              It returns to the Localize queue with all its boxes intact, and stops being exported
+              until someone submits it again.
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setRevertConfirmOpen(false)}
+                className="inline-flex items-center rounded-lg px-3 py-2 font-body text-sm font-medium text-haze hover:text-char"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => revertAlertMutation.mutate()}
+                disabled={revertAlertMutation.isPending}
+                className="inline-flex items-center rounded-lg bg-ember px-3 py-2 font-body text-sm font-semibold text-white hover:brightness-95 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Send back to queue
               </button>
             </div>
           </div>

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -957,18 +957,16 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // outlined-ember treatment. Both footer branches use it, so a partially
   // reverted alert opened from Done shows Submit AND this.
   const renderRevertButton = () => (
-    <Tooltip
-      placement="above"
-      tip="Spotted a mistake? This alert returns to the Localize queue with all its boxes intact, and stops being exported until it is submitted again."
-    >
+    <Tooltip placement="above" tip={revertTooltip}>
       <button
         type="button"
         onClick={e => {
           e.stopPropagation();
           setRevertConfirmOpen(true);
         }}
+        disabled={revertBlocked}
         data-testid="revert-to-queue-button"
-        className="inline-flex items-center rounded-lg border border-ember bg-paper px-3 py-2.5 font-body text-sm font-medium text-ember hover:bg-ember-soft"
+        className="inline-flex items-center rounded-lg border border-ember bg-paper px-3 py-2.5 font-body text-sm font-medium text-ember hover:bg-ember-soft disabled:cursor-not-allowed disabled:opacity-50"
       >
         Send back to queue
       </button>
@@ -1047,6 +1045,28 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   );
   const canRevert = mode === 'done' && revertableLanes.length > 0;
 
+  // The done list admits an alert on ONE annotated lane, but the queue demands
+  // every sibling be done and none undecided. Where they disagree the server
+  // refuses the revert (it would strand the alert in neither list), so say so
+  // on the button rather than letting a 422 explain it after the confirm.
+  const revertBlockingLanes = (alertDetail?.lanes ?? []).filter(lane => {
+    const annotation = lane.annotation;
+    if (!annotation) return true;
+    if (annotation.processing_stage === 'annotated') return false;
+    if (annotation.processing_stage !== 'seq_annotation_done') return true;
+    return annotation.is_unsure === true;
+  });
+  const revertBlocked = revertBlockingLanes.length > 0;
+  const revertTooltip = revertBlocked
+    ? `${revertBlockingLanes.length} object${
+        revertBlockingLanes.length === 1 ? '' : 's'
+      } of this alert ${
+        revertBlockingLanes.length === 1 ? 'is' : 'are'
+      } still unfinished or undecided, so it could not re-enter the Localize queue. Settle ${
+        revertBlockingLanes.length === 1 ? 'it' : 'them'
+      } in Classify first.`
+    : 'Spotted a mistake? This alert returns to the Localize queue with all its boxes intact, and stops being exported until it is submitted again.';
+
   // Submit: atomically ships the whole alert. No accept step of its own —
   // `allObjectsAccepted` gates the button, so every frame already carries a
   // committed box by the time this can fire.
@@ -1122,7 +1142,10 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.SEQUENCE_ANNOTATIONS });
       queryClient.invalidateQueries({ queryKey: alertDetailQueryKey });
       showToastNotification('Alert sent back to the queue', 'success');
-      navigate(listPath);
+      // Delayed like the submit path: navigating unmounts this page and with
+      // it the NotificationSystem that owns the toast, so an immediate
+      // navigate would swallow the confirmation entirely.
+      setTimeout(() => navigate(listPath), 1000);
     },
     onError: err => {
       const detail = (err as { detail?: string })?.detail || (err as Error)?.message || '';

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -117,6 +117,7 @@ import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/rea
 import { ArrowLeft, Keyboard, PlayCircle, Upload, X } from 'lucide-react';
 import { apiClient } from '@/services/api';
 import { QUERY_KEYS } from '@/utils/constants';
+import { QUEUE_COUNTS_KEY } from '@/hooks/useQueueTotals';
 import {
   ApiError,
   Detection,
@@ -1137,7 +1138,12 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       setRevertConfirmOpen(false);
       queryClient.invalidateQueries({ queryKey: ['localization-queue'] });
       queryClient.invalidateQueries({ queryKey: ['localize-done-queue'] });
-      queryClient.invalidateQueries({ queryKey: ['annotation-counts'] });
+      // The alert moves BETWEEN the two queues, so the sidebar's Localize
+      // badge and the dashboard card behind the same total both have to
+      // follow. Imported rather than spelled out so renaming the hook's key
+      // fails the test instead of silently freezing the badge for the full
+      // 5-minute staleTime.
+      queryClient.invalidateQueries({ queryKey: [QUEUE_COUNTS_KEY] });
       queryClient.invalidateQueries({ queryKey: ['pipeline-stats'] });
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.SEQUENCE_ANNOTATIONS });
       queryClient.invalidateQueries({ queryKey: alertDetailQueryKey });

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -266,6 +266,7 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // goes straight through instead of re-asking the same question).
   const [missedSmokeConfirm, setMissedSmokeConfirm] = useState(false);
   const [skipConfirmOpen, setSkipConfirmOpen] = useState(false);
+  const [revertConfirmOpen, setRevertConfirmOpen] = useState(false);
   const [skipNote, setSkipNote] = useState('');
   const [softConfirmResolved, setSoftConfirmResolved] = useState(false);
 
@@ -952,6 +953,28 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     );
   };
 
+  // Occupies the slot Skip alert holds in queue mode — same position, same
+  // outlined-ember treatment. Both footer branches use it, so a partially
+  // reverted alert opened from Done shows Submit AND this.
+  const renderRevertButton = () => (
+    <Tooltip
+      placement="above"
+      tip="Spotted a mistake? This alert returns to the Localize queue with all its boxes intact, and stops being exported until it is submitted again."
+    >
+      <button
+        type="button"
+        onClick={e => {
+          e.stopPropagation();
+          setRevertConfirmOpen(true);
+        }}
+        data-testid="revert-to-queue-button"
+        className="inline-flex items-center rounded-lg border border-ember bg-paper px-3 py-2.5 font-body text-sm font-medium text-ember hover:bg-ember-soft"
+      >
+        Send back to queue
+      </button>
+    </Tooltip>
+  );
+
   // Names the media column: with an object active the grid shows that
   // object's detections, so the column header should say whose they are.
   // The color also outlines the frames it actually appears on.
@@ -1006,6 +1029,23 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       }),
     [workableObjects, alertDetail]
   );
+
+  // The mirror image of `workableLanes`: the alert's already-annotated smoke
+  // lanes, which are exactly what localize-revert takes. Mirrors the
+  // endpoint's guards client-side so a deep link to an unfinished alert never
+  // offers an action the server would 409.
+  const revertableLanes: { laneSequenceId: number; annotationId: number }[] = useMemo(
+    () =>
+      (alertDetail?.lanes ?? []).flatMap(lane => {
+        const annotation = lane.annotation;
+        if (!annotation) return [];
+        if (annotation.processing_stage !== 'annotated') return [];
+        if (!laneNeedsLocalization(annotation)) return [];
+        return [{ laneSequenceId: lane.sequence.id, annotationId: annotation.id }];
+      }),
+    [alertDetail]
+  );
+  const canRevert = mode === 'done' && revertableLanes.length > 0;
 
   // Submit: atomically ships the whole alert. No accept step of its own —
   // `allObjectsAccepted` gates the button, so every frame already carries a
@@ -1762,12 +1802,15 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
             }
             footer={
               workableObjects.length === 0 ? (
-                <p
-                  data-testid="all-objects-localized"
-                  className="text-center font-body text-detail text-haze"
-                >
-                  All objects localized
-                </p>
+                <div className="flex flex-col items-center gap-2.5">
+                  <p
+                    data-testid="all-objects-localized"
+                    className="text-center font-body text-detail text-haze"
+                  >
+                    All objects localized
+                  </p>
+                  {canRevert && renderRevertButton()}
+                </div>
               ) : (
                 <div>
                   {/* An undecided object holds the whole alert back. Say so
@@ -1843,6 +1886,7 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
                         </button>
                       </Tooltip>
                     )}
+                    {canRevert && renderRevertButton()}
                   </div>
                 </div>
               )

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -35,6 +35,7 @@ import {
   ClassifySubmitRequest,
   ClassifySubmitResponse,
   LocalizeSubmitResponse,
+  LocalizeRevertResponse,
   SequenceGroup,
   SequenceGroupListItem,
   SequenceGroupStats,
@@ -326,6 +327,14 @@ class ApiClient {
   async localizeSubmit(annotationIds: number[]): Promise<LocalizeSubmitResponse> {
     const response: AxiosResponse<LocalizeSubmitResponse> = await this.client.post(
       `${API_ENDPOINTS.SEQUENCE_ANNOTATIONS}localize-submit`,
+      { annotation_ids: annotationIds }
+    );
+    return response.data;
+  }
+
+  async localizeRevert(annotationIds: number[]): Promise<LocalizeRevertResponse> {
+    const response: AxiosResponse<LocalizeRevertResponse> = await this.client.post(
+      `${API_ENDPOINTS.SEQUENCE_ANNOTATIONS}localize-revert`,
       { annotation_ids: annotationIds }
     );
     return response.data;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -171,6 +171,16 @@ export interface LocalizeSubmitResponse {
   results: LocalizeSubmitResult[];
 }
 
+export interface LocalizeRevertResult {
+  annotation_id: number;
+  sequence_id: number;
+  processing_stage: ProcessingStage;
+}
+
+export interface LocalizeRevertResponse {
+  results: LocalizeRevertResult[];
+}
+
 export interface Detection {
   id: number;
   sequence_id: number;

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -1608,9 +1608,83 @@ describe('LocalizeAlertPage', () => {
       await waitFor(() => {
         expect(vi.mocked(apiClient.localizeRevert)).toHaveBeenCalledWith([201, 202]);
       });
-      await waitFor(() => {
-        expect(screen.getByTestId('localize-done-landing')).toBeInTheDocument();
+      // The success toast has to be readable before the page goes away, so
+      // navigation is deliberately delayed — hence the widened timeout.
+      expect(await screen.findByText('Alert sent back to the queue')).toBeInTheDocument();
+      await waitFor(
+        () => {
+          expect(screen.getByTestId('localize-done-landing')).toBeInTheDocument();
+        },
+        { timeout: 2000 }
+      );
+    });
+
+    it('is disabled when a sibling would keep the alert out of the queue', async () => {
+      // The done list admits this alert on lane 101 alone, but lane 102 is
+      // still unfinished — reverting would strand it in neither list, so the
+      // server refuses. Say so on the button instead of after the confirm.
+      vi.mocked(apiClient.getAlertDetail).mockResolvedValue({
+        ...makeTwoLaneAlertDetail(),
+        lanes: [
+          {
+            sequence: makeSequence({ id: 101, alert_api_id: 9001 }),
+            annotation: makeAnnotation({
+              id: 201,
+              sequence_id: 101,
+              processing_stage: 'annotated',
+            }),
+          },
+          {
+            sequence: makeSequence({ id: 102, alert_api_id: 9002 }),
+            annotation: makeAnnotation({
+              id: 202,
+              sequence_id: 102,
+              processing_stage: 'ready_to_annotate',
+            }),
+          },
+        ],
       });
+      mockAllFramesAccepted();
+
+      await renderAndSettle(<LocalizeAlertPage mode="done" />, { wrapper: doneWrapper });
+
+      expect(screen.getByTestId('revert-to-queue-button')).toBeDisabled();
+
+      fireEvent.click(screen.getByTestId('revert-to-queue-button'));
+      expect(screen.queryByTestId('revert-to-queue-confirm')).not.toBeInTheDocument();
+      expect(vi.mocked(apiClient.localizeRevert)).not.toHaveBeenCalled();
+    });
+
+    it('stays enabled when the undecided sibling was deferred to annotated', async () => {
+      // A deferred-unsure lane settles at annotated: a done stage, and not
+      // "unsettled", so the queue would still take the alert.
+      vi.mocked(apiClient.getAlertDetail).mockResolvedValue({
+        ...makeTwoLaneAlertDetail(),
+        lanes: [
+          {
+            sequence: makeSequence({ id: 101, alert_api_id: 9001 }),
+            annotation: makeAnnotation({
+              id: 201,
+              sequence_id: 101,
+              processing_stage: 'annotated',
+            }),
+          },
+          {
+            sequence: makeSequence({ id: 102, alert_api_id: 9002 }),
+            annotation: makeAnnotation({
+              id: 202,
+              sequence_id: 102,
+              processing_stage: 'annotated',
+              is_unsure: true,
+            }),
+          },
+        ],
+      });
+      mockAllFramesAccepted();
+
+      await renderAndSettle(<LocalizeAlertPage mode="done" />, { wrapper: doneWrapper });
+
+      expect(screen.getByTestId('revert-to-queue-button')).toBeEnabled();
     });
 
     it('does nothing when the confirm is dismissed', async () => {

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -14,6 +14,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QUEUE_COUNTS_KEY } from '@/hooks/useQueueTotals';
 import {
   MemoryRouter,
   Routes,
@@ -1617,6 +1618,51 @@ describe('LocalizeAlertPage', () => {
         },
         { timeout: 2000 }
       );
+    });
+
+    // Regression guard: a revert moves the alert BETWEEN the two localize
+    // queues, so the sidebar's Localize badge and the dashboard card behind
+    // the same total must follow it. Miss the invalidation and they under-
+    // count for the full 5-minute staleTime. QUEUE_COUNTS_KEY is imported
+    // rather than spelled out so renaming the hook's key fails here instead
+    // of silently freezing the badge.
+    it('invalidates both queues and the shared queue-count key', async () => {
+      mockDoneAlert();
+      vi.mocked(apiClient.localizeRevert).mockResolvedValue({
+        results: [
+          { annotation_id: 201, sequence_id: 101, processing_stage: 'seq_annotation_done' },
+          { annotation_id: 202, sequence_id: 102, processing_stage: 'seq_annotation_done' },
+        ],
+      });
+      // spyOn, not a bare stub: the real invalidation still runs, so a
+      // throwing or refetch-looping invalidation surfaces instead of being
+      // swallowed.
+      const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
+
+      await renderAndSettle(<LocalizeAlertPage mode="done" />, { wrapper: doneWrapper });
+
+      fireEvent.click(screen.getByTestId('revert-to-queue-button'));
+      fireEvent.click(
+        within(screen.getByTestId('revert-to-queue-confirm')).getByRole('button', {
+          name: 'Send back to queue',
+        })
+      );
+
+      await waitFor(() => {
+        expect(vi.mocked(apiClient.localizeRevert)).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        const keys = invalidateSpy.mock.calls.map(([arg]) => String(arg?.queryKey?.[0]));
+        // The revert handler's whole contract: the list it leaves, the list
+        // it joins, the shared queue totals (sidebar badge + dashboard card),
+        // and the dashboard's stage counts.
+        expect(keys).toContain('localize-done-queue');
+        expect(keys).toContain('localization-queue');
+        expect(keys).toContain(QUEUE_COUNTS_KEY);
+        expect(keys).toContain('pipeline-stats');
+      });
+
+      invalidateSpy.mockRestore();
     });
 
     it('is disabled when a sibling would keep the alert out of the queue', async () => {

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -42,6 +42,7 @@ vi.mock('@/services/api', () => ({
     updateDetectionAnnotation: vi.fn(),
     updateSequenceAnnotation: vi.fn(),
     localizeSubmit: vi.fn(),
+    localizeRevert: vi.fn(),
     addObject: vi.fn(),
     skipAlert: vi.fn(),
     materializeFrame: vi.fn(),
@@ -1517,6 +1518,71 @@ describe('LocalizeAlertPage', () => {
       await waitFor(() => expect(screen.getByTestId('localize-done-landing')).toBeInTheDocument(), {
         timeout: 2000,
       });
+    });
+  });
+
+  describe('send back to queue', () => {
+    /** Both lanes annotated — the state an alert is in on the Done list. */
+    function mockDoneAlert() {
+      vi.mocked(apiClient.getAlertDetail).mockResolvedValue({
+        ...makeTwoLaneAlertDetail(),
+        lanes: [
+          {
+            sequence: makeSequence({ id: 101, alert_api_id: 9001 }),
+            annotation: makeAnnotation({
+              id: 201,
+              sequence_id: 101,
+              processing_stage: 'annotated',
+            }),
+          },
+          {
+            sequence: makeSequence({ id: 102, alert_api_id: 9002 }),
+            annotation: makeAnnotation({
+              id: 202,
+              sequence_id: 102,
+              processing_stage: 'annotated',
+            }),
+          },
+        ],
+      });
+      mockAllFramesAccepted();
+    }
+
+    it('is absent in queue mode — that slot carries Skip alert', async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      expect(screen.getByTestId('skip-alert-button')).toBeInTheDocument();
+      expect(screen.queryByTestId('revert-to-queue-button')).not.toBeInTheDocument();
+    });
+
+    it('takes the Skip slot in done mode', async () => {
+      mockDoneAlert();
+      await renderAndSettle(<LocalizeAlertPage mode="done" />, { wrapper: doneWrapper });
+
+      expect(screen.getByTestId('revert-to-queue-button')).toBeInTheDocument();
+      expect(screen.queryByTestId('skip-alert-button')).not.toBeInTheDocument();
+    });
+
+    it('is absent when no lane is annotated-and-needs-localization', async () => {
+      // A deep link to /localize/done/:id for an alert that never finished:
+      // offering an action the server would 409 is worse than offering none.
+      vi.mocked(apiClient.getAlertDetail).mockResolvedValue({
+        ...makeTwoLaneAlertDetail(),
+        lanes: [
+          {
+            sequence: makeSequence({ id: 101, alert_api_id: 9001 }),
+            annotation: makeAnnotation({
+              id: 201,
+              sequence_id: 101,
+              processing_stage: 'seq_annotation_done',
+            }),
+          },
+        ],
+      });
+
+      await renderAndSettle(<LocalizeAlertPage mode="done" />, { wrapper: doneWrapper });
+
+      expect(screen.queryByTestId('revert-to-queue-button')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -1584,6 +1584,94 @@ describe('LocalizeAlertPage', () => {
 
       expect(screen.queryByTestId('revert-to-queue-button')).not.toBeInTheDocument();
     });
+
+    it('posts every annotated smoke lane and returns to the Done list', async () => {
+      mockDoneAlert();
+      vi.mocked(apiClient.localizeRevert).mockResolvedValue({
+        results: [
+          { annotation_id: 201, sequence_id: 101, processing_stage: 'seq_annotation_done' },
+          { annotation_id: 202, sequence_id: 102, processing_stage: 'seq_annotation_done' },
+        ],
+      });
+
+      await renderAndSettle(<LocalizeAlertPage mode="done" />, { wrapper: doneWrapper });
+
+      fireEvent.click(screen.getByTestId('revert-to-queue-button'));
+      expect(screen.getByTestId('revert-to-queue-confirm')).toBeInTheDocument();
+
+      fireEvent.click(
+        within(screen.getByTestId('revert-to-queue-confirm')).getByRole('button', {
+          name: 'Send back to queue',
+        })
+      );
+
+      await waitFor(() => {
+        expect(vi.mocked(apiClient.localizeRevert)).toHaveBeenCalledWith([201, 202]);
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId('localize-done-landing')).toBeInTheDocument();
+      });
+    });
+
+    it('does nothing when the confirm is dismissed', async () => {
+      mockDoneAlert();
+      await renderAndSettle(<LocalizeAlertPage mode="done" />, { wrapper: doneWrapper });
+
+      fireEvent.click(screen.getByTestId('revert-to-queue-button'));
+      fireEvent.click(
+        within(screen.getByTestId('revert-to-queue-confirm')).getByRole('button', {
+          name: 'Cancel',
+        })
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('revert-to-queue-confirm')).not.toBeInTheDocument();
+      });
+      expect(vi.mocked(apiClient.localizeRevert)).not.toHaveBeenCalled();
+    });
+
+    it('keeps the alert on the page when the revert fails', async () => {
+      mockDoneAlert();
+      vi.mocked(apiClient.localizeRevert).mockRejectedValue({ detail: 'not at annotated' });
+
+      await renderAndSettle(<LocalizeAlertPage mode="done" />, { wrapper: doneWrapper });
+
+      fireEvent.click(screen.getByTestId('revert-to-queue-button'));
+      fireEvent.click(
+        within(screen.getByTestId('revert-to-queue-confirm')).getByRole('button', {
+          name: 'Send back to queue',
+        })
+      );
+
+      await waitFor(() => {
+        expect(vi.mocked(apiClient.localizeRevert)).toHaveBeenCalled();
+      });
+      expect(screen.queryByTestId('localize-done-landing')).not.toBeInTheDocument();
+    });
+
+    it('suspends the page shortcuts while the confirm is up', async () => {
+      // The confirm is a page overlay; leaving `c` live would toggle crop mode
+      // behind it. Crop state is observed exactly as the crop tests above do
+      // it: a zoomed cell carries a `scale(...)` transform on its image.
+      // A done alert has no workable object, so nothing auto-focuses and crop
+      // has nothing to zoom around. Activating a row puts it in focus mode,
+      // which forces crop on — that zoom is the state the guard must defend.
+      mockDoneAlert();
+      await renderAndSettle(<LocalizeAlertPage mode="done" />, { wrapper: doneWrapper });
+
+      fireEvent.click(screen.getByTestId('localize-object-row-object-1'));
+      await waitFor(() => {
+        const img = within(screen.getByTestId(`alert-frame-cell-${T1}`)).getByRole('img');
+        expect(img.style.transform).toContain('scale(');
+      });
+
+      fireEvent.click(screen.getByTestId('revert-to-queue-button'));
+      fireEvent.keyDown(window, { key: 'c' });
+
+      // Still cropped: the second press was swallowed by the overlay guard.
+      const img = within(screen.getByTestId(`alert-frame-cell-${T1}`)).getByRole('img');
+      expect(img.style.transform).toContain('scale(');
+    });
   });
 
   describe('false-positive context toggle', () => {


### PR DESCRIPTION
Adds a **Send back to queue** action to the done-mode localize cockpit
(`/localize/done/:sequenceId`), in the slot **Skip alert** occupies in queue mode.

Spec: `docs/specs/2026-08-07-localize-revert-to-queue-design.md`.

## Why

Once an alert is submitted from `/localize` its lanes sit at `annotated` forever.
There was no way back, so:

- a bad box spotted on a done alert could not be fixed, and
- **bad data could not be withheld from the export** — `/export/alerts` ships an
  alert whenever every one of its lanes is `annotated` (`export.py:225`), so a
  known-wrong localization kept flowing into the training set.

The second is the driving motivation. One stage flip covers both: the alert
leaves Done, re-enters the queue, and drops out of the export.

## What it does

Flips every `annotated` lane of the alert that matches the localization rule back
to `seq_annotation_done`. Nothing else moves:

- **Boxes and per-frame acceptance survive** — the annotator fixes one frame and
  resubmits rather than redoing the alert.
- FP lanes and deferred-unsure lanes are untouched (they never carried
  localization work).
- `auto_annotated_at` stays set, so the auto-annotate sweep does not re-fire and
  the lane instantly re-qualifies for the queue.
- No contribution row is written — reverting is a correction, not authorship.

## Backend

New `POST /api/v1/annotations/sequences/localize-revert`, mirroring
`localize-submit`'s validation spine. It deliberately does **not** route through
`apply_annotation_update`: this exact stage move on a smoke lane is the FP→smoke
promotion predicate, whose effects block 422s on any committed detection
annotation and otherwise deletes every `DetectionAnnotation` of the sequence —
the opposite of what is wanted here. Writing through the CRUD also keeps
`auto_create_detection_annotations`, the group fan-out, and the contribution
insert from firing.

Guards (one transaction, single commit): 404 unknown id, 422 cross-alert, 409
lane not at `annotated`, 422 lane that does not need localization. A post-commit
safety net re-arms auto-annotation for any reverted lane whose reference layer
never landed, which would otherwise leave it in neither queue for up to an hour.

## Export behaviour

Verified end to end: the alert exports, disappears after the revert, and returns
after a re-submit with a later `last_annotated_at` — so an incremental consumer
picks up the correction rather than keeping the stale copy.

**Known limitation:** the export emits no tombstone. A consumer that already
pulled the alert and then syncs incrementally will silently retain the bad copy;
withdrawal is only real for a full pull, or one that diffs against the complete
alert-key set. No pull script exists in the repo yet — this is a constraint on
whoever writes one, and it is recorded in the spec.

## Tests

- `annotation_api/src/tests/endpoints/test_localize_revert.py` — 15 tests: export
  withdrawal and re-admission, movement between both queues, boxes preserved,
  zero new contributions, FP siblings untouched, no group propagation, every
  guard, atomicity, and both branches of the auto-annotate safety net.
- `frontend/tests/pages/LocalizeAlertPage.test.tsx` — 7 tests: button absent in
  queue mode / present in done mode / absent when nothing is revertable, confirm
  posts the right ids and navigates, dismissal is inert, failure keeps you on the
  page, and page shortcuts are suspended while the confirm is up.

Full suites green: 698 backend, 1281 frontend.
