### PR TITLE
perf(api): reuse one httpx client for image downloads

### DIFF
--- a/annotation_api/src/app/main.py
+++ b/annotation_api/src/app/main.py
@@ -27,6 +27,7 @@ from app.crud import UserCRUD
 from app.db import get_session
 from app.schemas.base import Status
 from app.schemas.user import UserCreate
+from app.services.storage import close_download_client
 from app.worker import app as procrastinate_app
 
 logger = logging.getLogger("uvicorn.error")
@@ -109,6 +110,7 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         await procrastinate_app.close_async()
+        await close_download_client()
 
 
 app = FastAPI(

--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -457,7 +457,12 @@ def _get_download_client() -> httpx.AsyncClient:
 
 
 async def close_download_client() -> None:
-    """Release the image-download client. Called from the app lifespan."""
+    """Release the image-download client. Called from the app lifespan.
+
+    Must be awaited on the loop that built the client: closing a pool that
+    still holds live keep-alive connections from a finished loop raises
+    "Event loop is closed". The lifespan satisfies this by construction.
+    """
     global _download_client, _download_client_loop
 
     client = _download_client

--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -446,6 +446,12 @@ def _get_download_client() -> httpx.AsyncClient:
     connections belong to the loop that opened them. Production has one loop
     per worker process and never rebuilds; the tests run one loop per test and
     must not be handed a dead loop's connections.
+
+    A rebuild abandons the previous client without closing it -- it cannot be
+    awaited from here, and closing it would have to happen on its own loop
+    anyway (see close_download_client). Its sockets are released when it is
+    collected. This only ever costs anything under the test harness, which is
+    the only thing that changes loops.
     """
     global _download_client, _download_client_loop
 
@@ -497,6 +503,16 @@ async def upload_file_from_url(
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"Could not connect to source URL: {source_url}",
+        )
+    except httpx.RemoteProtocolError:
+        # Only reachable since the client became shared: a pooled connection
+        # can be handed out in the instant after the source closed it, and the
+        # request then hits EOF. Left unmapped this surfaces as a 500, which
+        # the importer does not retry (it retries 502/503/504) -- so a dropped
+        # connection would silently cost a detection.
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Source URL closed the connection before responding: {source_url}",
         )
     except httpx.HTTPStatusError as exc:
         code = exc.response.status_code

--- a/annotation_api/src/app/services/storage.py
+++ b/annotation_api/src/app/services/storage.py
@@ -3,6 +3,7 @@
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
+import asyncio
 import hashlib
 import logging
 import os
@@ -12,6 +13,7 @@ from mimetypes import guess_extension
 from typing import Any, Dict, Optional, Union
 
 import boto3
+import httpx
 import magic
 from botocore.exceptions import (
     ClientError,
@@ -25,6 +27,7 @@ from starlette.concurrency import run_in_threadpool
 from app.core.config import settings
 
 __all__ = [
+    "close_download_client",
     "copy_file_from_bucket",
     "s3_service",
     "upload_file",
@@ -426,6 +429,44 @@ def _store_downloaded_image(
     return bucket_key
 
 
+_download_client: Optional[httpx.AsyncClient] = None
+_download_client_loop: Optional[asyncio.AbstractEventLoop] = None
+
+
+def _get_download_client() -> httpx.AsyncClient:
+    """The image-download client, built on first use.
+
+    One client for the whole process: with IMAGE_TRANSFER=url an import runs
+    the download below once per detection, and a client per call made every
+    one of those thousands of images pay a fresh TCP+TLS handshake to the
+    source S3 host. This is the download-leg counterpart of the per-thread
+    boto3 client above.
+
+    Rebuilt when the running loop changes, because a client's pooled
+    connections belong to the loop that opened them. Production has one loop
+    per worker process and never rebuilds; the tests run one loop per test and
+    must not be handed a dead loop's connections.
+    """
+    global _download_client, _download_client_loop
+
+    loop = asyncio.get_running_loop()
+    if _download_client is None or _download_client_loop is not loop:
+        _download_client = httpx.AsyncClient()
+        _download_client_loop = loop
+    return _download_client
+
+
+async def close_download_client() -> None:
+    """Release the image-download client. Called from the app lifespan."""
+    global _download_client, _download_client_loop
+
+    client = _download_client
+    _download_client = None
+    _download_client_loop = None
+    if client is not None:
+        await client.aclose()
+
+
 async def upload_file_from_url(
     source_url: str,
     sequence_id: Optional[int] = None,
@@ -438,13 +479,10 @@ async def upload_file_from_url(
     This avoids the client downloading the image and re-uploading it via
     multipart form, cutting out one full network round-trip per detection.
     """
-    import httpx
-
     try:
-        async with httpx.AsyncClient(timeout=download_timeout) as client:
-            resp = await client.get(source_url)
-            resp.raise_for_status()
-            image_bytes = resp.content
+        resp = await _get_download_client().get(source_url, timeout=download_timeout)
+        resp.raise_for_status()
+        image_bytes = resp.content
     except httpx.TimeoutException:
         raise HTTPException(
             status_code=status.HTTP_504_GATEWAY_TIMEOUT,

--- a/annotation_api/src/tests/services/test_storage.py
+++ b/annotation_api/src/tests/services/test_storage.py
@@ -1,10 +1,15 @@
+import asyncio
 import io
 import threading
 
 import boto3
+import httpx
 import pytest
+import pytest_asyncio
+from fastapi import HTTPException
 
 from app.core.config import settings
+from app.services import storage
 from app.services.storage import S3Bucket, S3Service
 
 
@@ -200,3 +205,129 @@ def test_bucket_cache_is_per_thread():
     assert (
         other["client"] is not mine._s3
     ), "bucket handed a thread another thread's boto3 client"
+
+
+@pytest_asyncio.fixture
+async def fresh_download_client():
+    """Start and end with no cached download client.
+
+    The cache is process-wide, so a client built here -- especially one wired
+    to a mock transport -- would otherwise be handed to later tests.
+    """
+    await storage.close_download_client()
+    yield
+    await storage.close_download_client()
+
+
+def _mock_download_client(handler):
+    """An httpx.AsyncClient factory that answers every request from `handler`."""
+    real_client = httpx.AsyncClient
+
+    def build(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_client(*args, **kwargs)
+
+    return build
+
+
+@pytest.mark.asyncio
+async def test_upload_file_from_url_reuses_one_http_client(
+    monkeypatch, fresh_download_client
+):
+    """One client for all downloads, not one per detection.
+
+    With IMAGE_TRANSFER=url this path runs once per detection, so a per-call
+    client makes every one of an import's thousands of images pay a fresh
+    TCP+TLS handshake to the alert API's S3.
+    """
+    constructed = []
+    build = _mock_download_client(lambda request: httpx.Response(200, content=b"img"))
+
+    def counting_client(*args, **kwargs):
+        client = build(*args, **kwargs)
+        constructed.append(client)
+        return client
+
+    monkeypatch.setattr(storage.httpx, "AsyncClient", counting_client)
+    monkeypatch.setattr(storage, "_store_downloaded_image", lambda *args: "bucket-key")
+
+    for _ in range(3):
+        key = await storage.upload_file_from_url("https://example.invalid/a.jpg")
+        assert key == "bucket-key"
+
+    assert (
+        len(constructed) == 1
+    ), f"built {len(constructed)} clients for 3 downloads, expected 1"
+
+
+def test_download_client_is_rebuilt_for_a_new_event_loop():
+    """A client's pooled connections belong to the loop that opened them.
+
+    Handing a second loop the first loop's client would have it reuse
+    connections whose loop is gone. The test suite runs one loop per test,
+    which is exactly that situation.
+    """
+    first = asyncio.run(_current_download_client())
+    second = asyncio.run(_current_download_client())
+
+    assert second is not first, "a new event loop was handed the old loop's client"
+
+    asyncio.run(storage.close_download_client())
+
+
+async def _current_download_client():
+    return storage._get_download_client()
+
+
+@pytest.mark.asyncio
+async def test_close_download_client_closes_and_clears_it(fresh_download_client):
+    """Shutdown must actually release the client, not just drop the reference."""
+    client = storage._get_download_client()
+
+    await storage.close_download_client()
+
+    assert client.is_closed
+    assert storage._get_download_client() is not client
+
+
+def _raising_handler(exc):
+    def handler(request):
+        raise exc
+
+    return handler
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler", "expected_status", "expected_detail"),
+    [
+        (
+            _raising_handler(httpx.TimeoutException("slow")),
+            504,
+            "Timeout downloading image",
+        ),
+        (
+            _raising_handler(httpx.ConnectError("refused")),
+            502,
+            "Could not connect to source URL",
+        ),
+        (lambda request: httpx.Response(404), 422, "Source URL returned HTTP 404"),
+        (lambda request: httpx.Response(503), 502, "Source URL server error: HTTP 503"),
+        (
+            lambda request: httpx.Response(200, content=b""),
+            422,
+            "Source URL returned empty response",
+        ),
+    ],
+)
+async def test_upload_file_from_url_maps_download_failures(
+    monkeypatch, fresh_download_client, handler, expected_status, expected_detail
+):
+    """Sharing the client must not change what a failed download reports."""
+    monkeypatch.setattr(storage.httpx, "AsyncClient", _mock_download_client(handler))
+
+    with pytest.raises(HTTPException) as excinfo:
+        await storage.upload_file_from_url("https://example.invalid/a.jpg")
+
+    assert excinfo.value.status_code == expected_status
+    assert expected_detail in excinfo.value.detail

--- a/annotation_api/src/tests/services/test_storage.py
+++ b/annotation_api/src/tests/services/test_storage.py
@@ -207,6 +207,22 @@ def test_bucket_cache_is_per_thread():
     ), "bucket handed a thread another thread's boto3 client"
 
 
+def _forget_download_client():
+    """Drop the cached client without closing it.
+
+    A client must be closed on the loop that built it: aclose() on a pool
+    still holding live keep-alive connections from a finished loop raises
+    "Event loop is closed". Whatever is cached on entry to a test belongs to
+    an earlier test's loop, so it gets dropped rather than closed. It survives
+    here only because nothing else in the process reaches it.
+
+    The local test S3 happens to answer `Connection: close`, which empties the
+    pool and hides this -- don't let that become the reason it works.
+    """
+    storage._download_client = None
+    storage._download_client_loop = None
+
+
 @pytest_asyncio.fixture
 async def fresh_download_client():
     """Start and end with no cached download client.
@@ -214,8 +230,9 @@ async def fresh_download_client():
     The cache is process-wide, so a client built here -- especially one wired
     to a mock transport -- would otherwise be handed to later tests.
     """
-    await storage.close_download_client()
+    _forget_download_client()
     yield
+    # Always this test's own client, so closing it is safe.
     await storage.close_download_client()
 
 
@@ -267,12 +284,14 @@ def test_download_client_is_rebuilt_for_a_new_event_loop():
     connections whose loop is gone. The test suite runs one loop per test,
     which is exactly that situation.
     """
+    _forget_download_client()
+
     first = asyncio.run(_current_download_client())
     second = asyncio.run(_current_download_client())
 
     assert second is not first, "a new event loop was handed the old loop's client"
 
-    asyncio.run(storage.close_download_client())
+    _forget_download_client()
 
 
 async def _current_download_client():

--- a/annotation_api/src/tests/services/test_storage.py
+++ b/annotation_api/src/tests/services/test_storage.py
@@ -330,6 +330,11 @@ def _raising_handler(exc):
             502,
             "Could not connect to source URL",
         ),
+        (
+            _raising_handler(httpx.RemoteProtocolError("server disconnected")),
+            502,
+            "Source URL closed the connection",
+        ),
         (lambda request: httpx.Response(404), 422, "Source URL returned HTTP 404"),
         (lambda request: httpx.Response(503), 502, "Source URL server error: HTTP 503"),
         (


### PR DESCRIPTION
Closes #359 (item 2 of #358's suggested order).

## What changed

`upload_file_from_url` built a **new `httpx.AsyncClient` per call**. With
`IMAGE_TRANSFER=url` that runs once per detection, so each of the thousands of
images in an import paid a fresh TCP + TLS handshake to the alert API's S3 host.
This is the download-leg counterpart of #350's per-thread boto3 client.

Now: one client per process, built lazily and closed from the app lifespan.

- The per-request timeout moved to `client.get(..., timeout=download_timeout)`,
  so `download_timeout` still applies per call exactly as before.
- The existing exception mapping is untouched — `TimeoutException` → 504,
  `ConnectError` → 502, 4xx → 422, 5xx → 502, empty body → 422.
- **One mapping added**, for a failure mode pooling creates: see below.
- `import httpx` moved out of the function body to module top.

### `RemoteProtocolError` → 502 (new, and it matters)

A pooled connection can be handed out in the instant after the source closed
it; the request then hits EOF and httpx raises `RemoteProtocolError`. A per-call
client always dialled a fresh connection, so this was previously unreachable.

It matches none of the existing `except` clauses, so it would reach `main.py`'s
generic handler as a **500** — and the importer retries only 502/503/504
(`scripts/data_transfer/ingestion/alert_api/shared.py`). A dropped connection
would therefore have **silently cost a detection**. Mapped to 502, it re-enters
the existing retry path.

### Why the client is keyed on the event loop

A client's pooled connections belong to the loop that opened them. Production
has one loop per uvicorn worker process, so it builds the client once and never
rebuilds. The **test suite runs one loop per test**
(`asyncio_default_fixture_loop_scope = "function"`), and handing the second test
the first test's client would have it reuse connections whose loop is gone.

Same rule applies to closing: `aclose()` on a pool still holding live keep-alive
connections from a finished loop raises `RuntimeError: Event loop is closed`
(verified directly). The lifespan satisfies this by construction; the test
fixture drops a foreign-loop client rather than closing it. Worth keeping in
mind if the test stack ever moves off LocalStack — LocalStack answers
`Connection: close`, which empties the pool and hides this; root-compose MinIO
does keep connections alive.

## Verification

**Connection reuse actually happens.** Against a keep-alive server the shared
client serves every request on one connection; previously each call opened its
own:

```
req 1: 200 pooled=1 [AsyncHTTPConnection [http://…, HTTP/1.1, IDLE, Request Count: 1]]
…
req 5: 200 pooled=1 [AsyncHTTPConnection [http://…, HTTP/1.1, IDLE, Request Count: 5]]
```

**No correctness regression.** A probe against the real (LocalStack) S3 ran 5
sequential + 8 concurrent downloads through the shared client: all 13 stored
objects are byte-identical to the source (sha256), with 13 distinct bucket keys.

**The tests bite.** Reverting to the per-call `async with httpx.AsyncClient(...)`
fails `test_upload_file_from_url_reuses_one_http_client` with `assert 3 == 1`.

Full backend suite: **723 passed**. ruff format + check clean on the touched
files.

### Heads-up: the local stack cannot show this working

LocalStack answers image downloads with `Connection: close`, so the local test
stack gets **zero** connection reuse — a local benchmark of this change would
show exactly nothing, which is a sharper version of the warning in #359. By the
same token the win depends on the alert API's S3 host honouring keep-alive; that
is the one thing still unverified.

## Reviewed and deliberately left alone

- **Pool bound.** A shared pool caps concurrent downloads at httpx's default
  `max_connections=100` per worker, and `Timeout(30)` covers the pool wait too,
  so heavy concurrency could surface as `PoolTimeout` → 504 that reads as if the
  source were slow. Not data loss (the importer retries 504, which is the right
  response to pool pressure anyway), and nowhere near reach at the ~12 POSTs in
  flight #358 measured. Left at the default rather than inventing a number.
- **Cookie jar.** The shared client keeps one cookie jar for the process, which
  the per-call client did not. Presigned S3 GETs set no cookies, so this is
  inert here; clearing it per request would be code for a case that does not
  occur.

## Tests

`src/tests/services/test_storage.py`:

- `test_upload_file_from_url_reuses_one_http_client` — three downloads, one
  client constructed.
- `test_download_client_is_rebuilt_for_a_new_event_loop` — guards the keying.
- `test_close_download_client_closes_and_clears_it` — shutdown releases it
  rather than just dropping the reference.
- `test_upload_file_from_url_maps_download_failures` — all six failure mappings,
  including the new `RemoteProtocolError` → 502.

## Not done here: the remote measurement

#359 asks for a records/s comparison against a **remote** target plus the
output-equivalence gate. That needs this branch deployed to the test server and
a real cross-org import; it is not part of this PR. The throughput claim remains
unmeasured — what is measured here is that connections are reused and that the
stored bytes are unchanged.
