### PR TITLE
fix(worker): point the auto-annotate model default at the baked weights

### DIFF
--- a/annotation_api/src/app/core/config.py
+++ b/annotation_api/src/app/core/config.py
@@ -94,9 +94,12 @@ class Settings(BaseSettings):
         "PLATFORM_SERVER_NAME", "ovh-alert-api-prod-v2"
     )
 
-    # Auto-annotate model (baked into the image; see Dockerfile)
+    # Auto-annotate model. The Dockerfile extracts the release tarball straight
+    # into /app/models (it has no top-level directory), so the default must be
+    # that directory — not a subdirectory named after the model. Pinned by
+    # test_autoannotate_model_path_holds_the_weights, which globs this path.
     AUTOANNOTATE_MODEL_PATH: str = os.environ.get(
-        "AUTOANNOTATE_MODEL_PATH", "/app/models/yolo11s_sensitive-detector"
+        "AUTOANNOTATE_MODEL_PATH", "/app/models"
     )
     AUTOANNOTATE_MODEL_NAME: str = os.environ.get(
         "AUTOANNOTATE_MODEL_NAME", "yolo11s_sensitive-detector"

--- a/annotation_api/src/tests/test_autoannotate_model_path.py
+++ b/annotation_api/src/tests/test_autoannotate_model_path.py
@@ -1,0 +1,29 @@
+"""The configured auto-annotate model path must hold the baked weights.
+
+The default and the Dockerfile's extraction path drifted apart the day both
+were written (commit 9dc4c7d): the default named a subdirectory the tarball
+never creates, so anything running without an explicit override died at its
+first auto-annotate job with "No .onnx file found". Production only worked
+because two compose files set the variable by hand.
+
+This test reads the setting exactly as `app.worker.get_detector` does and
+checks the directory actually contains weights, so the default cannot drift
+from the image again without CI saying so.
+"""
+
+from pathlib import Path
+
+from app.core.config import settings
+
+
+def test_autoannotate_model_path_holds_the_weights():
+    model_dir = Path(settings.AUTOANNOTATE_MODEL_PATH)
+    assert model_dir.is_dir(), (
+        f"AUTOANNOTATE_MODEL_PATH={model_dir} is not a directory. "
+        "The Dockerfile extracts the model tarball into /app/models."
+    )
+    weights = sorted(model_dir.glob("*.onnx"))
+    assert weights, (
+        f"no .onnx file under AUTOANNOTATE_MODEL_PATH={model_dir}; "
+        f"contents: {sorted(p.name for p in model_dir.iterdir())}"
+    )

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -109,7 +109,6 @@ services:
       - S3_SECRET_KEY=${S3_SECRET_KEY}
       - S3_REGION=${S3_REGION}
       - S3_BUCKET_NAME=${S3_BUCKET_NAME}
-      - AUTOANNOTATE_MODEL_PATH=/app/models
     restart: unless-stopped
     command: "procrastinate --app=app.worker.app worker"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,8 +127,6 @@ services:
       - S3_ACCESS_KEY=fake
       - S3_SECRET_KEY=fakefake
       - S3_REGION=us-east-1
-      # Auto-annotate model (baked into the image)
-      - AUTOANNOTATE_MODEL_PATH=/app/models
     restart: unless-stopped
     command: "procrastinate --app=app.worker.app worker"
     healthcheck:


### PR DESCRIPTION
`AUTOANNOTATE_MODEL_PATH` has defaulted to a directory that has never existed. Auto-annotation therefore cannot run anywhere the variable is not set by hand — including `docker-compose-dev.yml`, so the pipeline could not be exercised locally at all.

## The bug

`Dockerfile:44-48` extracts the release tarball straight into `/app/models`:

```dockerfile
RUN mkdir -p /app/models \
    && curl -fsSL "https://huggingface.co/pyronear/yolo11s_sensitive-detector/resolve/main/onnx_cpu.tar.gz" -o /tmp/model.tar.gz \
    && tar -xzf /tmp/model.tar.gz -C /app/models
```

The tarball has no top-level directory, so the weights land at `/app/models/best.onnx` — verified in a running container:

```
$ ls /app/models
best.onnx
```

But `config.py` defaulted to `/app/models/yolo11s_sensitive-detector`, a path the image never creates. Both landed in the **same commit** (`9dc4c7d`, 2026-07-21), so the default has never been valid.

Running the worker task on the default fails immediately:

```
RuntimeError: No .onnx file found under /app/models/yolo11s_sensitive-detector
```

## Why nobody noticed

Two compose files set the variable by hand — `docker-compose.yml:131` and `docker-compose.server.yml:112` — so production and the deployed server both worked. Only consumers relying on the default were affected, and the one that matters is `docker-compose-dev.yml`, which never sets it.

## The fix

- **`config.py`** — the default becomes `/app/models`, matching the Dockerfile.
- **Both compose overrides removed.** They now merely restate the default, and keeping the real value in compose rather than in code is precisely what let the broken default survive. Both files still validate (`docker compose config`).
- **A guard test** globs the configured path for a `.onnx`. It reads the setting exactly as `app.worker.get_detector` does, and the dev/test image builds from the same `base` stage that bakes the model, so it exercises the real default with no override in play.

The test **fails against the old value** and passes against the new one — verified by reverting the default and re-running, not assumed.

## Scope

Deliberately not included: `docker-compose-dev.yml` still has **no worker service**, so the periodic sweep never runs locally even with this fixed. That is a separate gap and a larger decision — the dev stack is minimal by design, for running tests. Worth its own issue.

## Verification

Backend suite: **773 passed**. Ruff clean. Both compose files parse.
