### PR TITLE
deploy: bring the test-server compose onto main, on a real S3 bucket

### DIFF
--- a/.env.server.example
+++ b/.env.server.example
@@ -13,8 +13,14 @@ AUTH_PASSWORD=CHANGEME
 JWT_SECRET=CHANGEME
 
 # S3 storage as seen by the API/worker. These are the OVH Object Storage
-# settings for the test server; the credentials come from an S3 user scoped to
-# the bucket below. The bucket must already exist — nothing here creates it.
+# settings for the test server. The bucket must already exist — nothing here
+# creates it.
+#
+# Credential scope: the API's server-side image copy (IMAGE_TRANSFER=s3) reads
+# the platform's own alert-api buckets with THESE credentials, so a user scoped
+# to S3_BUCKET_NAME alone cannot serve that path. Those buckets also live in a
+# different region, and the copy runs against a single endpoint — so on this
+# server, run imports with `--image-transfer url`.
 S3_ENDPOINT_URL=https://s3.gra.io.cloud.ovh.net
 S3_ACCESS_KEY=CHANGEME
 S3_SECRET_KEY=CHANGEME
@@ -22,10 +28,20 @@ S3_REGION=gra
 S3_BUCKET_NAME=test-annotator
 
 # Only needed when presigned URLs would point at a host browsers cannot reach —
-# i.e. an S3 service running inside the compose network. Leave empty against a
-# real bucket, whose presigned URLs are already publicly resolvable.
+# i.e. an S3 service running inside the compose network. Leave empty against an
+# external bucket, whose presigned URLs are already publicly resolvable.
 S3_PROXY_URL=
 
+# MinIO root credentials. MinIO no longer backs the API (see S3_* above) but is
+# still published while the import tooling is exercised against it. Never
+# fake/fakefake on a public IP.
+MINIO_ROOT_USER=pyrominio
+MINIO_ROOT_PASSWORD=CHANGEME
+
 # Public API origin baked into the frontend at build time (no /api/v1 suffix —
-# the frontend appends it).
+# the frontend appends it). Changing it needs `up -d --build`.
 VITE_API_BASE_URL=http://162.19.113.48:5050
+
+# Uvicorn worker processes. Raising this raises the connection budget with it;
+# keep it within max_connections=150 (see src/tests/test_pool_sizing.py).
+UVICORN_WORKERS=2

--- a/.env.server.example
+++ b/.env.server.example
@@ -1,0 +1,31 @@
+# Server deployment env — copy to .env next to docker-compose.server.yml and
+# replace every CHANGEME. Never commit the real .env.
+#   openssl rand -hex 24   # for the generated secrets below
+
+# PostgreSQL (never published on the host)
+POSTGRES_USER=pyro
+POSTGRES_PASSWORD=CHANGEME
+POSTGRES_DB=pyro_annotator
+
+# Bootstrap admin user for the annotation API
+AUTH_USERNAME=admin
+AUTH_PASSWORD=CHANGEME
+JWT_SECRET=CHANGEME
+
+# S3 storage as seen by the API/worker. These are the OVH Object Storage
+# settings for the test server; the credentials come from an S3 user scoped to
+# the bucket below. The bucket must already exist — nothing here creates it.
+S3_ENDPOINT_URL=https://s3.gra.io.cloud.ovh.net
+S3_ACCESS_KEY=CHANGEME
+S3_SECRET_KEY=CHANGEME
+S3_REGION=gra
+S3_BUCKET_NAME=test-annotator
+
+# Only needed when presigned URLs would point at a host browsers cannot reach —
+# i.e. an S3 service running inside the compose network. Leave empty against a
+# real bucket, whose presigned URLs are already publicly resolvable.
+S3_PROXY_URL=
+
+# Public API origin baked into the frontend at build time (no /api/v1 suffix —
+# the frontend appends it).
+VITE_API_BASE_URL=http://162.19.113.48:5050

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -1,9 +1,16 @@
-name: pyro-annotator
+# Distinct from the dev docker-compose.yml's `pyro-annotator`. Sharing that
+# name meant a stray `docker compose up -d` from the repo root would recreate
+# these services in place with dev config — dummy_pg_user, MinIO endpoint —
+# on top of the server's data volume, with nothing reported as an orphan.
+name: pyro-annotator-server
 services:
   postgres:
     image: postgres:15-alpine
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    # Keep in step with POSTGRES_MAX_CONNECTIONS on annotation_api, which is
+    # what src/tests/test_pool_sizing.py checks the budget against.
+    command: postgres -c max_connections=150
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -14,6 +21,35 @@ services:
       timeout: 20s
       retries: 10
     restart: unless-stopped
+
+  # Transitional: storage has moved to the external bucket in .env, so the API
+  # and worker no longer depend on this. It stays published because the import
+  # tooling is still exercised against it, and goes away once that work is done.
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    command: server /data --address ':4566' --console-address ':9001'
+    ports:
+      - "4566:4566"
+    environment:
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/minio/health/ready"]
+      interval: 10s
+      timeout: 20s
+      retries: 10
+    restart: unless-stopped
+
+  minio-init:
+    image: minio/mc:RELEASE.2025-07-21T05-28-08Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "mc alias set local http://minio:4566 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}
+      && mc mb --ignore-existing local/${S3_BUCKET_NAME}"
 
   annotation_api:
     build:
@@ -33,14 +69,24 @@ services:
       - S3_REGION=${S3_REGION}
       - S3_BUCKET_NAME=${S3_BUCKET_NAME}
       # Only set when presigned URLs point at a host browsers cannot reach
-      # (a container-internal S3). Empty for a real bucket.
+      # (an S3 service inside this network). Empty for an external bucket.
       - S3_PROXY_URL=${S3_PROXY_URL:-}
       - AUTH_USERNAME=${AUTH_USERNAME}
       - AUTH_PASSWORD=${AUTH_PASSWORD}
       - JWT_SECRET=${JWT_SECRET}
       - ACCESS_TOKEN_EXPIRE_HOURS=24
+      # Serving / pool sizing, mirroring the dev compose: UVICORN_WORKERS is
+      # read both by the command below and by app.core.config, so the process
+      # count and the connection budget cannot drift apart.
+      # Budget: 2 x (10 + 10) = 40, plus the queue worker's 20, against
+      # max_connections=150 (less 3 reserved). See src/tests/test_pool_sizing.py.
+      - UVICORN_WORKERS=${UVICORN_WORKERS:-2}
+      - DB_POOL_SIZE=10
+      - DB_MAX_OVERFLOW=10
+      - POSTGRES_MAX_CONNECTIONS=150
     restart: unless-stopped
-    command: "sh -c 'alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 5050 --proxy-headers'"
+    # $$ escapes Compose interpolation so the shell expands it in-container.
+    command: "sh -c 'alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 5050 --proxy-headers --workers $${UVICORN_WORKERS:-2}'"
     healthcheck:
       test: ["CMD-SHELL", "curl http://localhost:5050/status"]
       interval: 10s
@@ -74,7 +120,11 @@ services:
       context: ./frontend
       dockerfile: ./Dockerfile
       args:
-        - VITE_API_BASE_URL=${VITE_API_BASE_URL}
+        # Baked in at build time, so a change needs `up -d --build`, not just
+        # `up -d`. Required rather than defaulted: an empty value overrides the
+        # Dockerfile ARG and ships a bundle pointing at the visitor's own
+        # localhost:5050.
+        - VITE_API_BASE_URL=${VITE_API_BASE_URL:?set VITE_API_BASE_URL in .env}
         - VITE_ENVIRONMENT=production
     depends_on:
       annotation_api:
@@ -89,5 +139,11 @@ services:
       retries: 3
       start_period: 40s
 
+# Pinned to their pre-rename names so the running server keeps its data when
+# the project name changes. Without this, `up -d` would silently start against
+# empty volumes.
 volumes:
   postgres_data:
+    name: pyro-annotator_postgres_data
+  minio_data:
+    name: pyro-annotator_minio_data

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -1,0 +1,93 @@
+name: pyro-annotator
+services:
+  postgres:
+    image: postgres:15-alpine
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 20s
+      retries: 10
+    restart: unless-stopped
+
+  annotation_api:
+    build:
+      context: ./annotation_api
+      dockerfile: ./Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "5050:5050"
+    environment:
+      - SUPPORT_EMAIL=contact@pyronear.org
+      - POSTGRES_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/${POSTGRES_DB}
+      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
+      - S3_ACCESS_KEY=${S3_ACCESS_KEY}
+      - S3_SECRET_KEY=${S3_SECRET_KEY}
+      - S3_REGION=${S3_REGION}
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME}
+      # Only set when presigned URLs point at a host browsers cannot reach
+      # (a container-internal S3). Empty for a real bucket.
+      - S3_PROXY_URL=${S3_PROXY_URL:-}
+      - AUTH_USERNAME=${AUTH_USERNAME}
+      - AUTH_PASSWORD=${AUTH_PASSWORD}
+      - JWT_SECRET=${JWT_SECRET}
+      - ACCESS_TOKEN_EXPIRE_HOURS=24
+    restart: unless-stopped
+    command: "sh -c 'alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 5050 --proxy-headers'"
+    healthcheck:
+      test: ["CMD-SHELL", "curl http://localhost:5050/status"]
+      interval: 10s
+      timeout: 20s
+      retries: 10
+
+  worker:
+    build:
+      context: ./annotation_api
+      dockerfile: ./Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+      annotation_api:
+        condition: service_healthy
+    environment:
+      - POSTGRES_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/${POSTGRES_DB}
+      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
+      - S3_ACCESS_KEY=${S3_ACCESS_KEY}
+      - S3_SECRET_KEY=${S3_SECRET_KEY}
+      - S3_REGION=${S3_REGION}
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME}
+      - AUTOANNOTATE_MODEL_PATH=/app/models
+    restart: unless-stopped
+    command: "procrastinate --app=app.worker.app worker"
+    healthcheck:
+      disable: true
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: ./Dockerfile
+      args:
+        - VITE_API_BASE_URL=${VITE_API_BASE_URL}
+        - VITE_ENVIRONMENT=production
+    depends_on:
+      annotation_api:
+        condition: service_healthy
+    ports:
+      - "80:80"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+volumes:
+  postgres_data:

--- a/docs/specs/2026-08-04-test-server-deployment-design.md
+++ b/docs/specs/2026-08-04-test-server-deployment-design.md
@@ -15,9 +15,10 @@ no monitoring.
 - **Test box, plain HTTP** on `http://162.19.113.48` — no domain or TLS.
 - **Fresh, empty database** — Alembic creates the schema on API startup; the bootstrap
   admin user comes from `AUTH_USERNAME`/`AUTH_PASSWORD`.
-- **Storage: OVH Object Storage.** The server writes to a real bucket
-  (`test-annotator`, region `gra`) via an S3 user provisioned for it. The stack ran
-  MinIO as interim storage until 2026-08-07; see "Storage history" below.
+- **Storage: OVH Object Storage.** The API and worker write to a bucket
+  (`test-annotator`, region `gra`) via an S3 user provisioned for it. MinIO still runs
+  alongside, unused by the API, while the import tooling is exercised against it; see
+  "Storage history" below.
 - **Images built on the server** — `git clone` + `docker compose build` on the box.
   No registry involved.
 
@@ -28,11 +29,18 @@ A new standalone compose file, `docker-compose.server.yml`, committed to the rep
 | Service | Host port | Notes |
 |---|---|---|
 | `postgres` | none | never published on the host |
+| `minio` | 4566 | no longer backs the API; kept published for import-tooling work |
+| `minio-init` | none | one-shot bucket bootstrap, as in the dev compose |
 | `annotation_api` | 5050 | Alembic migrate + uvicorn, as in the dev compose |
 | `worker` | none | procrastinate queue worker |
 | `frontend` | 80 | nginx serving the built React app |
 
-Storage is external (OVH), so no S3 service runs in the compose project.
+The compose project is named `pyro-annotator-server`, deliberately distinct from the
+dev `docker-compose.yml`'s `pyro-annotator`. Sharing a project name meant a stray
+`docker compose up -d` from the repo root would recreate these same service names in
+place with dev config, on top of the server's data volume, reporting nothing as an
+orphan. The volumes are pinned to their pre-rename names (`pyro-annotator_*`) so the
+running server keeps its data across the rename.
 
 All secrets and environment-specific values come from an untracked `.env` next to the
 compose file on the server, via compose variable interpolation. A committed
@@ -41,33 +49,50 @@ compose file on the server, via compose variable interpolation. A committed
 - `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` — generated
 - `AUTH_USERNAME` / `AUTH_PASSWORD` — bootstrap admin; password generated
 - `JWT_SECRET` — generated
+- `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` — generated (never `fake`/`fakefake` on a
+  public IP)
 - `S3_ENDPOINT_URL` / `S3_ACCESS_KEY` / `S3_SECRET_KEY` / `S3_REGION` / `S3_BUCKET_NAME`
   — the OVH bucket and the S3 user provisioned for it
-- `S3_PROXY_URL` — empty against a real bucket; only rewrites presigned URL hosts when
-  S3 runs inside the compose network and browsers cannot resolve it
-- `VITE_API_BASE_URL` — public API URL baked into the frontend at build time
-  (exact path shape confirmed against the frontend config during implementation)
+- `S3_PROXY_URL` — empty against an external bucket; only rewrites presigned URL hosts
+  when S3 runs inside the compose network and browsers cannot resolve it
+- `VITE_API_BASE_URL` — public API URL baked into the frontend at **build** time, so
+  changing it needs `up -d --build`. Required, not defaulted: an empty value overrides
+  the Dockerfile ARG and ships a bundle pointing at the visitor's own `localhost:5050`.
+- `UVICORN_WORKERS` — process count; also feeds the connection budget in
+  `app.core.config`, so it cannot drift from what the pool sizing assumes
 
-Changing bucket or credentials is an `.env` edit plus `up -d`, never a code change.
-The bucket itself is provisioned outside this repo; nothing in the compose project
-creates it.
+Changing bucket or credentials is an `.env` edit plus `up -d`, never a code change
+(`VITE_API_BASE_URL` excepted, per above). The bucket itself is provisioned outside
+this repo; nothing in the compose project creates it.
+
+### Credential scope and image transfer
+
+The S3 user needs more than the annotation bucket if server-side image copy is used.
+`POST /detections` derives its source bucket as
+`{PLATFORM_SERVER_NAME}-alert-api-{organisation_id}` and copies with the *same*
+credentials against the *same* endpoint. Those platform buckets live in a different
+region from `test-annotator`, so a single-endpoint copy cannot reach them regardless of
+scope: **run imports against this server with `--image-transfer url`.** A user scoped
+to `test-annotator` alone is therefore correct here, and is what credential rotation
+should aim for.
 
 ### Storage history
 
 The stack shipped with MinIO as interim storage (published on 4566, with
 `S3_PROXY_URL` rewriting presigned URLs to the public MinIO address). On 2026-08-07 an
-OVH bucket and a scoped S3 user became available and the switch was made as designed:
-`.env` repointed at the bucket with `S3_PROXY_URL` cleared, and the `minio` /
-`minio-init` services plus their `depends_on` entries and the `minio_data` volume
-removed from the compose file. Objects written to MinIO before the switch were not
-migrated — the test data was disposable and re-imported. Port 4566 no longer needs to
-be open.
+OVH bucket and an S3 user became available, and the API/worker moved to it: `.env`
+repointed at the bucket with `S3_PROXY_URL` cleared, and the API/worker `depends_on`
+entries pointing at MinIO dropped, since storage is no longer part of this project's
+lifecycle. MinIO itself stays published for now — import tooling is still exercised
+against it — and is removed once that work concludes. Objects written to MinIO before
+the switch were not migrated; that test data was disposable and is being re-imported.
 
 ## Server preparation (one-time)
 
 - Install Ubuntu's own `docker.io` + `docker-compose-v2` packages (Ubuntu 26.04 is too
   new to rely on Docker's upstream apt repo); add `ubuntu` to the `docker` group.
-- `ufw`: allow 22 (SSH), 80 (frontend), 5050 (API); default deny incoming.
+- `ufw`: allow 22 (SSH), 80 (frontend), 5050 (API), 4566 (MinIO, while in use);
+  default deny incoming.
 
 ## Deployment flow
 
@@ -76,6 +101,15 @@ be open.
    credentials.
 3. `docker compose -f docker-compose.server.yml up -d --build`.
 4. Iteration loop: SSH in, `git pull`, `up -d --build`.
+
+On the box that predates the `pyro-annotator-server` project name, the first deploy
+after the rename needs the old project torn down first — otherwise its containers keep
+holding ports 80/5050 while the renamed project tries to bind them:
+
+```bash
+docker compose -f docker-compose.server.yml -p pyro-annotator down   # containers only
+docker compose -f docker-compose.server.yml up -d --build            # volumes are pinned
+```
 
 ## Verification
 

--- a/docs/specs/2026-08-04-test-server-deployment-design.md
+++ b/docs/specs/2026-08-04-test-server-deployment-design.md
@@ -1,0 +1,89 @@
+# Test Server Deployment Design
+
+**Date**: 2026-08-04
+**Status**: Approved
+**Target**: `ubuntu@162.19.113.48` (hostname `test-anno-migration`, Ubuntu 26.04 LTS, 4 CPU, 7.6 GB RAM, 48 GB disk)
+
+## Goal
+
+Run the full pyro-annotator stack on an internet-facing test server, reachable over
+plain HTTP on the raw IP. Short-lived test/staging box: no domain, no TLS, no backups,
+no monitoring.
+
+## Decisions
+
+- **Test box, plain HTTP** on `http://162.19.113.48` — no domain or TLS.
+- **Fresh, empty database** — Alembic creates the schema on API startup; the bootstrap
+  admin user comes from `AUTH_USERNAME`/`AUTH_PASSWORD`.
+- **Storage: OVH Object Storage.** The server writes to a real bucket
+  (`test-annotator`, region `gra`) via an S3 user provisioned for it. The stack ran
+  MinIO as interim storage until 2026-08-07; see "Storage history" below.
+- **Images built on the server** — `git clone` + `docker compose build` on the box.
+  No registry involved.
+
+## Architecture
+
+A new standalone compose file, `docker-compose.server.yml`, committed to the repo:
+
+| Service | Host port | Notes |
+|---|---|---|
+| `postgres` | none | never published on the host |
+| `annotation_api` | 5050 | Alembic migrate + uvicorn, as in the dev compose |
+| `worker` | none | procrastinate queue worker |
+| `frontend` | 80 | nginx serving the built React app |
+
+Storage is external (OVH), so no S3 service runs in the compose project.
+
+All secrets and environment-specific values come from an untracked `.env` next to the
+compose file on the server, via compose variable interpolation. A committed
+`.env.server.example` documents the required keys:
+
+- `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` — generated
+- `AUTH_USERNAME` / `AUTH_PASSWORD` — bootstrap admin; password generated
+- `JWT_SECRET` — generated
+- `S3_ENDPOINT_URL` / `S3_ACCESS_KEY` / `S3_SECRET_KEY` / `S3_REGION` / `S3_BUCKET_NAME`
+  — the OVH bucket and the S3 user provisioned for it
+- `S3_PROXY_URL` — empty against a real bucket; only rewrites presigned URL hosts when
+  S3 runs inside the compose network and browsers cannot resolve it
+- `VITE_API_BASE_URL` — public API URL baked into the frontend at build time
+  (exact path shape confirmed against the frontend config during implementation)
+
+Changing bucket or credentials is an `.env` edit plus `up -d`, never a code change.
+The bucket itself is provisioned outside this repo; nothing in the compose project
+creates it.
+
+### Storage history
+
+The stack shipped with MinIO as interim storage (published on 4566, with
+`S3_PROXY_URL` rewriting presigned URLs to the public MinIO address). On 2026-08-07 an
+OVH bucket and a scoped S3 user became available and the switch was made as designed:
+`.env` repointed at the bucket with `S3_PROXY_URL` cleared, and the `minio` /
+`minio-init` services plus their `depends_on` entries and the `minio_data` volume
+removed from the compose file. Objects written to MinIO before the switch were not
+migrated — the test data was disposable and re-imported. Port 4566 no longer needs to
+be open.
+
+## Server preparation (one-time)
+
+- Install Ubuntu's own `docker.io` + `docker-compose-v2` packages (Ubuntu 26.04 is too
+  new to rely on Docker's upstream apt repo); add `ubuntu` to the `docker` group.
+- `ufw`: allow 22 (SSH), 80 (frontend), 5050 (API); default deny incoming.
+
+## Deployment flow
+
+1. `git clone` the repo on the server (HTTPS).
+2. Write `.env` from `.env.server.example` with generated secrets and the bucket
+   credentials.
+3. `docker compose -f docker-compose.server.yml up -d --build`.
+4. Iteration loop: SSH in, `git pull`, `up -d --build`.
+
+## Verification
+
+- `curl http://162.19.113.48:5050/status` succeeds from outside.
+- Frontend loads at `http://162.19.113.48/`; login with the admin creds works.
+- An image round-trips through storage (upload via API, image renders in the UI).
+
+## Out of scope
+
+TLS/domain, backups, monitoring, registry pushes, data migration (DB starts empty;
+a dump restore or alert-API import can happen later).


### PR DESCRIPTION
## Why

The test server's deployment config (`docker-compose.server.yml`, `.env.server.example`, the design doc) lived only on the long-lived `deploy-test-server` branch. Reproducing the box meant knowing that branch existed, and every deploy meant merging `main` into it first. This moves those three files onto `main` so a deploy is `git pull` + `up -d --build`, and the branch can go away.

## Storage: API/worker moved to the OVH bucket

The design doc always described MinIO as interim storage "until the real S3 bucket exists". A bucket now exists (`test-annotator`, region `gra`) with an S3 user for it, so the API and worker read and write there, driven entirely from `.env`:

- `S3_*` point at the OVH endpoint/bucket.
- `S3_PROXY_URL` is empty — an external bucket's presigned URLs already resolve for browsers, so the host rewrite MinIO needed is not.
- The API/worker `depends_on` entries pointing at MinIO are dropped. Previously the API could not start unless MinIO was healthy, which no longer makes sense now that storage is outside this project's lifecycle.

**MinIO itself stays published on 4566.** Import tooling is still being exercised against it; it gets removed once that work concludes. It simply no longer backs the API.

Bucket name and credentials stay in the untracked `.env`, so changing either (including the pending credential rotation) is an `.env` edit plus `up -d`, never a code change.

The local dev stack in the root `docker-compose.yml` is untouched.

## Fixes from review

**Project-name collision (would clobber the server).** Both compose files were named `pyro-annotator`, so they addressed the same containers *and the same `pyro-annotator_postgres_data` volume*. A stray `docker compose up -d` from the repo root — which is what the README Quick Start says to run — would recreate the server's services in place with dev config (`dummy_pg_user`, MinIO endpoint, port 3000) on top of live data, reporting nothing as an orphan. Renamed to `pyro-annotator-server`, with both volumes pinned to their pre-rename names so the running box keeps its data through the rename.

**Single-process API.** The server command dropped `--workers` and none of `UVICORN_WORKERS` / `DB_POOL_SIZE` / `DB_MAX_OVERFLOW` / `POSTGRES_MAX_CONNECTIONS` were set, so the internet-facing deployment served from one uvicorn process — the exact serialization the dev compose comment says two workers exist to remove — and it was not fixable from `.env`, because the flag that reads `UVICORN_WORKERS` was gone. Restored, together with `postgres -c max_connections=150`, which is the budget `src/tests/test_pool_sizing.py` checks against.

**`VITE_API_BASE_URL` failed open.** Baked in at build time, an empty value overrides the `ARG` default in `frontend/Dockerfile` and ships a bundle where every visitor's browser calls their own `localhost:5050`; the only signal was a Compose warning. Now `${VITE_API_BASE_URL:?...}`, which fails the build.

**Credential scope is documented.** `POST /detections` derives its copy source as `{PLATFORM_SERVER_NAME}-alert-api-{organisation_id}` and copies with the *same* credentials against the *same* endpoint. Those platform buckets are in a different region from `test-annotator`, so a single-endpoint copy cannot reach them at all: imports against this server must use `--image-transfer url`. That makes a bucket-scoped S3 user the correct target for rotation, and the example and spec now say so.

## Verified

- Round-trip against `test-annotator` from the VM through the app's own `s3_service`: upload → `check_file_existence` → presigned GET (HTTP 200 direct from `s3.gra.io.cloud.ovh.net`) → delete. Test object removed.
- `docker compose --env-file .env.server.example config` renders clean with no unset-variable warnings; project resolves to `pyro-annotator-server` while volumes resolve to `pyro-annotator_postgres_data` / `pyro-annotator_minio_data`.
- Removing `VITE_API_BASE_URL` from the env file makes `config` fail with the intended message rather than interpolating empty.
- The server has been running this `.env` shape since the switch; API `/status` and the frontend both return 200 externally.

## Follow-ups (not in this PR)

- **First deploy after merge needs the old project torn down** — `docker compose -f docker-compose.server.yml -p pyro-annotator down`, then `up -d --build`. Otherwise the old containers keep holding 80/5050. Volumes are pinned, so no data moves. Documented in the spec.
- Objects written to MinIO before the switch were not migrated; the DB still references those keys, so pre-switch images 404 until the planned re-import. That test data was disposable by design.
- After merge: point the VM checkout at `main` and delete `deploy-test-server`.
- `MINIO_ROOT_*` can leave `.env` once MinIO is retired.