### PR TITLE
perf(import): reuse the posting token for annotation creation

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/annotation_management.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/annotation_management.py
@@ -17,9 +17,7 @@ import logging
 from datetime import date, datetime
 from typing import Dict, Any, Optional
 
-from . import shared
 from app.clients.annotation_api import (
-    get_auth_token,
     list_sequence_annotations,
     create_sequence_annotation,
     update_sequence_annotation,
@@ -58,28 +56,32 @@ def valid_date(s: str) -> date:
         raise argparse.ArgumentTypeError(msg)
 
 
-def check_existing_annotation(base_url: str, sequence_id: int) -> Optional[int]:
+def check_existing_annotation(
+    base_url: str, sequence_id: int, auth_token: str
+) -> Optional[int]:
     """
     Check if a sequence already has an annotation.
 
     Args:
         base_url: Base URL of the annotation API
         sequence_id: ID of the sequence to check
+        auth_token: JWT held by the caller. This stage never mints its own —
+            a login costs ~143ms of bcrypt on the API's single event loop,
+            and it was previously paid once per sequence here.
 
     Returns:
         Annotation ID if found, None if no annotation exists
 
     Example:
-        >>> annotation_id = check_existing_annotation("http://localhost:5050", 123)
+        >>> annotation_id = check_existing_annotation(
+        ...     "http://localhost:5050", 123, auth_token
+        ... )
         >>> if annotation_id:
         ...     print(f"Found existing annotation with ID: {annotation_id}")
         >>> else:
         ...     print("No existing annotation found")
     """
     try:
-        # Get authentication token
-        login, password = shared.get_annotation_credentials(base_url)
-        auth_token = get_auth_token(base_url, login, password)
         response = list_sequence_annotations(
             base_url, auth_token, sequence_id=sequence_id
         )
@@ -104,6 +106,7 @@ def create_annotation_from_data(
     base_url: str,
     sequence_id: int,
     annotation_data: SequenceAnnotationData,
+    auth_token: str,
     dry_run: bool = False,
     existing_annotation_id: Optional[int] = None,
     processing_stage: SequenceAnnotationProcessingStage = SequenceAnnotationProcessingStage.READY_TO_ANNOTATE,
@@ -119,6 +122,9 @@ def create_annotation_from_data(
         base_url: Base URL of the annotation API
         sequence_id: ID of the sequence to annotate
         annotation_data: SequenceAnnotationData containing the annotation
+        auth_token: JWT held by the caller. This stage never mints its own —
+            a login costs ~143ms of bcrypt on the API's single event loop,
+            and it was previously paid once per sequence here.
         dry_run: If True, only log what would be done without making changes
         existing_annotation_id: ID of existing annotation to update (None to create new)
         processing_stage: Processing stage to set for the annotation
@@ -135,6 +141,7 @@ def create_annotation_from_data(
         ...     base_url="http://localhost:5050",
         ...     sequence_id=123,
         ...     annotation_data=annotation_data,
+        ...     auth_token=auth_token,
         ...     dry_run=False,
         ...     processing_stage=SequenceAnnotationProcessingStage.READY_TO_ANNOTATE
         ... )
@@ -144,15 +151,12 @@ def create_annotation_from_data(
         ...     base_url="http://localhost:5050",
         ...     sequence_id=123,
         ...     annotation_data=updated_data,
+        ...     auth_token=auth_token,
         ...     existing_annotation_id=456,
         ...     dry_run=False
         ... )
     """
     try:
-        # Get authentication token
-        login, password = shared.get_annotation_credentials(base_url)
-        auth_token = get_auth_token(base_url, login, password)
-
         if existing_annotation_id:
             # Update existing annotation (PATCH)
             update_dict = {
@@ -240,12 +244,12 @@ def create_annotation_from_data(
         return False
 
 
-def _rollback_sequence(sequence_id: int, annotation_api_url: str) -> None:
+def _rollback_sequence(
+    sequence_id: int, annotation_api_url: str, auth_token: str
+) -> None:
     """Delete a sequence as part of the `annotate_split_sequence` rollback path."""
-    login, password = shared.get_annotation_credentials(annotation_api_url)
     try:
-        token = get_auth_token(annotation_api_url, username=login, password=password)
-        delete_sequence(annotation_api_url, token, sequence_id)
+        delete_sequence(annotation_api_url, auth_token, sequence_id)
     except Exception as exc:
         logging.warning(f"Rollback delete of sequence {sequence_id} failed: {exc}")
 
@@ -253,6 +257,7 @@ def _rollback_sequence(sequence_id: int, annotation_api_url: str) -> None:
 def annotate_split_sequence(
     seq_result: Dict[str, Any],
     annotation_api_url: str,
+    auth_token: str,
     dry_run: bool = False,
 ) -> Dict[str, Any]:
     """Write the single-track annotation for one imported object sequence.
@@ -261,6 +266,10 @@ def annotate_split_sequence(
     the annotation fails outright, delete the sequence instead (a
     half-imported or annotation-less object would 409 on the next run and
     never be completed), and report the rollback as an error.
+
+    `auth_token` is the token the posting stage already holds. This stage runs
+    once per object lane, so minting one here cost two ~143ms bcrypt logins per
+    lane, serialized on the API's single event loop.
     """
     sequence_id = seq_result["sequence_id"]
     result: Dict[str, Any] = {
@@ -272,7 +281,7 @@ def annotate_split_sequence(
     }
 
     if seq_result["failed_detections"] > 0:
-        _rollback_sequence(sequence_id, annotation_api_url)
+        _rollback_sequence(sequence_id, annotation_api_url, auth_token)
         result["errors"].append(
             f"sequence {sequence_id} rolled back: "
             f"{seq_result['failed_detections']}/{seq_result['total_detections']} detections failed"
@@ -284,12 +293,13 @@ def annotate_split_sequence(
             seq_result.get("detection_results", [])
         )
         existing_annotation_id = check_existing_annotation(
-            annotation_api_url, sequence_id
+            annotation_api_url, sequence_id, auth_token
         )
         if create_annotation_from_data(
             annotation_api_url,
             sequence_id,
             annotation_data,
+            auth_token,
             dry_run,
             existing_annotation_id,
             SequenceAnnotationProcessingStage.READY_TO_ANNOTATE,
@@ -304,13 +314,13 @@ def annotate_split_sequence(
             )
         else:
             if not dry_run:
-                _rollback_sequence(sequence_id, annotation_api_url)
+                _rollback_sequence(sequence_id, annotation_api_url, auth_token)
             result["errors"].append(
                 f"sequence {sequence_id} rolled back: failed to create annotation"
             )
     except Exception as exc:
         if not dry_run:
-            _rollback_sequence(sequence_id, annotation_api_url)
+            _rollback_sequence(sequence_id, annotation_api_url, auth_token)
         result["errors"].append(
             f"sequence {sequence_id} rolled back: unexpected error building annotation: {exc}"
         )

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
@@ -697,10 +697,13 @@ def main() -> None:
         )
 
         alert_api_seq_results = []
+        annotation_auth_token = None
         if not args.dry_run:
             alert_api_seq_results = [
                 r for r in result.get("sequence_results", []) if not r.get("skipped")
             ]
+            # Captured here because the collection loop below rebinds `result`.
+            annotation_auth_token = result["auth_token"]
 
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=worker_config.annotation_processing
@@ -711,6 +714,7 @@ def main() -> None:
                     annotate_split_sequence,
                     seq_result=seq_result,
                     annotation_api_url=args.annotation_api_url,
+                    auth_token=annotation_auth_token,
                     dry_run=args.dry_run,
                 ): seq_result["sequence_id"]
                 for seq_result in alert_api_seq_results

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
@@ -732,6 +732,8 @@ def post_records_to_annotation_api(
             "total_detections": 0,
             "successful_sequence_ids": [],
             "sequence_results": [],
+            # No token was minted on this path; both returns share a shape.
+            "auth_token": None,
         }
 
     # Resolve credentials and get a single auth token up-front to avoid repeated logins
@@ -850,4 +852,6 @@ def post_records_to_annotation_api(
         "total_detections": len(records),
         "successful_sequence_ids": successful_sequence_ids,
         "sequence_results": sequence_results,
+        # Annotation creation reuses this instead of logging in once per lane.
+        "auth_token": auth_token,
     }

--- a/annotation_api/src/tests/scripts/test_annotate_split_sequence.py
+++ b/annotation_api/src/tests/scripts/test_annotate_split_sequence.py
@@ -34,14 +34,24 @@ def seq_result(failed=0, detection_results=None):
 class TestAnnotateSplitSequence:
     def test_happy_path_creates_one_track_annotation(self, monkeypatch):
         captured = {}
-        monkeypatch.setattr(am, "check_existing_annotation", lambda url, sid: None)
+        monkeypatch.setattr(
+            am, "check_existing_annotation", lambda url, sid, token: None
+        )
 
         def fake_create(
-            url, sid, annotation_data, dry_run, existing_id, stage, config=None
+            url,
+            sid,
+            annotation_data,
+            auth_token,
+            dry_run,
+            existing_id,
+            stage,
+            config=None,
         ):
             captured.update(
                 sid=sid,
                 data=annotation_data,
+                token=auth_token,
                 dry_run=dry_run,
                 existing=existing_id,
                 stage=stage,
@@ -50,9 +60,10 @@ class TestAnnotateSplitSequence:
 
         monkeypatch.setattr(am, "create_annotation_from_data", fake_create)
         result = am.annotate_split_sequence(
-            seq_result(), "http://annotation.test", dry_run=False
+            seq_result(), "http://annotation.test", "tok", dry_run=False
         )
         assert result["annotation_created"] is True
+        assert captured["token"] == "tok"
         assert result["errors"] == []
         assert captured["sid"] == 42
         assert len(captured["data"].sequences_bbox) == 1
@@ -64,35 +75,33 @@ class TestAnnotateSplitSequence:
 
     def test_partial_import_rolls_back_sequence(self, monkeypatch):
         deleted = []
+        tokens = []
         monkeypatch.setattr(
-            am.shared, "get_annotation_credentials", lambda url: ("u", "p")
-        )
-        monkeypatch.setattr(am, "get_auth_token", lambda url, username, password: "tok")
-        monkeypatch.setattr(
-            am, "delete_sequence", lambda url, token, sid: deleted.append(sid)
+            am,
+            "delete_sequence",
+            lambda url, token, sid: (deleted.append(sid), tokens.append(token)),
         )
         result = am.annotate_split_sequence(
-            seq_result(failed=1), "http://annotation.test", dry_run=False
+            seq_result(failed=1), "http://annotation.test", "tok", dry_run=False
         )
+        assert tokens == ["tok"]
         assert deleted == [42]
         assert result["annotation_created"] is False
         assert result["errors"] and "rolled back" in result["errors"][0]
 
     def test_annotation_failure_reports_error(self, monkeypatch):
         deleted = []
-        monkeypatch.setattr(am, "check_existing_annotation", lambda url, sid: None)
+        monkeypatch.setattr(
+            am, "check_existing_annotation", lambda url, sid, token: None
+        )
         monkeypatch.setattr(
             am, "create_annotation_from_data", lambda *args, **kwargs: False
         )
         monkeypatch.setattr(
-            am.shared, "get_annotation_credentials", lambda url: ("u", "p")
-        )
-        monkeypatch.setattr(am, "get_auth_token", lambda url, username, password: "tok")
-        monkeypatch.setattr(
             am, "delete_sequence", lambda url, token, sid: deleted.append(sid)
         )
         result = am.annotate_split_sequence(
-            seq_result(), "http://annotation.test", dry_run=False
+            seq_result(), "http://annotation.test", "tok", dry_run=False
         )
         assert result["annotation_created"] is False
         assert result["errors"]
@@ -100,19 +109,17 @@ class TestAnnotateSplitSequence:
 
     def test_annotation_failure_rolls_back_sequence(self, monkeypatch):
         deleted = []
-        monkeypatch.setattr(am, "check_existing_annotation", lambda url, sid: None)
+        monkeypatch.setattr(
+            am, "check_existing_annotation", lambda url, sid, token: None
+        )
         monkeypatch.setattr(
             am, "create_annotation_from_data", lambda *args, **kwargs: False
         )
         monkeypatch.setattr(
-            am.shared, "get_annotation_credentials", lambda url: ("u", "p")
-        )
-        monkeypatch.setattr(am, "get_auth_token", lambda url, username, password: "tok")
-        monkeypatch.setattr(
             am, "delete_sequence", lambda url, token, sid: deleted.append(sid)
         )
         result = am.annotate_split_sequence(
-            seq_result(), "http://annotation.test", dry_run=False
+            seq_result(), "http://annotation.test", "tok", dry_run=False
         )
         assert deleted == [42]
         assert result["annotation_created"] is False
@@ -128,15 +135,68 @@ class TestAnnotateSplitSequence:
 
         monkeypatch.setattr(am, "build_single_track_annotation", _raise)
         monkeypatch.setattr(
-            am.shared, "get_annotation_credentials", lambda url: ("u", "p")
-        )
-        monkeypatch.setattr(am, "get_auth_token", lambda url, username, password: "tok")
-        monkeypatch.setattr(
             am, "delete_sequence", lambda url, token, sid: deleted.append(sid)
         )
         result = am.annotate_split_sequence(
-            seq_result(), "http://annotation.test", dry_run=False
+            seq_result(), "http://annotation.test", "tok", dry_run=False
         )
         assert deleted == [42]
         assert result["annotation_created"] is False
         assert result["errors"] and "rolled back" in result["errors"][0]
+
+
+class TestAuthTokenReuse:
+    def test_annotate_split_sequence_does_not_log_in(self, monkeypatch):
+        """Stage 3 must reuse the caller's token, never mint its own.
+
+        Each login is ~143ms of bcrypt on the API's single event loop, and it
+        was being paid twice per lane.
+        """
+        logins = []
+
+        def _no_login(*args, **kwargs):
+            logins.append(1)
+            return "minted"
+
+        # raising=False so this holds whether or not the module still imports
+        # get_auth_token. Dropping the import is the stronger guarantee; this
+        # test is the guard against it being reintroduced along with a call.
+        monkeypatch.setattr(am, "get_auth_token", _no_login, raising=False)
+        monkeypatch.setattr(
+            am,
+            "list_sequence_annotations",
+            lambda url, token, sequence_id: {"items": []},
+        )
+        monkeypatch.setattr(
+            am, "create_sequence_annotation", lambda url, token, payload: {"id": 7}
+        )
+
+        result = am.annotate_split_sequence(
+            seq_result(), "http://annotation.test", "caller-token", dry_run=False
+        )
+
+        assert result["annotation_created"] is True
+        assert (
+            logins == []
+        ), "stage 3 minted its own token instead of reusing the caller's"
+
+    def test_caller_token_is_forwarded_to_the_api(self, monkeypatch):
+        seen = {}
+
+        def _list(url, token, sequence_id):
+            seen["list"] = token
+            return {"items": []}
+
+        def _create(url, token, payload):
+            seen["create"] = token
+            return {"id": 7}
+
+        monkeypatch.setattr(am, "list_sequence_annotations", _list)
+        monkeypatch.setattr(am, "create_sequence_annotation", _create)
+
+        am.annotate_split_sequence(
+            seq_result(), "http://annotation.test", "caller-token", dry_run=False
+        )
+
+        assert seen["list"] == "caller-token"
+        assert seen["create"] == "caller-token"


### PR DESCRIPTION
Stage 3 of the alert-API import minted a fresh JWT for **every lane, twice** — once in `check_existing_annotation`, once in `create_annotation_from_data` — plus a third on the rollback path.

## Why that is expensive

`login` runs passlib bcrypt synchronously inside an `async def`, and the API is a single uvicorn process with no `--workers`. Measured on a local stack:

```
single login            145 ms      idle /status: 1 ms
4 concurrent logins     567 ms wall (142 ms/login)
8 concurrent logins    1140 ms wall (143 ms/login)
/status during 8       794 ms
```

Perfectly linear — no concurrency at all — and it blocks every other request while it runs. At the 553-lane scale of a real import that is 1106 logins, roughly **158 seconds** spent doing nothing but logging in, during which the API is unusable for anyone else.

## The change

Thread the token `post_records_to_annotation_api` already holds through stage 3. Login count drops from `2N+3` to `3`.

`get_auth_token` and the `shared` import are now unused in `annotation_management.py` and are dropped, so the module can no longer log in at all.

**No new token-expiry exposure:** stage 2 already hoists a single token across the whole posting stage, which is the longer of the two, and that runs in production today. This matches the existing pattern rather than adding refresh-on-401 complexity.

## Verification

Measured on an isolated stack (fresh DB each run, fixed date, 10 alert sequences → 11 lanes, 211 detections, median of 3):

| | total | Step 1 | Step 3 |
|---|---|---|---|
| before | 18.33s | 14.7s | **3.2s** |
| after | 14.40s | 13.9s | **0.1s** |

Step 3 is where the fix applies: 32x faster, and the 3.2s baseline matches the predicted 22 logins x 143ms almost exactly.

- **Full suite:** 688 passed
- **Output equivalence:** an import of the same date range produces a byte-identical id-free projection of sequences, detections and annotation boxes versus baseline. All three post-change runs match. The projection deliberately rewrites annotation `detection_id` references to the referenced detection's `alert_api_id`, so it would catch annotations bound to the wrong rows rather than just comparing serial ids.
- **New regression tests:** one asserts stage 3 mints zero tokens (patched with `raising=False`, so it holds whether or not the import is ever reintroduced); one asserts the caller's token is what actually reaches the API.

Part of a three-PR series; the remaining two move blocking S3 work off the event loop and add uvicorn workers. Design: `docs/specs/2026-08-07-import-performance-design.md`.
