### PR TITLE
perf(api): run uvicorn with 2 workers and resize the DB pool

### DIFF
--- a/annotation_api/src/app/core/config.py
+++ b/annotation_api/src/app/core/config.py
@@ -38,6 +38,28 @@ class Settings(BaseSettings):
     ANNOTATOR_LOGIN: str = os.environ.get("ANNOTATOR_LOGIN", "admin")
     ANNOTATOR_PASSWORD: str = os.environ.get("ANNOTATOR_PASSWORD", "admin")
 
+    # Serving / DB pool sizing.
+    #
+    # Each uvicorn worker is a separate process with its own SQLAlchemy pool,
+    # so connection demand is UVICORN_WORKERS x (DB_POOL_SIZE +
+    # DB_MAX_OVERFLOW) and must stay under Postgres's max_connections (minus
+    # its 3 reserved superuser slots). src/tests/test_pool_sizing.py asserts
+    # this: overshooting it does not fail at startup, it surfaces as
+    # intermittent "too many clients already" under load.
+    #
+    # Two workers, not more: each is a whole extra Python process with the app
+    # loaded, and the deployment host is memory-constrained (a sibling VM is
+    # 7.5GB with one service already resident at 3GB). Two is enough to remove
+    # the single-process serialization, which is the point of this. Every value
+    # here is environment-overridable, so raise it once memory headroom on the
+    # real host is known -- no code change needed.
+    UVICORN_WORKERS: int = int(os.environ.get("UVICORN_WORKERS", "2"))
+    DB_POOL_SIZE: int = int(os.environ.get("DB_POOL_SIZE", "10"))
+    DB_MAX_OVERFLOW: int = int(os.environ.get("DB_MAX_OVERFLOW", "10"))
+    POSTGRES_MAX_CONNECTIONS: int = int(
+        os.environ.get("POSTGRES_MAX_CONNECTIONS", "150")
+    )
+
     # DB
     POSTGRES_URL: str = os.environ["POSTGRES_URL"]
 

--- a/annotation_api/src/app/db.py
+++ b/annotation_api/src/app/db.py
@@ -22,9 +22,11 @@ engine = AsyncEngine(
     create_engine(
         settings.POSTGRES_URL,
         echo=False,
-        # Connection pool configuration for handling thousands of requests
-        pool_size=20,  # Number of connections to maintain in the pool
-        max_overflow=30,  # Additional connections when pool is exhausted
+        # Connection pool configuration for handling thousands of requests.
+        # Sized per worker process: see UVICORN_WORKERS in core/config.py and
+        # the budget assertion in tests/test_pool_sizing.py.
+        pool_size=settings.DB_POOL_SIZE,  # Connections kept open per worker
+        max_overflow=settings.DB_MAX_OVERFLOW,  # Extra when the pool is busy
         pool_timeout=30,  # Seconds to wait for connection from pool
         pool_recycle=3600,  # Recycle connections after 1 hour
         pool_pre_ping=True,  # Validate connections before use

--- a/annotation_api/src/tests/test_pool_sizing.py
+++ b/annotation_api/src/tests/test_pool_sizing.py
@@ -1,0 +1,37 @@
+"""The connection budget must fit inside Postgres.
+
+Each uvicorn worker is a separate process with its own SQLAlchemy pool, so
+demand is multiplicative in the worker count. Getting this wrong does not fail
+at startup -- it surfaces as intermittent "too many clients already" under
+load, which is exactly the kind of thing that only shows up in production
+during an import. Hence an assertion rather than a comment.
+"""
+
+from app.core.config import settings
+
+
+def test_worker_connection_budget_fits_postgres():
+    demand = settings.UVICORN_WORKERS * (
+        settings.DB_POOL_SIZE + settings.DB_MAX_OVERFLOW
+    )
+    # Postgres keeps superuser_reserved_connections (default 3) back for
+    # superusers, so they are not available to the application.
+    budget = settings.POSTGRES_MAX_CONNECTIONS - 3
+    assert demand <= budget, (
+        f"{settings.UVICORN_WORKERS} workers x ("
+        f"{settings.DB_POOL_SIZE} pool + {settings.DB_MAX_OVERFLOW} overflow) "
+        f"= {demand} connections, but only {budget} are available"
+    )
+
+
+def test_engine_uses_the_configured_pool_size():
+    """db.py must read the settings, not hardcode its own numbers.
+
+    The pre-change engine hardcoded 20/30; if it drifts back to literals the
+    budget assertion above silently stops describing reality.
+    """
+    from app.db import engine
+
+    pool = engine.sync_engine.pool
+    assert pool.size() == settings.DB_POOL_SIZE
+    assert pool._max_overflow == settings.DB_MAX_OVERFLOW

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
       - postgres_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+    # The API runs several worker processes, each with its own connection
+    # pool, so the default max_connections=100 is tight. Keep this in step with
+    # POSTGRES_MAX_CONNECTIONS on annotation_api, which is what
+    # tests/test_pool_sizing.py checks the budget against.
+    command: postgres -c max_connections=150
     environment:
       - POSTGRES_USER=dummy_pg_user
       - POSTGRES_PASSWORD=dummy_pg_pwd
@@ -77,8 +82,23 @@ services:
       - AUTH_PASSWORD=admin12345
       - JWT_SECRET=your_jwt_secret_key_change_in_production_please
       - ACCESS_TOKEN_EXPIRE_HOURS=24
+      # Serving / pool sizing. UVICORN_WORKERS is read both by the command
+      # below and by app.core.config, so the process count and the connection
+      # budget can never drift apart.
+      # Budget: 2 workers x (10 + 10) = 40, plus the queue worker's 20, against
+      # max_connections=150 (less 3 reserved). See src/tests/test_pool_sizing.py.
+      #
+      # Deliberately 2, not one-per-core: each worker is a full Python process
+      # with the app loaded, and the host is memory-constrained. Two removes the
+      # single-process serialization, which is the point. Raise it here (and
+      # POSTGRES_MAX_CONNECTIONS with it) once memory headroom is known.
+      - UVICORN_WORKERS=2
+      - DB_POOL_SIZE=10
+      - DB_MAX_OVERFLOW=10
+      - POSTGRES_MAX_CONNECTIONS=150
     restart: unless-stopped
-    command: "sh -c 'alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 5050 --proxy-headers'"
+    # $$ escapes Compose interpolation so the shell expands it in-container.
+    command: "sh -c 'alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 5050 --proxy-headers --workers $${UVICORN_WORKERS:-2}'"
     healthcheck:
       test: ["CMD-SHELL", "curl http://localhost:5050/status"]
       interval: 10s


### PR DESCRIPTION
A single uvicorn process serialized every request. With #350 taking the blocking S3 work off the event loop, worker processes now multiply throughput instead of multiplying processes that each still block.

## Sizing: 2 workers, not one-per-core

Retuned down from an initial 4 after looking at the deployment hosts. Each worker is a whole extra Python process with the app loaded, and the boxes are memory-constrained — a sibling VM is 7.5GB with one service already resident at 3GB.

**Measured: on the import, 2 workers and 4 workers are indistinguishable — 17.13s vs 17.43s.** That isn't noise, it's the mechanism: the import's bottleneck was never login concurrency but the serialized S3 work, and #350's threadpool already parallelises that *within* a single process. Worker count buys concurrency for other API clients, not import throughput. So 2 workers costs nothing measurable here and halves the memory footprint.

Every value is environment-overridable (`UVICORN_WORKERS`, `DB_POOL_SIZE`, `DB_MAX_OVERFLOW`, `POSTGRES_MAX_CONNECTIONS`), so the host can be tuned without another PR once real memory headroom is known.

## Why the pool had to change with it

`db.py` sized the pool at `20 + 30` = **50 connections per process**, hardcoded. Each worker is a separate process with its own pool, so that's 100 across 2 workers against Postgres's default `max_connections=100` — no headroom at all, and 200 if anyone raised workers to 4.

Now `10 + 10` per worker: 40 across the fleet, plus the queue worker's 20, against `max_connections=150`.

`UVICORN_WORKERS` is read **both** by the compose command and by `app.core.config`, so the process count and the connection budget can't drift apart. Two tests guard it: one asserts the budget fits, the other asserts `db.py` actually reads the settings rather than drifting back to hardcoded literals — which would silently make the budget assertion stop describing reality.

## Measured

Login concurrency, bench stack (3 passes, machine under other load):

| | baseline | this PR |
|---|---|---|
| 4 concurrent logins | 564ms | **283–308ms** |
| 8 concurrent logins | 1125ms | 565–1031ms |
| `/status` under load | 795ms | 92–372ms |

4-concurrent is stable at ~285ms — exactly the 2-way parallelism intended. 8-concurrent is noisy on this machine; its best case (565ms) matches the theoretical 4 rounds × 142ms. Logins still block *within* a worker — that's the deferred bcrypt-to-threadpool follow-up, not a defect here.

Import benchmark, isolated stack with a 40ms S3 latency shim, 10 alert sequences → 11 lanes, 211 detections, median of 3:

| | total | Step 1 | Step 3 |
|---|---|---|---|
| before the series | 62.40s | 58.8s | 3.2s |
| with this PR | **17.13s** | 16.7s | 0.1s |

That 62.40s → 17.13s is the **cumulative** effect of #347 + #350 + this. Two caveats, stated rather than buried:

- The 40ms shim is an **emulation**. Production S3 is ~30–50ms so it's a fair middle estimate, but the honest claim is "3.6× under emulated production latency", not "3.6× in production".
- This PR's own marginal contribution to *import* time is ~zero, per the sizing note above. Its value is that the API stays responsive to everyone else while an import runs.

## Runtime verification, not just config

- uvicorn resolved `--workers 2` from `UVICORN_WORKERS` — the `$$` escape means the container shell expands it rather than Compose, so I checked the actual process cmdline
- `SHOW max_connections` → 150
- `alembic upgrade head` still runs exactly once, before uvicorn forks

## Gates

- **Full suite:** 713 passed
- **Output equivalence:** all three runs produce a byte-identical id-free projection of sequences, detections and annotation boxes versus baseline
- **Targeted tests:** connection-budget invariant + settings-are-actually-read

## Deploy note

**This is deploy-affecting.** The root `docker-compose.yml` is what runs production, `max_connections=150` requires a Postgres restart, and the API goes from one process to two. Worth deploying deliberately rather than as a side effect.

I was not able to verify sizing against the actual annotation host — `annotationapi.pyronear.org` resolves to a box I don't have access to. The conservative defaults here are chosen to be safe without that measurement.

Final PR of a three-part series (#347, #350, this). Design: `docs/specs/2026-08-07-import-performance-design.md`.