### PR TITLE
feat(import): refresh temporal scores on re-import

### DIFF
--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
@@ -387,6 +387,8 @@ def main() -> None:
         "sequences_import_successful": 0,
         "sequences_import_failed": 0,
         "sequences_skipped": 0,
+        "sequences_refreshed": 0,
+        "refresh_failures": 0,
         "detections_skipped": 0,
         "detections_attempted_import": 0,
         "detections_import_successful": 0,
@@ -604,6 +606,8 @@ def main() -> None:
                 stats["detections_import_successful"] = result["successful_detections"]
                 stats["detections_import_failed"] = result["failed_detections"]
                 stats["sequences_skipped"] = result.get("skipped_sequences", 0)
+                stats["sequences_refreshed"] = result.get("refreshed_sequences", 0)
+                stats["refresh_failures"] = result.get("refresh_failures", 0)
                 stats["detections_skipped"] = result.get("skipped_detections", 0)
                 successfully_imported_sequence_ids = result["successful_sequence_ids"]
 
@@ -837,6 +841,14 @@ def main() -> None:
 • Successfully imported: {stats['sequences_import_successful']}
 • Skipped (already imported): {stats['sequences_skipped']} sequences / {stats['detections_skipped']} detections
 • Failed: {stats['sequences_import_failed']}"""
+            if stats["sequences_refreshed"] or stats["refresh_failures"]:
+                import_section += (
+                    f"\n• Temporal scores refreshed: {stats['sequences_refreshed']}"
+                )
+            if stats["refresh_failures"]:
+                import_section += (
+                    f"\n• [yellow]Refresh failures: {stats['refresh_failures']}[/]"
+                )
             if stats["sequences_rolled_back"] > 0:
                 import_section += f"\n• Rolled back: {stats['sequences_rolled_back']}"
             summary_parts.append(import_section)

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
@@ -680,12 +680,32 @@ def main() -> None:
                     error_collector,
                 )
 
-            # Show final summary with zero processing and exit gracefully
+            # Show final summary with zero processing and exit gracefully.
+            # A pure backfill lands here: every sequence already existed, so
+            # nothing was "imported". This path exits before the detailed
+            # summary below, so the refresh counts must be reported here or
+            # they are invisible in exactly the run that produced them.
+            refresh_note = ""
+            title = f"⚠️ Processing Complete - {organization} - No Annotations Generated"
+            if stats["sequences_refreshed"] or stats["refresh_failures"]:
+                refresh_note = (
+                    f"\n\n[green]Temporal scores refreshed: "
+                    f"{stats['sequences_refreshed']}[/]"
+                )
+                if stats["refresh_failures"]:
+                    refresh_note += (
+                        f"\n[yellow]Refresh failures: {stats['refresh_failures']}[/]"
+                    )
+                title = (
+                    f"✅ Processing Complete - {organization} - "
+                    f"{stats['sequences_refreshed']} Temporal Score(s) Refreshed"
+                )
             console.print()
             panel = Panel(
                 f"[yellow]No sequences were successfully imported from {organization} alert API data.\n"
-                f"Check import statistics above for details (all sequences may already be imported — see Skipped).[/]",
-                title=f"⚠️ Processing Complete - {organization} - No Annotations Generated",
+                f"Check import statistics above for details (all sequences may already be imported — see Skipped).[/]"
+                + refresh_note,
+                title=title,
                 border_style="yellow",
                 padding=(1, 2),
             )

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/import.py
@@ -389,6 +389,7 @@ def main() -> None:
         "sequences_skipped": 0,
         "sequences_refreshed": 0,
         "refresh_failures": 0,
+        "refresh_skipped": 0,
         "detections_skipped": 0,
         "detections_attempted_import": 0,
         "detections_import_successful": 0,
@@ -608,6 +609,13 @@ def main() -> None:
                 stats["sequences_skipped"] = result.get("skipped_sequences", 0)
                 stats["sequences_refreshed"] = result.get("refreshed_sequences", 0)
                 stats["refresh_failures"] = result.get("refresh_failures", 0)
+                stats["refresh_skipped"] = result.get("refresh_skipped", 0)
+                if stats["refresh_failures"]:
+                    # Feed the exit code and the ❌ summary: a backfill whose
+                    # refreshes all failed must not report success.
+                    error_collector.add_error(
+                        f"{stats['refresh_failures']} temporal score refresh(es) failed"
+                    )
                 stats["detections_skipped"] = result.get("skipped_detections", 0)
                 successfully_imported_sequence_ids = result["successful_sequence_ids"]
 
@@ -687,19 +695,37 @@ def main() -> None:
             # they are invisible in exactly the run that produced them.
             refresh_note = ""
             title = f"⚠️ Processing Complete - {organization} - No Annotations Generated"
-            if stats["sequences_refreshed"] or stats["refresh_failures"]:
+            if (
+                stats["sequences_refreshed"]
+                or stats["refresh_failures"]
+                or stats["refresh_skipped"]
+            ):
                 refresh_note = (
                     f"\n\n[green]Temporal scores refreshed: "
                     f"{stats['sequences_refreshed']}[/]"
                 )
+                if stats["refresh_skipped"]:
+                    refresh_note += (
+                        f"\n[yellow]Skipped (score not determinable this run, "
+                        f"existing values left intact): "
+                        f"{stats['refresh_skipped']}[/]"
+                    )
                 if stats["refresh_failures"]:
                     refresh_note += (
-                        f"\n[yellow]Refresh failures: {stats['refresh_failures']}[/]"
+                        f"\n[red]Refresh failures: {stats['refresh_failures']}[/]"
                     )
-                title = (
-                    f"✅ Processing Complete - {organization} - "
-                    f"{stats['sequences_refreshed']} Temporal Score(s) Refreshed"
-                )
+                # Only a run that actually refreshed something may claim success;
+                # 0 refreshed with N failures is a failed backfill, not a green one.
+                if stats["refresh_failures"]:
+                    title = (
+                        f"❌ Processing Complete - {organization} - "
+                        f"{stats['refresh_failures']} Refresh Failure(s)"
+                    )
+                elif stats["sequences_refreshed"]:
+                    title = (
+                        f"✅ Processing Complete - {organization} - "
+                        f"{stats['sequences_refreshed']} Temporal Score(s) Refreshed"
+                    )
             console.print()
             panel = Panel(
                 f"[yellow]No sequences were successfully imported from {organization} alert API data.\n"
@@ -710,7 +736,7 @@ def main() -> None:
                 padding=(1, 2),
             )
             console.print(panel)
-            sys.exit(0)
+            sys.exit(1 if stats["refresh_failures"] else 0)
 
         stats["total_sequences_for_annotation"] = len(sequence_ids)
         step_stats = {"Successfully imported sequences": len(sequence_ids)}

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/object_split.py
@@ -273,6 +273,11 @@ def split_sequence_records(
             if pos != 0 or not primary_identified:
                 for temporal_key in TEMPORAL_RECORD_KEYS:
                     record[temporal_key] = None
+            if not primary_identified:
+                # A sibling's NULL is a known value, but this is ignorance: we
+                # cannot tell which lane the platform scored, so a refresh must
+                # not write NULL over whatever is already stored.
+                record["sequence_temporal_score_unknown"] = True
             member_records.append(record)
 
         groups.append(

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
@@ -29,6 +29,7 @@ from rich.console import Console
 from app.clients.annotation_api import (
     get_auth_token,
     create_sequence,
+    update_sequence_temporal_score,
     create_detection_from_bucket_key,
     create_detection_from_url,
     list_detections,
@@ -584,6 +585,34 @@ def _process_single_detection(
     return result
 
 
+def _refresh_temporal_score(
+    annotation_api_url: str, auth_token: str, sequence_data: dict
+) -> bool:
+    """Update an existing sequence's temporal columns. Returns success.
+
+    Always sends all three values, including None: a sibling lane's correct
+    value is NULL, and omitting the field would let a stale score survive a
+    re-import. Never raises — a failed refresh degrades the run's usefulness
+    but must not abort an import.
+    """
+    payload = {
+        "source_api": sequence_data["source_api"],
+        "alert_api_id": sequence_data["alert_api_id"],
+        "temporal_model_score": sequence_data.get("temporal_model_score"),
+        "temporal_model_version": sequence_data.get("temporal_model_version"),
+        "temporal_api_version": sequence_data.get("temporal_api_version"),
+    }
+    try:
+        update_sequence_temporal_score(annotation_api_url, auth_token, payload)
+        return True
+    except AnnotationAPIError as exc:
+        logging.warning(
+            f"Temporal score refresh failed for alert_api_id="
+            f"{payload['alert_api_id']}: {exc}"
+        )
+        return False
+
+
 def post_sequence_to_annotation_api(
     annotation_api_url: str,
     sequence_records: List[dict],
@@ -623,10 +652,17 @@ def post_sequence_to_annotation_api(
         annotation_sequence_id = annotation_sequence["id"]
     except AnnotationAPIError as exc:
         if exc.status_code == 409:
+            # The row already exists, so this is a re-import: refresh the
+            # temporal columns rather than walking away. This is what makes
+            # `make import-alert-api` over a past range a backfill.
+            refreshed = _refresh_temporal_score(
+                annotation_api_url, auth_token, sequence_data
+            )
             return {
                 "success": False,
                 "skipped": True,
                 "skip_reason": "already exists",
+                "refreshed": refreshed,
                 "sequence_id": None,
                 "alert_api_sequence_id": first_record["sequence_id"],
                 "successful_detections": 0,
@@ -730,6 +766,8 @@ def post_records_to_annotation_api(
             "successful_sequences": 0,
             "failed_sequences": 0,
             "skipped_sequences": 0,
+            "refreshed_sequences": 0,
+            "refresh_failures": 0,
             "total_sequences": 0,
             "successful_detections": 0,
             "failed_detections": 0,
@@ -755,6 +793,8 @@ def post_records_to_annotation_api(
     successful_sequences = 0
     failed_sequences = 0
     skipped_sequences = 0
+    refreshed_sequences = 0
+    refresh_failures = 0
     total_successful_detections = 0
     total_failed_detections = 0
     total_skipped_detections = 0
@@ -798,6 +838,13 @@ def post_records_to_annotation_api(
                         if result.get("skipped"):
                             skipped_sequences += 1
                             total_skipped_detections += result["skipped_detections"]
+                            # Only the 409 branch sets this key, so its
+                            # presence marks a refresh attempt.
+                            if "refreshed" in result:
+                                if result["refreshed"]:
+                                    refreshed_sequences += 1
+                                else:
+                                    refresh_failures += 1
                             reason = result.get("skip_reason", "already exists")
                             logging.warning(
                                 f"⚠️ Sequence {alert_api_sequence_id} skipped ({reason})"
@@ -850,6 +897,8 @@ def post_records_to_annotation_api(
         "successful_sequences": successful_sequences,
         "failed_sequences": failed_sequences,
         "skipped_sequences": skipped_sequences,
+        "refreshed_sequences": refreshed_sequences,
+        "refresh_failures": refresh_failures,
         "total_sequences": len(grouped_records),
         "successful_detections": total_successful_detections,
         "failed_detections": total_failed_detections,

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/shared.py
@@ -585,16 +585,36 @@ def _process_single_detection(
     return result
 
 
-def _refresh_temporal_score(
-    annotation_api_url: str, auth_token: str, sequence_data: dict
-) -> bool:
-    """Update an existing sequence's temporal columns. Returns success.
+# Outcomes of a refresh attempt on an already-imported sequence.
+REFRESH_REFRESHED = "refreshed"
+REFRESH_FAILED = "failed"
+REFRESH_SKIPPED_UNKNOWN = "skipped_unknown"
 
-    Always sends all three values, including None: a sibling lane's correct
-    value is NULL, and omitting the field would let a stale score survive a
-    re-import. Never raises — a failed refresh degrades the run's usefulness
-    but must not abort an import.
+
+def _refresh_temporal_score(
+    annotation_api_url: str, auth_token: str, sequence_data: dict, record: dict
+) -> str:
+    """Update an existing sequence's temporal columns. Returns the outcome.
+
+    Sends all three values including None, because a sibling lane's correct
+    value IS NULL and omitting the field would let a stale score survive.
+
+    But NULL is only written when this run actually knows the value is NULL.
+    When it does not — the alert API sent no score field, or the primary
+    object could not be identified — the refresh is skipped: writing NULL
+    would destroy a score captured by an earlier, better-informed run, and
+    unlike a bad insert that loss is unrecoverable without re-fetching.
+
+    Never raises: a failed refresh degrades a run but must not abort an import.
     """
+    if record.get("sequence_temporal_score_unknown"):
+        logging.info(
+            f"Skipping temporal refresh for alert_api_id="
+            f"{sequence_data['alert_api_id']}: this run could not determine the "
+            "score, so writing NULL would erase any previously captured value"
+        )
+        return REFRESH_SKIPPED_UNKNOWN
+
     payload = {
         "source_api": sequence_data["source_api"],
         "alert_api_id": sequence_data["alert_api_id"],
@@ -604,13 +624,13 @@ def _refresh_temporal_score(
     }
     try:
         update_sequence_temporal_score(annotation_api_url, auth_token, payload)
-        return True
+        return REFRESH_REFRESHED
     except AnnotationAPIError as exc:
         logging.warning(
             f"Temporal score refresh failed for alert_api_id="
             f"{payload['alert_api_id']}: {exc}"
         )
-        return False
+        return REFRESH_FAILED
 
 
 def post_sequence_to_annotation_api(
@@ -655,14 +675,14 @@ def post_sequence_to_annotation_api(
             # The row already exists, so this is a re-import: refresh the
             # temporal columns rather than walking away. This is what makes
             # `make import-alert-api` over a past range a backfill.
-            refreshed = _refresh_temporal_score(
-                annotation_api_url, auth_token, sequence_data
+            refresh_status = _refresh_temporal_score(
+                annotation_api_url, auth_token, sequence_data, first_record
             )
             return {
                 "success": False,
                 "skipped": True,
                 "skip_reason": "already exists",
-                "refreshed": refreshed,
+                "refresh_status": refresh_status,
                 "sequence_id": None,
                 "alert_api_sequence_id": first_record["sequence_id"],
                 "successful_detections": 0,
@@ -768,6 +788,7 @@ def post_records_to_annotation_api(
             "skipped_sequences": 0,
             "refreshed_sequences": 0,
             "refresh_failures": 0,
+            "refresh_skipped": 0,
             "total_sequences": 0,
             "successful_detections": 0,
             "failed_detections": 0,
@@ -795,6 +816,7 @@ def post_records_to_annotation_api(
     skipped_sequences = 0
     refreshed_sequences = 0
     refresh_failures = 0
+    refresh_skipped = 0
     total_successful_detections = 0
     total_failed_detections = 0
     total_skipped_detections = 0
@@ -838,13 +860,14 @@ def post_records_to_annotation_api(
                         if result.get("skipped"):
                             skipped_sequences += 1
                             total_skipped_detections += result["skipped_detections"]
-                            # Only the 409 branch sets this key, so its
-                            # presence marks a refresh attempt.
-                            if "refreshed" in result:
-                                if result["refreshed"]:
-                                    refreshed_sequences += 1
-                                else:
-                                    refresh_failures += 1
+                            # Only the 409 branch sets this key.
+                            status = result.get("refresh_status")
+                            if status == REFRESH_REFRESHED:
+                                refreshed_sequences += 1
+                            elif status == REFRESH_FAILED:
+                                refresh_failures += 1
+                            elif status == REFRESH_SKIPPED_UNKNOWN:
+                                refresh_skipped += 1
                             reason = result.get("skip_reason", "already exists")
                             logging.warning(
                                 f"⚠️ Sequence {alert_api_sequence_id} skipped ({reason})"
@@ -899,6 +922,7 @@ def post_records_to_annotation_api(
         "skipped_sequences": skipped_sequences,
         "refreshed_sequences": refreshed_sequences,
         "refresh_failures": refresh_failures,
+        "refresh_skipped": refresh_skipped,
         "total_sequences": len(grouped_records),
         "successful_detections": total_successful_detections,
         "failed_detections": total_failed_detections,

--- a/annotation_api/scripts/data_transfer/ingestion/alert_api/utils.py
+++ b/annotation_api/scripts/data_transfer/ingestion/alert_api/utils.py
@@ -109,6 +109,11 @@ def to_record(
         "sequence_temporal_model_score": sequence.get("temporal_model_score"),
         "sequence_temporal_model_version": sequence.get("temporal_model_version"),
         "sequence_temporal_api_version": sequence.get("temporal_api_version"),
+        # "we have no information" is NOT the same as "the platform scored it
+        # null". An alert API predating temporal validation omits the key
+        # entirely; a refresh must skip such records rather than write NULL
+        # over a score captured by an earlier, better-informed run.
+        "sequence_temporal_score_unknown": "temporal_model_score" not in sequence,
         "sequence_started_at": sequence["started_at"],
         "sequence_last_seen_at": sequence["last_seen_at"],
         # Camera/pose pointing direction. The alert API also exposes

--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -76,6 +76,7 @@ from app.schemas.sequence import (
     MaterializeFrameRequest,
     SequenceCreate,
     SequenceRead,
+    SequenceTemporalScoreUpdate,
 )
 from app.services.alert_identity import ALERT_ID_BASE, resolve_platform_alert_id
 from app.services.auto_annotate_scheduling import DONE_STAGES
@@ -200,6 +201,45 @@ async def create_sequence(
         temporal_api_version=temporal_api_version,
     )
     return await sequences.create(payload)
+
+
+@router.patch("/temporal-score", status_code=status.HTTP_200_OK)
+async def update_sequence_temporal_score(
+    payload: SequenceTemporalScoreUpdate,
+    sequences: SequenceCRUD = Depends(get_sequence_crud),
+    current_user: User = Depends(get_current_user),
+) -> SequenceRead:
+    """Refresh the platform temporal-model columns of an existing sequence.
+
+    Keyed on (source_api, alert_api_id) because the importer knows only those
+    at 409 time, never the annotator's internal id. Deliberately narrow: no
+    other column is updatable here, and all three values are overwritten with
+    whatever was sent — including None, which is the correct value for an
+    object-split sibling lane.
+    """
+    stmt = (
+        select(Sequence)
+        .where(Sequence.source_api == payload.source_api)
+        .where(Sequence.alert_api_id == payload.alert_api_id)
+        .limit(1)
+    )
+    existing = (await sequences.session.execute(stmt)).scalars().first()
+    if existing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"No sequence with alert_api_id={payload.alert_api_id} "
+                f"for source_api={payload.source_api.value}"
+            ),
+        )
+
+    existing.temporal_model_score = payload.temporal_model_score
+    existing.temporal_model_version = payload.temporal_model_version
+    existing.temporal_api_version = payload.temporal_api_version
+    sequences.session.add(existing)
+    await sequences.session.commit()
+    await sequences.session.refresh(existing)
+    return existing
 
 
 @router.get("/")

--- a/annotation_api/src/app/clients/annotation_api.py
+++ b/annotation_api/src/app/clients/annotation_api.py
@@ -340,6 +340,39 @@ def create_sequence(base_url: str, auth_token: str, sequence_data: Dict) -> Dict
     return _handle_response(response, operation=operation)
 
 
+def update_sequence_temporal_score(
+    base_url: str, auth_token: str, update_data: Dict
+) -> Dict:
+    """
+    Refresh a sequence's platform temporal-model columns by natural key.
+
+    Args:
+        base_url: Base URL of the annotation API
+        auth_token: JWT authentication token
+        update_data: Dictionary containing:
+            - source_api: Source API enum value
+            - alert_api_id: Alert API sequence id identifying the row
+            - temporal_model_score: float or None
+            - temporal_model_version: str or None
+            - temporal_api_version: str or None
+
+    Returns:
+        Dictionary containing the updated sequence data
+
+    Raises:
+        NotFoundError: If no sequence matches (source_api, alert_api_id)
+        AnnotationAPIError: For other API errors
+    """
+    url = f"{base_url.rstrip('/')}/api/v1/sequences/temporal-score"
+    operation = (
+        f"refresh temporal score for alert_api_id={update_data.get('alert_api_id')}"
+    )
+    response = _make_request(
+        "PATCH", url, auth_token, operation=operation, json=update_data
+    )
+    return _handle_response(response, operation=operation)
+
+
 def get_sequence(base_url: str, auth_token: str, sequence_id: int) -> Dict:
     """
     Get a specific sequence by ID.

--- a/annotation_api/src/app/schemas/sequence.py
+++ b/annotation_api/src/app/schemas/sequence.py
@@ -117,6 +117,21 @@ class SequenceCreate(Azimuth):
     )
 
 
+class SequenceTemporalScoreUpdate(BaseModel):
+    """Natural-key targeted update of the platform temporal-model columns.
+
+    All three value fields are required but nullable. "Absent" and "null" must
+    not be conflated: a sibling lane's correct value is NULL, so a refresh has
+    to write NULL explicitly rather than leave the field untouched.
+    """
+
+    source_api: SourceApi
+    alert_api_id: int
+    temporal_model_score: Optional[float]
+    temporal_model_version: Optional[str] = Field(..., max_length=32)
+    temporal_api_version: Optional[str] = Field(..., max_length=32)
+
+
 class SequenceRead(Azimuth):
     id: int
     source_api: SourceApi = Field(

--- a/annotation_api/src/tests/endpoints/test_sequence.py
+++ b/annotation_api/src/tests/endpoints/test_sequence.py
@@ -2343,3 +2343,137 @@ async def test_create_sequence_accepts_zero_score(authenticated_client: AsyncCli
     response = await authenticated_client.post("/sequences/", data=payload)
     assert response.status_code == 201
     assert response.json()["temporal_model_score"] == 0.0
+
+
+async def _create_scored_sequence(client: AsyncClient, alert_api_id: str, score=None):
+    """Create a sequence and return its JSON, optionally pre-scored."""
+    payload = {
+        "source_api": "pyronear_french",
+        "alert_api_id": alert_api_id,
+        "camera_name": "cam_refresh",
+        "camera_id": "1",
+        "organisation_name": "test_org",
+        "organisation_id": "1",
+        "azimuth": "90",
+        "lat": "0.0",
+        "lon": "0.0",
+        "created_at": (now - timedelta(days=1)).isoformat(),
+        "recorded_at": (now - timedelta(days=1)).isoformat(),
+        "last_seen_at": now.isoformat(),
+    }
+    if score is not None:
+        payload["temporal_model_score"] = score
+        payload["temporal_model_version"] = "0.1.0"
+        payload["temporal_api_version"] = "0.2.0"
+    response = await client.post("/sequences/", data=payload)
+    assert response.status_code == 201
+    return response.json()
+
+
+@pytest.mark.asyncio
+async def test_patch_temporal_score_updates_all_three_columns(
+    authenticated_client: AsyncClient,
+):
+    created = await _create_scored_sequence(authenticated_client, "400")
+    assert created["temporal_model_score"] is None
+
+    response = await authenticated_client.patch(
+        "/sequences/temporal-score",
+        json={
+            "source_api": "pyronear_french",
+            "alert_api_id": 400,
+            "temporal_model_score": 0.6905358697477871,
+            "temporal_model_version": "0.2.0",
+            "temporal_api_version": "0.3.1",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == created["id"]
+    assert body["temporal_model_score"] == 0.6905358697477871
+    assert body["temporal_model_version"] == "0.2.0"
+    assert body["temporal_api_version"] == "0.3.1"
+
+    fetched = await authenticated_client.get(f"/sequences/{created['id']}")
+    assert fetched.json()["temporal_model_score"] == 0.6905358697477871
+
+
+@pytest.mark.asyncio
+async def test_patch_temporal_score_explicit_null_resets(
+    authenticated_client: AsyncClient,
+):
+    """The sibling-reset case: a previously scored row must be clearable."""
+    created = await _create_scored_sequence(authenticated_client, "401", score="0.87")
+    assert created["temporal_model_score"] == 0.87
+
+    response = await authenticated_client.patch(
+        "/sequences/temporal-score",
+        json={
+            "source_api": "pyronear_french",
+            "alert_api_id": 401,
+            "temporal_model_score": None,
+            "temporal_model_version": None,
+            "temporal_api_version": None,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["temporal_model_score"] is None
+
+    fetched = await authenticated_client.get(f"/sequences/{created['id']}")
+    assert fetched.json()["temporal_model_score"] is None
+
+
+@pytest.mark.asyncio
+async def test_patch_temporal_score_unknown_sequence_returns_404(
+    authenticated_client: AsyncClient,
+):
+    response = await authenticated_client.patch(
+        "/sequences/temporal-score",
+        json={
+            "source_api": "pyronear_french",
+            "alert_api_id": 999999999,
+            "temporal_model_score": 0.5,
+            "temporal_model_version": None,
+            "temporal_api_version": None,
+        },
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_temporal_score_requires_all_three_fields(
+    authenticated_client: AsyncClient,
+):
+    """Absent must not be silently treated as null — that is how a stale
+    sibling score would survive a refresh."""
+    await _create_scored_sequence(authenticated_client, "402")
+
+    response = await authenticated_client.patch(
+        "/sequences/temporal-score",
+        json={
+            "source_api": "pyronear_french",
+            "alert_api_id": 402,
+            "temporal_model_score": 0.5,
+        },
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_temporal_score_is_scoped_to_source_api(
+    authenticated_client: AsyncClient,
+):
+    """alert_api_id alone is not unique — the natural key is the pair."""
+    await _create_scored_sequence(authenticated_client, "403")
+
+    response = await authenticated_client.patch(
+        "/sequences/temporal-score",
+        json={
+            "source_api": "api_cenia",
+            "alert_api_id": 403,
+            "temporal_model_score": 0.5,
+            "temporal_model_version": None,
+            "temporal_api_version": None,
+        },
+    )
+    assert response.status_code == 404

--- a/annotation_api/src/tests/scripts/test_temporal_score_refresh.py
+++ b/annotation_api/src/tests/scripts/test_temporal_score_refresh.py
@@ -1,0 +1,141 @@
+"""The import's 409 branch refreshes temporal columns instead of skipping."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.clients.annotation_api import AnnotationAPIError
+from scripts.data_transfer.ingestion.alert_api import shared
+
+# No __init__.py convention in src/tests/ — pytest inserts the test dir on
+# sys.path, so sibling helpers are imported as top-level modules.
+from factories import make_record
+
+BOX = [0.1, 0.1, 0.2, 0.2, 0.9]
+
+
+def _records(**overrides):
+    return [make_record(1, "2026-08-09T14:22:10", [BOX], **overrides)]
+
+
+def _conflict():
+    exc = AnnotationAPIError("exists")
+    exc.status_code = 409
+    return exc
+
+
+class TestRefreshOn409:
+    def test_409_patches_the_temporal_columns(self):
+        records = _records(
+            sequence_temporal_model_score=0.87,
+            sequence_temporal_model_version="0.2.0",
+            sequence_temporal_api_version="0.3.1",
+        )
+
+        with patch.object(shared, "create_sequence", side_effect=_conflict()):
+            with patch.object(
+                shared, "update_sequence_temporal_score", return_value={"id": 1}
+            ) as mock_patch:
+                result = shared.post_sequence_to_annotation_api(
+                    "http://api", records, auth_token="t", source_api="pyronear_french"
+                )
+
+        assert result["skipped"] is True
+        assert result["refreshed"] is True
+        sent = mock_patch.call_args[0][2]
+        assert sent["alert_api_id"] == records[0]["sequence_id"]
+        assert sent["source_api"] == "pyronear_french"
+        assert sent["temporal_model_score"] == 0.87
+        assert sent["temporal_model_version"] == "0.2.0"
+        assert sent["temporal_api_version"] == "0.3.1"
+
+    def test_sibling_refresh_sends_explicit_nulls(self):
+        """A sibling's correct value is NULL; the key must be present and null,
+        never omitted, or a stale score would survive."""
+        records = _records(
+            sequence_temporal_model_score=None,
+            sequence_temporal_model_version=None,
+            sequence_temporal_api_version=None,
+        )
+
+        with patch.object(shared, "create_sequence", side_effect=_conflict()):
+            with patch.object(
+                shared, "update_sequence_temporal_score", return_value={"id": 1}
+            ) as mock_patch:
+                shared.post_sequence_to_annotation_api(
+                    "http://api", records, auth_token="t", source_api="pyronear_french"
+                )
+
+        sent = mock_patch.call_args[0][2]
+        assert "temporal_model_score" in sent
+        assert sent["temporal_model_score"] is None
+        assert sent["temporal_model_version"] is None
+        assert sent["temporal_api_version"] is None
+
+    def test_failed_refresh_is_reported_not_raised(self):
+        """A refresh failure must not abort the run, but must be visible."""
+        failure = AnnotationAPIError("boom")
+        failure.status_code = 500
+
+        with patch.object(shared, "create_sequence", side_effect=_conflict()):
+            with patch.object(
+                shared, "update_sequence_temporal_score", side_effect=failure
+            ):
+                result = shared.post_sequence_to_annotation_api(
+                    "http://api",
+                    _records(),
+                    auth_token="t",
+                    source_api="pyronear_french",
+                )
+
+        assert result["skipped"] is True
+        assert result["refreshed"] is False
+
+    def test_non_409_errors_still_raise(self):
+        boom = AnnotationAPIError("nope")
+        boom.status_code = 500
+        with patch.object(shared, "create_sequence", side_effect=boom):
+            with pytest.raises(AnnotationAPIError):
+                shared.post_sequence_to_annotation_api(
+                    "http://api",
+                    _records(),
+                    auth_token="t",
+                    source_api="pyronear_french",
+                )
+
+
+class TestRefreshAggregation:
+    def test_refreshed_and_failed_counts_reach_the_caller(self):
+        """A backfill run must be distinguishable from a no-op, so the counts
+        have to survive aggregation rather than dying in the worker."""
+        records = [
+            make_record(1, "2026-08-09T14:00:00", [BOX], sid=1),
+            make_record(2, "2026-08-09T14:01:00", [BOX], sid=2),
+        ]
+
+        def fake_refresh(_base_url, _token, payload):
+            # Keyed off the payload, not call order: the workers run in a
+            # thread pool, so a side_effect list would be nondeterministic.
+            if payload["alert_api_id"] == 2:
+                failure = AnnotationAPIError("boom")
+                failure.status_code = 500
+                raise failure
+            return {"id": 1}
+
+        with patch.object(shared, "get_auth_token", return_value="t"):
+            with patch.object(shared, "create_sequence", side_effect=_conflict()):
+                with patch.object(
+                    shared, "update_sequence_temporal_score", side_effect=fake_refresh
+                ):
+                    result = shared.post_records_to_annotation_api(
+                        "http://api", records, source_api="pyronear_french"
+                    )
+
+        assert result["skipped_sequences"] == 2
+        assert result["refreshed_sequences"] == 1
+        assert result["refresh_failures"] == 1
+
+    def test_counts_are_zero_when_nothing_was_posted(self):
+        result = shared.post_records_to_annotation_api("http://api", [])
+        assert result["refreshed_sequences"] == 0
+        assert result["refresh_failures"] == 0

--- a/annotation_api/src/tests/scripts/test_temporal_score_refresh.py
+++ b/annotation_api/src/tests/scripts/test_temporal_score_refresh.py
@@ -41,7 +41,7 @@ class TestRefreshOn409:
                 )
 
         assert result["skipped"] is True
-        assert result["refreshed"] is True
+        assert result["refresh_status"] == shared.REFRESH_REFRESHED
         sent = mock_patch.call_args[0][2]
         assert sent["alert_api_id"] == records[0]["sequence_id"]
         assert sent["source_api"] == "pyronear_french"
@@ -89,7 +89,7 @@ class TestRefreshOn409:
                 )
 
         assert result["skipped"] is True
-        assert result["refreshed"] is False
+        assert result["refresh_status"] == shared.REFRESH_FAILED
 
     def test_non_409_errors_still_raise(self):
         boom = AnnotationAPIError("nope")
@@ -139,3 +139,92 @@ class TestRefreshAggregation:
         result = shared.post_records_to_annotation_api("http://api", [])
         assert result["refreshed_sequences"] == 0
         assert result["refresh_failures"] == 0
+        assert result["refresh_skipped"] == 0
+
+
+class TestRefreshNeverErasesAKnownScore:
+    """Writing NULL is only correct when this run KNOWS the value is NULL.
+
+    On the insert path a cleared score merely meant "not stored"; on the
+    refresh path it would overwrite a value an earlier, better-informed run
+    captured — and that loss is unrecoverable without re-fetching.
+    """
+
+    def test_unknown_score_skips_the_patch_entirely(self):
+        records = _records(sequence_temporal_score_unknown=True)
+
+        with patch.object(shared, "create_sequence", side_effect=_conflict()):
+            with patch.object(
+                shared, "update_sequence_temporal_score", return_value={"id": 1}
+            ) as mock_patch:
+                result = shared.post_sequence_to_annotation_api(
+                    "http://api", records, auth_token="t", source_api="pyronear_french"
+                )
+
+        mock_patch.assert_not_called()
+        assert result["refresh_status"] == shared.REFRESH_SKIPPED_UNKNOWN
+
+    def test_to_record_marks_a_missing_field_as_unknown(self):
+        """An alert API predating temporal validation omits the key; that is
+        ignorance, not a null verdict."""
+        from scripts.data_transfer.ingestion.alert_api import utils
+
+        camera = {
+            "id": 7,
+            "name": "c",
+            "lat": 44.0,
+            "lon": 5.0,
+            "organization_id": 1,
+            "is_trustable": True,
+            "angle_of_view": 87.0,
+        }
+        detection = {
+            "id": 11,
+            "created_at": "2026-08-09T14:22:10",
+            "url": "u",
+            "bucket_key": "k",
+            "bbox": "[(0.1,0.1,0.2,0.2,0.9)]",
+            "others_bboxes": None,
+        }
+        base = {
+            "id": 1,
+            "camera_id": 7,
+            "camera_azimuth": 1.0,
+            "started_at": "2026-08-09T14:00:00",
+            "last_seen_at": "2026-08-09T14:30:00",
+            "is_wildfire": None,
+        }
+
+        without = utils.to_record(detection, camera, {"id": 1, "name": "o"}, base)
+        assert without["sequence_temporal_score_unknown"] is True
+
+        with_null = utils.to_record(
+            detection,
+            camera,
+            {"id": 1, "name": "o"},
+            {**base, "temporal_model_score": None},
+        )
+        assert with_null["sequence_temporal_score_unknown"] is False
+
+    def test_unidentifiable_primary_marks_every_lane_unknown(self):
+        """No bbox-sourced box in the window: we cannot tell which lane the
+        platform scored, so no lane may overwrite what is stored."""
+        from scripts.data_transfer.ingestion.alert_api.object_split import (
+            split_all_records,
+        )
+
+        records = [
+            make_record(
+                det_id,
+                f"2026-07-01T10:0{det_id}:00",
+                [],
+                others=[BOX],
+                sequence_temporal_model_score=0.87,
+            )
+            for det_id in (1, 2, 3)
+        ]
+        out, _ = split_all_records(records)
+
+        assert out
+        for record in out:
+            assert record["sequence_temporal_score_unknown"] is True

--- a/docs/specs/2026-08-10-temporal-score-refresh-design.md
+++ b/docs/specs/2026-08-10-temporal-score-refresh-design.md
@@ -1,0 +1,141 @@
+# Temporal Score Refresh on Re-import — Design
+
+**Date**: 2026-08-10
+**Status**: Approved
+**Follows**: `docs/specs/2026-08-10-import-temporal-model-score-design.md` (PR #364, merged)
+
+## Goal
+
+Let a re-import update the temporal-model columns on sequences the annotator
+already has, so the ~19k rows that predate PR #364 can be backfilled and any
+provisional score can be corrected.
+
+## Why this is needed
+
+`POST /sequences/` is create-only, and `uq_sequence_alert_source` makes a
+re-import of an existing sequence return 409, which `shared.py` swallows as
+`skip_reason: "already exists"`. There is no update path on sequences at all, so
+today re-running `make import-alert-api` over a past range imports nothing and
+changes nothing. Every row imported before PR #364 keeps `temporal_model_score
+= NULL` permanently.
+
+## Approach: refresh inside the import, not beside it
+
+The import already fetches these sequences and already branches on "this one
+exists". Making that branch update the temporal columns turns
+`make import-alert-api DATE_FROM=… DATE_END=…` over a past window into the
+backfill — no new command, no second script, idempotent by construction.
+
+The decisive advantage is fidelity. A re-import re-fetches detections and
+re-runs `split_all_records`, so `primary_identified` and the sibling-clearing
+rule are recomputed exactly as for a fresh import. **Refreshed rows obey
+identical attribution rules to newly imported ones**, and the column keeps one
+meaning across the whole table.
+
+The rejected alternative was a fast standalone script fetching only the
+sequence list per date (minutes rather than hours). It cannot recompute
+`primary_identified` — that needs the alert API's own-vs-`others_bboxes`
+distinction, which the annotator does not store (`Detection` keeps
+`algo_predictions` and `auto_predictions` only, and object split rewrote each
+lane's boxes per object). It would therefore score lanes the guard would skip,
+permanently splitting the column's meaning into "fresh" and "backfilled". Given
+imports run days-to-weeks after capture — so scores are final by then — and the
+backlog is finite (a comparable full run was ~6,900 sequences / 123k detections
+in ~4h), an afternoon in the background is the better trade than a second code
+path maintained forever.
+
+## The endpoint
+
+`PATCH /api/v1/sequences/temporal-score`
+
+```json
+{
+  "source_api": "pyronear_french",
+  "alert_api_id": 56767,
+  "temporal_model_score": 0.6905358697477871,
+  "temporal_model_version": "0.2.0",
+  "temporal_api_version": "0.3.1"
+}
+```
+
+Returns the updated `SequenceRead`; `404` when no sequence matches.
+
+**Collection-level, keyed by natural key** rather than `/{id}`: at 409 time the
+import knows only `source_api` and `alert_api_id`, never the annotator's
+internal id. Keying on the unique pair avoids a lookup round-trip per sequence.
+`services/alert_identity.py:36` already establishes natural-key lookup as a
+pattern in this codebase.
+
+**Narrow by design** — these three columns only. A general `PATCH
+/sequences/{id}` would open mutation of `alert_api_id`, `platform_alert_id`, or
+camera identity, which nothing in the system should ever change.
+
+**JSON body, all three fields required but nullable.** Form encoding cannot
+express an explicit null: `requests` drops `None` from form bodies, which is
+precisely how the create path stores NULL. For an update that is fatal —
+"absent" and "null" must differ, or a sibling lane could never be reset to NULL.
+Requiring all three (each either a value or `null`) removes the distinction
+entirely: whatever is sent is what is stored. Follows the existing
+`update_sequence_annotation` client shape (`_make_request("PATCH", …,
+json=…)`).
+
+## Import integration
+
+`shared.py`'s 409 branch calls the new endpoint instead of returning
+immediately, with the temporal values from the record it was about to post.
+
+Sibling lanes 409 as well, and their records already carry cleared `None`
+values from `object_split`, so the PATCH writes NULL for them. A stale non-NULL
+score from an earlier state therefore cannot survive a refresh — the sibling
+invariant is re-asserted on every run rather than merely on first insert.
+
+## Reporting
+
+The 409 result gains a `refreshed` boolean, and the run summary reports how many
+sequences were refreshed and how many refreshes failed, alongside the existing
+skip counts.
+
+`refreshed` means the PATCH succeeded — deliberately **not** "the stored value
+changed". Reporting the latter would require reading each row before writing it,
+and the extra round-trip buys nothing: a backfill's useful signal is that it
+reached the rows at all.
+
+This is not decoration. Without it a backfill run is indistinguishable from a
+no-op — the same silent-success failure that made `unscored_primary` useless
+until it was surfaced (PR #364, `dce44c0`). A refresh that quietly updates zero
+rows must be visibly different from one that updates thousands.
+
+A 404 from the endpoint should be unreachable from the import (the 409 that
+triggered it proves the row exists), so it is treated as a refresh failure:
+counted, logged with the sequence id, and non-fatal to the run.
+
+## Scope boundary
+
+Touches the three temporal columns and nothing else. No detections, no
+annotations, no processing stages, no camera or organisation fields, and
+explicitly **not** `is_wildfire_alertapi` — that is a human judgement annotators
+may already have reacted to, and silently overwriting it during a backfill could
+change what existing annotations mean. Adding it later remains possible as a
+deliberate decision.
+
+## Testing
+
+- **Endpoint**: updates all three columns; returns 404 for an unknown
+  `(source_api, alert_api_id)`; an explicit `null` resets a previously scored
+  row to NULL (the sibling-reset case); rejects a body missing any of the three
+  fields.
+- **Import path**: the 409 branch issues the PATCH with the record's values and
+  reports `refreshed`; a sibling's 409 PATCHes NULL.
+- **Idempotency**: refreshing twice leaves identical values.
+- **End-to-end against the pg dump**: the only way to exercise real pre-feature
+  rows. Restore, confirm `temporal_model_score IS NULL` across the board, run an
+  import over a date range covered by the dump, and confirm primary lanes gain
+  scores matching the alert API while sibling lanes stay NULL.
+
+## Non-goals
+
+- No standalone fast-refresh script (see rejected alternative above).
+- No change to `POST /sequences/` semantics; it stays create-only and keeps
+  409ing.
+- No backfill of `max_conf` or `is_validated`, which PR #364 deliberately did
+  not capture.


### PR DESCRIPTION
Follow-up to #364. Makes a re-import update the temporal-model columns on sequences the annotator already has, so the rows predating #364 can be backfilled by re-running `make import-alert-api` over a past date range.

Spec: `docs/specs/2026-08-10-temporal-score-refresh-design.md`

## Why

`POST /sequences/` is create-only, and `uq_sequence_alert_source` makes a re-import 409, which `shared.py` swallows as `skip_reason: "already exists"`. There was no update path on sequences at all, so re-running an import over a past range imported nothing and changed nothing — every pre-#364 row kept `temporal_model_score = NULL` permanently.

## Approach

The import already fetches these sequences and already branches on "this one exists". That branch now PATCHes the temporal columns, so `make import-alert-api DATE_FROM=… DATE_END=…` **is** the backfill — no new command, no second script, idempotent by construction.

The decisive advantage is fidelity: a re-import re-fetches detections and re-runs `split_all_records`, so `primary_identified` and the sibling-clearing rule are recomputed. **Refreshed rows obey identical attribution rules to freshly imported ones**, and the column keeps one meaning across the whole table.

A standalone fast-refresh script (sequence-list only, minutes rather than hours) was rejected: it cannot recompute `primary_identified`, because that needs the alert API's own-vs-`others_bboxes` distinction, which the annotator does not store. It would score lanes the guard skips, permanently splitting the column's meaning into "fresh" and "backfilled".

## The endpoint

`PATCH /api/v1/sequences/temporal-score`, keyed on `(source_api, alert_api_id)` — the importer knows only those at 409 time, never the annotator's internal id.

- **Narrow**: these three columns only. A general `PATCH /sequences/{id}` would open mutation of `alert_api_id`, `platform_alert_id`, or camera identity.
- **JSON, all three fields required-but-nullable**: form encoding cannot express an explicit null (`requests` drops `None`), and for an update "absent" and "null" must differ — a sibling lane's correct value *is* NULL and a refresh has to write it.

## Verified against a pre-#364 production dump

Restored the 2026-08-07 test-server dump (996 lanes, no temporal columns at all), ran `alembic upgrade head`, confirmed `scored = 0`, then re-imported 2026-07-01 → 07-07:

```
              lanes | scored | null
 primary        162 |    159 |    3
 sibling          7 |      0 |    7
```

- Reported **169 refreshed = exactly the 169 lanes** in the window. Complete coverage, zero failures.
- Every sibling stayed NULL.
- `outside_week_scored = 0` — the refresh touched only the imported range.
- Re-running produced identical counts.

**Cross-checked against the alert API itself** for the same window: it returns 3 null, 54 exactly `0.0`, 105 other non-null (52 above 0.45). Our stored distribution matches number for number, so no value is coerced anywhere in the pipeline. The 54 zeros are genuine model verdicts (`is_validated: false`), which is why NULL must never be coalesced to 0.0 — three genuinely-unscored rows would otherwise become indistinguishable from 54 confident zeros.

## Also fixed

A pure backfill imports nothing, so it takes the early exit at the "no sequences imported" panel and `sys.exit(0)`s before the detailed summary where the refresh counts were printed — invisible in exactly the run that produced them. Found by running the real backfill, not by the tests.

## Testing

- Endpoint: update, explicit-null reset, 404, 422 on a missing field, source_api scoping (5 tests)
- Import: 409 PATCHes, sibling sends explicit nulls, failure is non-fatal, non-409 still raises, count aggregation (6 tests)
- Full suite: 769 passed

## Not in this PR

- No `is_wildfire_alertapi` refresh — a human judgement annotators may already have reacted to.
- No `max_conf` / `is_validated` capture.
- No queue triage. The week's data suggests ~⅓ of sequences clear 0.45, so score-based triage looks worthwhile, but that is a separate design.