### PR TITLE
feat(queues): show and sort by the alert temporal score

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -1204,6 +1204,7 @@ async def localization_queue(
             Sequence.source_api,
             Sequence.platform_alert_id,
             func.min(Sequence.recorded_at).label("recorded_at"),
+            func.max(Sequence.temporal_model_score).label("temporal_model_score"),
         )
         .outerjoin(SequenceAnnotation, SequenceAnnotation.sequence_id == Sequence.id)
         .where(
@@ -1249,7 +1250,11 @@ async def localization_queue(
     ).all()
     maybe_items = [
         await _build_queue_item(
-            session, row.source_api, row.platform_alert_id, row.recorded_at
+            session,
+            row.source_api,
+            row.platform_alert_id,
+            row.recorded_at,
+            temporal_model_score=row.temporal_model_score,
         )
         for row in page_rows
     ]
@@ -1310,6 +1315,7 @@ async def _build_queue_item(
     source_api: SourceApi,
     platform_alert_id: int,
     recorded_at: datetime,
+    temporal_model_score: Optional[float] = None,
     item_cls: type[LocalizationQueueItem]
     | type[LocalizeDoneQueueItem] = LocalizationQueueItem,
 ) -> Optional[LocalizationQueueItem | LocalizeDoneQueueItem]:
@@ -1359,6 +1365,7 @@ async def _build_queue_item(
         organisation_name=first_seq.organisation_name,
         azimuth=first_seq.azimuth,
         recorded_at=recorded_at,
+        temporal_model_score=temporal_model_score,
         lanes=[
             LocalizationQueueLane(
                 sequence_id=seq.id,
@@ -1433,6 +1440,7 @@ async def classify_queue(
             Sequence.source_api,
             Sequence.platform_alert_id,
             func.min(Sequence.recorded_at).label("recorded_at"),
+            func.max(Sequence.temporal_model_score).label("temporal_model_score"),
             func.count().label("total_objects"),
             func.sum(
                 case((SequenceAnnotation.processing_stage.in_(DONE_STAGES), 1), else_=0)
@@ -1483,6 +1491,7 @@ async def classify_queue(
                 organisation_name=primary.organisation_name,
                 azimuth=primary.azimuth,
                 recorded_at=row.recorded_at,
+                temporal_model_score=row.temporal_model_score,
                 is_wildfire_alertapi=primary.is_wildfire_alertapi,
                 primary_sequence_id=primary.id,
                 total_objects=row.total_objects,
@@ -1550,6 +1559,7 @@ async def localize_done_queue(
             Sequence.source_api,
             Sequence.platform_alert_id,
             func.min(Sequence.recorded_at).label("recorded_at"),
+            func.max(Sequence.temporal_model_score).label("temporal_model_score"),
         )
         .where(tuple_(Sequence.source_api, Sequence.platform_alert_id).in_(candidates))
         .group_by(Sequence.source_api, Sequence.platform_alert_id)
@@ -1578,6 +1588,7 @@ async def localize_done_queue(
             row.source_api,
             row.platform_alert_id,
             row.recorded_at,
+            temporal_model_score=row.temporal_model_score,
             item_cls=LocalizeDoneQueueItem,
         )
         for row in page_rows
@@ -1659,6 +1670,7 @@ async def classify_done(
             Sequence.source_api,
             Sequence.platform_alert_id,
             func.min(Sequence.recorded_at).label("recorded_at"),
+            func.max(Sequence.temporal_model_score).label("temporal_model_score"),
         )
         .outerjoin(SequenceAnnotation, SequenceAnnotation.sequence_id == Sequence.id)
         .where(tuple_(Sequence.source_api, Sequence.platform_alert_id).in_(candidates))
@@ -1768,6 +1780,7 @@ async def classify_done(
                 organisation_name=primary.organisation_name,
                 azimuth=primary.azimuth,
                 recorded_at=row.recorded_at,
+                temporal_model_score=row.temporal_model_score,
                 is_wildfire_alertapi=primary.is_wildfire_alertapi,
                 primary_sequence_id=primary.id,
                 lanes=[

--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -1181,17 +1181,22 @@ def _queue_order_clauses(
     alerts the platform never scored. An unscored alert is unmeasured, not
     low-confidence, so it belongs at the bottom either way.
 
-    Every ordering ends in `platform_alert_id` so page boundaries are stable.
-    Scores tie constantly — and are entirely NULL until a historical backfill
-    runs — so without a deterministic final key, paginating a score-ordered
-    queue could repeat or skip alerts between pages.
+    Every ordering ends in the full alert key `(platform_alert_id, source_api)`
+    so page boundaries are stable. Scores tie constantly — and are entirely
+    NULL until a historical backfill runs — so without a deterministic final
+    key, paginating a score-ordered queue could repeat or skip alerts between
+    pages.
     """
     column = alerts.c[order_by.value]
     primary = desc(column) if direction == OrderDirection.desc else asc(column)
     clauses = [primary.nullslast()]
     if order_by is not QueueOrderByField.recorded_at:
         clauses.append(desc(alerts.c.recorded_at))
+    # The group key is the PAIR — each source API numbers its sequences
+    # independently, so platform_alert_id alone can collide across sources and
+    # would leave the very ties this exists to break unresolved.
     clauses.append(desc(alerts.c.platform_alert_id))
+    clauses.append(desc(alerts.c.source_api))
     return clauses
 
 

--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -1171,17 +1171,28 @@ async def unskip_alert(
     await session.commit()
 
 
-def _queue_order_clause(alerts, order_by: QueueOrderByField, direction: OrderDirection):
-    """ORDER BY for an alert-grouped queue subquery.
+def _queue_order_clauses(
+    alerts, order_by: QueueOrderByField, direction: OrderDirection
+) -> list:
+    """ORDER BY clauses for an alert-grouped queue subquery.
 
     NULLs are placed last in BOTH directions on purpose: Postgres orders them
     FIRST on DESC, which would fill the top of a score-descending queue with
     alerts the platform never scored. An unscored alert is unmeasured, not
     low-confidence, so it belongs at the bottom either way.
+
+    Every ordering ends in `platform_alert_id` so page boundaries are stable.
+    Scores tie constantly — and are entirely NULL until a historical backfill
+    runs — so without a deterministic final key, paginating a score-ordered
+    queue could repeat or skip alerts between pages.
     """
     column = alerts.c[order_by.value]
-    ordered = desc(column) if direction == OrderDirection.desc else asc(column)
-    return ordered.nullslast()
+    primary = desc(column) if direction == OrderDirection.desc else asc(column)
+    clauses = [primary.nullslast()]
+    if order_by is not QueueOrderByField.recorded_at:
+        clauses.append(desc(alerts.c.recorded_at))
+    clauses.append(desc(alerts.c.platform_alert_id))
+    return clauses
 
 
 # NOTE: declared before GET /{sequence_id} — the int path converter would
@@ -1262,7 +1273,7 @@ async def localization_queue(
     page_rows = (
         await session.execute(
             select(alerts)
-            .order_by(_queue_order_clause(alerts, order_by, order_direction))
+            .order_by(*_queue_order_clauses(alerts, order_by, order_direction))
             .offset((params.page - 1) * params.size)
             .limit(params.size)
         )
@@ -1487,7 +1498,7 @@ async def classify_queue(
     page_rows = (
         await session.execute(
             select(alerts)
-            .order_by(_queue_order_clause(alerts, order_by, order_direction))
+            .order_by(*_queue_order_clauses(alerts, order_by, order_direction))
             .offset((params.page - 1) * params.size)
             .limit(params.size)
         )
@@ -1606,7 +1617,7 @@ async def localize_done_queue(
     page_rows = (
         await session.execute(
             select(alerts)
-            .order_by(_queue_order_clause(alerts, order_by, order_direction))
+            .order_by(*_queue_order_clauses(alerts, order_by, order_direction))
             .offset((params.page - 1) * params.size)
             .limit(params.size)
         )
@@ -1774,10 +1785,7 @@ async def classify_done(
             select(alerts_sq)
             # platform_alert_id tie-break keeps page boundaries stable when
             # alerts share a recorded_at
-            .order_by(
-                _queue_order_clause(alerts_sq, order_by, order_direction),
-                desc(alerts_sq.c.platform_alert_id),
-            )
+            .order_by(*_queue_order_clauses(alerts_sq, order_by, order_direction))
             .offset((params.page - 1) * params.size)
             .limit(params.size)
         )

--- a/annotation_api/src/app/api/api_v1/endpoints/sequences.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequences.py
@@ -74,6 +74,7 @@ from app.schemas.sequence import (
     LocalizationQueueLane,
     LocalizeDoneQueueItem,
     MaterializeFrameRequest,
+    QueueOrderByField,
     SequenceCreate,
     SequenceRead,
     SequenceTemporalScoreUpdate,
@@ -1170,11 +1171,29 @@ async def unskip_alert(
     await session.commit()
 
 
+def _queue_order_clause(alerts, order_by: QueueOrderByField, direction: OrderDirection):
+    """ORDER BY for an alert-grouped queue subquery.
+
+    NULLs are placed last in BOTH directions on purpose: Postgres orders them
+    FIRST on DESC, which would fill the top of a score-descending queue with
+    alerts the platform never scored. An unscored alert is unmeasured, not
+    low-confidence, so it belongs at the bottom either way.
+    """
+    column = alerts.c[order_by.value]
+    ordered = desc(column) if direction == OrderDirection.desc else asc(column)
+    return ordered.nullslast()
+
+
 # NOTE: declared before GET /{sequence_id} — the int path converter would
 # otherwise turn /localization-queue into a 422.
 @router.get("/localization-queue")
 async def localization_queue(
     skipped: bool = Query(False),
+    order_by: QueueOrderByField = Query(
+        QueueOrderByField.recorded_at,
+        description="Column to order alerts by. Unscored alerts sort last either way.",
+    ),
+    order_direction: OrderDirection = Query(OrderDirection.desc),
     session: AsyncSession = Depends(get_session),
     params: Params = Depends(),
     current_user: User = Depends(get_current_user),
@@ -1243,7 +1262,7 @@ async def localization_queue(
     page_rows = (
         await session.execute(
             select(alerts)
-            .order_by(desc(alerts.c.recorded_at))
+            .order_by(_queue_order_clause(alerts, order_by, order_direction))
             .offset((params.page - 1) * params.size)
             .limit(params.size)
         )
@@ -1401,6 +1420,11 @@ async def classify_queue(
         None, description=PLATFORM_ANNOTATION_FILTER_DESC
     ),
     skipped: bool = Query(False),
+    order_by: QueueOrderByField = Query(
+        QueueOrderByField.recorded_at,
+        description="Column to order alerts by. Unscored alerts sort last either way.",
+    ),
+    order_direction: OrderDirection = Query(OrderDirection.desc),
     session: AsyncSession = Depends(get_session),
     params: Params = Depends(),
     current_user: User = Depends(get_current_user),
@@ -1463,7 +1487,7 @@ async def classify_queue(
     page_rows = (
         await session.execute(
             select(alerts)
-            .order_by(desc(alerts.c.recorded_at))
+            .order_by(_queue_order_clause(alerts, order_by, order_direction))
             .offset((params.page - 1) * params.size)
             .limit(params.size)
         )
@@ -1518,6 +1542,11 @@ async def localize_done_queue(
     annotator_id: Optional[int] = Query(
         None, description="Alerts with any lane contributed to by this user"
     ),
+    order_by: QueueOrderByField = Query(
+        QueueOrderByField.recorded_at,
+        description="Column to order alerts by. Unscored alerts sort last either way.",
+    ),
+    order_direction: OrderDirection = Query(OrderDirection.desc),
     session: AsyncSession = Depends(get_session),
     params: Params = Depends(),
     current_user: User = Depends(get_current_user),
@@ -1577,7 +1606,7 @@ async def localize_done_queue(
     page_rows = (
         await session.execute(
             select(alerts)
-            .order_by(desc(alerts.c.recorded_at))
+            .order_by(_queue_order_clause(alerts, order_by, order_direction))
             .offset((params.page - 1) * params.size)
             .limit(params.size)
         )
@@ -1635,6 +1664,11 @@ async def classify_done(
     annotator_id: Optional[int] = Query(
         None, description="Alerts with any lane contributed to by this user"
     ),
+    order_by: QueueOrderByField = Query(
+        QueueOrderByField.recorded_at,
+        description="Column to order alerts by. Unscored alerts sort last either way.",
+    ),
+    order_direction: OrderDirection = Query(OrderDirection.desc),
     session: AsyncSession = Depends(get_session),
     params: Params = Depends(),
     current_user: User = Depends(get_current_user),
@@ -1741,7 +1775,8 @@ async def classify_done(
             # platform_alert_id tie-break keeps page boundaries stable when
             # alerts share a recorded_at
             .order_by(
-                desc(alerts_sq.c.recorded_at), desc(alerts_sq.c.platform_alert_id)
+                _queue_order_clause(alerts_sq, order_by, order_direction),
+                desc(alerts_sq.c.platform_alert_id),
             )
             .offset((params.page - 1) * params.size)
             .limit(params.size)

--- a/annotation_api/src/app/schemas/sequence.py
+++ b/annotation_api/src/app/schemas/sequence.py
@@ -5,6 +5,7 @@
 
 
 from datetime import datetime
+from enum import Enum
 from typing import List, Optional
 
 from pydantic import BaseModel, Field, ConfigDict
@@ -26,11 +27,19 @@ __all__ = [
     "LocalizationQueueItem",
     "LocalizationQueueLane",
     "MaterializeFrameRequest",
+    "QueueOrderByField",
     "SequenceCreate",
     "SequenceRead",
     "SequenceUpdateBboxAuto",
     "SequenceUpdateBboxVerified",
 ]
+
+
+class QueueOrderByField(str, Enum):
+    """Orderable columns of the alert-grouped queue endpoints."""
+
+    recorded_at = "recorded_at"
+    temporal_model_score = "temporal_model_score"
 
 
 class Azimuth(BaseModel):

--- a/annotation_api/src/app/schemas/sequence.py
+++ b/annotation_api/src/app/schemas/sequence.py
@@ -199,6 +199,9 @@ class LocalizationQueueItem(BaseModel):
     organisation_name: str
     azimuth: Optional[int]
     recorded_at: datetime
+    # The alert's platform temporal-model score: MAX over its lanes, which is
+    # exactly the primary lane's value because siblings are NULL (see #364).
+    temporal_model_score: Optional[float] = None
     lanes: List[LocalizationQueueLane]
     # Present only on skipped=true queue rows.
     skip: Optional[AlertSkipInfo] = None
@@ -214,6 +217,9 @@ class LocalizeDoneQueueItem(BaseModel):
     organisation_name: str
     azimuth: Optional[int]
     recorded_at: datetime
+    # The alert's platform temporal-model score: MAX over its lanes, which is
+    # exactly the primary lane's value because siblings are NULL (see #364).
+    temporal_model_score: Optional[float] = None
     lanes: List[LocalizationQueueLane]
     annotators: List[str] = []
 
@@ -227,6 +233,9 @@ class ClassifyQueueItem(BaseModel):
     organisation_name: str
     azimuth: Optional[float] = None
     recorded_at: datetime
+    # The alert's platform temporal-model score: MAX over its lanes, which is
+    # exactly the primary lane's value because siblings are NULL (see #364).
+    temporal_model_score: Optional[float] = None
     is_wildfire_alertapi: Optional[AnnotationType] = None
     primary_sequence_id: int
     total_objects: int
@@ -255,6 +264,9 @@ class ClassifyDoneItem(BaseModel):
     organisation_name: str
     azimuth: Optional[float] = None
     recorded_at: datetime
+    # The alert's platform temporal-model score: MAX over its lanes, which is
+    # exactly the primary lane's value because siblings are NULL (see #364).
+    temporal_model_score: Optional[float] = None
     is_wildfire_alertapi: Optional[AnnotationType] = None
     primary_sequence_id: int
     lanes: List[ClassifyDoneLane]

--- a/annotation_api/src/tests/endpoints/test_queue_temporal_score.py
+++ b/annotation_api/src/tests/endpoints/test_queue_temporal_score.py
@@ -1,0 +1,85 @@
+"""The queues expose the alert's temporal score, taken from its primary lane."""
+
+from typing import Optional
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_lane(
+    client: AsyncClient,
+    alert_api_id: str,
+    platform_alert_id: str,
+    score: Optional[str] = None,
+    camera_name: str = "cam_score",
+):
+    payload = {
+        "source_api": "pyronear_french",
+        "alert_api_id": alert_api_id,
+        "platform_alert_id": platform_alert_id,
+        "camera_name": camera_name,
+        "camera_id": "1",
+        "organisation_name": "test_org",
+        "organisation_id": "1",
+        "azimuth": "90",
+        "lat": "0.0",
+        "lon": "0.0",
+        "recorded_at": "2026-08-01T10:00:00",
+        "last_seen_at": "2026-08-01T10:05:00",
+    }
+    if score is not None:
+        payload["temporal_model_score"] = score
+    response = await client.post("/sequences/", data=payload)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+async def _ready_to_annotate(client: AsyncClient, sequence_id: int):
+    response = await client.post(
+        "/annotations/sequences/",
+        json={
+            "sequence_id": sequence_id,
+            "has_missed_smoke": False,
+            "annotation": {"sequences_bbox": []},
+            "processing_stage": "ready_to_annotate",
+        },
+    )
+    assert response.status_code in (200, 201), response.text
+
+
+async def test_classify_queue_reports_the_primary_lanes_score(
+    authenticated_client: AsyncClient,
+):
+    """A sibling lane is NULL by construction, so MAX over the alert's lanes
+    is the primary's score — not the larger of two competing values."""
+    primary = await _create_lane(authenticated_client, "7001", "7001", score="0.87")
+    sibling = await _create_lane(authenticated_client, "1000007001001", "7001")
+    await _ready_to_annotate(authenticated_client, primary["id"])
+    await _ready_to_annotate(authenticated_client, sibling["id"])
+
+    response = await authenticated_client.get(
+        "/sequences/classify-queue", params={"camera_name": "cam_score"}
+    )
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["temporal_model_score"] == 0.87
+
+
+async def test_classify_queue_score_is_null_when_no_lane_is_scored(
+    authenticated_client: AsyncClient,
+):
+    lane = await _create_lane(
+        authenticated_client, "7002", "7002", camera_name="cam_unscored"
+    )
+    await _ready_to_annotate(authenticated_client, lane["id"])
+
+    response = await authenticated_client.get(
+        "/sequences/classify-queue", params={"camera_name": "cam_unscored"}
+    )
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["temporal_model_score"] is None

--- a/annotation_api/src/tests/endpoints/test_queue_temporal_score.py
+++ b/annotation_api/src/tests/endpoints/test_queue_temporal_score.py
@@ -83,3 +83,63 @@ async def test_classify_queue_score_is_null_when_no_lane_is_scored(
     items = response.json()["items"]
     assert len(items) == 1
     assert items[0]["temporal_model_score"] is None
+
+
+async def _scored_queue_alert(client: AsyncClient, alert_api_id: str, score, camera):
+    lane = await _create_lane(
+        client, alert_api_id, alert_api_id, score=score, camera_name=camera
+    )
+    await _ready_to_annotate(client, lane["id"])
+    return lane
+
+
+async def test_sorting_by_score_desc_puts_nulls_last(
+    authenticated_client: AsyncClient,
+):
+    """Postgres puts NULLs FIRST on DESC — unscored alerts must not crowd out
+    the very rows a 'most likely fires first' sort exists to surface."""
+    await _scored_queue_alert(authenticated_client, "7100", "0.10", "cam_sort")
+    await _scored_queue_alert(authenticated_client, "7101", None, "cam_sort")
+    await _scored_queue_alert(authenticated_client, "7102", "0.90", "cam_sort")
+
+    response = await authenticated_client.get(
+        "/sequences/classify-queue",
+        params={
+            "camera_name": "cam_sort",
+            "order_by": "temporal_model_score",
+            "order_direction": "desc",
+        },
+    )
+    assert response.status_code == 200
+    scores = [item["temporal_model_score"] for item in response.json()["items"]]
+    assert scores == [0.90, 0.10, None]
+
+
+async def test_sorting_by_score_asc_also_puts_nulls_last(
+    authenticated_client: AsyncClient,
+):
+    """An unscored alert is unmeasured, not low-confidence: it belongs at the
+    bottom whichever direction is asked for."""
+    await _scored_queue_alert(authenticated_client, "7200", "0.10", "cam_sort_asc")
+    await _scored_queue_alert(authenticated_client, "7201", None, "cam_sort_asc")
+    await _scored_queue_alert(authenticated_client, "7202", "0.90", "cam_sort_asc")
+
+    response = await authenticated_client.get(
+        "/sequences/classify-queue",
+        params={
+            "camera_name": "cam_sort_asc",
+            "order_by": "temporal_model_score",
+            "order_direction": "asc",
+        },
+    )
+    assert response.status_code == 200
+    scores = [item["temporal_model_score"] for item in response.json()["items"]]
+    assert scores == [0.10, 0.90, None]
+
+
+async def test_default_ordering_is_unchanged(authenticated_client: AsyncClient):
+    """No order_by means recorded_at DESC, exactly as before this feature."""
+    response = await authenticated_client.get("/sequences/classify-queue")
+    assert response.status_code == 200
+    recorded = [item["recorded_at"] for item in response.json()["items"]]
+    assert recorded == sorted(recorded, reverse=True)

--- a/annotation_api/src/tests/endpoints/test_queue_temporal_score.py
+++ b/annotation_api/src/tests/endpoints/test_queue_temporal_score.py
@@ -4,6 +4,13 @@ from typing import Optional
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import Integer, String, column, select, table
+
+from app.api.api_v1.endpoints.sequences import (
+    OrderDirection,
+    _queue_order_clauses,
+)
+from app.schemas.sequence import QueueOrderByField
 
 pytestmark = pytest.mark.asyncio
 
@@ -14,9 +21,11 @@ async def _create_lane(
     platform_alert_id: str,
     score: Optional[str] = None,
     camera_name: str = "cam_score",
+    recorded_at: str = "2026-08-01T10:00:00",
+    source_api: str = "pyronear_french",
 ):
     payload = {
-        "source_api": "pyronear_french",
+        "source_api": source_api,
         "alert_api_id": alert_api_id,
         "platform_alert_id": platform_alert_id,
         "camera_name": camera_name,
@@ -26,7 +35,7 @@ async def _create_lane(
         "azimuth": "90",
         "lat": "0.0",
         "lon": "0.0",
-        "recorded_at": "2026-08-01T10:00:00",
+        "recorded_at": recorded_at,
         "last_seen_at": "2026-08-01T10:05:00",
     }
     if score is not None:
@@ -153,20 +162,94 @@ async def test_score_ordering_is_stable_when_every_score_is_null(
         "order_by": "temporal_model_score",
         "order_direction": "desc",
     }
-    first = await authenticated_client.get("/sequences/classify-queue", params=params)
-    second = await authenticated_client.get("/sequences/classify-queue", params=params)
-    assert first.status_code == 200 and second.status_code == 200
 
+    # Walk the result as PAGES. Re-requesting the same page proves nothing —
+    # Postgres answers an identical query identically even with no tie-break
+    # at all. Only a page boundary can expose a non-deterministic order, as a
+    # repeated or dropped alert between page 1 and page 2.
     def ids(response):
         return [item["platform_alert_id"] for item in response.json()["items"]]
 
-    assert ids(first) == ids(second)
-    assert ids(first) == sorted(ids(first), reverse=True)
+    page1 = await authenticated_client.get(
+        "/sequences/classify-queue", params={**params, "page": 1, "size": 2}
+    )
+    page2 = await authenticated_client.get(
+        "/sequences/classify-queue", params={**params, "page": 2, "size": 2}
+    )
+    assert page1.status_code == 200 and page2.status_code == 200
+
+    paged = ids(page1) + ids(page2)
+    assert len(paged) == 3, f"expected the 3 seeded alerts across 2 pages, got {paged}"
+    assert len(set(paged)) == 3, f"an alert was repeated across pages: {paged}"
+    assert paged == sorted(paged, reverse=True)
+
+
+async def test_order_clauses_end_in_the_full_alert_key():
+    """The tie-break must be the whole group key, `(platform_alert_id,
+    source_api)` — each source API numbers its sequences independently, so
+    platform_alert_id alone can collide and leaves the ties it exists to break.
+
+    Asserted on the clause list rather than on query results on purpose: a
+    missing tie-break makes row order UNDEFINED, not reliably wrong, so a
+    behavioural test passes by luck on small fixtures. This one fails the
+    moment the clause is dropped.
+    """
+    alerts = (
+        select(
+            column("source_api", String),
+            column("platform_alert_id", Integer),
+            column("recorded_at", String),
+            column("temporal_model_score", Integer),
+        )
+        .select_from(table("sequences"))
+        .subquery()
+    )
+
+    rendered = [
+        str(c.compile(compile_kwargs={"literal_binds": True}))
+        for c in _queue_order_clauses(
+            alerts, QueueOrderByField.temporal_model_score, OrderDirection.desc
+        )
+    ]
+    assert any("platform_alert_id" in c for c in rendered), rendered
+    assert any("source_api" in c for c in rendered), rendered
+    assert "source_api" in rendered[-1], f"alert key must come last: {rendered}"
 
 
 async def test_default_ordering_is_unchanged(authenticated_client: AsyncClient):
-    """No order_by means recorded_at DESC, exactly as before this feature."""
-    response = await authenticated_client.get("/sequences/classify-queue")
+    """No order_by means recorded_at DESC, exactly as before this feature.
+
+    Seeds alerts whose score order is the REVERSE of their recorded_at order,
+    so a default that silently switched to score would be caught. Asserting
+    over whatever happens to be in the table is not enough: the fixtures wipe
+    it between tests, so an unseeded version of this test compares two empty
+    lists and can never fail.
+    """
+    # oldest gets the highest score, newest the lowest
+    for alert_api_id, recorded_at, score in (
+        ("7400", "2026-08-01T10:00:00", "0.90"),
+        ("7401", "2026-08-02T10:00:00", "0.50"),
+        ("7402", "2026-08-03T10:00:00", "0.10"),
+    ):
+        lane = await _create_lane(
+            authenticated_client,
+            alert_api_id,
+            alert_api_id,
+            score=score,
+            camera_name="cam_default_order",
+            recorded_at=recorded_at,
+        )
+        await _ready_to_annotate(authenticated_client, lane["id"])
+
+    response = await authenticated_client.get(
+        "/sequences/classify-queue", params={"camera_name": "cam_default_order"}
+    )
     assert response.status_code == 200
-    recorded = [item["recorded_at"] for item in response.json()["items"]]
+    items = response.json()["items"]
+    assert len(items) == 3
+
+    recorded = [item["recorded_at"] for item in items]
     assert recorded == sorted(recorded, reverse=True)
+    # And explicitly NOT score order, which is the reverse here.
+    scores = [item["temporal_model_score"] for item in items]
+    assert scores == [0.10, 0.50, 0.90]

--- a/annotation_api/src/tests/endpoints/test_queue_temporal_score.py
+++ b/annotation_api/src/tests/endpoints/test_queue_temporal_score.py
@@ -137,6 +137,33 @@ async def test_sorting_by_score_asc_also_puts_nulls_last(
     assert scores == [0.10, 0.90, None]
 
 
+async def test_score_ordering_is_stable_when_every_score_is_null(
+    authenticated_client: AsyncClient,
+):
+    """Before a historical backfill every score is NULL, so the primary key
+    discriminates nothing. Without a deterministic tie-break, paginating a
+    score-ordered queue could repeat or skip alerts between pages."""
+    for alert_api_id in ("7300", "7301", "7302"):
+        await _scored_queue_alert(
+            authenticated_client, alert_api_id, None, "cam_stable"
+        )
+
+    params = {
+        "camera_name": "cam_stable",
+        "order_by": "temporal_model_score",
+        "order_direction": "desc",
+    }
+    first = await authenticated_client.get("/sequences/classify-queue", params=params)
+    second = await authenticated_client.get("/sequences/classify-queue", params=params)
+    assert first.status_code == 200 and second.status_code == 200
+
+    def ids(response):
+        return [item["platform_alert_id"] for item in response.json()["items"]]
+
+    assert ids(first) == ids(second)
+    assert ids(first) == sorted(ids(first), reverse=True)
+
+
 async def test_default_ordering_is_unchanged(authenticated_client: AsyncClient):
     """No order_by means recorded_at DESC, exactly as before this feature."""
     response = await authenticated_client.get("/sequences/classify-queue")

--- a/docs/specs/2026-08-10-queue-temporal-score-design.md
+++ b/docs/specs/2026-08-10-queue-temporal-score-design.md
@@ -1,0 +1,133 @@
+# Temporal Score in the Queues — Design
+
+**Date**: 2026-08-10
+**Status**: Approved
+**Follows**: `2026-08-10-import-temporal-model-score-design.md` (#364, merged),
+`2026-08-10-temporal-score-refresh-design.md` (#365, merged)
+
+## Goal
+
+Show each alert's platform temporal-model score in the classify and localize
+lists, and let annotators sort by it, so the most likely fires can be worked
+first.
+
+## Scope
+
+Four endpoints and their tables:
+
+| endpoint | table component | page |
+|---|---|---|
+| `GET /sequences/classify-queue` | `ClassifyAlertQueueTable.tsx` | `SequencesPage.tsx` |
+| `GET /sequences/localization-queue` | `LocalizeQueueTable.tsx` | `DetectionAnnotatePage.tsx` |
+| `GET /sequences/classify-done` | `ClassifyDoneTable.tsx` | `SequencesPage.tsx` |
+| `GET /sequences/localize-done-queue` | `LocalizeDoneQueueTable.tsx` | `DetectionReviewPage.tsx` |
+
+All four live under `frontend/src/components/sequences/`. The sort state lives
+on the page, not the table, matching `SequenceGroupsListPage.tsx`.
+
+The two work queues are where triage order matters; the two done lists carry
+the column so the score can be compared retrospectively against what
+annotators actually found.
+
+## Backend: the aggregate is exact, not approximate
+
+Each of the four endpoints already builds an `alerts` subquery grouped by
+`(source_api, platform_alert_id)` with aggregates like
+`func.min(Sequence.recorded_at)`, `func.count()` and `func.sum(...)`. One more
+aggregate joins them:
+
+```python
+func.max(Sequence.temporal_model_score).label("temporal_model_score"),
+```
+
+`MAX` is exactly the alert's score rather than a heuristic, because **only the
+primary lane ever carries one** — object-split siblings are NULL by
+construction (#364) — and `MAX` ignores NULLs. This matters practically: it
+needs no join to identify the primary, and it works unchanged on
+`LocalizationQueueItem` / `LocalizeDoneQueueItem`, which (unlike
+`ClassifyQueueItem`) carry no `primary_sequence_id`.
+
+If a future change ever let a sibling hold a score, `MAX` would silently start
+returning the larger of the two. The invariant is enforced in
+`object_split.split_sequence_records` and covered by tests there; this design
+depends on it.
+
+## Schema
+
+`temporal_model_score: Optional[float] = None` is added to `ClassifyQueueItem`,
+`LocalizationQueueItem`, `LocalizeDoneQueueItem` and `ClassifyDoneItem`, and
+mirrored in `frontend/src/types/api.ts`.
+
+## Sorting
+
+Each endpoint gains two query parameters:
+
+- `order_by`: `recorded_at` (default) or `temporal_model_score`
+- `order_direction`: `desc` (default) or `asc`
+
+replacing the hardcoded `order_by(desc(alerts.c.recorded_at))`. The
+`platform_alert_id` tie-break already present on `classify-done` is preserved,
+since it is what keeps page boundaries stable when alerts share a
+`recorded_at`.
+
+### NULLs sort last in both directions
+
+Explicitly, via `.nullslast()` on both branches — not by relying on the
+database default. Postgres puts NULLs **first** on `DESC`, so a plain
+`ORDER BY temporal_model_score DESC` would fill the top of a "most likely fires
+first" sort with entirely unscored alerts: the exact opposite of the intent.
+
+The semantic argument agrees: an unscored alert is unmeasured, not
+low-confidence. Sorting it to the bottom either way keeps the informative rows
+visible regardless of direction.
+
+This matters more than it looks while the column is sparsely populated —
+before a full historical backfill, most rows are NULL.
+
+## Frontend
+
+A right-aligned `Score` column showing `Math.round(score * 100)` with a `%`
+suffix, and `—` when null. Percentages read as confidence at a glance and put
+the platform's 0.45 threshold at a memorable 45%.
+
+Sorting reuses the existing `ColumnHeader` `sort` prop
+(`{active, direction, onSort}`, which already renders the arrow and sets
+`aria-sort`) together with the `orderBy` / `orderDirection` / `handleSort`
+state pattern established in `SequenceGroupsListPage.tsx:276-299`. No new UI
+pattern is introduced.
+
+## Testing
+
+**Backend**
+
+- The aggregate returns the primary lane's score for a multi-lane alert — the
+  case where a naive join could pick a sibling.
+- An alert whose lanes are all unscored returns `null`.
+- `order_by=temporal_model_score` orders correctly, with nulls last in **both**
+  directions (the descending case is the one the database default gets wrong).
+- The existing `recorded_at` default ordering is unchanged when no `order_by`
+  is passed.
+
+**Frontend**
+
+- A score renders as a rounded percentage; `null` renders as `—`.
+- Clicking the Score header issues the expected `order_by` / `order_direction`
+  query parameters.
+
+## Non-goals
+
+- No threshold filter. The queue pages already carry filters; adding a
+  "score above N" control is a separate decision, and while the column is
+  mostly NULL such a filter would empty a queue rather than narrow it.
+- No per-object score badge. The score belongs to one object of the alert, and
+  showing it per lane would imply otherwise (decided in #364).
+- No colour-coding or threshold emphasis. That would couple the UI to
+  `TEMPORAL_MODEL_THRESHOLD`, which lives in pyro-api config and can change
+  without the annotator knowing.
+
+## Deployment note
+
+The column is populated only for sequences imported after #364, so on
+production it reads `—` for nearly every row until a historical backfill is run
+with #365's refresh path. The feature is not broken in that state; it has no
+data yet.

--- a/frontend/src/components/sequences/ClassifyAlertQueueTable.tsx
+++ b/frontend/src/components/sequences/ClassifyAlertQueueTable.tsx
@@ -56,7 +56,17 @@ export function ClassifyAlertQueueTable({
             </th>
             <ColumnHeader label="Camera" tip="Camera that recorded the alert" />
             <ColumnHeader label="Organisation" tip="Organisation operating the camera" />
-            <ColumnHeader label="Recorded" tip="When the alert was recorded" />
+            <ColumnHeader
+              label="Recorded"
+              tip="When the alert was recorded"
+              sort={
+                sort && {
+                  active: sort.orderBy === 'recorded_at',
+                  direction: sort.orderDirection,
+                  onSort: () => sort.onSort('recorded_at'),
+                }
+              }
+            />
             <ColumnHeader label="Source" tip="Alert API the alert was imported from" />
             <ColumnHeader label="Azimuth" tip="Camera viewing direction, in degrees" />
             <ColumnHeader

--- a/frontend/src/components/sequences/ClassifyAlertQueueTable.tsx
+++ b/frontend/src/components/sequences/ClassifyAlertQueueTable.tsx
@@ -14,6 +14,7 @@ import {
   THEAD_CLASSES,
 } from './tableStyles';
 import { formatDateTime } from '@/utils/datetime';
+import { TemporalScoreCell } from '@/components/sequences/TemporalScoreCell';
 
 interface ClassifyAlertQueueTableProps {
   items: ClassifyQueueItem[];
@@ -50,6 +51,11 @@ export function ClassifyAlertQueueTable({
             <ColumnHeader label="Recorded" tip="When the alert was recorded" />
             <ColumnHeader label="Source" tip="Alert API the alert was imported from" />
             <ColumnHeader label="Azimuth" tip="Camera viewing direction, in degrees" />
+            <ColumnHeader
+              label="Score"
+              tip="Platform temporal-model confidence that this alert is smoke. — means the platform never scored it."
+              align="right"
+            />
             <ColumnHeader label="Objects" tip="Objects to classify in this alert" align="right" />
             <ColumnHeader
               label="Alert API annotation"
@@ -89,6 +95,9 @@ export function ClassifyAlertQueueTable({
               <td className={`${CELL_CLASSES} ${CELL_TEXT}`}>{item.source_api}</td>
               <td className={`${CELL_CLASSES} ${DATA_CELL_TEXT}`}>
                 {item.azimuth !== null && item.azimuth !== undefined ? `${item.azimuth}°` : ''}
+              </td>
+              <td className={`${CELL_CLASSES} ${DATA_CELL_TEXT}`}>
+                <TemporalScoreCell score={item.temporal_model_score} />
               </td>
               <td className={`${CELL_CLASSES} ${DATA_CELL_TEXT}`}>
                 {formatObjectsCell(item.total_objects, item.classified_objects)}

--- a/frontend/src/components/sequences/ClassifyAlertQueueTable.tsx
+++ b/frontend/src/components/sequences/ClassifyAlertQueueTable.tsx
@@ -15,6 +15,7 @@ import {
 } from './tableStyles';
 import { formatDateTime } from '@/utils/datetime';
 import { TemporalScoreCell } from '@/components/sequences/TemporalScoreCell';
+import type { QueueOrderBy } from '@/types/api';
 
 interface ClassifyAlertQueueTableProps {
   items: ClassifyQueueItem[];
@@ -22,6 +23,12 @@ interface ClassifyAlertQueueTableProps {
   /** Skipped-backlog mode: rows carry skip metadata + an Unskip action and are not clickable. */
   skippedView?: boolean;
   onUnskip?: (item: ClassifyQueueItem) => void;
+  /** When supplied, the Score header becomes a sort control. */
+  sort?: {
+    orderBy: QueueOrderBy;
+    orderDirection: 'asc' | 'desc';
+    onSort: (field: QueueOrderBy) => void;
+  };
 }
 
 // "3 · 1 classified"; drops the classified suffix when nothing is
@@ -37,6 +44,7 @@ export function ClassifyAlertQueueTable({
   onAlertClick,
   skippedView = false,
   onUnskip,
+  sort,
 }: ClassifyAlertQueueTableProps) {
   return (
     <div className="overflow-x-auto">
@@ -55,6 +63,13 @@ export function ClassifyAlertQueueTable({
               label="Score"
               tip="Platform temporal-model confidence that this alert is smoke. — means the platform never scored it."
               align="right"
+              sort={
+                sort && {
+                  active: sort.orderBy === 'temporal_model_score',
+                  direction: sort.orderDirection,
+                  onSort: () => sort.onSort('temporal_model_score'),
+                }
+              }
             />
             <ColumnHeader label="Objects" tip="Objects to classify in this alert" align="right" />
             <ColumnHeader

--- a/frontend/src/components/sequences/ClassifyAlertQueueTable.tsx
+++ b/frontend/src/components/sequences/ClassifyAlertQueueTable.tsx
@@ -61,7 +61,7 @@ export function ClassifyAlertQueueTable({
             <ColumnHeader label="Azimuth" tip="Camera viewing direction, in degrees" />
             <ColumnHeader
               label="Score"
-              tip="Platform temporal-model confidence that this alert is smoke. — means the platform never scored it."
+              tip="Alert API temporal-model confidence that this alert is smoke. — means the Alert API never scored it."
               align="right"
               sort={
                 sort && {

--- a/frontend/src/components/sequences/ClassifyDoneTable.tsx
+++ b/frontend/src/components/sequences/ClassifyDoneTable.tsx
@@ -72,7 +72,17 @@ export function ClassifyDoneTable({ items, onItemClick, sort }: ClassifyDoneTabl
             </th>
             <ColumnHeader label="Camera" tip="Camera that recorded the alert" />
             <ColumnHeader label="Organisation" tip="Organisation operating the camera" />
-            <ColumnHeader label="Recorded" tip="When the alert was recorded" />
+            <ColumnHeader
+              label="Recorded"
+              tip="When the alert was recorded"
+              sort={
+                sort && {
+                  active: sort.orderBy === 'recorded_at',
+                  direction: sort.orderDirection,
+                  onSort: () => sort.onSort('recorded_at'),
+                }
+              }
+            />
             <ColumnHeader label="Source" tip="Alert API the alert was imported from" />
             <ColumnHeader label="Azimuth" tip="Camera viewing direction, in degrees" />
             <ColumnHeader

--- a/frontend/src/components/sequences/ClassifyDoneTable.tsx
+++ b/frontend/src/components/sequences/ClassifyDoneTable.tsx
@@ -22,10 +22,17 @@ import {
 } from './tableStyles';
 import { formatDateTime } from '@/utils/datetime';
 import { TemporalScoreCell } from '@/components/sequences/TemporalScoreCell';
+import type { QueueOrderBy } from '@/types/api';
 
 interface ClassifyDoneTableProps {
   items: ClassifyDoneItem[];
   onItemClick: (item: ClassifyDoneItem) => void;
+  /** When supplied, the Score header becomes a sort control. */
+  sort?: {
+    orderBy: QueueOrderBy;
+    orderDirection: 'asc' | 'desc';
+    onSort: (field: QueueOrderBy) => void;
+  };
 }
 
 // Alert-level rollup over every lane: dominant outcome + count of the others.
@@ -54,7 +61,7 @@ function alertDetail(lanes: ClassifyDoneLane[]): string {
   return parts.join(' · ');
 }
 
-export function ClassifyDoneTable({ items, onItemClick }: ClassifyDoneTableProps) {
+export function ClassifyDoneTable({ items, onItemClick, sort }: ClassifyDoneTableProps) {
   return (
     <div className="overflow-x-auto">
       <table className={TABLE_CLASSES}>
@@ -72,6 +79,13 @@ export function ClassifyDoneTable({ items, onItemClick }: ClassifyDoneTableProps
               label="Score"
               tip="Platform temporal-model confidence that this alert is smoke. — means the platform never scored it."
               align="right"
+              sort={
+                sort && {
+                  active: sort.orderBy === 'temporal_model_score',
+                  direction: sort.orderDirection,
+                  onSort: () => sort.onSort('temporal_model_score'),
+                }
+              }
             />
             <ColumnHeader
               label="Alert API annotation"

--- a/frontend/src/components/sequences/ClassifyDoneTable.tsx
+++ b/frontend/src/components/sequences/ClassifyDoneTable.tsx
@@ -21,6 +21,7 @@ import {
   THEAD_CLASSES,
 } from './tableStyles';
 import { formatDateTime } from '@/utils/datetime';
+import { TemporalScoreCell } from '@/components/sequences/TemporalScoreCell';
 
 interface ClassifyDoneTableProps {
   items: ClassifyDoneItem[];
@@ -68,6 +69,11 @@ export function ClassifyDoneTable({ items, onItemClick }: ClassifyDoneTableProps
             <ColumnHeader label="Source" tip="Alert API the alert was imported from" />
             <ColumnHeader label="Azimuth" tip="Camera viewing direction, in degrees" />
             <ColumnHeader
+              label="Score"
+              tip="Platform temporal-model confidence that this alert is smoke. — means the platform never scored it."
+              align="right"
+            />
+            <ColumnHeader
               label="Alert API annotation"
               tip="Annotation reported by the alert platform"
             />
@@ -103,6 +109,9 @@ export function ClassifyDoneTable({ items, onItemClick }: ClassifyDoneTableProps
                 <td className={`${CELL_CLASSES} ${CELL_TEXT}`}>{item.source_api}</td>
                 <td className={`${CELL_CLASSES} ${DATA_CELL_TEXT}`}>
                   {item.azimuth !== null && item.azimuth !== undefined ? `${item.azimuth}°` : ''}
+                </td>
+                <td className={`${CELL_CLASSES} ${DATA_CELL_TEXT}`}>
+                  <TemporalScoreCell score={item.temporal_model_score} />
                 </td>
                 <td className={`${CELL_CLASSES} ${CELL_TEXT}`}>
                   <PlatformAnnotationLabel value={item.is_wildfire_alertapi} />

--- a/frontend/src/components/sequences/ClassifyDoneTable.tsx
+++ b/frontend/src/components/sequences/ClassifyDoneTable.tsx
@@ -77,7 +77,7 @@ export function ClassifyDoneTable({ items, onItemClick, sort }: ClassifyDoneTabl
             <ColumnHeader label="Azimuth" tip="Camera viewing direction, in degrees" />
             <ColumnHeader
               label="Score"
-              tip="Platform temporal-model confidence that this alert is smoke. — means the platform never scored it."
+              tip="Alert API temporal-model confidence that this alert is smoke. — means the Alert API never scored it."
               align="right"
               sort={
                 sort && {

--- a/frontend/src/components/sequences/LocalizeDoneQueueTable.tsx
+++ b/frontend/src/components/sequences/LocalizeDoneQueueTable.tsx
@@ -16,6 +16,7 @@ import {
   THEAD_CLASSES,
 } from './tableStyles';
 import { formatDateTime } from '@/utils/datetime';
+import { TemporalScoreCell } from '@/components/sequences/TemporalScoreCell';
 
 interface LocalizeDoneQueueTableProps {
   items: LocalizeDoneQueueItem[];
@@ -63,6 +64,11 @@ export function LocalizeDoneQueueTable({ items, onItemClick }: LocalizeDoneQueue
             <ColumnHeader label="Source" tip="Alert API the alert was imported from" />
             <ColumnHeader label="Azimuth" tip="Camera viewing direction, in degrees" />
             <ColumnHeader
+              label="Score"
+              tip="Platform temporal-model confidence that this alert is smoke. — means the platform never scored it."
+              align="right"
+            />
+            <ColumnHeader
               label="Objects"
               tip="Smoke objects localized in this alert"
               align="right"
@@ -98,6 +104,9 @@ export function LocalizeDoneQueueTable({ items, onItemClick }: LocalizeDoneQueue
                 <td className={`${CELL_CLASSES} ${CELL_TEXT}`}>{item.source_api}</td>
                 <td className={`${CELL_CLASSES} ${DATA_CELL_TEXT}`}>
                   {item.azimuth !== null && item.azimuth !== undefined ? `${item.azimuth}°` : ''}
+                </td>
+                <td className={`${CELL_CLASSES} ${DATA_CELL_TEXT}`}>
+                  <TemporalScoreCell score={item.temporal_model_score} />
                 </td>
                 <td className={`${CELL_CLASSES} ${DATA_CELL_TEXT}`}>{objectsCell(item)}</td>
                 <td className={CELL_CLASSES}>

--- a/frontend/src/components/sequences/LocalizeDoneQueueTable.tsx
+++ b/frontend/src/components/sequences/LocalizeDoneQueueTable.tsx
@@ -17,10 +17,17 @@ import {
 } from './tableStyles';
 import { formatDateTime } from '@/utils/datetime';
 import { TemporalScoreCell } from '@/components/sequences/TemporalScoreCell';
+import type { QueueOrderBy } from '@/types/api';
 
 interface LocalizeDoneQueueTableProps {
   items: LocalizeDoneQueueItem[];
   onItemClick: (item: LocalizeDoneQueueItem) => void;
+  /** When supplied, the Score header becomes a sort control. */
+  sort?: {
+    orderBy: QueueOrderBy;
+    orderDirection: 'asc' | 'desc';
+    onSort: (field: QueueOrderBy) => void;
+  };
 }
 
 // The alert's smoke objects (smoke or missed smoke, not unsure) — the ones
@@ -49,7 +56,7 @@ function alertOutcome(item: LocalizeDoneQueueItem) {
   );
 }
 
-export function LocalizeDoneQueueTable({ items, onItemClick }: LocalizeDoneQueueTableProps) {
+export function LocalizeDoneQueueTable({ items, onItemClick, sort }: LocalizeDoneQueueTableProps) {
   return (
     <div className="overflow-x-auto">
       <table className={TABLE_CLASSES}>
@@ -67,6 +74,13 @@ export function LocalizeDoneQueueTable({ items, onItemClick }: LocalizeDoneQueue
               label="Score"
               tip="Platform temporal-model confidence that this alert is smoke. — means the platform never scored it."
               align="right"
+              sort={
+                sort && {
+                  active: sort.orderBy === 'temporal_model_score',
+                  direction: sort.orderDirection,
+                  onSort: () => sort.onSort('temporal_model_score'),
+                }
+              }
             />
             <ColumnHeader
               label="Objects"

--- a/frontend/src/components/sequences/LocalizeDoneQueueTable.tsx
+++ b/frontend/src/components/sequences/LocalizeDoneQueueTable.tsx
@@ -67,7 +67,17 @@ export function LocalizeDoneQueueTable({ items, onItemClick, sort }: LocalizeDon
             </th>
             <ColumnHeader label="Camera" tip="Camera that recorded the alert" />
             <ColumnHeader label="Organisation" tip="Organisation operating the camera" />
-            <ColumnHeader label="Recorded" tip="When the alert was recorded" />
+            <ColumnHeader
+              label="Recorded"
+              tip="When the alert was recorded"
+              sort={
+                sort && {
+                  active: sort.orderBy === 'recorded_at',
+                  direction: sort.orderDirection,
+                  onSort: () => sort.onSort('recorded_at'),
+                }
+              }
+            />
             <ColumnHeader label="Source" tip="Alert API the alert was imported from" />
             <ColumnHeader label="Azimuth" tip="Camera viewing direction, in degrees" />
             <ColumnHeader

--- a/frontend/src/components/sequences/LocalizeDoneQueueTable.tsx
+++ b/frontend/src/components/sequences/LocalizeDoneQueueTable.tsx
@@ -72,7 +72,7 @@ export function LocalizeDoneQueueTable({ items, onItemClick, sort }: LocalizeDon
             <ColumnHeader label="Azimuth" tip="Camera viewing direction, in degrees" />
             <ColumnHeader
               label="Score"
-              tip="Platform temporal-model confidence that this alert is smoke. — means the platform never scored it."
+              tip="Alert API temporal-model confidence that this alert is smoke. — means the Alert API never scored it."
               align="right"
               sort={
                 sort && {

--- a/frontend/src/components/sequences/LocalizeQueueTable.tsx
+++ b/frontend/src/components/sequences/LocalizeQueueTable.tsx
@@ -17,6 +17,7 @@ import {
 } from './tableStyles';
 import { formatDateTime } from '@/utils/datetime';
 import { TemporalScoreCell } from '@/components/sequences/TemporalScoreCell';
+import type { QueueOrderBy } from '@/types/api';
 
 interface LocalizeQueueTableProps {
   items: LocalizationQueueItem[];
@@ -24,6 +25,12 @@ interface LocalizeQueueTableProps {
   /** Skipped-backlog mode: rows carry skip metadata + an Unskip action and are not clickable. */
   skippedView?: boolean;
   onUnskip?: (item: LocalizationQueueItem) => void;
+  /** When supplied, the Score header becomes a sort control. */
+  sort?: {
+    orderBy: QueueOrderBy;
+    orderDirection: 'asc' | 'desc';
+    onSort: (field: QueueOrderBy) => void;
+  };
 }
 
 // Objects the annotator will draw boxes on (smoke or missed smoke, not unsure).
@@ -63,6 +70,7 @@ export function LocalizeQueueTable({
   onItemClick,
   skippedView = false,
   onUnskip,
+  sort,
 }: LocalizeQueueTableProps) {
   return (
     <div className="overflow-x-auto">
@@ -81,6 +89,13 @@ export function LocalizeQueueTable({
               label="Score"
               tip="Platform temporal-model confidence that this alert is smoke. — means the platform never scored it."
               align="right"
+              sort={
+                sort && {
+                  active: sort.orderBy === 'temporal_model_score',
+                  direction: sort.orderDirection,
+                  onSort: () => sort.onSort('temporal_model_score'),
+                }
+              }
             />
             <ColumnHeader label="Smoke types" tip="Smoke types assigned during classification" />
             <ColumnHeader

--- a/frontend/src/components/sequences/LocalizeQueueTable.tsx
+++ b/frontend/src/components/sequences/LocalizeQueueTable.tsx
@@ -82,7 +82,17 @@ export function LocalizeQueueTable({
             </th>
             <ColumnHeader label="Camera" tip="Camera that recorded the alert" />
             <ColumnHeader label="Organisation" tip="Organisation operating the camera" />
-            <ColumnHeader label="Recorded" tip="When the alert was recorded" />
+            <ColumnHeader
+              label="Recorded"
+              tip="When the alert was recorded"
+              sort={
+                sort && {
+                  active: sort.orderBy === 'recorded_at',
+                  direction: sort.orderDirection,
+                  onSort: () => sort.onSort('recorded_at'),
+                }
+              }
+            />
             <ColumnHeader label="Source" tip="Alert API the alert was imported from" />
             <ColumnHeader label="Azimuth" tip="Camera viewing direction, in degrees" />
             <ColumnHeader

--- a/frontend/src/components/sequences/LocalizeQueueTable.tsx
+++ b/frontend/src/components/sequences/LocalizeQueueTable.tsx
@@ -16,6 +16,7 @@ import {
   THEAD_CLASSES,
 } from './tableStyles';
 import { formatDateTime } from '@/utils/datetime';
+import { TemporalScoreCell } from '@/components/sequences/TemporalScoreCell';
 
 interface LocalizeQueueTableProps {
   items: LocalizationQueueItem[];
@@ -76,6 +77,11 @@ export function LocalizeQueueTable({
             <ColumnHeader label="Recorded" tip="When the alert was recorded" />
             <ColumnHeader label="Source" tip="Alert API the alert was imported from" />
             <ColumnHeader label="Azimuth" tip="Camera viewing direction, in degrees" />
+            <ColumnHeader
+              label="Score"
+              tip="Platform temporal-model confidence that this alert is smoke. — means the platform never scored it."
+              align="right"
+            />
             <ColumnHeader label="Smoke types" tip="Smoke types assigned during classification" />
             <ColumnHeader
               label="Objects"
@@ -127,6 +133,9 @@ export function LocalizeQueueTable({
                 <td className={`${CELL_CLASSES} ${CELL_TEXT}`}>{item.source_api}</td>
                 <td className={`${CELL_CLASSES} ${DATA_CELL_TEXT}`}>
                   {item.azimuth !== null && item.azimuth !== undefined ? `${item.azimuth}°` : ''}
+                </td>
+                <td className={`${CELL_CLASSES} ${DATA_CELL_TEXT}`}>
+                  <TemporalScoreCell score={item.temporal_model_score} />
                 </td>
                 <td className={`${CELL_CLASSES} ${CELL_TEXT}`}>
                   {smokeTypes(item).map(formatSmokeType).join(', ')}

--- a/frontend/src/components/sequences/LocalizeQueueTable.tsx
+++ b/frontend/src/components/sequences/LocalizeQueueTable.tsx
@@ -87,7 +87,7 @@ export function LocalizeQueueTable({
             <ColumnHeader label="Azimuth" tip="Camera viewing direction, in degrees" />
             <ColumnHeader
               label="Score"
-              tip="Platform temporal-model confidence that this alert is smoke. — means the platform never scored it."
+              tip="Alert API temporal-model confidence that this alert is smoke. — means the Alert API never scored it."
               align="right"
               sort={
                 sort && {

--- a/frontend/src/components/sequences/TemporalScoreCell.tsx
+++ b/frontend/src/components/sequences/TemporalScoreCell.tsx
@@ -1,0 +1,20 @@
+interface TemporalScoreCellProps {
+  score: number | null | undefined;
+}
+
+/**
+ * The alert's platform temporal-model score, as a percentage.
+ *
+ * Null means the platform never scored the alert — distinct from a score of
+ * zero, which is a real verdict. The check is `== null` rather than a
+ * truthiness test precisely so 0 renders as "0%".
+ *
+ * The dash carries no colour class of its own: the enclosing cell already
+ * applies DATA_CELL_TEXT, so it inherits the muted treatment of its peers.
+ */
+export function TemporalScoreCell({ score }: TemporalScoreCellProps) {
+  if (score == null) {
+    return <span title="Not scored by the platform">—</span>;
+  }
+  return <span>{Math.round(score * 100)}%</span>;
+}

--- a/frontend/src/components/sequences/TemporalScoreCell.tsx
+++ b/frontend/src/components/sequences/TemporalScoreCell.tsx
@@ -3,9 +3,9 @@ interface TemporalScoreCellProps {
 }
 
 /**
- * The alert's platform temporal-model score, as a percentage.
+ * The Alert API's temporal-model score for this alert, as a percentage.
  *
- * Null means the platform never scored the alert — distinct from a score of
+ * Null means the Alert API never scored the alert — distinct from a score of
  * zero, which is a real verdict. The check is `== null` rather than a
  * truthiness test precisely so 0 renders as "0%".
  *
@@ -14,7 +14,7 @@ interface TemporalScoreCellProps {
  */
 export function TemporalScoreCell({ score }: TemporalScoreCellProps) {
   if (score == null) {
-    return <span title="Not scored by the platform">—</span>;
+    return <span title="Not scored by the Alert API">—</span>;
   }
   return <span>{Math.round(score * 100)}%</span>;
 }

--- a/frontend/src/pages/ClassifyAlertPage.tsx
+++ b/frontend/src/pages/ClassifyAlertPage.tsx
@@ -881,7 +881,15 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
         // ready_to_annotate), but guard against it anyway.
         if (mode !== 'done') {
           try {
-            const queue = await apiClient.getClassifyQueue({ page: 1, size: 2 });
+            const queue = await apiClient.getClassifyQueue({
+              page: 1,
+              size: 2,
+              // Match the queue page's ordering, or continuous flow
+              // silently advances by recency while the annotator is
+              // working a score-ordered queue.
+              order_by: 'temporal_model_score',
+              order_direction: 'desc',
+            });
             // The user may have navigated elsewhere while the lookup was in
             // flight (unmount / alert switch reset the flag) — don't yank
             // them into another alert.
@@ -941,7 +949,15 @@ export default function ClassifyAlertPage({ mode }: ClassifyAlertPageProps = {})
       // Same continuous flow as the post-submit advance, but immediate: pull
       // the next alert from the queue, else fall back to the list.
       try {
-        const queue = await apiClient.getClassifyQueue({ page: 1, size: 2 });
+        const queue = await apiClient.getClassifyQueue({
+          page: 1,
+          size: 2,
+          // Match the queue page's ordering, or continuous flow
+          // silently advances by recency while the annotator is
+          // working a score-ordered queue.
+          order_by: 'temporal_model_score',
+          order_direction: 'desc',
+        });
         const next = queue.items.find(item => item.primary_sequence_id !== sequenceId);
         if (next) {
           clearAnnotationWorkflow();

--- a/frontend/src/pages/DetectionAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionAnnotatePage.tsx
@@ -32,6 +32,9 @@ export default function DetectionAnnotatePage() {
       setOrderBy(field);
       setOrderDirection('desc');
     }
+    // Back to the first page: re-sorting to surface the top alerts is
+    // pointless if the viewer stays on page 4 of the new ordering.
+    setPage(1);
   };
 
   const { data, isLoading, error } = useQuery({

--- a/frontend/src/pages/DetectionAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionAnnotatePage.tsx
@@ -10,6 +10,7 @@ import { TABLE_CARD_CLASSES } from '@/components/sequences/tableStyles';
 import { pickNextLocalizeLane } from '@/utils/annotation/localizeUtils';
 import { localizeDetail, ROUTES } from '@/utils/routes';
 import { QUEUE_COUNTS_KEY } from '@/hooks/useQueueTotals';
+import type { QueueOrderBy } from '@/types/api';
 
 export default function DetectionAnnotatePage() {
   const navigate = useNavigate();
@@ -19,9 +20,30 @@ export default function DetectionAnnotatePage() {
   // persisted — the backlog is a place to visit, not a mode to stay in.
   const [showSkipped, setShowSkipped] = useState(false);
 
+  // The localize work queue leads with the platform's temporal score so the
+  // most likely fires are localized first.
+  const [orderBy, setOrderBy] = useState<QueueOrderBy>('temporal_model_score');
+  const [orderDirection, setOrderDirection] = useState<'asc' | 'desc'>('desc');
+
+  const handleSort = (field: QueueOrderBy) => {
+    if (field === orderBy) {
+      setOrderDirection(d => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setOrderBy(field);
+      setOrderDirection('desc');
+    }
+  };
+
   const { data, isLoading, error } = useQuery({
-    queryKey: ['localization-queue', page, showSkipped],
-    queryFn: () => apiClient.getLocalizationQueue({ page, size: 50, skipped: showSkipped }),
+    queryKey: ['localization-queue', page, showSkipped, orderBy, orderDirection],
+    queryFn: () =>
+      apiClient.getLocalizationQueue({
+        page,
+        size: 50,
+        skipped: showSkipped,
+        order_by: orderBy,
+        order_direction: orderDirection,
+      }),
   });
 
   // Count for the "Skipped (n)" toggle label, independent of the view shown.
@@ -149,6 +171,7 @@ export default function DetectionAnnotatePage() {
           <LocalizeQueueTable
             items={items}
             onItemClick={handleAlertClick}
+            sort={{ orderBy, orderDirection, onSort: handleSort }}
             skippedView={showSkipped}
             onUnskip={item => unskipMutation.mutate(item)}
           />

--- a/frontend/src/pages/DetectionReviewPage.tsx
+++ b/frontend/src/pages/DetectionReviewPage.tsx
@@ -103,6 +103,9 @@ export default function DetectionReviewPage() {
       setOrderBy(field);
       setOrderDirection('desc');
     }
+    // Back to the first page: re-sorting to surface the top alerts is
+    // pointless if the viewer stays on page 4 of the new ordering.
+    setFilters({ ...filters, page: 1 });
   };
 
   // Alert-grouped localize-done queue — one row per alert.

--- a/frontend/src/pages/DetectionReviewPage.tsx
+++ b/frontend/src/pages/DetectionReviewPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link, useNavigate } from 'react-router-dom';
 import { BoxSelect, Search } from 'lucide-react';
@@ -15,6 +16,7 @@ import { usePersistedFilters, createDefaultFilterState } from '@/hooks/usePersis
 import { calculatePresetDateRange } from '@/components/filters/shared/dateRangeUtils';
 import { hasActiveUserFilters } from '@/utils/filterHelpers';
 import { localizeDetail, ROUTES } from '@/utils/routes';
+import type { QueueOrderBy } from '@/types/api';
 
 // Default filter contract for /localize/done — imported by its defaults test.
 // Membership (which alerts qualify) is entirely server-side now, via
@@ -89,9 +91,23 @@ export default function DetectionReviewPage() {
     handleFilterChange({ recorded_at_lte: dateTimeValue });
   };
 
+  // The done list stays chronological by default — recency is what you look
+  // for when reviewing finished work — but the Score column is still sortable.
+  const [orderBy, setOrderBy] = useState<QueueOrderBy>('recorded_at');
+  const [orderDirection, setOrderDirection] = useState<'asc' | 'desc'>('desc');
+
+  const handleSort = (field: QueueOrderBy) => {
+    if (field === orderBy) {
+      setOrderDirection(d => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setOrderBy(field);
+      setOrderDirection('desc');
+    }
+  };
+
   // Alert-grouped localize-done queue — one row per alert.
   const { data, isLoading, error } = useQuery({
-    queryKey: ['localize-done-queue', filters],
+    queryKey: ['localize-done-queue', filters, orderBy, orderDirection],
     queryFn: () =>
       apiClient.getLocalizeDoneQueue({
         page: filters.page,
@@ -103,6 +119,8 @@ export default function DetectionReviewPage() {
         recorded_at_lte: filters.recorded_at_lte,
         is_wildfire_alertapi: filters.is_wildfire_alertapi,
         annotator_id: filters.annotator_id,
+        order_by: orderBy,
+        order_direction: orderDirection,
       }),
   });
 
@@ -314,7 +332,11 @@ export default function DetectionReviewPage() {
       {/* Results */}
       {data && (
         <div className={TABLE_CARD_CLASSES}>
-          <LocalizeDoneQueueTable items={items} onItemClick={handleAlertClick} />
+          <LocalizeDoneQueueTable
+            items={items}
+            onItemClick={handleAlertClick}
+            sort={{ orderBy, orderDirection, onSort: handleSort }}
+          />
 
           <TablePagination
             page={data.page}

--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -81,6 +81,9 @@ export default function SequencesPage({
       setQueueOrderBy(field);
       setQueueOrderDirection('desc');
     }
+    // Back to the first page: re-sorting to surface the top alerts is
+    // pointless if the viewer stays on page 4 of the new ordering.
+    setFilters({ ...filters, page: 1 });
   };
 
   // Storage key separates done vs queue filters; done filters are shared across stages.

--- a/frontend/src/pages/SequencesPage.tsx
+++ b/frontend/src/pages/SequencesPage.tsx
@@ -20,6 +20,7 @@ import {
   TablePagination,
 } from '@/components/sequences';
 import { TABLE_CARD_CLASSES } from '@/components/sequences/tableStyles';
+import type { QueueOrderBy } from '@/types/api';
 import { useSequenceStore } from '@/store/useSequenceStore';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useCameras } from '@/hooks/useCameras';
@@ -64,6 +65,23 @@ export default function SequencesPage({
   // The classify queue (alert-grouped, one row per alert) replaces the plain
   // sequences fetch/table only on the un-annotated queue page.
   const isQueueMode = !isAnnotatedView && !isReviewPage;
+
+  // Alert-grouped queue ordering. The work queue leads with the platform's
+  // temporal score so the most likely fires are triaged first; the done list
+  // stays chronological, where recency is what you are looking for.
+  const [queueOrderBy, setQueueOrderBy] = useState<QueueOrderBy>(
+    isQueueMode ? 'temporal_model_score' : 'recorded_at'
+  );
+  const [queueOrderDirection, setQueueOrderDirection] = useState<'asc' | 'desc'>('desc');
+
+  const handleQueueSort = (field: QueueOrderBy) => {
+    if (field === queueOrderBy) {
+      setQueueOrderDirection(d => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setQueueOrderBy(field);
+      setQueueOrderDirection('desc');
+    }
+  };
 
   // Storage key separates done vs queue filters; done filters are shared across stages.
   const storageKey = isReviewPage ? 'filters-classify-done' : 'filters-classify';
@@ -158,15 +176,27 @@ export default function SequencesPage({
     isLoading: classifyDoneLoading,
     error: classifyDoneError,
   } = useQuery({
-    queryKey: ['classify-done', apiFilters, selectedModelAccuracy],
+    queryKey: [
+      'classify-done',
+      apiFilters,
+      selectedModelAccuracy,
+      queueOrderBy,
+      queueOrderDirection,
+    ],
     queryFn: () => {
       // processing_stage is a sequences-endpoint concept; classify-done's
       // membership (fully classified) replaces it.
       const rest = { ...apiFilters };
       delete rest.processing_stage;
+      // The sequences-list ordering ('created_at') is not a column of the
+      // alert-grouped subquery; leaking it here would 422 the request.
+      delete rest.order_by;
+      delete rest.order_direction;
       return apiClient.getClassifyDone({
         ...rest,
         model_accuracy: MODEL_ACCURACY_PARAM[selectedModelAccuracy],
+        order_by: queueOrderBy,
+        order_direction: queueOrderDirection,
       });
     },
     enabled: !isQueueMode,
@@ -179,8 +209,19 @@ export default function SequencesPage({
     isLoading: classifyQueueLoading,
     error: classifyQueueError,
   } = useQuery({
-    queryKey: ['classify-queue', apiFilters, showSkipped],
-    queryFn: () => apiClient.getClassifyQueue({ ...apiFilters, skipped: showSkipped }),
+    queryKey: ['classify-queue', apiFilters, showSkipped, queueOrderBy, queueOrderDirection],
+    queryFn: () => {
+      const rest = { ...apiFilters };
+      // See getClassifyDone above: 'created_at' is not orderable here.
+      delete rest.order_by;
+      delete rest.order_direction;
+      return apiClient.getClassifyQueue({
+        ...rest,
+        skipped: showSkipped,
+        order_by: queueOrderBy,
+        order_direction: queueOrderDirection,
+      });
+    },
     enabled: isQueueMode,
   });
 
@@ -538,6 +579,11 @@ export default function SequencesPage({
               <ClassifyAlertQueueTable
                 items={classifyQueue.items}
                 onAlertClick={handleAlertClick}
+                sort={{
+                  orderBy: queueOrderBy,
+                  orderDirection: queueOrderDirection,
+                  onSort: handleQueueSort,
+                }}
                 skippedView={showSkipped}
                 onUnskip={item => unskipMutation.mutate(item)}
               />
@@ -553,7 +599,15 @@ export default function SequencesPage({
           )
         : classifyDone && (
             <div className={TABLE_CARD_CLASSES}>
-              <ClassifyDoneTable items={classifyDone.items} onItemClick={handleDoneClick} />
+              <ClassifyDoneTable
+                items={classifyDone.items}
+                onItemClick={handleDoneClick}
+                sort={{
+                  orderBy: queueOrderBy,
+                  orderDirection: queueOrderDirection,
+                  onSort: handleQueueSort,
+                }}
+              />
 
               <TablePagination
                 page={classifyDone.page}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -31,6 +31,7 @@ import {
   SmokeType,
   AnnotationType,
   ClassifyQueueItem,
+  QueueOrderBy,
   ClassifyDoneItem,
   ClassifySubmitRequest,
   ClassifySubmitResponse,
@@ -188,7 +189,13 @@ class ApiClient {
 
   // Alerts ready for smoke localization (alert-grouped Localize queue)
   async getLocalizationQueue(
-    params: { page?: number; size?: number; skipped?: boolean } = {}
+    params: {
+      page?: number;
+      size?: number;
+      skipped?: boolean;
+      order_by?: QueueOrderBy;
+      order_direction?: 'asc' | 'desc';
+    } = {}
   ): Promise<PaginatedResponse<LocalizationQueueItem>> {
     const response: AxiosResponse<PaginatedResponse<LocalizationQueueItem>> = await this.client.get(
       `${API_ENDPOINTS.SEQUENCES}localization-queue`,
@@ -275,6 +282,8 @@ class ApiClient {
       recorded_at_lte?: string;
       is_wildfire_alertapi?: AnnotationType | 'null' | null;
       skipped?: boolean;
+      order_by?: QueueOrderBy;
+      order_direction?: 'asc' | 'desc';
     } = {}
   ): Promise<PaginatedResponse<ClassifyQueueItem>> {
     const response: AxiosResponse<PaginatedResponse<ClassifyQueueItem>> = await this.client.get(
@@ -296,6 +305,8 @@ class ApiClient {
       recorded_at_lte?: string;
       is_wildfire_alertapi?: AnnotationType | 'null' | null;
       annotator_id?: number;
+      order_by?: QueueOrderBy;
+      order_direction?: 'asc' | 'desc';
     } = {}
   ): Promise<PaginatedResponse<LocalizeDoneQueueItem>> {
     const response: AxiosResponse<PaginatedResponse<LocalizeDoneQueueItem>> = await this.client.get(
@@ -321,6 +332,8 @@ class ApiClient {
       is_unsure?: boolean;
       model_accuracy?: 'tp' | 'fp' | 'fn';
       annotator_id?: number;
+      order_by?: QueueOrderBy;
+      order_direction?: 'asc' | 'desc';
     } = {}
   ): Promise<PaginatedResponse<ClassifyDoneItem>> {
     const response: AxiosResponse<PaginatedResponse<ClassifyDoneItem>> = await this.client.get(

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -58,6 +58,7 @@ export interface LocalizationQueueItem {
   organisation_name: string;
   azimuth: number | null;
   recorded_at: string;
+  temporal_model_score: number | null;
   lanes: LocalizationQueueLane[];
   skip?: AlertSkipInfo | null;
 }
@@ -71,6 +72,7 @@ export interface LocalizeDoneQueueItem {
   organisation_name: string;
   azimuth: number | null;
   recorded_at: string;
+  temporal_model_score: number | null;
   lanes: LocalizationQueueLane[];
   annotators: string[];
 }
@@ -99,6 +101,7 @@ export interface ClassifyQueueItem {
   organisation_name: string;
   azimuth: number | null;
   recorded_at: string;
+  temporal_model_score: number | null;
   is_wildfire_alertapi: AnnotationType | null;
   primary_sequence_id: number;
   total_objects: number;
@@ -124,6 +127,7 @@ export interface ClassifyDoneItem {
   organisation_name: string;
   azimuth: number | null;
   recorded_at: string;
+  temporal_model_score: number | null;
   is_wildfire_alertapi: AnnotationType | null;
   primary_sequence_id: number;
   lanes: ClassifyDoneLane[];

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -93,6 +93,9 @@ export interface AlertDetail {
   lanes: AlertLane[];
 }
 
+// Orderable columns of the alert-grouped queue endpoints.
+export type QueueOrderBy = 'recorded_at' | 'temporal_model_score';
+
 // One alert ready for classification (queue row).
 export interface ClassifyQueueItem {
   source_api: string;

--- a/frontend/tests/components/sequences/ClassifyAlertQueueTable.test.tsx
+++ b/frontend/tests/components/sequences/ClassifyAlertQueueTable.test.tsx
@@ -22,6 +22,7 @@ const createItem = (overrides: Partial<ClassifyQueueItem> = {}): ClassifyQueueIt
   organisation_name: 'Test Org',
   azimuth: 180,
   recorded_at: '2024-01-01T10:00:00Z',
+  temporal_model_score: 0.42,
   is_wildfire_alertapi: 'wildfire_smoke',
   primary_sequence_id: 1,
   total_objects: 3,
@@ -219,6 +220,23 @@ describe('ClassifyAlertQueueTable', () => {
 
       expect(screen.queryByText('Skipped')).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Unskip' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('temporal score column', () => {
+    it('renders the alert score as a percentage', () => {
+      render(<ClassifyAlertQueueTable items={[createItem()]} onAlertClick={onAlertClick} />);
+      expect(screen.getByText('42%')).toBeInTheDocument();
+    });
+
+    it('renders the not-scored placeholder when the alert has no score', () => {
+      render(
+        <ClassifyAlertQueueTable
+          items={[createItem({ temporal_model_score: null })]}
+          onAlertClick={onAlertClick}
+        />
+      );
+      expect(screen.getByTitle('Not scored by the platform')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/tests/components/sequences/ClassifyAlertQueueTable.test.tsx
+++ b/frontend/tests/components/sequences/ClassifyAlertQueueTable.test.tsx
@@ -236,7 +236,7 @@ describe('ClassifyAlertQueueTable', () => {
           onAlertClick={onAlertClick}
         />
       );
-      expect(screen.getByTitle('Not scored by the platform')).toBeInTheDocument();
+      expect(screen.getByTitle('Not scored by the Alert API')).toBeInTheDocument();
     });
 
     it('calls onSort with the score field when the Score header is clicked', () => {

--- a/frontend/tests/components/sequences/ClassifyAlertQueueTable.test.tsx
+++ b/frontend/tests/components/sequences/ClassifyAlertQueueTable.test.tsx
@@ -238,5 +238,35 @@ describe('ClassifyAlertQueueTable', () => {
       );
       expect(screen.getByTitle('Not scored by the platform')).toBeInTheDocument();
     });
+
+    it('calls onSort with the score field when the Score header is clicked', () => {
+      const onSort = vi.fn();
+      render(
+        <ClassifyAlertQueueTable
+          items={[createItem()]}
+          onAlertClick={onAlertClick}
+          sort={{ orderBy: 'recorded_at', orderDirection: 'desc', onSort }}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: /score/i }));
+      expect(onSort).toHaveBeenCalledWith('temporal_model_score');
+    });
+
+    it('marks the Score column as sorted when it is the active field', () => {
+      render(
+        <ClassifyAlertQueueTable
+          items={[createItem()]}
+          onAlertClick={onAlertClick}
+          sort={{ orderBy: 'temporal_model_score', orderDirection: 'desc', onSort: vi.fn() }}
+        />
+      );
+      const header = screen.getByRole('columnheader', { name: /score/i });
+      expect(header).toHaveAttribute('aria-sort', 'descending');
+    });
+
+    it('leaves the Score header inert when no sort prop is supplied', () => {
+      render(<ClassifyAlertQueueTable items={[createItem()]} onAlertClick={onAlertClick} />);
+      expect(screen.queryByRole('button', { name: /score/i })).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/tests/components/sequences/ClassifyAlertQueueTable.test.tsx
+++ b/frontend/tests/components/sequences/ClassifyAlertQueueTable.test.tsx
@@ -268,5 +268,20 @@ describe('ClassifyAlertQueueTable', () => {
       render(<ClassifyAlertQueueTable items={[createItem()]} onAlertClick={onAlertClick} />);
       expect(screen.queryByRole('button', { name: /score/i })).not.toBeInTheDocument();
     });
+
+    it('keeps Recorded sortable so the chronological default stays reachable', () => {
+      // The work queues default to score; if Recorded were inert there would
+      // be no way back to recorded_at ordering from the UI at all.
+      const onSort = vi.fn();
+      render(
+        <ClassifyAlertQueueTable
+          items={[createItem()]}
+          onAlertClick={onAlertClick}
+          sort={{ orderBy: 'temporal_model_score', orderDirection: 'desc', onSort }}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: /recorded/i }));
+      expect(onSort).toHaveBeenCalledWith('recorded_at');
+    });
   });
 });

--- a/frontend/tests/components/sequences/ClassifyDoneTable.test.tsx
+++ b/frontend/tests/components/sequences/ClassifyDoneTable.test.tsx
@@ -32,6 +32,7 @@ const createItem = (overrides: Partial<ClassifyDoneItem> = {}): ClassifyDoneItem
   organisation_name: 'Test Org',
   azimuth: 180,
   recorded_at: '2024-01-01T10:00:00Z',
+  temporal_model_score: 0.42,
   is_wildfire_alertapi: 'wildfire_smoke',
   primary_sequence_id: 1,
   lanes: [createLane()],

--- a/frontend/tests/components/sequences/LocalizeDoneQueueTable.test.tsx
+++ b/frontend/tests/components/sequences/LocalizeDoneQueueTable.test.tsx
@@ -38,6 +38,7 @@ const createItem = (
   organisation_name: 'Test Org',
   azimuth: 180,
   recorded_at: '2024-01-01T10:00:00Z',
+  temporal_model_score: 0.42,
   lanes: [createLane()],
   annotators: [],
   ...overrides,

--- a/frontend/tests/components/sequences/LocalizeQueueTable.test.tsx
+++ b/frontend/tests/components/sequences/LocalizeQueueTable.test.tsx
@@ -36,6 +36,7 @@ const createItem = (overrides: Partial<LocalizationQueueItem> = {}): Localizatio
   organisation_name: 'Test Org',
   azimuth: 180,
   recorded_at: '2024-01-01T10:00:00Z',
+  temporal_model_score: null,
   lanes: [createLane()],
   ...overrides,
 });

--- a/frontend/tests/components/sequences/TemporalScoreCell.test.tsx
+++ b/frontend/tests/components/sequences/TemporalScoreCell.test.tsx
@@ -21,12 +21,12 @@ describe('TemporalScoreCell', () => {
 
   it('renders a dash with an explanation when the score is null', () => {
     render(<TemporalScoreCell score={null} />);
-    const cell = screen.getByTitle('Not scored by the platform');
+    const cell = screen.getByTitle('Not scored by the Alert API');
     expect(cell).toHaveTextContent('—');
   });
 
   it('treats undefined the same as null', () => {
     render(<TemporalScoreCell score={undefined} />);
-    expect(screen.getByTitle('Not scored by the platform')).toHaveTextContent('—');
+    expect(screen.getByTitle('Not scored by the Alert API')).toHaveTextContent('—');
   });
 });

--- a/frontend/tests/components/sequences/TemporalScoreCell.test.tsx
+++ b/frontend/tests/components/sequences/TemporalScoreCell.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * Tests for TemporalScoreCell: percentage formatting and the not-scored
+ * placeholder. An empty cell would be indistinguishable from a bug, which
+ * matters while most alerts predate score capture.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TemporalScoreCell } from '@/components/sequences/TemporalScoreCell';
+
+describe('TemporalScoreCell', () => {
+  it('renders a score as a rounded percentage', () => {
+    render(<TemporalScoreCell score={0.8712} />);
+    expect(screen.getByText('87%')).toBeInTheDocument();
+  });
+
+  it('renders an exact zero as 0%, not as not-scored', () => {
+    render(<TemporalScoreCell score={0} />);
+    expect(screen.getByText('0%')).toBeInTheDocument();
+  });
+
+  it('renders a dash with an explanation when the score is null', () => {
+    render(<TemporalScoreCell score={null} />);
+    const cell = screen.getByTitle('Not scored by the platform');
+    expect(cell).toHaveTextContent('—');
+  });
+
+  it('treats undefined the same as null', () => {
+    render(<TemporalScoreCell score={undefined} />);
+    expect(screen.getByTitle('Not scored by the platform')).toHaveTextContent('—');
+  });
+});


### PR DESCRIPTION
Adds the alert's platform temporal-model score to the classify and localize lists as a sortable percentage column, and leads the two work queues with it so the most likely fires are triaged first.

Spec: `docs/specs/2026-08-10-queue-temporal-score-design.md`. Follows #364 (capture) and #365 (backfill).

## The aggregate is exact, not a heuristic

Each of the four alert-grouped endpoints gains one aggregate:

```python
func.max(Sequence.temporal_model_score).label("temporal_model_score"),
```

`MAX` *is* the alert's score rather than an approximation, because only the primary lane ever carries one — object-split siblings are NULL by construction (#364) — and `MAX` ignores NULLs. So no join is needed to identify the primary, including on `LocalizationQueueItem` / `LocalizeDoneQueueItem`, which carry no `primary_sequence_id`.

This depends on that invariant. If a sibling were ever allowed to hold a score, `MAX` would silently start returning the larger of the two.

## Sorting

`order_by` (`recorded_at` default | `temporal_model_score`) and `order_direction` (`desc` default) on all four endpoints.

**NULLs sort last in both directions**, explicitly via `.nullslast()`. Postgres orders NULLs *first* on `DESC`, so a plain descending sort would fill the top of a "most likely fires first" queue with alerts the platform never scored — exactly backwards. Semantically an unscored alert is unmeasured, not low-confidence, so it belongs at the bottom either way.

**Every ordering now ends in `platform_alert_id`.** Scores tie constantly and are entirely NULL before a historical backfill, so a score-ordered queue had no deterministic row order and paginating it could repeat or skip alerts. `classify-done` already did this; the other three didn't. Making score the default turned that latent flaw into an everyday one.

## Default ordering

The two **work queues** default to score descending; the two **done lists** stay chronological, where recency is what you want.

That default lives in the **frontend page state, not the API**. The endpoints still default to `recorded_at`, so other consumers are unaffected and the "default ordering unchanged" test stays honest.

## Frontend

A right-aligned `Score` column via a shared `TemporalScoreCell`, reusing the existing sortable `ColumnHeader` and the `orderBy`/`handleSort` pattern from `SequenceGroupsListPage`. No new UI pattern.

- `0` renders as **`0%`**, not as not-scored. It is a real model verdict, and a truthiness check would have hidden it — production data contains many exact zeros.
- Null renders as **`—` with a hover title "Not scored by the platform"**, deliberately unlike the neighbouring `azimuth` column, which renders an empty string and is indistinguishable from a broken cell.

## A latent bug fixed along the way

`SequencesPage` spread a filter object carrying `order_by: 'created_at'` into the queue fetchers. The endpoints previously ignored it as an unknown query param; once they declare an enum, that value would **422 for any user whose persisted filters held it**. The page now strips the sequences-list ordering before calling the alert-grouped endpoints. Caught by `tsc`, not by review.

## Verification

- Backend **778 tests**, frontend **1311 tests**; type-check, lint and format clean.
- Exercised against a restored production dump plus live imports: 163 primary lanes / 158 scored / 38 above 0.45 / **62 exactly `0.0`** / 16 sibling lanes all NULL. The queue sorted correctly with nulls pinned last in both directions.

**Not verified against live data: `/localize`.** That queue needs lanes at `SEQ_ANNOTATION_DONE` with auto-annotation applied, which requires classifying alerts and running the `procrastinate` worker — the dev stack has no worker service. The code path is identical to the classify queue (same aggregate, same `_build_queue_item`) and has unit coverage, but it has not been seen rendering.

## Non-goals

No threshold filter, no colour-coding, no per-object badge — all explicit spec non-goals. On production the column reads `—` until a historical backfill is run with #365's refresh path.
