### PR TITLE
feat(scripts): make export-alerts pulls annotated alerts into a manifest+images dataset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,15 @@ make import-alert-api DATE_FROM=2024-01-01 DATE_END=2024-01-02
 
 The import object-splits each alert sequence from the alert API's own boxes and writes one annotation track per object client-side (no pyro-engine/pyro-dataset involved).
 
+### Alert Export
+
+```bash
+# Pull finished annotation work into a dataset directory
+make export-alerts OUTPUT_DIR=outputs/alerts_export
+```
+
+Writes `manifest.jsonl` (one line per alert) plus `images/{source_api}/{platform_alert_id}/{detection_id}.jpg`; each frame carries an `image_path` into that tree. Only alerts whose every lane reached `ANNOTATED` are exported. Re-runs are idempotent — the manifest is rewritten and only missing images are downloaded.
+
 ## Key Architecture Concepts
 
 **Backend data flow**: Alert API → ingestion scripts → annotation_api DB → frontend UI → human annotations

--- a/annotation_api/Makefile
+++ b/annotation_api/Makefile
@@ -22,6 +22,7 @@ help:
 	@echo ""
 	@echo "Other data commands:"
 	@echo "  import-alert-api     - (Admin) Import from alert API into annotation API"
+	@echo "  export-alerts        - Export annotated alerts (manifest + images) from annotation API"
 	@echo ""
 	@echo "Override variables inline, e.g.:"
 	@echo "  make import-alert-api DATE_FROM=2025-03-04 MAX_SEQUENCES=20"
@@ -117,6 +118,19 @@ import-alert-api:
 		$(if $(IMAGE_TRANSFER),--image-transfer $(IMAGE_TRANSFER)) \
 		--loglevel $(LOGLEVEL)
 
+# Pull annotated alerts from the annotation API's /export/alerts endpoint into
+# a dataset directory (manifest.jsonl + images/). Idempotent: re-runs rewrite
+# the manifest and only download missing images.
+# Requires MAIN_ANNOTATION_LOGIN/PASSWORD in .env for the default remote API.
+# Usage: make export-alerts [OUTPUT_DIR=outputs/alerts_export] [REMOTE_API=http://localhost:5050]
+export-alerts: OUTPUT_DIR ?= outputs/alerts_export
+export-alerts:
+	uv run python -m scripts.data_transfer.export.export_alerts \
+		--annotation-api-url $(REMOTE_API) \
+		--output-dir $(OUTPUT_DIR) \
+		--max-workers $(MAX_WORKERS) \
+		--loglevel $(LOGLEVEL)
+
 .PHONY: help lint fix docker-build start stop clean test test-specific \
 	migrate migrate-up \
-	import-alert-api
+	import-alert-api export-alerts

--- a/annotation_api/scripts/data_transfer/export/export_alerts.py
+++ b/annotation_api/scripts/data_transfer/export/export_alerts.py
@@ -19,7 +19,13 @@ uv run python -m scripts.data_transfer.export.export_alerts \
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Optional, Set, Tuple
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
 
 
 def frame_rel_path(source_api: str, platform_alert_id: int, detection_id: int) -> str:
@@ -66,3 +72,94 @@ def to_manifest_item(item: Dict[str, Any], materialized: Set[int]) -> Dict[str, 
                 else None
             )
     return out
+
+
+@dataclass
+class ExportStats:
+    alerts: int = 0
+    downloaded: int = 0
+    skipped: int = 0
+    failed: int = 0
+    missing_url: int = 0
+
+
+FetchPage = Callable[[Optional[str]], Dict[str, Any]]
+Download = Callable[[str, Path], None]
+
+
+def _download_pending(
+    pending: List[Tuple[int, str, Path]],
+    download: Download,
+    max_workers: int,
+    stats: ExportStats,
+) -> None:
+    """Download (detection_id, url, dest) triples concurrently, tallying stats.
+
+    Workers return a success flag and the tally happens on the main thread —
+    `stats.x += 1` from worker threads would race.
+    """
+
+    def fetch_one(entry: Tuple[int, str, Path]) -> bool:
+        det_id, url, dest = entry
+        try:
+            download(url, dest)
+            return True
+        except Exception:
+            logger.warning("Download failed for detection %s", det_id, exc_info=True)
+            return False
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        results = list(pool.map(fetch_one, pending))
+    stats.downloaded += sum(results)
+    stats.failed += len(results) - sum(results)
+
+
+def run_export(
+    fetch_page: FetchPage,
+    download: Download,
+    output_dir: Path,
+    max_workers: int,
+) -> ExportStats:
+    """Walk the export cursor, download missing images, rewrite the manifest.
+
+    The manifest is written to a .tmp sibling and renamed only after the walk
+    completes, so an interrupted run never replaces a good manifest.
+    """
+    stats = ExportStats()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tmp_manifest = output_dir / "manifest.jsonl.tmp"
+
+    with tmp_manifest.open("w", encoding="utf-8") as manifest:
+        cursor: Optional[str] = None
+        while True:
+            page = fetch_page(cursor)
+            plans = [(item, plan_downloads(item)) for item in page["items"]]
+
+            pending: List[Tuple[int, str, Path]] = []
+            for _, plan in plans:
+                for det_id, (url, rel) in plan.items():
+                    dest = output_dir / rel
+                    if dest.exists():
+                        stats.skipped += 1
+                    elif url is None:
+                        stats.missing_url += 1
+                        logger.warning("No image_url for detection %s", det_id)
+                    else:
+                        pending.append((det_id, url, dest))
+            _download_pending(pending, download, max_workers, stats)
+
+            for item, plan in plans:
+                materialized = {
+                    det_id
+                    for det_id, (_, rel) in plan.items()
+                    if (output_dir / rel).exists()
+                }
+                manifest.write(json.dumps(to_manifest_item(item, materialized)) + "\n")
+                stats.alerts += 1
+
+            cursor = page.get("next_cursor")
+            if cursor is None:
+                break
+
+    tmp_manifest.replace(output_dir / "manifest.jsonl")
+    return stats

--- a/annotation_api/scripts/data_transfer/export/export_alerts.py
+++ b/annotation_api/scripts/data_transfer/export/export_alerts.py
@@ -1,0 +1,68 @@
+"""
+Pull annotated alerts from the annotation API's GET /api/v1/export/alerts
+endpoint (see docs/specs/2026-08-07-export-alerts-pull-script-design.md) and
+materialize them as a self-contained ML dataset:
+
+    OUTPUT_DIR/
+    ├── manifest.jsonl                 # one line per alert
+    └── images/{source_api}/{platform_alert_id}/{detection_id}.jpg
+
+Idempotent full pull: every run re-walks the export and rewrites the
+manifest; only images missing on disk are downloaded.
+
+Example:
+uv run python -m scripts.data_transfer.export.export_alerts \
+  --annotation-api-url http://localhost:5050 \
+  --output-dir outputs/alerts_export --loglevel info
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional, Set, Tuple
+
+
+def frame_rel_path(source_api: str, platform_alert_id: int, detection_id: int) -> str:
+    """Dataset-relative image path for one frame of an alert."""
+    return f"images/{source_api}/{platform_alert_id}/{detection_id}.jpg"
+
+
+def plan_downloads(item: Dict[str, Any]) -> Dict[int, Tuple[Optional[str], str]]:
+    """Map detection_id -> (image_url, rel_path) for every frame of an alert.
+
+    Objects (lanes) of one alert share frames, so entries are deduped by
+    detection_id; a copy of the frame that carries a URL wins over one
+    without.
+    """
+    plan: Dict[int, Tuple[Optional[str], str]] = {}
+    for obj in item["objects"]:
+        for frame in obj["frames"]:
+            det_id = frame["detection_id"]
+            url = frame.get("image_url")
+            if det_id not in plan or (url and not plan[det_id][0]):
+                plan[det_id] = (
+                    url,
+                    frame_rel_path(
+                        item["source_api"], item["platform_alert_id"], det_id
+                    ),
+                )
+    return plan
+
+
+def to_manifest_item(item: Dict[str, Any], materialized: Set[int]) -> Dict[str, Any]:
+    """Copy of the API item with each frame's image_url swapped for image_path.
+
+    image_path is set when the image file exists on disk (detection_id in
+    `materialized`), else None so a re-run can heal it.
+    """
+    out = json.loads(json.dumps(item))  # deep copy; payload is JSON-only data
+    for obj in out["objects"]:
+        for frame in obj["frames"]:
+            det_id = frame["detection_id"]
+            frame.pop("image_url", None)
+            frame["image_path"] = (
+                frame_rel_path(out["source_api"], out["platform_alert_id"], det_id)
+                if det_id in materialized
+                else None
+            )
+    return out

--- a/annotation_api/scripts/data_transfer/export/export_alerts.py
+++ b/annotation_api/scripts/data_transfer/export/export_alerts.py
@@ -22,6 +22,7 @@ import argparse
 import json
 import logging
 import sys
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -233,13 +234,29 @@ def _fetch_page_impl(
     return fetch_page
 
 
+_thread_local = threading.local()
+
+
+def _download_session() -> requests.Session:
+    """One unauthenticated session per worker thread.
+
+    Unauthenticated because presigned S3 URLs reject an extra Authorization
+    header, so the API session must not be reused here. Per-thread rather
+    than shared because requests.Session is not thread-safe; pooling still
+    keeps a TCP+TLS handshake off all but the first image each thread pulls.
+    """
+    session: Optional[requests.Session] = getattr(_thread_local, "session", None)
+    if session is None:
+        session = requests.Session()
+        _thread_local.session = session
+    return session
+
+
 def _download_impl(url: str, dest: Path) -> None:
-    # Plain requests.get: presigned S3 URLs reject an extra Authorization
-    # header, so the authenticated session must not be used here.
     dest.parent.mkdir(parents=True, exist_ok=True)
     for attempt in range(DOWNLOAD_ATTEMPTS):
         try:
-            response = requests.get(url, timeout=DOWNLOAD_TIMEOUT_S)
+            response = _download_session().get(url, timeout=DOWNLOAD_TIMEOUT_S)
             response.raise_for_status()
             part = dest.with_suffix(dest.suffix + ".part")
             part.write_bytes(response.content)

--- a/annotation_api/scripts/data_transfer/export/export_alerts.py
+++ b/annotation_api/scripts/data_transfer/export/export_alerts.py
@@ -18,14 +18,31 @@ uv run python -m scripts.data_transfer.export.export_alerts \
 
 from __future__ import annotations
 
+import argparse
 import json
 import logging
+import sys
+import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
+import requests
+from dotenv import load_dotenv
+
+from app.clients.annotation_api import get_auth_token
+from scripts.data_transfer.ingestion.alert_api.shared import (
+    get_annotation_credentials,
+)
+
+load_dotenv()
+
 logger = logging.getLogger(__name__)
+
+DOWNLOAD_ATTEMPTS = 3
+DOWNLOAD_TIMEOUT_S = 30
+PAGE_TIMEOUT_S = 120
 
 
 def frame_rel_path(source_api: str, platform_alert_id: int, detection_id: int) -> str:
@@ -163,3 +180,112 @@ def run_export(
 
     tmp_manifest.replace(output_dir / "manifest.jsonl")
     return stats
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export annotated alerts (manifest + images) from the "
+        "annotation API"
+    )
+    parser.add_argument(
+        "--annotation-api-url",
+        default="http://localhost:5050",
+        help="Base URL of the annotation API",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("outputs/alerts_export"),
+        help="Dataset directory to write manifest.jsonl and images/ into",
+    )
+    parser.add_argument(
+        "--page-size",
+        type=int,
+        default=100,
+        help="Alerts per page (max 500); one page's downloads bound how old "
+        "a presigned image URL can get before use",
+    )
+    parser.add_argument(
+        "--max-workers", type=int, default=4, help="Concurrent image downloads"
+    )
+    parser.add_argument(
+        "--loglevel",
+        default="info",
+        choices=["debug", "info", "warning", "error"],
+        help="Logging level",
+    )
+    return parser.parse_args()
+
+
+def _fetch_page_impl(
+    session: requests.Session, api_url: str, page_size: int
+) -> FetchPage:
+    def fetch_page(cursor: Optional[str]) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"limit": page_size}
+        if cursor is not None:
+            params["cursor"] = cursor
+        response = session.get(
+            f"{api_url}/api/v1/export/alerts", params=params, timeout=PAGE_TIMEOUT_S
+        )
+        response.raise_for_status()
+        return response.json()
+
+    return fetch_page
+
+
+def _download_impl(url: str, dest: Path) -> None:
+    # Plain requests.get: presigned S3 URLs reject an extra Authorization
+    # header, so the authenticated session must not be used here.
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    for attempt in range(DOWNLOAD_ATTEMPTS):
+        try:
+            response = requests.get(url, timeout=DOWNLOAD_TIMEOUT_S)
+            response.raise_for_status()
+            part = dest.with_suffix(dest.suffix + ".part")
+            part.write_bytes(response.content)
+            part.replace(dest)
+            return
+        except requests.RequestException:
+            if attempt == DOWNLOAD_ATTEMPTS - 1:
+                raise
+            time.sleep(2**attempt)
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(
+        level=args.loglevel.upper(),
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+
+    login, password = get_annotation_credentials(args.annotation_api_url)
+    token = get_auth_token(args.annotation_api_url, login, password)
+    session = requests.Session()
+    session.headers["Authorization"] = f"Bearer {token}"
+
+    stats = run_export(
+        _fetch_page_impl(session, args.annotation_api_url, args.page_size),
+        _download_impl,
+        args.output_dir,
+        args.max_workers,
+    )
+    logger.info(
+        "Exported %d alerts: %d images downloaded, %d already present, "
+        "%d failed, %d without URL",
+        stats.alerts,
+        stats.downloaded,
+        stats.skipped,
+        stats.failed,
+        stats.missing_url,
+    )
+    if stats.failed:
+        logger.error(
+            "%d image downloads failed (image_path null in manifest); "
+            "re-run to heal",
+            stats.failed,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/annotation_api/src/tests/scripts/test_export_alerts.py
+++ b/annotation_api/src/tests/scripts/test_export_alerts.py
@@ -1,6 +1,11 @@
+import json
+from pathlib import Path
+
 from scripts.data_transfer.export.export_alerts import (
+    ExportStats,
     frame_rel_path,
     plan_downloads,
+    run_export,
     to_manifest_item,
 )
 
@@ -112,3 +117,105 @@ def test_to_manifest_item_swaps_image_url_for_image_path():
     assert frames[1]["image_path"] is None  # failed/missing download
     # input not mutated
     assert item["objects"][0]["frames"][0]["image_url"] == "https://s3/presigned"
+
+
+def fake_pages(pages):
+    """fetch_page stub walking a list of AlertExportPage dicts via cursor."""
+
+    def fetch_page(cursor):
+        index = 0 if cursor is None else int(cursor)
+        page = dict(pages[index])
+        page["next_cursor"] = str(index + 1) if index + 1 < len(pages) else None
+        return page
+
+    return fetch_page
+
+
+def make_download(calls, fail_detection_ids=()):
+    def download(url, dest: Path):
+        calls.append(url)
+        det_id = int(Path(url).stem)
+        if det_id in fail_detection_ids:
+            raise RuntimeError("boom")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"jpg")
+
+    return download
+
+
+def two_page_export():
+    item_a = make_item(
+        [
+            {
+                "sequence_id": 1,
+                "record_kind": "smoke",
+                "smoke_types": ["wildfire"],
+                "false_positive_types": [],
+                "frames": [
+                    make_frame(10, image_url="https://s3/10"),
+                    make_frame(11, image_url="https://s3/11"),
+                ],
+            },
+        ]
+    )
+    item_b = make_item(
+        [
+            {
+                "sequence_id": 2,
+                "record_kind": "false_positive",
+                "smoke_types": [],
+                "false_positive_types": ["cliff"],
+                "frames": [make_frame(20, image_url="https://s3/20")],
+            },
+        ]
+    )
+    item_b["platform_alert_id"] = 5678
+    return [{"items": [item_a]}, {"items": [item_b]}]
+
+
+def test_run_export_walks_cursor_and_materializes(tmp_path):
+    calls: list[str] = []
+    stats = run_export(
+        fake_pages(two_page_export()), make_download(calls), tmp_path, max_workers=2
+    )
+    assert stats == ExportStats(alerts=2, downloaded=3, skipped=0, failed=0)
+    lines = [
+        json.loads(line)
+        for line in (tmp_path / "manifest.jsonl").read_text().splitlines()
+    ]
+    assert [item["platform_alert_id"] for item in lines] == [1234, 5678]
+    frame = lines[0]["objects"][0]["frames"][0]
+    assert frame["image_path"] == "images/pyronear_french/1234/10.jpg"
+    assert (tmp_path / "images/pyronear_french/1234/10.jpg").read_bytes() == b"jpg"
+    assert not (tmp_path / "manifest.jsonl.tmp").exists()
+
+
+def test_run_export_second_run_downloads_nothing(tmp_path):
+    first: list[str] = []
+    run_export(fake_pages(two_page_export()), make_download(first), tmp_path, 2)
+    manifest_after_first = (tmp_path / "manifest.jsonl").read_text()
+
+    second: list[str] = []
+    stats = run_export(
+        fake_pages(two_page_export()), make_download(second), tmp_path, 2
+    )
+    assert second == []
+    assert stats.skipped == 3 and stats.downloaded == 0
+    assert (tmp_path / "manifest.jsonl").read_text() == manifest_after_first
+
+
+def test_run_export_failed_download_yields_null_path(tmp_path):
+    stats = run_export(
+        fake_pages(two_page_export()),
+        make_download([], fail_detection_ids={11}),
+        tmp_path,
+        max_workers=2,
+    )
+    assert stats.failed == 1 and stats.downloaded == 2
+    lines = [
+        json.loads(line)
+        for line in (tmp_path / "manifest.jsonl").read_text().splitlines()
+    ]
+    frames = lines[0]["objects"][0]["frames"]
+    assert frames[0]["image_path"] is not None
+    assert frames[1]["image_path"] is None

--- a/annotation_api/src/tests/scripts/test_export_alerts.py
+++ b/annotation_api/src/tests/scripts/test_export_alerts.py
@@ -219,3 +219,19 @@ def test_run_export_failed_download_yields_null_path(tmp_path):
     frames = lines[0]["objects"][0]["frames"]
     assert frames[0]["image_path"] is not None
     assert frames[1]["image_path"] is None
+
+
+def test_run_export_frame_without_url_is_counted_not_downloaded(tmp_path):
+    # The endpoint sends image_url=None for a detection with no bucket_key.
+    pages = two_page_export()
+    pages[0]["items"][0]["objects"][0]["frames"][1]["image_url"] = None
+
+    calls: list[str] = []
+    stats = run_export(fake_pages(pages), make_download(calls), tmp_path, 2)
+    assert stats.missing_url == 1
+    assert calls == ["https://s3/10", "https://s3/20"]
+    lines = [
+        json.loads(line)
+        for line in (tmp_path / "manifest.jsonl").read_text().splitlines()
+    ]
+    assert lines[0]["objects"][0]["frames"][1]["image_path"] is None

--- a/annotation_api/src/tests/scripts/test_export_alerts.py
+++ b/annotation_api/src/tests/scripts/test_export_alerts.py
@@ -1,0 +1,114 @@
+from scripts.data_transfer.export.export_alerts import (
+    frame_rel_path,
+    plan_downloads,
+    to_manifest_item,
+)
+
+
+def make_frame(detection_id: int, image_url: str | None = "https://s3/presigned"):
+    return {
+        "detection_id": detection_id,
+        "recorded_at": "2026-07-01T10:00:00",
+        "bucket_key": f"key-{detection_id}.jpg",
+        "image_url": image_url,
+        "boxes": [
+            {
+                "xyxyn": [0.1, 0.1, 0.2, 0.2],
+                "smoke_type": "wildfire",
+                "false_positive_types": None,
+                "origin": "human",
+            }
+        ],
+    }
+
+
+def make_item(objects):
+    return {
+        "source_api": "pyronear_french",
+        "platform_alert_id": 1234,
+        "camera_id": 1,
+        "camera_name": "cam",
+        "organisation_id": 1,
+        "organisation_name": "org",
+        "lat": 44.0,
+        "lon": 4.0,
+        "azimuth": 90,
+        "recorded_at": "2026-07-01T10:00:00",
+        "last_annotated_at": "2026-07-02T10:00:00",
+        "objects": objects,
+    }
+
+
+def test_frame_rel_path_layout():
+    assert (
+        frame_rel_path("pyronear_french", 1234, 18709)
+        == "images/pyronear_french/1234/18709.jpg"
+    )
+
+
+def test_plan_downloads_dedupes_shared_frames_across_objects():
+    # Objects (lanes) of one alert share frames: same detection twice.
+    item = make_item(
+        [
+            {
+                "sequence_id": 1,
+                "record_kind": "smoke",
+                "smoke_types": ["wildfire"],
+                "false_positive_types": [],
+                "frames": [make_frame(10), make_frame(11)],
+            },
+            {
+                "sequence_id": 2,
+                "record_kind": "false_positive",
+                "smoke_types": [],
+                "false_positive_types": ["cliff"],
+                "frames": [make_frame(10)],
+            },
+        ]
+    )
+    plan = plan_downloads(item)
+    assert set(plan) == {10, 11}
+    assert plan[10] == ("https://s3/presigned", "images/pyronear_french/1234/10.jpg")
+
+
+def test_plan_downloads_prefers_frame_copy_that_has_a_url():
+    item = make_item(
+        [
+            {
+                "sequence_id": 1,
+                "record_kind": "smoke",
+                "smoke_types": ["wildfire"],
+                "false_positive_types": [],
+                "frames": [make_frame(10, image_url=None)],
+            },
+            {
+                "sequence_id": 2,
+                "record_kind": "false_positive",
+                "smoke_types": [],
+                "false_positive_types": ["cliff"],
+                "frames": [make_frame(10)],
+            },
+        ]
+    )
+    assert plan_downloads(item)[10][0] == "https://s3/presigned"
+
+
+def test_to_manifest_item_swaps_image_url_for_image_path():
+    item = make_item(
+        [
+            {
+                "sequence_id": 1,
+                "record_kind": "smoke",
+                "smoke_types": ["wildfire"],
+                "false_positive_types": [],
+                "frames": [make_frame(10), make_frame(11)],
+            },
+        ]
+    )
+    out = to_manifest_item(item, materialized={10})
+    frames = out["objects"][0]["frames"]
+    assert "image_url" not in frames[0]
+    assert frames[0]["image_path"] == "images/pyronear_french/1234/10.jpg"
+    assert frames[1]["image_path"] is None  # failed/missing download
+    # input not mutated
+    assert item["objects"][0]["frames"][0]["image_url"] == "https://s3/presigned"

--- a/docs/specs/2026-08-07-export-alerts-pull-script-design.md
+++ b/docs/specs/2026-08-07-export-alerts-pull-script-design.md
@@ -1,0 +1,122 @@
+# Export Alerts Pull Script — Design
+
+**Date**: 2026-08-07
+**Status**: Approved
+
+## Goal
+
+A `make export-alerts` command that pulls finished annotation work from the
+annotation API's `GET /api/v1/export/alerts` endpoint (added in PR #310) and
+materializes it on disk as a self-contained ML dataset: a JSONL manifest plus
+every frame image.
+
+## Artifact layout
+
+```
+outputs/alerts_export/                 # OUTPUT_DIR
+├── manifest.jsonl                     # one line per alert
+└── images/
+    └── pyronear_french/               # source_api
+        └── 1234/                      # platform_alert_id
+            ├── 18709.jpg              # detection_id.jpg (one per frame)
+            └── 18710.jpg
+```
+
+- Each manifest line is the API's `AlertExportItem` payload verbatim, except
+  each frame's expiring `image_url` is replaced by `image_path`: the
+  dataset-relative path `images/{source_api}/{platform_alert_id}/{detection_id}.jpg`
+  (or `null` if the download ultimately failed).
+- `source_api/platform_alert_id` mirrors the endpoint's alert identity (its
+  cursor key); `detection_id.jpg` is unique and joins back to
+  `frames[].detection_id`.
+- Images live at the alert level because objects (lanes) of one alert share
+  the same frames; each image is downloaded once.
+
+Measured scale (local stack, 2026-08-07): ~8 KB of manifest per alert without
+`image_url` (~25 frame entries/alert), so even 100k alerts is a ~800 MB
+manifest — under 1% of the dataset once images are counted.
+
+## Script
+
+New package `annotation_api/scripts/data_transfer/export/` containing
+`export_alerts.py`. It talks only to the annotation API (unlike the
+`ingestion/alert_api/` scripts, which involve the alert API), hence the new
+`export/` sibling. Auth reuses `get_annotation_credentials` +
+`get_auth_token` from `ingestion/alert_api/shared.py` — same `.env`
+convention as the other scripts (`MAIN_ANNOTATION_LOGIN`/`PASSWORD` for
+remote targets, `ANNOTATOR_*` fallback for localhost).
+
+CLI:
+
+- `--annotation-api-url` (required from make; `REMOTE_API`)
+- `--output-dir`
+- `--page-size` (default 100, endpoint max 500)
+- `--max-workers` (concurrent image downloads)
+- `--loglevel`
+
+## Data flow
+
+1. Login, then walk the cursor to exhaustion, page by page.
+2. Per page: collect every frame with a `bucket_key`; dedupe by
+   `detection_id` (the same detection appears under multiple objects of one
+   alert); skip files already present on disk; download the rest concurrently
+   (ThreadPoolExecutor, `--max-workers`) via the presigned `image_url` to a
+   temp name, renaming into place on success.
+3. Append one manifest line per alert to `manifest.jsonl.tmp`
+   (`image_url` → `image_path` as above).
+4. After the last page, atomically rename `manifest.jsonl.tmp` →
+   `manifest.jsonl`.
+
+### Idempotent full pull
+
+Every run re-walks the full export and rewrites the manifest; only missing
+images are downloaded. Since a detection's image never changes, existing
+files are always valid. No state file; the endpoint's
+`annotation_updated_gte` watermark stays unused until full walks ever become
+too slow (YAGNI).
+
+### Presigned URL expiry
+
+`S3_URL_EXPIRATION` defaults to 24 h (JWT: 24 h), but the design does not
+depend on that: URLs are consumed within one page's download time of being
+minted, so even a short server-side expiry is safe. The 100-item default
+page size keeps that window tight. An expired-URL 403 falls into the normal
+download-failure path below.
+
+## Error handling
+
+- Image download: 3 attempts with short backoff; a frame that still fails is
+  written with `image_path: null`, the run continues, and the script exits
+  non-zero at the end, logging the failure count. A re-run heals it.
+- API-level errors (auth failure, 4xx/5xx on a page fetch): abort
+  immediately; the `.tmp` manifest is never renamed, so a previous good
+  `manifest.jsonl` survives.
+
+## Make target
+
+```make
+# Usage: make export-alerts [OUTPUT_DIR=outputs/alerts_export]
+export-alerts: OUTPUT_DIR ?= outputs/alerts_export
+export-alerts:
+	uv run python -m scripts.data_transfer.export.export_alerts \
+		--annotation-api-url $(REMOTE_API) \
+		--output-dir $(OUTPUT_DIR) \
+		--max-workers $(MAX_WORKERS) \
+		--loglevel $(LOGLEVEL)
+```
+
+Defaults to production (`REMOTE_API`), like `import-alert-api`; plus a
+`help` entry. The older `export_annotations.py` (raw sequences+annotations
+dump, includes unfinished work) is a different artifact and stays untouched.
+
+## Testing
+
+- Unit tests for the pure pieces, structured so transform logic is separable
+  from I/O:
+  - manifest-line transformation (`image_url` → `image_path`, including the
+    failed-download `null` case);
+  - per-page download plan (dedupe across objects of one alert,
+    skip-existing, frames without `bucket_key`).
+- End-to-end verification against the local stack: run the target twice —
+  the second run must download zero images and produce an identical
+  `manifest.jsonl`.


### PR DESCRIPTION
## Summary

Adds the pull side of the alert-centric export (`GET /api/v1/export/alerts`, PR #310): a `make export-alerts` command that materializes finished annotation work as a self-contained ML dataset.

```
OUTPUT_DIR/
├── manifest.jsonl                 # one line per alert (image_url → image_path)
└── images/{source_api}/{platform_alert_id}/{detection_id}.jpg
```

- New package `scripts/data_transfer/export/` with `export_alerts.py`: cursor walk, per-page concurrent image downloads, dedupe across objects of one alert (lanes share frames), atomic manifest rename.
- Idempotent full pull: re-runs rewrite the manifest and only download missing images; failed downloads leave `image_path: null` and a non-zero exit so a re-run heals. No watermark/state file — `annotation_updated_gte` stays unused until full walks get slow.
- Presigned URLs are consumed within one page's download window (default `--page-size 100`), so the export never races `S3_URL_EXPIRATION`.
- One pooled `requests.Session` per download worker (unauthenticated — presigned S3 rejects an extra Authorization header; per-thread because Session isn't thread-safe), so only the first image per worker pays a TCP+TLS handshake.
- Auth reuses the ingestion scripts' `.env` conventions (`MAIN_ANNOTATION_LOGIN/PASSWORD` remote, `ANNOTATOR_*` local); target API via `REMOTE_API`, like `import-alert-api`.

Spec: `docs/specs/2026-08-07-export-alerts-pull-script-design.md`

Known limitation, fine at current scale: the JWT is minted once at startup, so a pull running longer than `ACCESS_TOKEN_EXPIRE_HOURS` (24 h) would 401 mid-walk.

## Test plan

- [x] 8 unit tests (path layout, download planning/dedupe, URL-less frames, manifest transform, cursor walk, idempotence, failure → null path) — full suite 722 passed, CI green
- [x] E2E against the local stack: 29 alerts / 30 lanes / 722 frames / 722 images (57 MB). Manifest cross-checked against an independent API re-walk: identical alert set, object/frame counts, and byte-identical `boxes`; every `image_path` resolves to a valid JPEG, every file on disk is referenced, no `.part`/`.tmp` residue
- [x] Idempotence: second run downloads 0 with a byte-identical manifest; after deleting 3 images a re-run pulls exactly those 3 and reproduces the same manifest
- [x] `make export-alerts` wiring: `OUTPUT_DIR` default resolves, overrides work, fails fast on an unreachable API