### PR TITLE
perf(clients): pool annotation-API connections per thread

### DIFF
--- a/annotation_api/src/app/clients/annotation_api.py
+++ b/annotation_api/src/app/clients/annotation_api.py
@@ -10,6 +10,7 @@ import threading
 from typing import Dict, Optional
 
 import requests
+from requests.adapters import HTTPAdapter, Retry
 
 # -------------------- CUSTOM EXCEPTIONS --------------------
 
@@ -93,13 +94,35 @@ __all__ = [
 
 # -------------------- CONNECTION POOLING --------------------
 
-# The import script drives this client from a pool of threads (sequence workers
-# times detection workers), and `requests.Session` is not documented as
-# thread-safe, so each thread keeps its own. Same reasoning as the thread-local
-# boto3 client in `app/services/storage.py`. Without a session, every one of the
-# thousands of calls in an import re-does the TCP (and, against an HTTPS
-# deployment, TLS) handshake.
+# The import script drives this client from several threads at once — a pool for
+# sequences, and a nested one per sequence for its detections — and
+# `requests.Session` is not documented as thread-safe, so each thread keeps its
+# own. Same reasoning as the thread-local boto3 client in
+# `app/services/storage.py`.
+#
+# Without a session every call re-does the TCP (and, against an HTTPS
+# deployment, TLS) handshake. How far one connection then stretches differs by
+# pool: the sequence pool is built once per import, so its sessions last the
+# whole run, while the detection pool is rebuilt for every sequence
+# (`shared.py`), so its sessions die with it. That still collapses a sequence's
+# ~20 detections onto one connection per worker instead of one each.
 _thread_local = threading.local()
+
+# Pooling introduces a failure that dialing fresh every time could not produce:
+# the server (or an intermediary) closes an idle keep-alive socket, and the next
+# request on it fails with RemoteDisconnected. urllib3 discards connections whose
+# close it has already noticed, but not one closed between that check and the
+# write, so a redial is still needed. The importer would not recover on its own —
+# its retry only matches 502/503/504, and a network error carries no status code.
+#
+# `read=1` is what covers this: a dropped connection is classified as a read
+# error, not a connection error. `allowed_methods=None` is required for it to
+# apply to POST, which urllib3 will not retry by default; that is safe here
+# because the import handles a duplicate create as 409. Statuses are left alone
+# (`status=0`) so the script's own 502/503/504 backoff stays the only one.
+_CONNECTION_RETRY = Retry(
+    total=2, connect=2, read=1, status=0, allowed_methods=None, backoff_factor=0.2
+)
 
 
 def _get_session() -> requests.Session:
@@ -107,6 +130,9 @@ def _get_session() -> requests.Session:
     session: Optional[requests.Session] = getattr(_thread_local, "session", None)
     if session is None:
         session = requests.Session()
+        adapter = HTTPAdapter(max_retries=_CONNECTION_RETRY)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
         _thread_local.session = session
     return session
 

--- a/annotation_api/src/app/clients/annotation_api.py
+++ b/annotation_api/src/app/clients/annotation_api.py
@@ -6,6 +6,7 @@ using the requests library for HTTP communication.
 """
 
 import json
+import threading
 from typing import Dict, Optional
 
 import requests
@@ -90,6 +91,26 @@ __all__ = [
 ]
 
 
+# -------------------- CONNECTION POOLING --------------------
+
+# The import script drives this client from a pool of threads (sequence workers
+# times detection workers), and `requests.Session` is not documented as
+# thread-safe, so each thread keeps its own. Same reasoning as the thread-local
+# boto3 client in `app/services/storage.py`. Without a session, every one of the
+# thousands of calls in an import re-does the TCP (and, against an HTTPS
+# deployment, TLS) handshake.
+_thread_local = threading.local()
+
+
+def _get_session() -> requests.Session:
+    """The calling thread's `requests.Session`, built on first use."""
+    session: Optional[requests.Session] = getattr(_thread_local, "session", None)
+    if session is None:
+        session = requests.Session()
+        _thread_local.session = session
+    return session
+
+
 # -------------------- AUTHENTICATION UTILITIES --------------------
 
 
@@ -112,7 +133,7 @@ def get_auth_token(base_url: str, username: str, password: str) -> str:
     login_data = {"username": username, "password": password}
 
     try:
-        response = requests.post(login_url, json=login_data, timeout=30)
+        response = _get_session().post(login_url, json=login_data, timeout=30)
         response.raise_for_status()
 
         token_data = response.json()
@@ -176,7 +197,7 @@ def _make_request(
         # forever. Callers may override by passing their own `timeout`.
         kwargs.setdefault("timeout", (10, 120))
 
-        response = requests.request(method, url, **kwargs)
+        response = _get_session().request(method, url, **kwargs)
 
         # Don't raise for status here - we'll handle it in _handle_response
         return response

--- a/annotation_api/src/tests/clients/test_annotation_api.py
+++ b/annotation_api/src/tests/clients/test_annotation_api.py
@@ -6,6 +6,7 @@ including HTTP utilities, exception handling, and CRUD operations for all resour
 """
 
 import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from unittest.mock import Mock
 
 import pytest
@@ -376,8 +377,96 @@ class TestHTTPUtilities:
 # ==================== CONNECTION REUSE TESTS ====================
 
 
+class _CountingServer(ThreadingHTTPServer):
+    """A local HTTP server that counts accepted TCP connections."""
+
+    daemon_threads = True
+
+    def __init__(self, *args, **kwargs):
+        self.accepted = 0
+        super().__init__(*args, **kwargs)
+
+    def get_request(self):
+        # Called from the single-threaded accept loop, once per handshake.
+        request = super().get_request()
+        self.accepted += 1
+        return request
+
+
+class _KeepAliveHandler(BaseHTTPRequestHandler):
+    # HTTP/1.0 (the default) closes the connection after every response, which
+    # would make the reuse below impossible to observe.
+    protocol_version = "HTTP/1.1"
+
+    def _reply(self):
+        body = b'{"ok": true}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        self._reply()
+
+    def do_POST(self):
+        self._reply()
+
+    def log_message(self, *args):
+        """Silence the per-request stderr logging."""
+
+
+class _DropFirstConnectionHandler(_KeepAliveHandler):
+    """Answers nothing on the first connection, then serves normally.
+
+    Stands in for a pooled socket the server has already closed: the request
+    goes out fine and the read finds the connection gone.
+    """
+
+    def _reply(self):
+        if self.server.accepted == 1:
+            self.close_connection = True
+            return
+        super()._reply()
+
+
 class TestConnectionReuse:
     """Requests must go through a thread-local session so connections are pooled."""
+
+    def test_repeated_calls_share_one_tcp_connection(self):
+        """The whole point: N calls against one host cost one handshake, not N."""
+        server = _CountingServer(("127.0.0.1", 0), _KeepAliveHandler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        url = f"http://127.0.0.1:{server.server_address[1]}/detections"
+
+        try:
+            for _ in range(3):
+                response = _make_request("GET", url, "test_token")
+                assert response.json() == {"ok": True}
+        finally:
+            server.shutdown()
+            server.server_close()
+
+        assert server.accepted == 1
+
+    def test_a_dropped_pooled_connection_is_redialed(self):
+        """Pooling must not turn a closed keep-alive socket into a failed call.
+
+        Before pooling, every request dialed fresh, so this could not happen;
+        the importer's retry only matches 502/503/504 and would give up on it.
+        """
+        server = _CountingServer(("127.0.0.1", 0), _DropFirstConnectionHandler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        url = f"http://127.0.0.1:{server.server_address[1]}/detections"
+
+        try:
+            response = _make_request("POST", url, "test_token")
+            assert response.json() == {"ok": True}
+        finally:
+            server.shutdown()
+            server.server_close()
+
+        assert server.accepted == 2
 
     def test_same_thread_reuses_one_session(self):
         """A thread gets the same session object every time it asks."""

--- a/annotation_api/src/tests/clients/test_annotation_api.py
+++ b/annotation_api/src/tests/clients/test_annotation_api.py
@@ -5,17 +5,20 @@ This module tests all functionality of the synchronous annotation API client,
 including HTTP utilities, exception handling, and CRUD operations for all resource types.
 """
 
+import threading
 from unittest.mock import Mock
 
 import pytest
 import requests
 import requests_mock
 
+from app.clients import annotation_api
 from app.clients.annotation_api import (
     AnnotationAPIError,
     NotFoundError,
     ServerError,
     ValidationError,
+    _get_session,
     _handle_response,
     _make_request,
     create_detection,
@@ -26,6 +29,7 @@ from app.clients.annotation_api import (
     delete_detection_annotation,
     delete_sequence,
     delete_sequence_annotation,
+    get_auth_token,
     get_detection,
     get_detection_annotation,
     get_detection_url,
@@ -367,6 +371,72 @@ class TestHTTPUtilities:
         error = exc_info.value
         assert error.status_code == 400
         assert "Bad Request" in str(error)
+
+
+# ==================== CONNECTION REUSE TESTS ====================
+
+
+class TestConnectionReuse:
+    """Requests must go through a thread-local session so connections are pooled."""
+
+    def test_same_thread_reuses_one_session(self):
+        """A thread gets the same session object every time it asks."""
+        assert _get_session() is _get_session()
+
+    def test_each_thread_gets_its_own_session(self):
+        """Sessions are not shared across threads (requests.Session isn't thread-safe)."""
+        sessions = []
+        threads = [
+            threading.Thread(target=lambda: sessions.append(_get_session()))
+            for _ in range(2)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert sessions[0] is not sessions[1]
+        assert _get_session() not in sessions
+
+    def test_make_request_goes_through_the_session(self, monkeypatch):
+        """_make_request must not use the connection-less module-level requests API."""
+        session = requests.Session()
+        calls = []
+        original_request = session.request
+
+        def spy(method, url, **kwargs):
+            calls.append((method, url))
+            return original_request(method, url, **kwargs)
+
+        monkeypatch.setattr(session, "request", spy)
+        monkeypatch.setattr(annotation_api, "_get_session", lambda: session)
+
+        with requests_mock.Mocker() as m:
+            m.get("http://example.com/test", json={"success": True})
+            response = _make_request("GET", "http://example.com/test", "test_token")
+
+        assert calls == [("GET", "http://example.com/test")]
+        assert response.json() == {"success": True}
+
+    def test_get_auth_token_goes_through_the_session(self, monkeypatch):
+        """The login call is on the same pooled connection as everything else."""
+        session = requests.Session()
+        calls = []
+        original_post = session.post
+
+        def spy(url, **kwargs):
+            calls.append(url)
+            return original_post(url, **kwargs)
+
+        monkeypatch.setattr(session, "post", spy)
+        monkeypatch.setattr(annotation_api, "_get_session", lambda: session)
+
+        with requests_mock.Mocker() as m:
+            m.post(f"{API_BASE}/auth/login", json={"access_token": "tok"})
+            token = get_auth_token(BASE_URL, "user", "password")
+
+        assert calls == [f"{API_BASE}/auth/login"]
+        assert token == "tok"
 
 
 # ==================== EXCEPTION TESTS ====================


### PR DESCRIPTION
Closes #361.

## What

`_make_request` and the login call in `app/clients/annotation_api.py` used the
module-level `requests` functions, which build and throw away a `Session` per
call. Every one of the thousands of calls an import makes therefore re-did the
TCP handshake, plus TLS against anything but a plain-HTTP localhost.

Both now go through a **thread-local** `requests.Session`. Thread-local rather
than one shared session because the importer posts concurrently and
`requests.Session` is not documented as thread-safe. Same shape as the
thread-local boto3 client from #350 and the per-worker download session in
`export_alerts.py`.

Deliberately unchanged: the `(10, 120)` default timeout and the
`RequestException` -> `AnnotationAPIError` mapping.

Scope is the annotation-API client only; the alert-API client
(`scripts/.../client.py:66`) still has no session and is not touched here.

### How far the reuse actually reaches

Not uniformly across the import, and the code comment now says so. The
sequence-level pool (`shared.py:759`) is built once per run, so those sessions
live the whole import. The detection-level pool (`shared.py:656`) is rebuilt
**inside each sequence**, so its threads — and their sessions — die with it.
Reuse there is bounded to one sequence: ~20 detections over 4 workers costs 4
handshakes instead of ~20. Hoisting that inner pool would remove the remaining
per-sequence floor; that is not attempted here.

## A regression this introduced, and the fix

Pooling makes a failure possible that dialing fresh every time could not
produce: the server closes an idle keep-alive socket and the next request on it
raises `RemoteDisconnected`. urllib3 drops connections whose close it has
already observed, but not one closed between that check and the write.

The importer cannot recover from it on its own. `_process_single_detection`
matches `e.status_code in (502, 503, 504)` (`shared.py:554`) and a network error
carries `status_code=None`, so the detection would be marked permanently failed
— even though the docstring at `shared.py:454` already claims network errors are
retried.

Fixed inside the client by mounting an adapter that redials:

```python
Retry(total=2, connect=2, read=1, status=0, allowed_methods=None, backoff_factor=0.2)
```

- `read=1` is the load-bearing part: a dropped pooled connection is classified
  by urllib3 as a **read** error, not a connection error (verified against
  urllib3 2.5.0 — a `connect`-only retry would re-raise immediately).
- `allowed_methods=None` is required for POST, which urllib3 will not retry by
  default. Safe here because the import already treats a duplicate create as 409
  and reuses the existing row (`shared.py:526`).
- `status=0` leaves HTTP statuses alone, so the script's own 502/503/504 backoff
  remains the only status-level retry.

## Verification

**Output-equivalence gate (the project's standard for import changes).** Two
imports against an isolated stack, same pinned alert set
(`--sequence-list 51914,...,51970`, 11 lanes / 211 detections), dumped to the
canonical id-free projection with annotation `detection_id` rewritten to the
detection's `alert_api_id` — the rewrite that would expose boxes bound to the
wrong rows:

```
baseline (pre-change client) vs final (session + redial): byte-identical
md5 9f10c6444d606fcfc15f83135fe5ec7a  (449 lines: 11 sequences,
                                       211 detections, 211 annotation boxes)
```

**Tests** — 6 in `TestConnectionReuse`, each watched failing first:

- `test_repeated_calls_share_one_tcp_connection` — a real local HTTP server
  counts accepted connections; 3 calls, 1 handshake. Red before the fix with
  `assert 3 == 1`.
- `test_a_dropped_pooled_connection_is_redialed` — server drops the first
  connection unanswered; red before the adapter with the exact production
  symptom, `Network error: ('Connection aborted.', RemoteDisconnected(...))`.
- `test_same_thread_reuses_one_session` — red against a session-per-call stub.
- `test_each_thread_gets_its_own_session` — red against a process-wide session.
- `test_make_request_goes_through_the_session` / `..._get_auth_token_...` — red
  while the call sites still used module-level `requests`.

Full backend suite green in an isolated stack: **728 passed**. Ruff format +
check clean.

## Not done

The remote-target benchmark from the issue. Localhost hides handshake cost by
design, so the local wall-clock here (13.5s vs 14.6s over 211 records) measures
noise, not the change — it is reported only as evidence of no regression. The
real number needs an import against a remote deployment.
