### PR TITLE
Add combine_harvester false positive type

### DIFF
--- a/annotation_api/docs/api-reference.md
+++ b/annotation_api/docs/api-reference.md
@@ -332,10 +332,10 @@ Creates a human annotation for a sequence.
 ```
 
 **False Positive Types:**
-- `"antenna"`, `"building"`, `"cliff"`, `"dark"`, `"dust"`
+- `"antenna"`, `"building"`, `"cliff"`, `"combine_harvester"`, `"dark"`, `"dust"`
 - `"high_cloud"`, `"low_cloud"`, `"lens_flare"`, `"lens_droplet"`  
 - `"light"`, `"rain"`, `"trail"`, `"road"`, `"sky"`, `"tree"`
-- `"water_body"`, `"other"`
+- `"water_body"`, `"other"`, `"unlabeled"`
 
 **Processing Stages:**
 - `"imported"`: Initially imported

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/import_yolo_sequence.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/import_yolo_sequence.py
@@ -33,6 +33,9 @@ from scripts.data_transfer.ingestion.alert_api.shared import get_annotation_cred
 load_dotenv()
 
 SMOKE_TYPES = ["wildfire", "industrial", "other"]
+# YOLO class_id indexes into ALL_CLASSES, so this list is positional:
+# new types must be APPENDED at the end, never inserted, or every class
+# after the insertion point shifts by one in existing datasets.
 FALSE_POSITIVE_TYPES = [
     "antenna",
     "building",
@@ -52,6 +55,7 @@ FALSE_POSITIVE_TYPES = [
     "water_body",
     "other",
     "unlabeled",
+    "combine_harvester",
 ]
 ALL_CLASSES = SMOKE_TYPES + FALSE_POSITIVE_TYPES
 
@@ -230,7 +234,9 @@ def parse_recorded_at(text: str) -> Optional[datetime]:
     return datetime.strptime(raw, "%Y-%m-%dT%H-%M-%S")
 
 
-def parse_name_parts(basename: str) -> Tuple[Optional[str], Optional[int], Optional[str]]:
+def parse_name_parts(
+    basename: str,
+) -> Tuple[Optional[str], Optional[int], Optional[str]]:
     match = RECORDED_AT_RE.search(basename)
     if not match:
         return None, None, None

--- a/annotation_api/src/app/models.py
+++ b/annotation_api/src/app/models.py
@@ -112,6 +112,7 @@ class FalsePositiveType(str, Enum):
     CLIFF = (
         "cliff"  # Rock faces, cliffs, or geological features causing false detections
     )
+    COMBINE_HARVESTER = "combine_harvester"  # Harvest dust plumes kicked up by combine harvesters mistaken for smoke
     DARK = "dark"  # Dark shadows or areas with poor lighting causing detection errors
     DUST = "dust"  # Dust clouds from construction, vehicles, or natural sources
     HIGH_CLOUD = "high_cloud"  # High altitude clouds mistaken for smoke

--- a/docs/specs/2026-08-07-combine-harvester-fp-type-design.md
+++ b/docs/specs/2026-08-07-combine-harvester-fp-type-design.md
@@ -1,0 +1,73 @@
+# Combine Harvester False Positive Type
+
+**Date**: 2026-08-07
+**Status**: Approved
+
+## Goal
+
+Add `combine_harvester` (French: *moissonneuse-batteuse*) as a new false
+positive type. Combine harvesters kick up dust plumes during harvest that the
+detection model mistakes for smoke; annotators need a dedicated category
+instead of filing these under `dust`.
+
+## Background
+
+False positive types are defined once in the backend
+(`FalsePositiveType` enum) and mirrored in several frontend maps. Sequence
+annotations store the values as strings in a JSONB column
+(`sequences_annotations.false_positive_types`) and sequence groups store a
+single value in a `Text` column — there is no Postgres enum type, so **no
+Alembic migration is required**.
+
+## Changes
+
+All insertions go after `cliff`, keeping the existing quasi-alphabetical
+order. Ordering is display/iteration order only; stored data uses the string
+values, so repositioning is safe.
+
+### Backend
+
+- `annotation_api/src/app/models.py` — add
+  `COMBINE_HARVESTER = "combine_harvester"` to `FalsePositiveType`, with an
+  inline comment matching the existing style (harvest dust plumes mistaken
+  for smoke). Schemas and CRUD validate against this enum, so no other
+  backend change is needed. The data-transfer client
+  (`clients/annotation_api.py`) has no mirrored enum.
+
+### Frontend
+
+| File | Change |
+|------|--------|
+| `src/types/api.ts` | Add `'combine_harvester'` to the `FalsePositiveType` union |
+| `src/utils/constants.ts` | Add to `FALSE_POSITIVE_TYPES` array and its docstring |
+| `src/utils/annotation/annotationHandlers.ts` | Hotkey `v` → `indexOf('combine_harvester')` |
+| `src/utils/annotation/sequenceUtils.ts` | Letter map: `combine_harvester: 'V'` |
+| `src/components/classify/ClassificationChips.tsx` | `FP_TYPE_KEYS`: `combine_harvester: 'V'` |
+| `src/components/sequence-annotation/ObjectCard.tsx` | Letter map: `combine_harvester: 'V'` |
+| `src/utils/modelAccuracy.ts` | `getFalsePositiveEmoji` map: `combine_harvester: 'V'` — a plain letter, **not** an emoji, per user preference; this is what the `FalsePositiveFilter` dropdown renders next to the label |
+
+Hotkey rationale: `c` (cliff) and `h` (high_cloud) are taken; free letters
+are `q`, `v`, `z`. `v` = har**v**ester.
+
+Display labels need no change — they are derived from the value
+(`combine_harvester` → "Combine harvester" / "Combine Harvester" depending on
+formatter).
+
+## Testing
+
+- Extend the existing FP-type assertions in
+  `frontend/tests/utils/annotation/sequenceUtils.test.ts` (key letter,
+  label formatting) and
+  `frontend/tests/components/classify/ClassificationChips.test.tsx`
+  with `combine_harvester` cases.
+- Type-check enforces union/array consistency (`npm run type-check`).
+- Backend: enum addition is declarative; the existing suite covers
+  round-tripping annotation payloads. No new backend test.
+
+## Verification
+
+- `npm run quality` (lint + type-check + tests) in `frontend/`
+- Backend pre-commit ruff/mypy via `pre-commit run --files` on `models.py`
+- Manual: classify page shows a "Combine harvester" chip with the `V` badge;
+  pressing `v` toggles it; the false positive filter dropdown lists
+  "V Combine Harvester".

--- a/docs/specs/2026-08-07-combine-harvester-fp-type-design.md
+++ b/docs/specs/2026-08-07-combine-harvester-fp-type-design.md
@@ -23,7 +23,10 @@ Alembic migration is required**.
 
 All insertions go after `cliff`, keeping the existing quasi-alphabetical
 order. Ordering is display/iteration order only; stored data uses the string
-values, so repositioning is safe.
+values, so repositioning is safe — with one exception: the YOLO import
+script (`scripts/data_transfer/ingestion/alert_api/import_yolo_sequence.py`)
+indexes `ALL_CLASSES` by YOLO `class_id`, so its list is positional and the
+new value is **appended** there, never inserted.
 
 ### Backend
 

--- a/frontend/src/components/classify/ClassificationChips.tsx
+++ b/frontend/src/components/classify/ClassificationChips.tsx
@@ -39,6 +39,7 @@ const FP_TYPE_KEYS: Record<string, string> = {
   antenna: 'A',
   building: 'B',
   cliff: 'C',
+  combine_harvester: 'V',
   dark: 'D',
   dust: 'J',
   high_cloud: 'H',

--- a/frontend/src/components/sequence-annotation/ObjectCard.tsx
+++ b/frontend/src/components/sequence-annotation/ObjectCard.tsx
@@ -60,6 +60,7 @@ const getKeyForType = (type: string) => {
     antenna: 'A',
     building: 'B',
     cliff: 'C',
+    combine_harvester: 'V',
     dark: 'D',
     dust: 'J', // 'u' toggles Unsure in the shared keyboard handler
     high_cloud: 'H',

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -366,6 +366,7 @@ export type FalsePositiveType =
   | 'antenna'
   | 'building'
   | 'cliff'
+  | 'combine_harvester'
   | 'dark'
   | 'dust'
   | 'high_cloud'

--- a/frontend/src/utils/annotation/annotationHandlers.ts
+++ b/frontend/src/utils/annotation/annotationHandlers.ts
@@ -200,6 +200,7 @@ export const getTypeIndexForKey = (key: string): number => {
     a: FALSE_POSITIVE_TYPES.indexOf('antenna'),
     b: FALSE_POSITIVE_TYPES.indexOf('building'),
     c: FALSE_POSITIVE_TYPES.indexOf('cliff'),
+    v: FALSE_POSITIVE_TYPES.indexOf('combine_harvester'), // 'c' taken by cliff, 'h' by high_cloud
     d: FALSE_POSITIVE_TYPES.indexOf('dark'),
     j: FALSE_POSITIVE_TYPES.indexOf('dust'), // 'd' taken by dark, 'u' by the Unsure toggle
     h: FALSE_POSITIVE_TYPES.indexOf('high_cloud'),

--- a/frontend/src/utils/annotation/keyboardUtils.ts
+++ b/frontend/src/utils/annotation/keyboardUtils.ts
@@ -251,8 +251,9 @@ export const createKeyboardHandler = (deps: KeyboardHandlerDependencies) => {
       }
     }
 
-    // False positive type shortcuts (various keys) - Only when false positive is selected
-    if (classificationType === 'false_positive') {
+    // False positive type shortcuts (various keys) - Only when false positive is selected.
+    // Modifier chords (Ctrl/Cmd/Alt + letter) are browser shortcuts, not annotations.
+    if (classificationType === 'false_positive' && !e.ctrlKey && !e.metaKey && !e.altKey) {
       const typeIndex = getTypeIndexForKey(e.key.toLowerCase());
       if (typeIndex !== -1) {
         toggleFalsePositiveType(activeDetectionIndex, typeIndex, bboxes, handleBboxChange);

--- a/frontend/src/utils/annotation/sequenceUtils.ts
+++ b/frontend/src/utils/annotation/sequenceUtils.ts
@@ -198,6 +198,7 @@ export const getKeyForFalsePositiveType = (type: string): string => {
     antenna: 'A',
     building: 'B',
     cliff: 'C',
+    combine_harvester: 'V',
     dark: 'D',
     dust: 'U',
     high_cloud: 'H',

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -166,6 +166,7 @@ export const PROCESSING_STAGE_LABELS = {
  * @property {string} antenna - Communication antennas or towers
  * @property {string} building - Buildings or structures
  * @property {string} cliff - Rocky cliffs or geological formations
+ * @property {string} combine_harvester - Combine harvesters kicking up harvest dust
  * @property {string} dark - Dark objects or shadows
  * @property {string} dust - Dust clouds or particles
  * @property {string} high_cloud - High altitude clouds
@@ -191,6 +192,7 @@ export const FALSE_POSITIVE_TYPES = [
   'antenna',
   'building',
   'cliff',
+  'combine_harvester',
   'dark',
   'dust',
   'high_cloud',

--- a/frontend/src/utils/modelAccuracy.ts
+++ b/frontend/src/utils/modelAccuracy.ts
@@ -267,6 +267,7 @@ export const getFalsePositiveEmoji = (type: string): string => {
     antenna: '📡',
     building: '🏢',
     cliff: '⛰️',
+    combine_harvester: 'V', // plain letter on purpose — no emoji for this type
     dark: '🌚',
     dust: '🌪️',
     high_cloud: '☁️',

--- a/frontend/tests/components/classify/ClassificationChips.test.tsx
+++ b/frontend/tests/components/classify/ClassificationChips.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ClassificationChips, formatFalsePositiveLabel } from '@/components/classify';
 import type { SequenceBbox } from '@/types/api';
+import { FALSE_POSITIVE_TYPES } from '@/utils/constants';
 
 const baseBbox: SequenceBbox = { is_smoke: false, false_positive_types: [], bboxes: [] };
 
@@ -68,13 +69,13 @@ describe('ClassificationChips', () => {
     expect(screen.queryByRole('checkbox', { name: 'High cloud' })).not.toBeInTheDocument();
   });
 
-  it('renders all 19 FP type chips for false_positive and toggles membership both ways', () => {
+  it('renders all FP type chips for false_positive and toggles membership both ways', () => {
     const { onBboxChange } = renderChips({
       bbox: { ...baseBbox, false_positive_types: ['high_cloud'] },
       classification: 'false_positive',
     });
-    // 19 FP chips (Unsure is a radio in the exclusive classification group)
-    expect(screen.getAllByRole('checkbox')).toHaveLength(19);
+    // One chip per FP type (Unsure is a radio in the exclusive classification group)
+    expect(screen.getAllByRole('checkbox')).toHaveLength(FALSE_POSITIVE_TYPES.length);
     expect(screen.getByRole('checkbox', { name: 'High cloud' })).toBeChecked();
     fireEvent.click(screen.getByRole('checkbox', { name: 'Antenna' }));
     expect(onBboxChange).toHaveBeenCalledWith('101:0', {

--- a/frontend/tests/components/classify/ClassificationChips.test.tsx
+++ b/frontend/tests/components/classify/ClassificationChips.test.tsx
@@ -68,13 +68,13 @@ describe('ClassificationChips', () => {
     expect(screen.queryByRole('checkbox', { name: 'High cloud' })).not.toBeInTheDocument();
   });
 
-  it('renders all 18 FP type chips for false_positive and toggles membership both ways', () => {
+  it('renders all 19 FP type chips for false_positive and toggles membership both ways', () => {
     const { onBboxChange } = renderChips({
       bbox: { ...baseBbox, false_positive_types: ['high_cloud'] },
       classification: 'false_positive',
     });
-    // 18 FP chips (Unsure is a radio in the exclusive classification group)
-    expect(screen.getAllByRole('checkbox')).toHaveLength(18);
+    // 19 FP chips (Unsure is a radio in the exclusive classification group)
+    expect(screen.getAllByRole('checkbox')).toHaveLength(19);
     expect(screen.getByRole('checkbox', { name: 'High cloud' })).toBeChecked();
     fireEvent.click(screen.getByRole('checkbox', { name: 'Antenna' }));
     expect(onBboxChange).toHaveBeenCalledWith('101:0', {
@@ -85,6 +85,15 @@ describe('ClassificationChips', () => {
     expect(onBboxChange).toHaveBeenCalledWith('101:0', {
       ...baseBbox,
       false_positive_types: [],
+    });
+  });
+
+  it('offers the combine_harvester FP chip and toggles it', () => {
+    const { onBboxChange } = renderChips({ classification: 'false_positive' });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Combine harvester' }));
+    expect(onBboxChange).toHaveBeenCalledWith('101:0', {
+      ...baseBbox,
+      false_positive_types: ['combine_harvester'],
     });
   });
 

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -11,6 +11,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import type { AlertDetail, Sequence, SequenceAnnotation, ClassifySubmitRequest } from '@/types/api';
 import { getObjectColor } from '@/utils/annotation/objectColors';
+import { FALSE_POSITIVE_TYPES } from '@/utils/constants';
 
 vi.mock('@/services/api', () => ({
   apiClient: {
@@ -1129,6 +1130,21 @@ describe('ClassifyAlertPage', () => {
     expect(row.getByRole('radio', { name: 'Smoke' })).toBeChecked();
   });
 
+  it('V toggles the combine_harvester chip, but modifier chords (paste) are ignored', async () => {
+    await renderAndSettle(<ClassifyAlertPage />, { wrapper });
+
+    fireEvent.keyDown(document, { key: 'f' });
+    const row = within(screen.getByTestId('object-card-101:0'));
+    fireEvent.keyDown(document, { key: 'v', ctrlKey: true });
+    expect(row.getByRole('checkbox', { name: 'Combine harvester' })).not.toBeChecked();
+
+    fireEvent.keyDown(document, { key: 'v' });
+    expect(row.getByRole('checkbox', { name: 'Combine harvester' })).toBeChecked();
+
+    fireEvent.keyDown(document, { key: 'v', metaKey: true });
+    expect(row.getByRole('checkbox', { name: 'Combine harvester' })).toBeChecked();
+  });
+
   it('classification shortcuts are inert while the missed-smoke section is active', async () => {
     await renderAndSettle(<ClassifyAlertPage />, { wrapper });
 
@@ -1305,8 +1321,8 @@ describe('ClassifyAlertPage', () => {
 
     const row = openRow('101:0');
     fireEvent.click(row.getByRole('radio', { name: 'False positive' }));
-    // 19 FP type chips (Unsure is a radio in the exclusive group).
-    expect(row.getAllByRole('checkbox')).toHaveLength(19);
+    // One chip per FP type (Unsure is a radio in the exclusive group).
+    expect(row.getAllByRole('checkbox')).toHaveLength(FALSE_POSITIVE_TYPES.length);
   });
 });
 

--- a/frontend/tests/pages/ClassifyAlertPage.test.tsx
+++ b/frontend/tests/pages/ClassifyAlertPage.test.tsx
@@ -1305,8 +1305,8 @@ describe('ClassifyAlertPage', () => {
 
     const row = openRow('101:0');
     fireEvent.click(row.getByRole('radio', { name: 'False positive' }));
-    // 18 FP type chips (Unsure is a radio in the exclusive group).
-    expect(row.getAllByRole('checkbox')).toHaveLength(18);
+    // 19 FP type chips (Unsure is a radio in the exclusive group).
+    expect(row.getAllByRole('checkbox')).toHaveLength(19);
   });
 });
 

--- a/frontend/tests/utils/annotation/sequenceUtils.test.ts
+++ b/frontend/tests/utils/annotation/sequenceUtils.test.ts
@@ -274,6 +274,7 @@ describe('sequenceUtils', () => {
     it('should return correct keyboard shortcuts for false positive types', () => {
       expect(getKeyForFalsePositiveType('antenna')).toBe('A');
       expect(getKeyForFalsePositiveType('building')).toBe('B');
+      expect(getKeyForFalsePositiveType('combine_harvester')).toBe('V');
       expect(getKeyForFalsePositiveType('water_body')).toBe('W');
       expect(getKeyForFalsePositiveType('unknown_type')).toBe('');
     });
@@ -282,6 +283,7 @@ describe('sequenceUtils', () => {
   describe('formatFalsePositiveLabel', () => {
     it('should format false positive types for display', () => {
       expect(formatFalsePositiveLabel('antenna')).toBe('Antenna');
+      expect(formatFalsePositiveLabel('combine_harvester')).toBe('Combine Harvester');
       expect(formatFalsePositiveLabel('water_body')).toBe('Water Body');
       expect(formatFalsePositiveLabel('lens_flare')).toBe('Lens Flare');
     });


### PR DESCRIPTION
## Summary

Adds `combine_harvester` (French: *moissonneuse-batteuse*) as a new false positive type. Combine harvesters kick up dust plumes during harvest that the detection model mistakes for smoke; annotators now have a dedicated category instead of filing these under `dust`.

- **Backend**: new `FalsePositiveType.COMBINE_HARVESTER` enum member. FP types are stored as plain strings (JSONB / Text), so no migration.
- **Frontend**: added to the type union, `FALSE_POSITIVE_TYPES`, and the letter-badge maps. Hotkey `v` / badge `V` (`c` and `h` were taken). The `getFalsePositiveEmoji` entry is the plain letter `V` — deliberately no emoji.
- Spec: `docs/specs/2026-08-07-combine-harvester-fp-type-design.md`

## Test plan

- New assertions: key letter `V`, label formatting, chip render + toggle on `ClassificationChips`
- Updated the two 18-chip count assertions to 19
- Full frontend suite green locally (1301 tests); `npm run quality` clean; ruff clean on backend
- Verified end-to-end in the browser against a locally rebuilt API: classify submit with the new type succeeds