### PR TITLE
feat(import): capture the platform temporal model score

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/batch_import_local_yolo.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/batch_import_local_yolo.py
@@ -213,7 +213,7 @@ def main() -> int:
 
     folders = sorted(p for p in seq_root.iterdir() if p.is_dir())
     if args.skip:
-        folders = folders[args.skip:]
+        folders = folders[args.skip :]
     if args.limit:
         folders = folders[: args.limit]
 
@@ -276,9 +276,7 @@ def main() -> int:
                 continue
             if rc == 0:
                 successes += 1
-                logging.info(
-                    "[%d/%d] OK   %s (seq_id=%d)", idx, total, label, seq_id
-                )
+                logging.info("[%d/%d] OK   %s (seq_id=%d)", idx, total, label, seq_id)
             else:
                 failures += 1
                 logging.error(

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/cleanup_sequences.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/cleanup_sequences.py
@@ -92,7 +92,9 @@ def main() -> None:
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-    alert_ids = parse_sequence_selection(args.sequence_list) if args.sequence_list else None
+    alert_ids = (
+        parse_sequence_selection(args.sequence_list) if args.sequence_list else None
+    )
 
     login, password = shared.get_annotation_credentials(args.url_api_annotation)
     token = annotation_api.get_auth_token(args.url_api_annotation, login, password)
@@ -108,7 +110,11 @@ def main() -> None:
     logging.info(
         f"Found {len(sequences)} sequence(s) matching processing_stage={args.processing_stage}"
         + (f" and alert_ids filter ({len(alert_ids)} provided)" if alert_ids else "")
-        + (f" and organisation_name={args.organisation_name}" if args.organisation_name else "")
+        + (
+            f" and organisation_name={args.organisation_name}"
+            if args.organisation_name
+            else ""
+        )
     )
 
     if args.dry_run or not sequences:
@@ -122,7 +128,9 @@ def main() -> None:
             annotation_api.delete_sequence(args.url_api_annotation, token, seq_id)
             logging.info(f"Deleted sequence id={seq_id} alert_api_id={alert_id}")
         except Exception as exc:
-            logging.error(f"Failed to delete sequence id={seq_id} alert_api_id={alert_id}: {exc}")
+            logging.error(
+                f"Failed to delete sequence id={seq_id} alert_api_id={alert_id}: {exc}"
+            )
 
 
 if __name__ == "__main__":

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
@@ -562,12 +562,12 @@ def main() -> None:
         )
         # Anomaly, not a routine stat: printed only when it fires, so a dropped
         # verdict stays distinguishable from an alert API that sends no score.
-        if split_stats["unscored_primary"]:
+        if split_stats["dropped_temporal_scores"]:
             console.print(
-                f"[yellow]⚠️  {split_stats['unscored_primary']} alert sequence(s) had no "
-                "identifiable primary object (no bbox-sourced box in the imported "
-                "window); their temporal model score was dropped rather than "
-                "attributed to an arbitrary object[/]"
+                f"[yellow]⚠️  {split_stats['dropped_temporal_scores']} scored alert "
+                "sequence(s) had no identifiable primary object (no bbox-sourced box "
+                "in the imported window); their temporal model score was dropped "
+                "rather than attributed to an arbitrary object[/]"
             )
 
         # Boxless alerts import as zero-object lanes the classify page cannot

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
@@ -453,9 +453,7 @@ def main() -> None:
     )
 
     if args.loglevel == "debug":
-        console.print(
-            f"[blue]ℹ️  Date range: {args.date_from} to {args.date_end}[/]"
-        )
+        console.print(f"[blue]ℹ️  Date range: {args.date_from} to {args.date_end}[/]")
         console.print(
             f"[blue]ℹ️  Alert API: {args.alert_api_url} (source_api: {source_api})[/]"
         )
@@ -562,6 +560,15 @@ def main() -> None:
             f"{split_stats['cross_deduped_siblings']} cross-deduped, "
             f"{split_stats['same_frame_merges']} same-frame merge(s))[/]"
         )
+        # Anomaly, not a routine stat: printed only when it fires, so a dropped
+        # verdict stays distinguishable from an alert API that sends no score.
+        if split_stats["unscored_primary"]:
+            console.print(
+                f"[yellow]⚠️  {split_stats['unscored_primary']} alert sequence(s) had no "
+                "identifiable primary object (no bbox-sourced box in the imported "
+                "window); their temporal model score was dropped rather than "
+                "attributed to an arbitrary object[/]"
+            )
 
         # Boxless alerts import as zero-object lanes the classify page cannot
         # act on (#333); they are auto-skipped after annotation creation below.

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
@@ -153,12 +153,13 @@ class ObjectGroup:
     records: List[dict]
     # Frames on which this object's boxes were collapsed into one union box.
     same_frame_merges: int = 0
-    # False when no box in the imported window was `bbox`-sourced: the primary
-    # then fell through to "earliest start", which is arbitrary with respect to
-    # the object the temporal model scored, so no lane claims its verdict (the
-    # records are already cleared). Reported by `split_all_records` so a fired
-    # guard stays distinguishable from an alert API that sends no score.
-    primary_identified: bool = True
+    # True only when a REAL verdict was discarded: the alert sequence carried a
+    # temporal score and no box in the imported window was `bbox`-sourced, so
+    # the primary fell through to "earliest start" and no lane could claim it.
+    # Deliberately not just "the primary was unidentifiable" — a sequence the
+    # platform never scored loses nothing, and while the column is mostly NULL
+    # that case is the common one. Reported by `split_all_records`.
+    dropped_temporal_score: bool = False
 
 
 def split_sequence_records(
@@ -192,6 +193,12 @@ def split_sequence_records(
 
     primary = select_primary_index(objects, primary_keys)
     primary_identified = bbox_sourced_count(objects[primary], primary_keys) > 0
+    # Every record of one alert sequence carries that sequence's score, so any
+    # one of them answers "was there a verdict to lose".
+    had_temporal_score = any(
+        record.get("sequence_temporal_model_score") is not None
+        for record in sequence_records
+    )
     ordered = [objects[primary]] + sorted(
         (o for i, o in enumerate(objects) if i != primary), key=lambda o: o.started_at
     )
@@ -276,7 +283,7 @@ def split_sequence_records(
                 is_fallback=False,
                 records=member_records,
                 same_frame_merges=same_frame_merges,
-                primary_identified=primary_identified,
+                dropped_temporal_score=had_temporal_score and not primary_identified,
             )
         )
     return groups
@@ -328,11 +335,11 @@ def split_all_records(
         "fallback_sequences": 0,
         "cross_deduped_siblings": 0,
         "same_frame_merges": 0,
-        # Alert sequences whose primary object could not be identified, so the
-        # platform's temporal verdict was dropped rather than misattributed.
-        # Reported so "the guard fired" stays distinguishable from "the alert
-        # API never sent a score" while the column is still mostly NULL.
-        "unscored_primary": 0,
+        # Alert sequences that HAD a temporal verdict which was discarded
+        # because the primary object could not be identified. Reported so a
+        # real drop stays distinguishable from the far commoner case of a
+        # sequence the platform simply never scored.
+        "dropped_temporal_scores": 0,
     }
 
     grouped = group_records_by_sequence(records)
@@ -390,8 +397,8 @@ def split_all_records(
             stats["objects"] += 1
             if not group.is_primary:
                 stats["sibling_objects"] += 1
-            elif not group.primary_identified:
-                stats["unscored_primary"] += 1
+            elif group.dropped_temporal_score:
+                stats["dropped_temporal_scores"] += 1
             out.extend(group.records)
     return out, stats
 

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
@@ -155,7 +155,9 @@ class ObjectGroup:
     same_frame_merges: int = 0
     # False when no box in the imported window was `bbox`-sourced: the primary
     # then fell through to "earliest start", which is arbitrary with respect to
-    # the object the temporal model scored, so no lane may claim its verdict.
+    # the object the temporal model scored, so no lane claims its verdict (the
+    # records are already cleared). Reported by `split_all_records` so a fired
+    # guard stays distinguishable from an alert API that sends no score.
     primary_identified: bool = True
 
 
@@ -259,6 +261,11 @@ def split_sequence_records(
             record["sequence_last_seen_at"] = recorded[-1]
             if cone is not None:
                 record["camera_azimuth"] = cone
+            # Cleared here, where the copy is made, so every caller of this
+            # function gets the invariant — not just the import pipeline.
+            if pos != 0 or not primary_identified:
+                for temporal_key in TEMPORAL_RECORD_KEYS:
+                    record[temporal_key] = None
             member_records.append(record)
 
         groups.append(
@@ -321,6 +328,11 @@ def split_all_records(
         "fallback_sequences": 0,
         "cross_deduped_siblings": 0,
         "same_frame_merges": 0,
+        # Alert sequences whose primary object could not be identified, so the
+        # platform's temporal verdict was dropped rather than misattributed.
+        # Reported so "the guard fired" stays distinguishable from "the alert
+        # API never sent a score" while the column is still mostly NULL.
+        "unscored_primary": 0,
     }
 
     grouped = group_records_by_sequence(records)
@@ -378,10 +390,8 @@ def split_all_records(
             stats["objects"] += 1
             if not group.is_primary:
                 stats["sibling_objects"] += 1
-            if not group.is_primary or not group.primary_identified:
-                for record in group.records:
-                    for temporal_key in TEMPORAL_RECORD_KEYS:
-                        record[temporal_key] = None
+            elif not group.primary_identified:
+                stats["unscored_primary"] += 1
             out.extend(group.records)
     return out, stats
 

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
@@ -40,6 +40,16 @@ from .shared import group_records_by_sequence
 
 DEFAULT_ALERT_ID_BASE = 1_000_000_000
 
+# The temporal model scores a single tracked object: its ROI is the union of
+# the sequence's own `bbox` values, explicitly excluding `others_bboxes`
+# (pyro-api services/validation.py). Sibling lanes are built from exactly
+# those excluded boxes, so they must not inherit the primary's verdict.
+TEMPORAL_RECORD_KEYS = (
+    "sequence_temporal_model_score",
+    "sequence_temporal_model_version",
+    "sequence_temporal_api_version",
+)
+
 # (frame_key, (x1, y1, x2, y2)) identifying one box on one frame
 BoxKey = Tuple[str, Tuple[float, float, float, float]]
 
@@ -94,21 +104,23 @@ def build_frames(sequence_records: List[dict]) -> Tuple[List[dict], Set[BoxKey]]
     return frames, primary_keys
 
 
+def bbox_sourced_count(obj: TrackedObject, primary_keys: Set[BoxKey]) -> int:
+    """How many of this object's boxes came from the alert API's own `bbox`."""
+    return sum(
+        1 for m in obj.members if (m.image_filename, tuple(m.box[:4])) in primary_keys
+    )
+
+
 def select_primary_index(
     objects: List[TrackedObject], primary_keys: Set[BoxKey]
 ) -> int:
     """Index of the primary object: most `bbox`-sourced boxes, earliest start on ties."""
-
-    def bbox_sourced_count(obj: TrackedObject) -> int:
-        return sum(
-            1
-            for m in obj.members
-            if (m.image_filename, tuple(m.box[:4])) in primary_keys
-        )
-
     return min(
         range(len(objects)),
-        key=lambda i: (-bbox_sourced_count(objects[i]), objects[i].started_at),
+        key=lambda i: (
+            -bbox_sourced_count(objects[i], primary_keys),
+            objects[i].started_at,
+        ),
     )
 
 
@@ -141,6 +153,10 @@ class ObjectGroup:
     records: List[dict]
     # Frames on which this object's boxes were collapsed into one union box.
     same_frame_merges: int = 0
+    # False when no box in the imported window was `bbox`-sourced: the primary
+    # then fell through to "earliest start", which is arbitrary with respect to
+    # the object the temporal model scored, so no lane may claim its verdict.
+    primary_identified: bool = True
 
 
 def split_sequence_records(
@@ -173,6 +189,7 @@ def split_sequence_records(
         ]
 
     primary = select_primary_index(objects, primary_keys)
+    primary_identified = bbox_sourced_count(objects[primary], primary_keys) > 0
     ordered = [objects[primary]] + sorted(
         (o for i, o in enumerate(objects) if i != primary), key=lambda o: o.started_at
     )
@@ -252,6 +269,7 @@ def split_sequence_records(
                 is_fallback=False,
                 records=member_records,
                 same_frame_merges=same_frame_merges,
+                primary_identified=primary_identified,
             )
         )
     return groups
@@ -360,6 +378,10 @@ def split_all_records(
             stats["objects"] += 1
             if not group.is_primary:
                 stats["sibling_objects"] += 1
+            if not group.is_primary or not group.primary_identified:
+                for record in group.records:
+                    for temporal_key in TEMPORAL_RECORD_KEYS:
+                        record[temporal_key] = None
             out.extend(group.records)
     return out, stats
 

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/sequence_fetching.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/sequence_fetching.py
@@ -55,6 +55,24 @@ from .progress_management import ErrorCollector, LogSuppressor
 from .worker_config import WorkerConfig
 
 
+def temporal_scores_unsupported(sequences: List[Dict[str, Any]]) -> bool:
+    """True when the alert API never sends the temporal-model score field.
+
+    `temporal_model_score` is a declared field on the alert API's SequenceRead,
+    so it is always serialized — as `null` for a sequence the platform never
+    scored. Its total absence across every fetched sequence therefore means the
+    alert API predates temporal validation (pyro-api #615, 2026-06-11) rather
+    than "nothing scored today".
+
+    The distinction matters because both cases otherwise import identically:
+    every sequence lands with a NULL score and the run reports success. Empty
+    input is not evidence either way, so it returns False.
+    """
+    if not sequences:
+        return False
+    return not any("temporal_model_score" in sequence for sequence in sequences)
+
+
 def get_dates_within(date_from: date, date_end: date) -> List[date]:
     """
     Get all dates between date_from and date_end (inclusive).
@@ -395,6 +413,21 @@ def fetch_all_sequences_within(
         )
 
     console.print(f"[green]✅ Found {len(sequences)} sequences[/]")
+
+    # Without this the two cases are indistinguishable: an alert API that
+    # predates temporal validation imports exactly like a day where nothing was
+    # scored — every sequence NULL, run reports success. Warn rather than fail:
+    # not every alert API deployment (e.g. CENIA) necessarily runs the feature,
+    # and a missing provenance field must not block ingestion.
+    if temporal_scores_unsupported(sequences):
+        message = (
+            "Alert API responses carry no `temporal_model_score` field at all "
+            f"({len(sequences)} sequences checked) — this deployment predates "
+            "temporal validation. Every sequence will import with a NULL score, "
+            "which is indistinguishable from 'never scored' downstream."
+        )
+        console.print(f"[yellow]⚠️  {message}[/]")
+        error_collector.add_error(message)
 
     # Now fetch detections and build flattened records using parallel processing
     records = []

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
@@ -197,6 +197,11 @@ def transform_sequence_data(record: dict, source_api: str = "pyronear_french") -
         "is_wildfire_alertapi": record[
             "sequence_is_wildfire"
         ],  # Alert API enum: 'wildfire_smoke', 'other_smoke', 'other'
+        # None values are dropped from the form body by requests, so an
+        # unscored sequence simply omits these and the server stores NULL.
+        "temporal_model_score": record.get("sequence_temporal_model_score"),
+        "temporal_model_version": record.get("sequence_temporal_model_version"),
+        "temporal_api_version": record.get("sequence_temporal_api_version"),
         "lat": record["camera_lat"],
         "lon": record["camera_lon"],
         "azimuth": azimuth,

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/update_annotation_stage.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/update_annotation_stage.py
@@ -28,7 +28,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--username",
         type=str,
-        default=os.getenv("MAIN_ANNOTATION_LOGIN", os.getenv("ANNOTATOR_LOGIN", "admin")),
+        default=os.getenv(
+            "MAIN_ANNOTATION_LOGIN", os.getenv("ANNOTATOR_LOGIN", "admin")
+        ),
         help="API username",
     )
     parser.add_argument(
@@ -92,7 +94,9 @@ def list_sequences_by_stage(api_url: str, token: str, stage: str) -> List[Dict]:
 
 def main() -> None:
     args = parse_args()
-    logging.basicConfig(level=args.loglevel.upper(), format="%(levelname)s - %(message)s")
+    logging.basicConfig(
+        level=args.loglevel.upper(), format="%(levelname)s - %(message)s"
+    )
 
     token = annotation_api.get_auth_token(args.api_url, args.username, args.password)
     sequences = list_sequences_by_stage(args.api_url, token, args.from_stage)
@@ -113,7 +117,9 @@ def main() -> None:
             ann_resp = annotation_api.list_sequence_annotations(
                 args.api_url, token, sequence_id=seq_id, page=1, size=1
             )
-            items = ann_resp.get("items", []) if isinstance(ann_resp, dict) else ann_resp
+            items = (
+                ann_resp.get("items", []) if isinstance(ann_resp, dict) else ann_resp
+            )
             if not items:
                 logging.warning("Sequence %s has no annotation, skipping", seq_id)
                 continue

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/utils.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/utils.py
@@ -104,6 +104,11 @@ def to_record(
         # Sequence metadata
         "sequence_id": sequence["id"],
         "sequence_is_wildfire": sequence.get("is_wildfire"),
+        # Platform temporal-model verdict for this sequence's tracked object.
+        # `.get` (not `[...]`) because an older alert API omits these keys.
+        "sequence_temporal_model_score": sequence.get("temporal_model_score"),
+        "sequence_temporal_model_version": sequence.get("temporal_model_version"),
+        "sequence_temporal_api_version": sequence.get("temporal_api_version"),
         "sequence_started_at": sequence["started_at"],
         "sequence_last_seen_at": sequence["last_seen_at"],
         # Camera/pose pointing direction. The alert API also exposes

--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -167,6 +167,12 @@ async def create_sequence(
         None,
         description="Platform alert grouping id (object-split siblings share it). Defaults server-side: synthetic ids are decoded when their primary exists (platform sources), else alert_api_id.",
     ),
+    temporal_model_score: Optional[float] = Form(
+        None,
+        description="Alert-API temporal-model smoke probability for this object. Omit when the platform never scored it.",
+    ),
+    temporal_model_version: Optional[str] = Form(None, max_length=32),
+    temporal_api_version: Optional[str] = Form(None, max_length=32),
     sequences: SequenceCRUD = Depends(get_sequence_crud),
     current_user: User = Depends(get_current_user),
 ) -> SequenceRead:
@@ -189,6 +195,9 @@ async def create_sequence(
         created_at=created_at or datetime.now(UTC),
         last_seen_at=last_seen_at or datetime.now(UTC),
         platform_alert_id=platform_alert_id,
+        temporal_model_score=temporal_model_score,
+        temporal_model_version=temporal_model_version,
+        temporal_api_version=temporal_api_version,
     )
     return await sequences.create(payload)
 

--- a/annotation_api/src/app/models.py
+++ b/annotation_api/src/app/models.py
@@ -163,6 +163,7 @@ class Sequence(SQLModel, table=True):
         Index("ix_sequence_organisation_id", "organisation_id"),
         Index("ix_sequence_organisation_name", "organisation_name"),
         Index("ix_sequence_is_wildfire", "is_wildfire_alertapi"),
+        Index("ix_sequence_temporal_model_score", "temporal_model_score"),
         # Composite indices for common filter combinations
         Index("ix_sequence_source_camera", "source_api", "camera_name"),
         Index("ix_sequence_source_org", "source_api", "organisation_name"),
@@ -218,6 +219,14 @@ class Sequence(SQLModel, table=True):
     is_wildfire_alertapi: Optional[AnnotationType] = Field(
         default=None, sa_column=Column(SQLEnum(AnnotationType))
     )
+    # Platform temporal-model verdict, captured at import time.
+    # NULL means the platform never scored THIS object — pre-2026-06-11
+    # sequences, fail-opens, sub-MIN_FRAMES sequences, risk-gated sequences,
+    # non-primary object-split lanes, and anything imported before this column
+    # existed. It never means "scored low"; do not coalesce it to 0.0.
+    temporal_model_score: Optional[float] = Field(default=None)
+    temporal_model_version: Optional[str] = Field(default=None, max_length=32)
+    temporal_api_version: Optional[str] = Field(default=None, max_length=32)
     organisation_name: str
     organisation_id: int
     # Membership in a SequenceGroup. NULL until `assign_groups` runs (which

--- a/annotation_api/src/app/schemas/sequence.py
+++ b/annotation_api/src/app/schemas/sequence.py
@@ -103,6 +103,18 @@ class SequenceCreate(Azimuth):
         default=None,
         description="Platform alert grouping id. Defaults server-side: decoded from a synthetic alert_api_id when the primary exists (platform sources), else alert_api_id.",
     )
+    temporal_model_score: Optional[float] = Field(
+        default=None,
+        description="Alert-API temporal-model smoke probability for this object. NULL when the platform never scored it — not the same as a low score.",
+    )
+    temporal_model_version: Optional[str] = Field(
+        default=None,
+        description="Model release that produced temporal_model_score (e.g. '0.1.0').",
+    )
+    temporal_api_version: Optional[str] = Field(
+        default=None,
+        description="Temporal API serving-code version (image tag) that produced temporal_model_score.",
+    )
 
 
 class SequenceRead(Azimuth):
@@ -126,6 +138,9 @@ class SequenceRead(Azimuth):
     organisation_id: int
     platform_alert_id: int
     sequence_group_id: Optional[int] = None
+    temporal_model_score: Optional[float] = None
+    temporal_model_version: Optional[str] = None
+    temporal_api_version: Optional[str] = None
 
 
 class SequenceUpdateBboxAuto(BaseModel):

--- a/annotation_api/src/migrations/versions/2026_08_10_1000-c5d6e7f8a9b0_add_temporal_model_score_to_sequences.py
+++ b/annotation_api/src/migrations/versions/2026_08_10_1000-c5d6e7f8a9b0_add_temporal_model_score_to_sequences.py
@@ -1,0 +1,46 @@
+"""Add platform temporal model score to sequences
+
+Revision ID: c5d6e7f8a9b0
+Revises: b4c5d6e7f8a9
+Create Date: 2026-08-10 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c5d6e7f8a9b0"
+down_revision = "b4c5d6e7f8a9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sequences", sa.Column("temporal_model_score", sa.Float(), nullable=True)
+    )
+    op.add_column(
+        "sequences",
+        sa.Column("temporal_model_version", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "sequences",
+        sa.Column("temporal_api_version", sa.String(length=32), nullable=True),
+    )
+    op.create_index(
+        "ix_sequence_temporal_model_score", "sequences", ["temporal_model_score"]
+    )
+    # No backfill: existing rows predate capture and were genuinely never
+    # scored by this pipeline, which is exactly what NULL means here.
+    op.execute(
+        "COMMENT ON COLUMN sequences.temporal_model_score IS "
+        "'Alert-API temporal-model smoke probability for this object. "
+        "NULL = never scored (not scored low); never coalesce to 0.0.'"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sequence_temporal_model_score", table_name="sequences")
+    op.drop_column("sequences", "temporal_api_version")
+    op.drop_column("sequences", "temporal_model_version")
+    op.drop_column("sequences", "temporal_model_score")

--- a/annotation_api/src/tests/endpoints/test_sequence.py
+++ b/annotation_api/src/tests/endpoints/test_sequence.py
@@ -2257,3 +2257,89 @@ async def test_needs_localization_filter(
     )
     ids = {item["id"] for item in resp.json()["items"]}
     assert ids == {fp.id, unsure.id}
+
+
+@pytest.mark.asyncio
+async def test_create_sequence_with_temporal_model_score(
+    authenticated_client: AsyncClient,
+):
+    payload = {
+        "source_api": "pyronear_french",
+        "alert_api_id": "300",
+        "camera_name": "test_cam_temporal",
+        "camera_id": "1",
+        "organisation_name": "test_org",
+        "organisation_id": "1",
+        "azimuth": "90",
+        "lat": "0.0",
+        "lon": "0.0",
+        "created_at": (now - timedelta(days=1)).isoformat(),
+        "recorded_at": (now - timedelta(days=1)).isoformat(),
+        "last_seen_at": now.isoformat(),
+        "temporal_model_score": "0.87",
+        "temporal_model_version": "0.1.0",
+        "temporal_api_version": "v1.4.2",
+    }
+
+    response = await authenticated_client.post("/sequences/", data=payload)
+    assert response.status_code == 201
+    sequence = response.json()
+    assert sequence["temporal_model_score"] == 0.87
+    assert sequence["temporal_model_version"] == "0.1.0"
+    assert sequence["temporal_api_version"] == "v1.4.2"
+
+    fetched = await authenticated_client.get(f"/sequences/{sequence['id']}")
+    assert fetched.status_code == 200
+    assert fetched.json()["temporal_model_score"] == 0.87
+
+
+@pytest.mark.asyncio
+async def test_create_sequence_without_temporal_fields_stores_null(
+    authenticated_client: AsyncClient,
+):
+    """Absent fields must store None, not 0.0 — NULL means 'never scored'."""
+    payload = {
+        "source_api": "pyronear_french",
+        "alert_api_id": "301",
+        "camera_name": "test_cam_no_temporal",
+        "camera_id": "1",
+        "organisation_name": "test_org",
+        "organisation_id": "1",
+        "azimuth": "90",
+        "lat": "0.0",
+        "lon": "0.0",
+        "created_at": (now - timedelta(days=1)).isoformat(),
+        "recorded_at": (now - timedelta(days=1)).isoformat(),
+        "last_seen_at": now.isoformat(),
+    }
+
+    response = await authenticated_client.post("/sequences/", data=payload)
+    assert response.status_code == 201
+    sequence = response.json()
+    assert sequence["temporal_model_score"] is None
+    assert sequence["temporal_model_version"] is None
+    assert sequence["temporal_api_version"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_sequence_accepts_zero_score(authenticated_client: AsyncClient):
+    """0.0 is a real verdict and must round-trip as 0.0, never as None."""
+    payload = {
+        "source_api": "pyronear_french",
+        "alert_api_id": "302",
+        "camera_name": "test_cam_zero_temporal",
+        "camera_id": "1",
+        "organisation_name": "test_org",
+        "organisation_id": "1",
+        "azimuth": "90",
+        "lat": "0.0",
+        "lon": "0.0",
+        "created_at": (now - timedelta(days=1)).isoformat(),
+        "recorded_at": (now - timedelta(days=1)).isoformat(),
+        "last_seen_at": now.isoformat(),
+        "temporal_model_score": "0.0",
+    }
+
+    response = await authenticated_client.post("/sequences/", data=payload)
+    assert response.status_code == 201
+    assert response.json()["temporal_model_score"] == 0.0

--- a/annotation_api/src/tests/scripts/test_object_clustering.py
+++ b/annotation_api/src/tests/scripts/test_object_clustering.py
@@ -51,7 +51,8 @@ class TestClusterObjects:
         frames.append(
             {
                 "frame_idx": 3,
-                "recorded_at": T0 + timedelta(minutes=30),  # > 5min spawn window, < 2h relaxation
+                "recorded_at": T0
+                + timedelta(minutes=30),  # > 5min spawn window, < 2h relaxation
                 "image_filename": "img_3.jpg",
                 "boxes": [BOX_A],
             }

--- a/annotation_api/src/tests/scripts/test_object_split.py
+++ b/annotation_api/src/tests/scripts/test_object_split.py
@@ -223,6 +223,7 @@ class TestSplitAllRecords:
             "fallback_sequences": 0,
             "cross_deduped_siblings": 0,
             "same_frame_merges": 0,
+            "unscored_primary": 0,
         }
         assert {r["sequence_id"] for r in out} == {
             47105,
@@ -483,3 +484,49 @@ class TestTemporalScoreAttribution:
             assert record["sequence_temporal_model_score"] is None
             assert record["sequence_temporal_model_version"] is None
             assert record["sequence_temporal_api_version"] is None
+
+    def test_split_sequence_records_clears_siblings_on_its_own(self):
+        """The invariant must hold for direct callers of the public splitter,
+        not only for the import pipeline going through split_all_records."""
+        records = [
+            make_record(
+                det_id,
+                f"2026-07-01T10:0{det_id}:00",
+                [BOX_A],
+                others=[BOX_B],
+                **TEMPORAL_FIELDS,
+            )
+            for det_id in (1, 2, 3)
+        ]
+        groups = split_sequence_records(records)
+
+        assert len(groups) >= 2, "fixture must produce a primary and a sibling"
+        for group in groups:
+            expected = 0.87 if group.is_primary else None
+            for record in group.records:
+                assert record["sequence_temporal_model_score"] == expected
+
+    def test_unscored_primary_is_reported_in_stats(self):
+        """A fired guard must be visible, so it stays distinguishable from an
+        alert API that simply never sends a score."""
+        scored = [
+            make_record(
+                det_id, f"2026-07-01T10:0{det_id}:00", [BOX_A], **TEMPORAL_FIELDS
+            )
+            for det_id in (1, 2, 3)
+        ]
+        _, stats = split_all_records(scored)
+        assert stats["unscored_primary"] == 0
+
+        continuity_only = [
+            make_record(
+                det_id,
+                f"2026-07-01T10:0{det_id}:00",
+                [],
+                others=[BOX_A],
+                **TEMPORAL_FIELDS,
+            )
+            for det_id in (1, 2, 3)
+        ]
+        _, stats = split_all_records(continuity_only)
+        assert stats["unscored_primary"] == 1

--- a/annotation_api/src/tests/scripts/test_object_split.py
+++ b/annotation_api/src/tests/scripts/test_object_split.py
@@ -223,7 +223,7 @@ class TestSplitAllRecords:
             "fallback_sequences": 0,
             "cross_deduped_siblings": 0,
             "same_frame_merges": 0,
-            "unscored_primary": 0,
+            "dropped_temporal_scores": 0,
         }
         assert {r["sequence_id"] for r in out} == {
             47105,
@@ -506,7 +506,7 @@ class TestTemporalScoreAttribution:
             for record in group.records:
                 assert record["sequence_temporal_model_score"] == expected
 
-    def test_unscored_primary_is_reported_in_stats(self):
+    def test_dropped_temporal_scores_is_reported_in_stats(self):
         """A fired guard must be visible, so it stays distinguishable from an
         alert API that simply never sends a score."""
         scored = [
@@ -516,7 +516,7 @@ class TestTemporalScoreAttribution:
             for det_id in (1, 2, 3)
         ]
         _, stats = split_all_records(scored)
-        assert stats["unscored_primary"] == 0
+        assert stats["dropped_temporal_scores"] == 0
 
         continuity_only = [
             make_record(
@@ -529,4 +529,18 @@ class TestTemporalScoreAttribution:
             for det_id in (1, 2, 3)
         ]
         _, stats = split_all_records(continuity_only)
-        assert stats["unscored_primary"] == 1
+        assert stats["dropped_temporal_scores"] == 1
+
+    def test_unscorable_primary_without_a_score_is_not_a_drop(self):
+        """The commonest case today: the platform never scored the sequence, so
+        an unidentifiable primary discards nothing and must not warn."""
+        records = [
+            make_record(det_id, f"2026-07-01T10:0{det_id}:00", [], others=[BOX_A])
+            for det_id in (1, 2, 3)
+        ]
+        out, stats = split_all_records(records)
+
+        assert stats["dropped_temporal_scores"] == 0
+        assert out
+        for record in out:
+            assert record.get("sequence_temporal_model_score") is None

--- a/annotation_api/src/tests/scripts/test_object_split.py
+++ b/annotation_api/src/tests/scripts/test_object_split.py
@@ -383,3 +383,103 @@ class TestPlatformAlertId:
         (group,) = split_sequence_records(records)
         for record in group.records:
             assert record["platform_alert_id"] == 47105
+
+
+TEMPORAL_FIELDS = {
+    "sequence_temporal_model_score": 0.87,
+    "sequence_temporal_model_version": "0.1.0",
+    "sequence_temporal_api_version": "v1.4.2",
+}
+
+
+class TestTemporalScoreAttribution:
+    """The temporal model scores ONE object: its ROI is the union of the
+    sequence's primary bboxes, deliberately excluding others_bboxes. Siblings
+    are built from those excluded boxes, so they must not inherit the score.
+    """
+
+    def test_primary_keeps_the_score_and_siblings_are_cleared(self):
+        records = [
+            make_record(
+                det_id,
+                f"2026-07-01T10:0{det_id}:00",
+                [BOX_A],
+                others=[BOX_B],
+                **TEMPORAL_FIELDS,
+            )
+            for det_id in (1, 2, 3)
+        ]
+        out, stats = split_all_records(records)
+
+        assert stats["sibling_objects"] >= 1, "fixture must produce a sibling"
+        by_lane = {}
+        for record in out:
+            by_lane.setdefault(record["sequence_id"], []).append(record)
+
+        primary_lane = [
+            recs for sid, recs in by_lane.items() if sid == recs[0]["platform_alert_id"]
+        ]
+        sibling_lanes = [
+            recs for sid, recs in by_lane.items() if sid != recs[0]["platform_alert_id"]
+        ]
+        assert primary_lane and sibling_lanes
+
+        for record in primary_lane[0]:
+            assert record["sequence_temporal_model_score"] == 0.87
+            assert record["sequence_temporal_model_version"] == "0.1.0"
+            assert record["sequence_temporal_api_version"] == "v1.4.2"
+
+        for lane in sibling_lanes:
+            for record in lane:
+                assert record["sequence_temporal_model_score"] is None
+                assert record["sequence_temporal_model_version"] is None
+                assert record["sequence_temporal_api_version"] is None
+
+    def test_fallback_lane_keeps_the_score(self):
+        """Clustering yields no objects, so one lane represents the whole
+        sequence — which is exactly what the model scored."""
+        records = [
+            make_record(1, "2026-07-01T10:00:00", [], **TEMPORAL_FIELDS),
+        ]
+        out, stats = split_all_records(records)
+
+        assert stats["fallback_sequences"] == 1
+        assert out, "the fallback lane must still be emitted"
+        for record in out:
+            assert record["sequence_temporal_model_score"] == 0.87
+
+    def test_unscored_sequence_stays_none_everywhere(self):
+        records = [
+            make_record(det_id, f"2026-07-01T10:0{det_id}:00", [BOX_A], others=[BOX_B])
+            for det_id in (1, 2, 3)
+        ]
+        out, _ = split_all_records(records)
+        assert out
+        for record in out:
+            assert record.get("sequence_temporal_model_score") is None
+
+    def test_no_lane_scored_when_no_box_is_bbox_sourced(self):
+        """Every imported frame is a continuity row (empty `bbox`), so all boxes
+        come from others_bboxes. `select_primary_index` then falls through to
+        'earliest start', which is arbitrary w.r.t. the model's ROI — so no lane
+        may claim the score."""
+        records = [
+            make_record(
+                det_id,
+                f"2026-07-01T10:0{det_id}:00",
+                [],
+                others=[BOX_A],
+                **TEMPORAL_FIELDS,
+            )
+            for det_id in (1, 2, 3)
+        ]
+        out, stats = split_all_records(records)
+
+        assert (
+            stats["fallback_sequences"] == 0
+        ), "fixture must cluster into a real object, not fall back"
+        assert out
+        for record in out:
+            assert record["sequence_temporal_model_score"] is None
+            assert record["sequence_temporal_model_version"] is None
+            assert record["sequence_temporal_api_version"] is None

--- a/annotation_api/src/tests/scripts/test_temporal_score_mapping.py
+++ b/annotation_api/src/tests/scripts/test_temporal_score_mapping.py
@@ -1,6 +1,6 @@
 """Temporal-model score mapping from alert-API payload to sequence payload."""
 
-from scripts.data_transfer.ingestion.alert_api import shared, utils
+from scripts.data_transfer.ingestion.alert_api import sequence_fetching, shared, utils
 
 # No __init__.py convention in src/tests/ — pytest inserts the test dir on
 # sys.path, so sibling helpers are imported as top-level modules.
@@ -101,3 +101,28 @@ class TestTransformSequenceData:
         )
         data = shared.transform_sequence_data(record)
         assert data["temporal_model_score"] == 0.0
+
+
+class TestTemporalScoresUnsupported:
+    """Distinguishes 'this alert API predates temporal validation' from
+    'nothing was scored today' — both otherwise import as all-NULL and report
+    success."""
+
+    def test_absent_field_is_unsupported(self):
+        sequences = [{"id": 1}, {"id": 2}]
+        assert sequence_fetching.temporal_scores_unsupported(sequences) is True
+
+    def test_present_but_null_is_supported(self):
+        """A scored-nothing day still sends the key, explicitly as null."""
+        sequences = [
+            {"id": 1, "temporal_model_score": None},
+            {"id": 2, "temporal_model_score": None},
+        ]
+        assert sequence_fetching.temporal_scores_unsupported(sequences) is False
+
+    def test_any_sequence_carrying_the_key_counts_as_supported(self):
+        sequences = [{"id": 1}, {"id": 2, "temporal_model_score": 0.87}]
+        assert sequence_fetching.temporal_scores_unsupported(sequences) is False
+
+    def test_empty_input_is_not_evidence(self):
+        assert sequence_fetching.temporal_scores_unsupported([]) is False

--- a/annotation_api/src/tests/scripts/test_temporal_score_mapping.py
+++ b/annotation_api/src/tests/scripts/test_temporal_score_mapping.py
@@ -1,0 +1,103 @@
+"""Temporal-model score mapping from alert-API payload to sequence payload."""
+
+from scripts.data_transfer.ingestion.alert_api import shared, utils
+
+# No __init__.py convention in src/tests/ — pytest inserts the test dir on
+# sys.path, so sibling helpers are imported as top-level modules.
+from factories import make_record
+
+CAMERA = {
+    "id": 7,
+    "name": "cam-01",
+    "lat": 44.0,
+    "lon": 5.0,
+    "organization_id": 1,
+    "is_trustable": True,
+    "angle_of_view": 87.0,
+}
+ORGANIZATION = {"id": 1, "name": "org"}
+DETECTION = {
+    "id": 11,
+    "created_at": "2026-08-09T14:22:10",
+    "url": "https://img.example/11.jpg",
+    "bucket_key": "key/11.jpg",
+    "bbox": "[(0.1,0.1,0.2,0.2,0.9)]",
+    "others_bboxes": None,
+}
+
+
+def _sequence(**overrides):
+    sequence = {
+        "id": 48211,
+        "camera_id": 7,
+        "camera_azimuth": 212.4,
+        "started_at": "2026-08-09T14:22:10",
+        "last_seen_at": "2026-08-09T14:51:03",
+        "is_wildfire": None,
+    }
+    sequence.update(overrides)
+    return sequence
+
+
+class TestToRecord:
+    def test_carries_temporal_fields(self):
+        sequence = _sequence(
+            temporal_model_score=0.87,
+            temporal_model_version="0.1.0",
+            temporal_api_version="v1.4.2",
+        )
+        record = utils.to_record(DETECTION, CAMERA, ORGANIZATION, sequence)
+        assert record["sequence_temporal_model_score"] == 0.87
+        assert record["sequence_temporal_model_version"] == "0.1.0"
+        assert record["sequence_temporal_api_version"] == "v1.4.2"
+
+    def test_absent_temporal_fields_become_none(self):
+        """An older alert API omits the keys entirely; must be None, not 0.0."""
+        record = utils.to_record(DETECTION, CAMERA, ORGANIZATION, _sequence())
+        assert record["sequence_temporal_model_score"] is None
+        assert record["sequence_temporal_model_version"] is None
+        assert record["sequence_temporal_api_version"] is None
+
+    def test_null_score_stays_none(self):
+        sequence = _sequence(temporal_model_score=None)
+        record = utils.to_record(DETECTION, CAMERA, ORGANIZATION, sequence)
+        assert record["sequence_temporal_model_score"] is None
+
+    def test_zero_score_is_preserved(self):
+        """0.0 is a real verdict and must not be flattened to None."""
+        sequence = _sequence(temporal_model_score=0.0)
+        record = utils.to_record(DETECTION, CAMERA, ORGANIZATION, sequence)
+        assert record["sequence_temporal_model_score"] == 0.0
+
+
+class TestTransformSequenceData:
+    def test_maps_temporal_fields_to_payload(self):
+        record = make_record(
+            1,
+            "2026-08-09T14:22:10",
+            [[0.1, 0.1, 0.2, 0.2, 0.9]],
+            sequence_temporal_model_score=0.87,
+            sequence_temporal_model_version="0.1.0",
+            sequence_temporal_api_version="v1.4.2",
+        )
+        data = shared.transform_sequence_data(record)
+        assert data["temporal_model_score"] == 0.87
+        assert data["temporal_model_version"] == "0.1.0"
+        assert data["temporal_api_version"] == "v1.4.2"
+
+    def test_missing_temporal_fields_map_to_none(self):
+        record = make_record(1, "2026-08-09T14:22:10", [[0.1, 0.1, 0.2, 0.2, 0.9]])
+        data = shared.transform_sequence_data(record)
+        assert data["temporal_model_score"] is None
+        assert data["temporal_model_version"] is None
+        assert data["temporal_api_version"] is None
+
+    def test_zero_score_survives_the_payload(self):
+        record = make_record(
+            1,
+            "2026-08-09T14:22:10",
+            [[0.1, 0.1, 0.2, 0.2, 0.9]],
+            sequence_temporal_model_score=0.0,
+        )
+        data = shared.transform_sequence_data(record)
+        assert data["temporal_model_score"] == 0.0

--- a/docs/specs/2026-08-10-import-temporal-model-score-design.md
+++ b/docs/specs/2026-08-10-import-temporal-model-score-design.md
@@ -89,6 +89,8 @@ model scored it low". It covers:
 - fail-opens — the model was unreachable or the job went stale;
 - sequences that never reached the model's `MIN_FRAMES`;
 - sequences the risk gate dropped;
+- **sibling lanes** — this object is not the one the model scored (see Object
+  attribution below);
 - everything imported before this change ships (no backfill — see Non-goals).
 
 This distinction is the whole value of the column, so it carries a SQL comment
@@ -115,21 +117,69 @@ directly and emitted under the module's existing `sequence_*` naming:
 **2. `shared.py`** (`transform_sequence_data`, line 173). Map the three record
 keys into the sequence-creation payload.
 
-**3. `object_split.py`** — **no change required.** `split_sequence_records`
-copies the whole record per member (`record = dict(records_by_key[key])`, line
-233), so the new keys reach every sibling automatically.
+**3. `object_split.py`** (`split_sequence_records`). `record =
+dict(records_by_key[key])` (line 233) copies the new keys to *every* member, so
+the three keys must be **cleared on non-primary members** — see below.
 
-### Sibling semantics
+### Object attribution: the score belongs to one object only
 
-Object-splitting turns one alert-API sequence into N annotator lanes. All N
-share one score, which is correct by construction: `platform_alert_id` is the
-alert-API *sequence* id (`object_split.py:322`), so a `platform_alert_id` group
-descends from exactly one scored sequence. Aggregating a score per alert is
-unambiguous — `MAX` and `ANY` are identical.
+The temporal model does not score a whole frame. `_sequence_frames_and_roi`
+(`validation.py:98-133`) builds an ROI and passes it to `predict()`:
 
-The consequence to remember downstream: **the score is an alert-level prior, not
-per-object truth**. An alert-sequence containing both a real plume and a cloud
-produces two lanes carrying the same high score.
+> "The ROI is the union envelope of the kept detections' **primary** bboxes …
+> scoping the temporal verdict to the tracked region so unrelated activity
+> elsewhere in the frame can't pollute it."
+
+It is built from `det.bbox` only, never `others_bboxes`. A pyro-api `Sequence`
+is therefore *already one tracked object*, and its score is that object's,
+computed on a crop that deliberately **excludes** the other boxes in the frame —
+`detections.py:648` states it plainly: "Only the primary bbox tracks the
+sequence; siblings in others_bboxes are unrelated detections."
+
+The annotator's object split, by contrast, builds lanes from both `bbox` and
+`others_bboxes`. So:
+
+| annotator lane | relationship to the score |
+|---|---|
+| **primary** (`alert_api_id == platform_alert_id`) | correct — the object the model scored |
+| **sibling** (synthetic `alert_api_id`) | **not scored** — the model's ROI was drawn to exclude this region |
+
+Propagating the score to siblings would assert a verdict about an object the
+model was specifically prevented from looking at: a cloud beside a real plume
+would inherit the plume's `0.87`, and that `0.87` exists *because* the cloud was
+excluded. **Only the primary lane carries the score; siblings are `NULL`.**
+
+Sibling objects generally do have a real score under a *different* alert-API
+sequence (each box in a multi-box frame spawns its own detection and joins its
+own sequence). Recovering that link is the known cross-alert sibling problem
+(#262) and is out of scope here.
+
+No new column is needed to tell them apart: primary lanes keep the real
+`alert_api_id`, siblings get synthetic ids
+(`alert_id_base + sid * 1000 + object_index`), so `alert_api_id ==
+platform_alert_id` identifies the primary.
+
+Two edge cases:
+
+- `select_primary_index` (`object_split.py:97-106`) picks the primary
+  heuristically ("most `bbox`-sourced boxes, earliest start on ties"). It is a
+  reconstruction of which object pyro-api tracked, not a guaranteed match.
+- **Fallback lanes** (`is_fallback`, emitted when clustering yields no objects)
+  keep the real `alert_api_id` and represent the sequence as a whole, so they
+  keep the score.
+
+### Consuming the score per alert
+
+All three queues are alert-shaped rows, so an alert's score is simply its
+primary lane's — no aggregate over a mix of real and inherited values:
+
+- `ClassifyQueueItem` (`schemas/sequence.py:191`) already carries
+  `primary_sequence_id` — a direct join.
+- `LocalizationQueueItem` / `LocalizeDoneQueueItem` (`:163`, `:177`) have no
+  such field, but embed `lanes`, and `LocalizationQueueLane` (`:148`) carries
+  `alert_api_id` — so the primary is identifiable without a schema change.
+
+Wiring any of this up belongs to the triage follow-up, not this spec.
 
 ### Staleness
 
@@ -153,8 +203,9 @@ Read-only exposure. No filtering, ordering, or mutation endpoints in this spec.
   carrying it; a sequence whose key is absent *or* explicitly `null` yields
   `None` — asserting `None` and not `0.0`, since that is the distinction the
   `NULL` semantics rest on.
-- **Object split**: every sibling produced from a split sequence carries the
-  parent's score and versions.
+- **Object split**: the primary lane of a split sequence carries the score and
+  versions; every sibling carries `None` for all three. A fallback lane keeps
+  the score.
 - **Endpoint round-trip**: `POST /sequences/` with the three fields returns them
   from `GET`; `POST` without them stores `None`.
 
@@ -170,6 +221,10 @@ Read-only exposure. No filtering, ordering, or mutation endpoints in this spec.
   score is a separate phase. Note that until the backfill lands, the column is
   `NULL` for existing rows, so a "hide below threshold" filter would empty the
   queue rather than narrow it.
+- **No per-object score badge in the UI** (decided 2026-08-10). Objects of an
+  alert are displayed exactly as today; nothing is hidden or reordered by this
+  change. Score-based triage, when built, acts on the alert row — opening an
+  alert still shows all of its objects, siblings included.
 - **Import-time filtering.** No `--confirmed-fires-only` flag. Storing the score
   supersedes filtering on it: the import stays lossless and triage becomes a
   reversible UI decision.

--- a/docs/specs/2026-08-10-import-temporal-model-score-design.md
+++ b/docs/specs/2026-08-10-import-temporal-model-score-design.md
@@ -1,0 +1,179 @@
+# Import Temporal Model Score — Design
+
+**Date**: 2026-08-10
+**Status**: Approved
+
+## Goal
+
+Capture the alert API's temporal-model verdict on every sequence the importer
+creates, so annotation work can later be triaged by "did the platform's temporal
+model think this was a fire" instead of importing an undifferentiated stream of
+detection candidates.
+
+This spec covers **capture only**. Backfilling the sequences already in the
+annotator is a follow-up (see Non-goals).
+
+## Background: what the alert API knows
+
+A pyro-api `Sequence` is not raw footage. It exists only after the on-camera
+YOLO detector fired on ≥3 spatially-overlapping frames within 5 minutes
+(`SEQUENCE_MIN_INTERVAL_DETS=3`, `SEQUENCE_MIN_INTERVAL_SECONDS=300`). That is a
+persistence filter, not a fire confirmation — clouds, fog, dust and industrial
+plumes all clear it, which is why the annotator carries a false-positive
+taxonomy at all.
+
+pyro-api then runs a second-opinion pipeline (`app/services/validation.py`,
+added 2026-06-11 in PR #615, migration `c5e2f7a8b1d0`):
+
+1. **Risk gate** — drops low-`max_conf` sequences on low-FWI days.
+2. **Temporal model** — scores the frame sequence; `probability >
+   TEMPORAL_MODEL_THRESHOLD` (default `0.45`) sets `validation_status='model'`,
+   flips `is_validated`, and triggers triangulation + notification.
+
+The importer currently takes everything that reaches step 1 and explicitly
+bypasses the risk gate by passing `risk_score="extreme"` (`import.py:548`;
+`FWI_MIN_CONF["extreme"] = 0.0`, and `min_confidence_for_class` maps `0.0` to
+`None`, i.e. no filter).
+
+### Which field carries the verdict
+
+`validation_status` is the exact signal, but it is `exclude=True` on both the
+model (`models.py:186`) and the read schema (`schemas/sequences.py:31`), so it
+never appears in an API response. `temporal_model_score` is a faithful stand-in:
+
+- It is written **only** after a real model call returned a probability
+  (`validation.py:325-332`) — never on a fail-open, never by the migration's
+  backfill.
+- `validated = probability > threshold`, and validated implies
+  `validation_status='model'` (`validation.py:320-321`).
+- Once `is_validated` is set, the worker resumes without re-scoring
+  (`validation.py:234-238`), so a high score cannot later decay.
+
+Therefore `temporal_model_score > 0.45` ⟺ the temporal model confirmed the
+sequence.
+
+It also subsumes the risk gate: the gate runs in phase 1 and returns early on
+failure (`validation.py:252-255`), before the model call at `:310`. A sequence
+that fails the risk gate is never scored, so a non-`NULL` score implies the risk
+gate passed.
+
+`is_validated` is deliberately **not** captured. It is true for both fail-open
+paths (`fail_open_unavailable`, `fail_open_stale`), and the migration backfilled
+`is_validated = true` for every sequence predating 2026-06-11
+(`c5e2f7a8b1d0:58-62`), which makes it a constant on historical data.
+
+## Data model
+
+Three nullable columns on the annotator `Sequence` (`annotation_api/src/app/models.py`):
+
+| column | type | source |
+|---|---|---|
+| `temporal_model_score` | `float`, nullable | alert API `SequenceRead.temporal_model_score` |
+| `temporal_model_version` | `str(32)`, nullable | `SequenceRead.temporal_model_version` |
+| `temporal_api_version` | `str(32)`, nullable | `SequenceRead.temporal_api_version` |
+
+Plus `Index("ix_sequence_temporal_model_score", "temporal_model_score")`, for the
+follow-up triage phase.
+
+The version pair is captured alongside the score because pyro-api writes them in
+the same `UPDATE` for exactly this purpose (`models.py:137-139`): a score is only
+interpretable against the model release and serving image that produced it, and
+a redeploy otherwise makes stored scores incomparable.
+
+### `NULL` semantics
+
+`NULL` means precisely **"the platform never scored this sequence"**, never "the
+model scored it low". It covers:
+
+- sequences recorded before 2026-06-11 (the feature did not exist);
+- fail-opens — the model was unreachable or the job went stale;
+- sequences that never reached the model's `MIN_FRAMES`;
+- sequences the risk gate dropped;
+- everything imported before this change ships (no backfill — see Non-goals).
+
+This distinction is the whole value of the column, so it carries a SQL comment
+saying so. Consumers must treat `NULL` and `0.0` as different, and in particular
+must not coalesce `NULL` to `0.0` when filtering.
+
+One additive Alembic migration. No data migration.
+
+## Import capture
+
+Three touch points, all in
+`annotation_api/scripts/data_transfer/ingestion/alert_api/`:
+
+**1. `utils.py`** (`to_record`, the flattened-record builder). The raw alert-API
+`SequenceRead` JSON is already in hand as `sequence`, so the values are read
+directly and emitted under the module's existing `sequence_*` naming:
+
+```python
+"sequence_temporal_model_score": sequence.get("temporal_model_score"),
+"sequence_temporal_model_version": sequence.get("temporal_model_version"),
+"sequence_temporal_api_version": sequence.get("temporal_api_version"),
+```
+
+**2. `shared.py`** (`transform_sequence_data`, line 173). Map the three record
+keys into the sequence-creation payload.
+
+**3. `object_split.py`** — **no change required.** `split_sequence_records`
+copies the whole record per member (`record = dict(records_by_key[key])`, line
+233), so the new keys reach every sibling automatically.
+
+### Sibling semantics
+
+Object-splitting turns one alert-API sequence into N annotator lanes. All N
+share one score, which is correct by construction: `platform_alert_id` is the
+alert-API *sequence* id (`object_split.py:322`), so a `platform_alert_id` group
+descends from exactly one scored sequence. Aggregating a score per alert is
+unambiguous — `MAX` and `ANY` are identical.
+
+The consequence to remember downstream: **the score is an alert-level prior, not
+per-object truth**. An alert-sequence containing both a real plume and a cloud
+produces two lanes carrying the same high score.
+
+### Staleness
+
+Validation is asynchronous. A sequence imported shortly after it started may
+still be pending, so the import captures `NULL` (or a provisional
+below-threshold score) and — with no update path — keeps it permanently. Same-day
+imports therefore capture provisional verdicts. Refreshing them is the
+follow-up's job.
+
+## API surface
+
+- `SequenceCreate` (`schemas/sequence.py:46`) and the `POST /sequences/` form
+  (`endpoints/sequences.py:145`) gain the three fields, all optional.
+- `SequenceRead` (`schemas/sequence.py:108`) returns them.
+
+Read-only exposure. No filtering, ordering, or mutation endpoints in this spec.
+
+## Testing
+
+- **Import mapping**: a fetched sequence carrying a score yields a create-payload
+  carrying it; a sequence whose key is absent *or* explicitly `null` yields
+  `None` — asserting `None` and not `0.0`, since that is the distinction the
+  `NULL` semantics rest on.
+- **Object split**: every sibling produced from a split sequence carries the
+  parent's score and versions.
+- **Endpoint round-trip**: `POST /sequences/` with the three fields returns them
+  from `GET`; `POST` without them stores `None`.
+
+## Non-goals
+
+- **Backfill.** `POST /sequences/` is create-only and `uq_sequence_alert_source`
+  makes a re-import of an existing sequence 409, which the importer swallows as
+  `skip_reason: "already exists"` (`shared.py:620-624`). Re-running the import
+  over past dates will therefore **not** populate scores on existing rows; only
+  sequences imported fresh after this ships carry them. A follow-up will add a
+  bulk upsert path and a backfill script that can also refresh stale scores.
+- **Queue triage.** Filtering or sorting the classify/localization queues by
+  score is a separate phase. Note that until the backfill lands, the column is
+  `NULL` for existing rows, so a "hide below threshold" filter would empty the
+  queue rather than narrow it.
+- **Import-time filtering.** No `--confirmed-fires-only` flag. Storing the score
+  supersedes filtering on it: the import stays lossless and triage becomes a
+  reversible UI decision.
+- **`max_conf` and `is_validated`** are not captured.
+- **No pyro-api changes.** Exposing `validation_status` would give finer
+  resolution (fail-open cause, terminal vs pending), but only within the rows
+  this design already discards, and would require a cross-repo PR plus a deploy.

--- a/docs/specs/2026-08-10-import-temporal-model-score-design.md
+++ b/docs/specs/2026-08-10-import-temporal-model-score-design.md
@@ -159,14 +159,41 @@ No new column is needed to tell them apart: primary lanes keep the real
 (`alert_id_base + sid * 1000 + object_index`), so `alert_api_id ==
 platform_alert_id` identifies the primary.
 
-Two edge cases:
+### How the primary is identified
 
-- `select_primary_index` (`object_split.py:97-106`) picks the primary
-  heuristically ("most `bbox`-sourced boxes, earliest start on ties"). It is a
-  reconstruction of which object pyro-api tracked, not a guaranteed match.
-- **Fallback lanes** (`is_fallback`, emitted when clustering yields no objects)
-  keep the real `alert_api_id` and represent the sequence as a whole, so they
-  keep the score.
+Not by guessing which object looks like smoke — by a label the alert API already
+supplies. Each detection arrives with its tracking box in `detection_bboxes`
+(`det.bbox`) and everything else in `detection_others_bboxes`
+(`det.others_bboxes`). `build_frames` (`object_split.py:56-94`) merges both for
+clustering, but first records every `own` box as `(detection_id, coords)` in
+`primary_keys`. `select_primary_index` (`:97-112`) then picks the cluster with
+the **most `bbox`-sourced members**, earliest start on ties.
+
+Since a pyro-api sequence *is* the chain of `det.bbox` boxes, and the model's ROI
+is the union of exactly those boxes, the winning cluster is by construction the
+chain the model scored.
+
+Three edge cases:
+
+- **Clustering splits the tracked chain** (a drifting plume crossing the IoU
+  threshold): one fragment wins, the other is treated as a sibling and loses the
+  score. Conservative — `NULL`, not a wrong number.
+- **Clustering merges a sibling into the primary**: the sibling shares the lane
+  and inherits the score. Only occurs when clustering already judged them one
+  object.
+- **No `bbox`-sourced box in the imported window**: `bbox_sourced_count` is 0 for
+  every cluster, so the primary falls through to "earliest start" — arbitrary
+  with respect to the model's ROI. Reachable, because pyro-api writes continuity
+  rows with `bbox="[]"` and the importer only takes a 30-frame window, so a
+  window of continuity-only frames has no own boxes at all. **In this case no
+  lane gets the score**, since we cannot tell which object the ROI covered.
+
+That last rule is what keeps the column's guarantee exact: a non-`NULL` score
+always means *we know* this lane is the object the model scored.
+
+**Fallback lanes** (`is_fallback`, emitted when clustering yields no objects or
+splitting raises) keep the real `alert_api_id` and represent the sequence as a
+whole, so they keep the score.
 
 ### Consuming the score per alert
 
@@ -205,7 +232,8 @@ Read-only exposure. No filtering, ordering, or mutation endpoints in this spec.
   `NULL` semantics rest on.
 - **Object split**: the primary lane of a split sequence carries the score and
   versions; every sibling carries `None` for all three. A fallback lane keeps
-  the score.
+  the score. When no box in the imported window is `bbox`-sourced, *no* lane
+  carries the score.
 - **Endpoint round-trip**: `POST /sequences/` with the three fields returns them
   from `GET`; `POST` without them stores `None`.
 


### PR DESCRIPTION
Captures the alert API's temporal-model verdict on every sequence the importer creates, so annotation work can later be triaged by "did the platform's temporal model think this was a fire" instead of by an undifferentiated stream of detection candidates.

Spec: `docs/specs/2026-08-10-import-temporal-model-score-design.md`

## Why the score, and not `is_validated`

`validation_status == 'model'` is the exact signal, but it is `exclude=True` in pyro-api (`models.py:186`, `schemas/sequences.py:31`) and never appears in an API response. `temporal_model_score` is a faithful stand-in:

- written only after a real model call returned a probability (`validation.py:325-332`) — never on a fail-open, never by pyro-api's own backfill;
- `validated = probability > threshold`, and validated implies `validation_status='model'` (`:320-321`);
- once `is_validated` is set the worker resumes without re-scoring (`:234-238`), so a high score cannot decay.

It also subsumes the risk gate, which runs in phase 1 and returns early on failure (`:252-255`) before the model call at `:310` — so a non-NULL score implies the risk gate passed.

`is_validated` is deliberately **not** captured: it is true for both fail-open paths, and pyro-api's migration backfilled it `true` for every sequence predating 2026-06-11.

## Object attribution

The temporal model scores **one object**. `_sequence_frames_and_roi` builds its ROI from the sequence's own `bbox` values only, explicitly "so unrelated activity elsewhere in the frame can't pollute it". Object-splitting builds lanes from both `bbox` and `others_bboxes`, so propagating the score to siblings would assert a verdict about an object the model was prevented from looking at.

- **primary lane** (`alert_api_id == platform_alert_id`) — carries the score
- **sibling lanes** — NULL
- **fallback lanes** — carry the score (they represent the whole sequence)
- **no `bbox`-sourced box in the imported window** — primary selection falls through to "earliest start" and is arbitrary, so *no* lane is scored, and `stats['unscored_primary']` records it

That last rule keeps the guarantee exact: a non-NULL score always means we know this lane is the object the model scored.

## NULL semantics

NULL means "the platform never scored this object", never "scored low". It covers pre-2026-06-11 sequences, fail-opens, sub-MIN_FRAMES sequences, risk-gated sequences, sibling lanes, and everything imported before this change. Tests assert `0.0` round-trips as `0.0` rather than collapsing to None.

## Changes

- Three nullable columns + index on `Sequence`; migration `c5d6e7f8a9b0` (additive, no backfill)
- `SequenceCreate` / `SequenceRead` / `POST /sequences/` form fields
- `utils.to_record` reads the alert-API fields; `shared.transform_sequence_data` maps them to the payload
- `object_split` clears them on siblings and unidentifiable primaries, at record-construction time so the invariant holds for every caller

## Verification

- Full backend suite: 753 passed
- Migration round-trips (`c5d6e7f8a9b0` → `b4c5d6e7f8a9` → back)
- ruff format + check clean; mypy at the pre-existing baseline

## Not in this PR

- **Backfill.** `POST /sequences/` is create-only and `uq_sequence_alert_source` makes a re-import 409, swallowed as `skip_reason: "already exists"`. Re-running the import over past dates will **not** populate scores on existing rows — only sequences imported fresh after this ships carry them. A follow-up will add a bulk upsert path that can also refresh stale scores.
- **Queue triage** (filter/sort by score) and any UI badge. Until the backfill lands the column is NULL for existing rows, so a "hide below threshold" filter would empty the queue rather than narrow it.
- No import-time filtering, no `max_conf`/`is_validated` capture, no pyro-api changes.