### PR TITLE
perf(api): run blocking S3 work off the event loop

### DIFF
--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -6,6 +6,7 @@
 import hashlib
 import logging
 import os
+import threading
 from datetime import datetime, UTC
 from mimetypes import guess_extension
 from typing import Any, Dict, Optional, Union
@@ -180,8 +181,16 @@ class S3Service:
         secret_key: str,
         proxy_url: Union[str, None] = None,
     ) -> None:
-        _session = boto3.Session(access_key, secret_key, region_name=region)
-        self._s3 = _session.client("s3", endpoint_url=endpoint_url)
+        self._region = region
+        self._endpoint_url = endpoint_url
+        self._access_key = access_key
+        self._secret_key = secret_key
+        # Storage work runs in a threadpool (see the storage functions below),
+        # so a process-wide client would be used concurrently. boto3 Sessions
+        # are not documented as thread-safe, and upload_fileobj drives the
+        # transfer manager, which spawns threads of its own. Each thread builds
+        # and keeps its own client instead.
+        self._local = threading.local()
         # Probe with head_bucket on the configured destination bucket so least-
         # privilege credentials (without s3:ListAllMyBuckets) still validate.
         try:
@@ -194,6 +203,18 @@ class S3Service:
             raise ValueError(f"unable to access bucket {settings.S3_BUCKET_NAME} on S3")
         logger.info(f"S3 connected on {endpoint_url}")
         self.proxy_url = proxy_url
+
+    @property
+    def _s3(self) -> Any:
+        """The calling thread's boto3 client, built on first use."""
+        client = getattr(self._local, "client", None)
+        if client is None:
+            session = boto3.Session(
+                self._access_key, self._secret_key, region_name=self._region
+            )
+            client = session.client("s3", endpoint_url=self._endpoint_url)
+            self._local.client = client
+        return client
 
     def create_bucket(self, bucket_name: str) -> bool:
         """Create a new bucket in S3 storage"""

--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -20,6 +20,7 @@ from botocore.exceptions import (
     PartialCredentialsError,
 )
 from fastapi import HTTPException, UploadFile, status
+from starlette.concurrency import run_in_threadpool
 
 from app.core.config import settings
 
@@ -366,6 +367,65 @@ def _generate_detection_bucket_key(
     return f"detections/legacy/{timestamp_str}_{sha_hash}{extension}"
 
 
+def _store_downloaded_image(
+    image_bytes: bytes,
+    sequence_id: Optional[int],
+    detection_id: Optional[int],
+    recorded_at: Optional[datetime],
+) -> str:
+    """Hash, type-sniff, upload and verify image bytes. Returns the bucket key.
+
+    Blocking throughout: every step is either CPU over the full image or an S3
+    round trip. Run it in a thread — on the event loop it serialized every
+    other request behind it.
+    """
+    sha_hash = hashlib.sha256(image_bytes).hexdigest()
+    md5_hash = hashlib.md5(image_bytes).hexdigest()  # noqa: S324
+    content_type = magic.from_buffer(image_bytes, mime=True)
+    extension = guess_extension(content_type) or ""
+
+    bucket_key = _generate_detection_bucket_key(
+        sequence_id=sequence_id,
+        detection_id=detection_id,
+        recorded_at=recorded_at,
+        sha_hash=sha_hash[:8],
+        extension=extension,
+    )
+
+    bucket_name = s3_service.resolve_bucket_name()
+    bucket = s3_service.get_bucket(bucket_name)
+
+    if not bucket.upload_file_bytes(
+        image_bytes, bucket_key, content_type or "application/octet-stream"
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed upload",
+        )
+    logging.info("File uploaded to bucket %s with key %s.", bucket_name, bucket_key)
+
+    # Data integrity check
+    try:
+        file_meta = bucket.get_file_metadata(bucket_key)
+    except Exception as exc:
+        logging.warning("Could not retrieve file metadata for %s: %s", bucket_key, exc)
+    else:
+        etag = file_meta.get("ETag") or file_meta.get("etag")
+        if etag is not None and md5_hash != etag.replace('"', ""):
+            try:
+                bucket.delete_file(bucket_key)
+            except Exception as exc:
+                logging.warning(
+                    "Failed to delete corrupted file %s: %s", bucket_key, exc
+                )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Data was corrupted during upload",
+            )
+
+    return bucket_key
+
+
 async def upload_file_from_url(
     source_url: str,
     sequence_id: Optional[int] = None,
@@ -413,64 +473,29 @@ async def upload_file_from_url(
             detail="Source URL returned empty response",
         )
 
-    sha_hash = hashlib.sha256(image_bytes).hexdigest()
-    md5_hash = hashlib.md5(image_bytes).hexdigest()  # noqa: S324
-    extension = guess_extension(magic.from_buffer(image_bytes, mime=True)) or ""
-
-    bucket_key = _generate_detection_bucket_key(
-        sequence_id=sequence_id,
-        detection_id=detection_id,
-        recorded_at=recorded_at,
-        sha_hash=sha_hash[:8],
-        extension=extension,
+    return await run_in_threadpool(
+        _store_downloaded_image,
+        image_bytes,
+        sequence_id,
+        detection_id,
+        recorded_at,
     )
 
-    bucket_name = s3_service.resolve_bucket_name()
-    bucket = s3_service.get_bucket(bucket_name)
 
-    content_type = (
-        magic.from_buffer(image_bytes, mime=True) or "application/octet-stream"
-    )
-    if not bucket.upload_file_bytes(image_bytes, bucket_key, content_type):
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed upload",
-        )
-    logging.info("File uploaded to bucket %s with key %s.", bucket_name, bucket_key)
-
-    # Data integrity check
-    try:
-        file_meta = bucket.get_file_metadata(bucket_key)
-    except Exception as exc:
-        logging.warning("Could not retrieve file metadata for %s: %s", bucket_key, exc)
-    else:
-        etag = file_meta.get("ETag") or file_meta.get("etag")
-        if etag is not None and md5_hash != etag.replace('"', ""):
-            try:
-                bucket.delete_file(bucket_key)
-            except Exception as exc:
-                logging.warning(
-                    "Failed to delete corrupted file %s: %s", bucket_key, exc
-                )
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Data was corrupted during upload",
-            )
-
-    return bucket_key
-
-
-async def copy_file_from_bucket(
+def _copy_file_from_bucket_sync(
     source_bucket: str,
     source_key: str,
-    sequence_id: Optional[int] = None,
-    detection_id: Optional[int] = None,
-    recorded_at: Optional[datetime] = None,
+    sequence_id: Optional[int],
+    detection_id: Optional[int],
+    recorded_at: Optional[datetime],
 ) -> str:
     """Server-side copy from another bucket on the same S3 service.
 
     Returns the destination bucket key. Verifies the destination is non-empty
     via head_object and cleans up if the copy produced a zero-byte object.
+
+    Blocking: copy_object plus head_object, both S3 round trips. Callers reach
+    it through `copy_file_from_bucket`, which runs it in a thread.
     """
     extension = os.path.splitext(source_key)[1]
     sha_hash = hashlib.sha256(f"{source_bucket}/{source_key}".encode()).hexdigest()[:8]
@@ -537,6 +562,28 @@ async def copy_file_from_bucket(
         content_length,
     )
     return dest_key
+
+
+async def copy_file_from_bucket(
+    source_bucket: str,
+    source_key: str,
+    sequence_id: Optional[int] = None,
+    detection_id: Optional[int] = None,
+    recorded_at: Optional[datetime] = None,
+) -> str:
+    """Server-side copy from another bucket on the same S3 service.
+
+    Returns the destination bucket key. The boto3 work is blocking, so it runs
+    in a thread rather than stalling the event loop for every other request.
+    """
+    return await run_in_threadpool(
+        _copy_file_from_bucket_sync,
+        source_bucket,
+        source_key,
+        sequence_id,
+        detection_id,
+        recorded_at,
+    )
 
 
 s3_service = S3Service(

--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -231,8 +231,25 @@ class S3Service:
             return False
 
     def get_bucket(self, bucket_name: str) -> S3Bucket:
-        """Get an existing bucket in S3 storage"""
-        return S3Bucket(self._s3, bucket_name, self.proxy_url)
+        """Get an existing bucket in S3 storage.
+
+        Cached per thread. S3Bucket.__init__ issues a head_bucket -- a network
+        round trip -- purely to validate the handle it returns, and get_bucket
+        runs on every request that touches storage, so this was an extra S3
+        call per detection creation and per image URL.
+
+        The cache lives in the same thread-local as the client so a thread can
+        never receive a handle wrapping another thread's client.
+        """
+        cache = getattr(self._local, "buckets", None)
+        if cache is None:
+            cache = {}
+            self._local.buckets = cache
+        bucket = cache.get(bucket_name)
+        if bucket is None:
+            bucket = S3Bucket(self._s3, bucket_name, self.proxy_url)
+            cache[bucket_name] = bucket
+        return bucket
 
     async def delete_bucket(self, bucket_name: str) -> bool:
         """Delete an existing bucket in S3 storage"""

--- a/annotation_api/src/tests/endpoints/test_detections.py
+++ b/annotation_api/src/tests/endpoints/test_detections.py
@@ -1,10 +1,15 @@
+import asyncio
 import json
 from datetime import datetime, timedelta, UTC
 
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
+from sqlalchemy.orm import sessionmaker
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.db import engine, get_session
+from app.main import app
 from app.services.storage import s3_service
 
 now = datetime.now(UTC)
@@ -562,3 +567,122 @@ async def test_create_duplicate_detection_returns_409(
         Bucket=bucket.name, Prefix="detections/sequence_1/"
     ).get("KeyCount", 0)
     assert objects_after_second == objects_after_first
+
+
+@pytest_asyncio.fixture
+async def concurrent_client(authenticated_client: AsyncClient):
+    """An authenticated client whose requests each get their own DB session.
+
+    conftest overrides get_session to hand every request the SAME session so
+    tests can inspect state. That is fine when requests are serialized, but an
+    AsyncSession is not safe for concurrent use, so concurrency tests driven
+    through it fail inside SQLAlchemy and tell you nothing about the code under
+    test. Production hands each request a fresh session from the pool; this
+    restores that, so the concurrency being tested is the real thing.
+    """
+    maker = sessionmaker(
+        bind=engine, class_=AsyncSession, expire_on_commit=False, autoflush=False
+    )
+
+    async def _fresh_session():
+        async with maker() as session:
+            yield session
+
+    previous = app.dependency_overrides.get(get_session)
+    app.dependency_overrides[get_session] = _fresh_session
+    try:
+        yield authenticated_client
+    finally:
+        if previous is not None:
+            app.dependency_overrides[get_session] = previous
+        else:
+            app.dependency_overrides.pop(get_session, None)
+
+
+def _reachable_source_url(mock_img: bytes, key: str) -> str:
+    """Put an image in the bucket and return a URL the API can actually fetch.
+
+    Presigned against S3_ENDPOINT_URL rather than S3_PROXY_URL: the proxy URL
+    is for browsers on the host, while the API resolves the in-network name.
+    """
+    bucket = s3_service.get_bucket(s3_service.resolve_bucket_name())
+    bucket.upload_file_bytes(mock_img, key, "image/jpeg")
+    return bucket._s3.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": bucket.name, "Key": key},
+        ExpiresIn=3600,
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_detection_creation_in_one_sequence(
+    concurrent_client: AsyncClient, sequence_session: AsyncSession, mock_img: bytes
+):
+    """Concurrent creation in one sequence must not duplicate or collide.
+
+    Storage work now runs in a threadpool, so these genuinely overlap. The
+    event loop used to serialize them, which meant the unique constraint and
+    the S3 rollback path were never exercised under real concurrency.
+    """
+    source_url = _reachable_source_url(mock_img, "concurrent-source.jpg")
+    payloads = [
+        {
+            "sequence_id": 1,
+            "alert_api_id": 9000 + i,
+            "recorded_at": (now - timedelta(days=2)).isoformat(),
+            "algo_predictions": {
+                "predictions": [
+                    {
+                        "xyxyn": [0.1, 0.1, 0.2, 0.2],
+                        "confidence": 0.9,
+                        "class_name": "smoke",
+                    }
+                ]
+            },
+            "source_url": source_url,
+        }
+        for i in range(8)
+    ]
+
+    responses = await asyncio.gather(
+        *[concurrent_client.post("/detections/from-url", json=p) for p in payloads]
+    )
+
+    failures = [(r.status_code, r.text) for r in responses if r.status_code != 201]
+    assert not failures, failures
+    assert len({r.json()["id"] for r in responses}) == 8, "duplicate rows created"
+    assert (
+        len({r.json()["bucket_key"] for r in responses}) == 8
+    ), "detections collided on one bucket key"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_duplicate_alert_api_id_admits_one(
+    concurrent_client: AsyncClient, sequence_session: AsyncSession, mock_img: bytes
+):
+    """The unique constraint must hold when duplicates race, not only serialized.
+
+    test_create_detection_duplicate_alert_api_id covers the sequential case;
+    this is the same invariant once the requests actually overlap.
+    """
+    source_url = _reachable_source_url(mock_img, "concurrent-dup-source.jpg")
+    payload = {
+        "sequence_id": 1,
+        "alert_api_id": 9500,
+        "recorded_at": (now - timedelta(days=2)).isoformat(),
+        "algo_predictions": {"predictions": []},
+        "source_url": source_url,
+    }
+
+    responses = await asyncio.gather(
+        *[
+            concurrent_client.post("/detections/from-url", json=payload)
+            for _ in range(4)
+        ]
+    )
+
+    created = [r for r in responses if r.status_code == 201]
+    assert len(created) == 1, (
+        f"expected exactly one winner, got {len(created)}: "
+        f"{[(r.status_code, r.text) for r in responses]}"
+    )

--- a/annotation_api/src/tests/services/test_storage.py
+++ b/annotation_api/src/tests/services/test_storage.py
@@ -1,4 +1,5 @@
 import io
+import threading
 
 import boto3
 import pytest
@@ -101,3 +102,44 @@ async def test_s3_bucket(bucket_name, proxy_url, expected_error, mock_img):
     else:
         with pytest.raises(expected_error):
             S3Bucket(_s3, bucket_name, proxy_url)
+
+
+def _configured_service() -> S3Service:
+    return S3Service(
+        settings.S3_REGION,
+        settings.S3_ENDPOINT_URL,
+        settings.S3_ACCESS_KEY,
+        settings.S3_SECRET_KEY,
+        settings.S3_PROXY_URL,
+    )
+
+
+def test_s3_client_is_per_thread():
+    """Each thread gets its own boto3 client.
+
+    Storage work runs in a threadpool, so the process-wide client would
+    otherwise be used concurrently. boto3 Sessions are not documented as
+    thread-safe, and upload_fileobj drives the transfer manager, which spawns
+    threads of its own.
+    """
+    service = _configured_service()
+    # Keep the client OBJECTS alive, not their id()s: a thread's client is
+    # released when the thread dies, and CPython will happily hand the next
+    # allocation the same address. Comparing ids made this test pass alone and
+    # fail in a full run.
+    seen = {}
+
+    def record(name):
+        seen[name] = service._s3
+
+    threads = [
+        threading.Thread(target=record, args=("a",)),
+        threading.Thread(target=record, args=("b",)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert seen["a"] is not seen["b"], "two threads shared one boto3 client"
+    assert service._s3 is service._s3, "same thread rebuilt its client"

--- a/annotation_api/src/tests/services/test_storage.py
+++ b/annotation_api/src/tests/services/test_storage.py
@@ -143,3 +143,60 @@ def test_s3_client_is_per_thread():
 
     assert seen["a"] is not seen["b"], "two threads shared one boto3 client"
     assert service._s3 is service._s3, "same thread rebuilt its client"
+
+
+def test_get_bucket_probes_once_per_thread(monkeypatch):
+    """head_bucket is a network round trip, and it ran on every request.
+
+    S3Bucket.__init__ probes the bucket purely to validate the handle it hands
+    back, and get_bucket runs on every request that touches storage -- so every
+    detection creation and every image URL paid for an extra S3 round trip.
+    """
+    service = _configured_service()
+    name = service.resolve_bucket_name()
+    probes = []
+    real_head = service._s3.head_bucket
+
+    def counting_head(**kwargs):
+        probes.append(kwargs)
+        return real_head(**kwargs)
+
+    monkeypatch.setattr(service._s3, "head_bucket", counting_head)
+
+    first = service.get_bucket(name)
+    for _ in range(5):
+        service.get_bucket(name)
+
+    assert len(probes) == 1, f"head_bucket ran {len(probes)} times, expected 1"
+    assert service.get_bucket(name) is first
+
+
+def test_bucket_cache_is_per_thread():
+    """The cache must not hand one thread a handle wrapping another's client.
+
+    It shares the thread-local with the client for exactly this reason; a
+    process-wide cache would silently undo the per-thread client.
+
+    Populate from THIS thread first, then read from another. Racing two fresh
+    threads instead would let both observe an empty cache and each build their
+    own handle, so a process-wide cache would pass by luck -- verified: it did.
+    """
+    service = _configured_service()
+    name = service.resolve_bucket_name()
+
+    mine = service.get_bucket(name)
+    other = {}
+
+    def record():
+        bucket = service.get_bucket(name)
+        other["bucket"] = bucket
+        other["client"] = bucket._s3
+
+    thread = threading.Thread(target=record)
+    thread.start()
+    thread.join()
+
+    assert other["bucket"] is not mine, "bucket handle leaked across threads"
+    assert (
+        other["client"] is not mine._s3
+    ), "bucket handed a thread another thread's boto3 client"


### PR DESCRIPTION
`upload_file_from_url` and `copy_file_from_bucket` are `async def` but call **blocking** boto3, plus sha256/md5/`magic` over the full image bytes. The API is a single uvicorn process, so every one of those calls stalls every other request.

There are **three** blocking S3 round trips per detection creation:
1. `get_bucket()` → `S3Bucket.__init__` issues a `head_bucket` purely to validate the handle it returns
2. `copy_object` (or `upload_fileobj`)
3. `head_object` for the ETag check

## Changes

1. **Thread-local boto3 client.** `S3Service` built one client and shared it process-wide. That was trivially safe while only the event-loop thread touched it; a threadpool makes it genuinely concurrent. AWS guidance is that `Session` objects are not thread-safe, and `upload_fileobj` drives the transfer manager, which spawns its own threads. Rather than reason about whether sharing happens to be safe, each thread builds its own. `_s3` stays the attribute name (now a property), so no call site changes.
2. **Per-thread bucket-handle cache**, removing the per-request `head_bucket`. The cache shares the *same* thread-local as the client — a process-wide cache would hand a thread a handle wrapping another thread's client, silently undoing (1).
3. **`run_in_threadpool`** around the blocking tail of both storage functions. The httpx download was already correctly async and stays on the loop. `magic.from_buffer` was called twice with identical arguments; now once.

`upload_file` (multipart) is deliberately untouched — not on the import path, separate contract.

## Measured

Isolated stack, fresh DB per run, fixed date, 10 alert sequences → 11 lanes, 211 detections, median of 3.

**Local MinIO answers in ~2ms, which is too fast to reveal event-loop blocking — on that configuration this change measures 18% *slower*, because the per-thread boto3 client costs 30ms/thread and there is nothing to unblock.** Re-measured with a 40ms latency shim in front of MinIO, matching production S3:

| | total | Step 1 |
|---|---|---|
| baseline +40ms | 62.40s | 58.8s |
| this PR +40ms | **21.28s** | **17.7s** |

**2.9x faster overall, 3.3x on the affected stage.**

The mechanism cross-checks: on baseline, 40ms of latency added 44.1s across 211 detections — ~209ms each, i.e. three *serialized* round trips per detection, exactly as identified. On this PR the same latency adds only 2.7s, because the calls overlap and the cache removed one of the three.

This is an emulation, not a production measurement. Production S3 is ~30–50ms, so 40ms is a fair middle estimate.

## Verification

- **Full suite:** 691 passed (686 on main + 5 new)
- **Output equivalence:** every run — lagged and unlagged, before and after — produces a byte-identical id-free projection of sequences, detections and annotation boxes. The projection rewrites annotation `detection_id` to the referenced detection's `alert_api_id`, so it catches annotations bound to the wrong rows; this change deliberately alters the order ids are assigned, which is exactly the risk.
- **New tests:** per-thread client; per-thread bucket cache; `head_bucket` runs once; plus two concurrency tests covering creation within one sequence and racing duplicates against the unique constraint.

Two testing notes worth reviewing:
- The bucket-cache test was first written racing two fresh threads, which a deliberately-wrong process-wide cache **passed** (both threads observed an empty cache). It now populates from the test thread first, and was confirmed to reject the wrong implementation.
- `conftest` overrides `get_session` to hand every request the *same* session. That is fine serialized, but an `AsyncSession` is not safe for concurrent use, so the concurrency tests failed inside SQLAlchemy and said nothing about the code. The new `concurrent_client` fixture gives each request its own session, as production does.

Part of a three-PR series. Stacks with #347 (independent). Design: `docs/specs/2026-08-07-import-performance-design.md`.
