### PR TITLE
test(api): count every pool in the DB connection budget

### DIFF
--- a/annotation_api/src/tests/test_pool_sizing.py
+++ b/annotation_api/src/tests/test_pool_sizing.py
@@ -1,26 +1,73 @@
 """The connection budget must fit inside Postgres.
 
-Each uvicorn worker is a separate process with its own SQLAlchemy pool, so
-demand is multiplicative in the worker count. Getting this wrong does not fail
-at startup -- it surfaces as intermittent "too many clients already" under
-load, which is exactly the kind of thing that only shows up in production
-during an import. Hence an assertion rather than a comment.
+Every process that talks to the database holds TWO pools, not one:
+
+  - a SQLAlchemy pool (DB_POOL_SIZE + DB_MAX_OVERFLOW), and
+  - a procrastinate psycopg pool, opened by `procrastinate_app.open_async()`
+    in the API's lifespan and by the queue worker itself.
+
+And there are UVICORN_WORKERS + 1 such processes: each uvicorn worker is its
+own process, plus the `worker` compose service, which imports `app.db.engine`
+and opens its own AsyncSession (see app/worker.py).
+
+Getting this wrong does not fail at startup. It surfaces as intermittent
+"too many clients already" under load -- exactly the kind of thing that only
+appears in production during an import. Hence assertions rather than comments.
 """
+
+import psycopg_pool
 
 from app.core.config import settings
 
 
-def test_worker_connection_budget_fits_postgres():
-    demand = settings.UVICORN_WORKERS * (
-        settings.DB_POOL_SIZE + settings.DB_MAX_OVERFLOW
+def procrastinate_pool_max() -> int:
+    """Ceiling of one procrastinate connector's psycopg pool.
+
+    Read from psycopg rather than hardcoded, so the budget tracks the library
+    default instead of silently going stale. `open=False` means no connection
+    is attempted. PsycopgConnector passes no size arguments (see
+    app/worker.py), so the defaults are what actually runs -- and psycopg
+    defaults max_size to min_size, making this a hard ceiling, not a floor.
+    """
+    pool = psycopg_pool.AsyncConnectionPool("postgresql://unused", open=False)
+    return pool.max_size
+
+
+def test_connection_budget_fits_postgres():
+    per_process = (
+        settings.DB_POOL_SIZE + settings.DB_MAX_OVERFLOW + procrastinate_pool_max()
     )
-    # Postgres keeps superuser_reserved_connections (default 3) back for
-    # superusers, so they are not available to the application.
+    # + 1 for the `worker` compose service alongside the API's uvicorn workers.
+    processes = settings.UVICORN_WORKERS + 1
+    demand = processes * per_process
+    # Postgres holds superuser_reserved_connections (default 3) back, so those
+    # are not available to the application.
     budget = settings.POSTGRES_MAX_CONNECTIONS - 3
     assert demand <= budget, (
-        f"{settings.UVICORN_WORKERS} workers x ("
-        f"{settings.DB_POOL_SIZE} pool + {settings.DB_MAX_OVERFLOW} overflow) "
-        f"= {demand} connections, but only {budget} are available"
+        f"{processes} processes ({settings.UVICORN_WORKERS} uvicorn workers "
+        f"+ 1 queue worker) x {per_process} connections each "
+        f"({settings.DB_POOL_SIZE} pool + {settings.DB_MAX_OVERFLOW} overflow "
+        f"+ {procrastinate_pool_max()} procrastinate) = {demand}, "
+        f"but only {budget} are available"
+    )
+
+
+def test_budget_rejects_an_oversubscribed_worker_count():
+    """The budget must actually bind, not just pass at today's numbers.
+
+    Without this, a formula that under-counts pools would keep returning
+    'fits' right up to the point where it doesn't -- which is what the
+    original version of this test did.
+    """
+    per_process = (
+        settings.DB_POOL_SIZE + settings.DB_MAX_OVERFLOW + procrastinate_pool_max()
+    )
+    budget = settings.POSTGRES_MAX_CONNECTIONS - 3
+    breaking_workers = budget // per_process + 1  # +1 process => over budget
+
+    assert (breaking_workers + 1) * per_process > budget, (
+        "the budget formula never rejects any worker count, so it is not "
+        "actually constraining anything"
     )
 
 


### PR DESCRIPTION
Follow-up to #351. The connection-budget test it added counted only SQLAlchemy pools, so it understated real demand by roughly half.

## What it missed

**1. Every process also opens a procrastinate psycopg pool.** The API opens one per uvicorn worker in `lifespan` via `procrastinate_app.open_async()`, and the queue worker opens its own. `PsycopgConnector` passes no size arguments, and psycopg defaults `max_size` to `min_size` — so that's a hard **4 per process**, not a floor.

**2. The `worker` compose service is a process too.** `app/worker.py` imports `app.db.engine` and opens its own `AsyncSession`, so it carries a full SQLAlchemy pool as well — it was absent from the formula entirely.

Real demand is:

```
(UVICORN_WORKERS + 1) × (DB_POOL_SIZE + DB_MAX_OVERFLOW + procrastinate_pool)
```

**72** at today's settings, where the old formula computed **40**.

## Why this mattered

Not academic. I swept `UVICORN_WORKERS` against both formulas:

| workers | old test | new test | actual demand |
|---|---|---|---|
| 2 | pass | pass | 72 |
| 4 | pass | pass | 120 |
| 5 | pass | pass | 144 |
| 6 | **pass** ← wrong | **fail** | 168 > 147 |
| 8 | **pass** ← wrong | **fail** | 216 > 147 |

At 6 workers the old test computed 120 ≤ 147 and waved it through, while actual demand is 168. It would have kept reporting "fits" right up to intermittent `too many clients already` under load — which, per the test's own docstring, is precisely the failure mode it exists to prevent.

Confirmed empirically; the failure message carries the arithmetic:

```
UVICORN_WORKERS=6 -> FAIL  7 processes (6 uvicorn workers + 1 queue worker)
  x 24 connections each (10 pool + 10 overflow + 4 procrastinate) = 168,
  but only 147 are available
```

Current production settings are unaffected: 2 workers → 72 of 147, and a real import was measured peaking at **28** connections.

## Two guards against this recurring

- **`test_budget_rejects_an_oversubscribed_worker_count`** asserts the formula rejects *some* worker count. The original failure mode was a budget that always returned "fits"; this makes that state itself a test failure.
- **The procrastinate pool size is read from psycopg**, not hardcoded, so the budget tracks the library default rather than silently going stale.

## Verification

- Full suite: **714 passed**
- ruff format + check clean
- Worker-count sweep above, run against a live test stack

No production behaviour changes — test-only.
