### PR TITLE
fix(classify): stop the object player from resizing the page while it loops

### DIFF
--- a/docs/specs/2026-08-11-classify-media-stability-design.md
+++ b/docs/specs/2026-08-11-classify-media-stability-design.md
@@ -1,0 +1,156 @@
+# Classify cockpit: stop the object player from resizing the page
+
+Date: 2026-08-11
+Status: approved
+
+## Problem
+
+On `/classify/:id`, the object section of the media column moves continuously
+while the frame loop plays. The column changes height, which changes the page
+height, which toggles the window scrollbar and reflows the whole cockpit. The
+missed-smoke section of the same page does not do this at all.
+
+## Root cause
+
+Both symptoms come from `frontend/src/components/annotation/FullImageSequence.tsx`.
+
+1. **Nothing reserves the height.** The image container is
+   `width: 1280px; height: auto` and the image inside it is `w-full h-auto`.
+   The container's height is therefore whatever the `<img>` decodes to. An
+   `<img>` whose `src` has no decoded content has zero intrinsic height, so on
+   such a frame the container collapses to roughly nothing.
+
+2. **The loop lands on frames that have not decoded yet.** The playback
+   interval starts as soon as *two* images report `loaded`, then advances
+   `(prev + 1) % images.length` across the whole list. For the first several
+   seconds it therefore steps onto entries whose image is still in flight.
+
+Together: every uncached frame collapses the container for ~200ms, then the
+next cached frame restores it. The "Loading image…" overlay is
+`absolute inset-0`, so inside a collapsed box it is invisible — the user sees
+the jump, not a spinner.
+
+A third, smaller contributor: the interval effect lists `images` in its
+dependencies, so the 200ms timer is torn down and recreated on *every*
+individual image load. During the initial load burst the timer keeps resetting
+and playback paces erratically.
+
+`SequencePlayer` (the missed-smoke player) is immune for exactly the reasons
+`FullImageSequence` is not: a fixed `aspect-video` container, an
+`object-contain` image that cannot resize that container, and preloading via
+`useImagePreloader` with ahead/behind windows. `CroppedImageSequence` is
+likewise immune — a fixed `aspect-square` canvas viewport.
+
+## Non-goals
+
+- **The loading placeholder is out of scope.** When `isLoading` is true the
+  component still returns a bare `py-8` text row instead of the player, so
+  first load and alert-advance still snap once. That is a transition, not the
+  continuous motion this change targets, and the user explicitly scoped it out.
+- **No port onto `useImagePreloader`.** Converging the two players is a real
+  refactor of a component with three test files, a seek-hold protocol and
+  sibling-overlay geometry, and the hook is typed around `Detection[]` rather
+  than `FullImageFrame[]`. Not warranted by this symptom.
+- No changes to `CroppedImageSequence`, `ClassifyMediaPanel`, `DecisionRail`,
+  or the decision rail's row-expansion behaviour.
+
+## Design
+
+All changes are in `FullImageSequence.tsx`. Both of its consumers —
+`ClassifyMediaPanel` (the classify cockpit) and
+`sequence-annotation/ObjectCard` (the legacy `AnnotationInterface` flow) —
+render the same alert frames and get the fix without changes of their own.
+
+### 1. Reserve the box
+
+The image container declares its own aspect ratio and stops deriving height
+from the image:
+
+- container: `style={{ width: 1280, maxWidth: '100%', aspectRatio: aspect ?? 16 / 9 }}`,
+  plus `flex items-center justify-center bg-gray-900` alongside the existing
+  `relative … overflow-hidden` chrome.
+- image: `max-w-full max-h-full object-contain`, replacing `w-full h-auto`. The
+  image can no longer influence the container's size.
+
+`aspect` is a `number | null` piece of state, set once from
+`naturalWidth / naturalHeight` on the first frame that decodes, and reset to
+`null` alongside the other per-frame-list resets when `frameKey` changes, so a
+new alert re-measures. The `16 / 9` default covers the window before the first
+decode.
+
+Locking to the measured ratio rather than hard-coding `aspect-video` means a
+non-16:9 camera is never letterboxed; the cost is a single settling change on
+load, from the default to the measured value.
+
+The overlay geometry needs no change. `handleImageLoad` already derives
+`offsetX` / `offsetY` from `imgRect.left - containerRect.left`, which is
+correct for an image centred inside a larger box. One accepted consequence: at
+the instant the aspect locks, the image's rect changes after `imageInfo` was
+measured, so the boxes are one frame stale. `onLoad` fires on every frame swap,
+so this self-heals within ~200ms.
+
+### 2. Advance only to decoded frames
+
+The interval's `setCurrentIndex` scans forward with wraparound for the next
+entry with `loaded === true`, and returns the current index unchanged if none
+is ready.
+
+Errored frames stay in the rotation deliberately. "Not loaded yet" is
+transient, so excluding such a frame is temporary and it rejoins the loop when
+it arrives; an error is permanent, and excluding it would silently shorten the
+loop and hide a broken frame. With the container now fixed, an errored frame
+shows its overlay without moving anything.
+
+The `images` array moves behind a ref that the interval callback reads, so the
+interval is created once per play/pause transition instead of once per image
+load. The effect's dependencies become `[canPlay, isLoading, isHolding]` and no
+longer include `images`.
+
+`canPlay` is the existing start condition collapsed into a single boolean —
+`images.length > 1 && loadedCount > 1`. It is still derived from `images` on
+each render, but because it is a boolean it flips false→true once, early in the
+load, and stays true; the effect therefore re-runs on that one transition
+rather than on every individual image load. The remaining conditions (not
+loading, not holding) are unchanged.
+
+### Interaction with `seekRequest`
+
+Unchanged. The seek effect sets `currentIndex` directly and sets `isHolding`,
+which stops the interval for `SEEK_HOLD_MS`. A seek may therefore land on a
+not-yet-decoded frame, which is correct: the user asked for that specific
+frame, and it now shows the loading overlay inside a stable box rather than
+collapsing it.
+
+## Testing
+
+New file `tests/components/annotation/FullImageSequence.stability.test.tsx`,
+following the `vi.mock('@/services/api')` pattern of the three existing
+`FullImageSequence` test files:
+
+1. **Reserved box** — the image container carries an `aspect-ratio` style
+   before any image has decoded.
+2. **Skip undecoded frames** — with frame 1 decoded and frame 2 not, advancing
+   the 200ms interval lands on the next decoded frame rather than frame 2.
+
+Test (2) requires stubbing `global.Image` with a controllable `onload`. jsdom
+never fires load events for `new Image()`, which is why the existing three test
+files never exercise the playback interval at all; the same gap means those
+files are not expected to be affected by either change.
+
+Regression surface to keep green: `FullImageSequence.seek.test.tsx`,
+`FullImageSequence.frameSwitch.test.tsx`,
+`FullImageSequence.overlays.test.tsx`, `ClassifyMediaPanel.test.tsx`,
+`ObjectCard.test.tsx`, plus `npm run type-check` and `npm run lint`.
+
+Manual verification: on `/classify/:id` with a fresh alert, the media column's
+height must not change once the player is showing, from the first loop pass
+onward, including while frames are still arriving.
+
+## Risks
+
+- `ObjectCard` (legacy `AnnotationInterface`) shares the component. It renders
+  the same alert frames in a narrower column, so the reserved box is the same
+  shape it already resolves to; visual change there should be nil.
+- If an alert ever mixes resolutions across frames, the box keeps the *first*
+  decoded frame's ratio and later frames letterbox inside it. That is the
+  desired trade — a stable box beats a per-frame-accurate one.

--- a/docs/specs/2026-08-11-classify-media-stability-design.md
+++ b/docs/specs/2026-08-11-classify-media-stability-design.md
@@ -82,12 +82,20 @@ Locking to the measured ratio rather than hard-coding `aspect-video` means a
 non-16:9 camera is never letterboxed; the cost is a single settling change on
 load, from the default to the measured value.
 
-The overlay geometry needs no change. `handleImageLoad` already derives
-`offsetX` / `offsetY` from `imgRect.left - containerRect.left`, which is
-correct for an image centred inside a larger box. One accepted consequence: at
-the instant the aspect locks, the image's rect changes after `imageInfo` was
-measured, so the boxes are one frame stale. `onLoad` fires on every frame swap,
-so this self-heals within ~200ms.
+The overlay geometry keeps deriving `offsetX` / `offsetY` from
+`imgRect.left - containerRect.left`, which is correct for an image centred
+inside a larger box. It does, however, need to be measured **twice**: locking
+the aspect resizes the box, which moves the image inside it, so the numbers
+`handleImageLoad` takes synchronously describe the pre-lock box. For a 4:3
+frame in the 16:9 default that is 25% too narrow and horizontally offset.
+
+An earlier draft of this spec dismissed that as self-healing on the next
+frame's `onLoad`. That is wrong for a single-frame alert: the loop needs two
+decoded frames to start, so no second `onLoad` ever fires and the overlays stay
+misplaced for as long as the card is open. The measurement therefore moves into
+a `measureImage` callback invoked both from `handleImageLoad` and from a
+`useLayoutEffect` keyed on `aspect`, which re-measures once the lock has been
+applied to the box.
 
 ### 2. Advance only to decoded frames
 

--- a/frontend/src/components/annotation/FullImageSequence.tsx
+++ b/frontend/src/components/annotation/FullImageSequence.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useCallback, useLayoutEffect, useRef } from 'react';
 import { Loader2, AlertCircle } from 'lucide-react';
 import { apiClient } from '@/services/api';
 import { ObjectOverlay } from '@/utils/annotation/objectColors';
@@ -217,6 +217,12 @@ export default function FullImageSequence({
         // rotation on purpose: "not decoded yet" is transient and the frame
         // rejoins the loop when it arrives, but an error is permanent, and
         // skipping it would silently shorten the loop and hide the failure.
+        // The transient assumption holds for the cases that actually occur —
+        // a frame queued behind the browser's per-host connection limit
+        // settles in seconds, and a hard failure fires onerror. A request
+        // that hangs without firing either handler would stay skipped, which
+        // is accepted: bounding the skip to N passes would just reinstate the
+        // blanking this exists to remove.
         const frames = imagesRef.current;
         for (let step = 1; step <= frames.length; step++) {
           const next = (prev + step) % frames.length;
@@ -246,31 +252,45 @@ export default function FullImageSequence({
     };
   }, []);
 
+  // Where the image actually sits inside the reserved box — the overlays are
+  // positioned against this, and `object-contain` means it is not simply the
+  // box itself (a frame whose ratio differs from the box's is letterboxed).
+  const measureImage = useCallback(() => {
+    if (!imgRef.current || !containerRef.current) return;
+
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const imgRect = imgRef.current.getBoundingClientRect();
+
+    setImageInfo({
+      width: imgRect.width,
+      height: imgRect.height,
+      offsetX: imgRect.left - containerRect.left,
+      offsetY: imgRect.top - containerRect.top,
+    });
+  }, []);
+
+  // Re-measure once a newly locked aspect has actually been applied to the
+  // box. `handleImageLoad` below measures synchronously, before the resize
+  // commits, so its numbers describe the old box — for a 4:3 frame in the
+  // 16:9 default that is 25% too narrow and offset. A multi-frame alert would
+  // paper over it on the next frame's onLoad, but a single-frame alert never
+  // fires one (the loop needs two decoded frames to start), so without this
+  // the overlays would stay wrong for as long as the card is open.
+  useLayoutEffect(() => {
+    if (aspect === null) return;
+    measureImage();
+  }, [aspect, measureImage]);
+
   // Handle image load to get dimensions for bbox positioning
   const handleImageLoad = () => {
     if (imgRef.current && containerRef.current) {
       // Lock the reserved box to the first decoded frame's own ratio. The
-      // measurement below is one frame stale at the instant this locks (the
-      // image's rect moves as the box resizes) — onLoad fires on every frame
-      // swap, so that self-heals within one 200ms tick.
+      // layout effect above re-measures once that lock lands.
       if (aspect === null && imgRef.current.naturalWidth > 0 && imgRef.current.naturalHeight > 0) {
         setAspect(imgRef.current.naturalWidth / imgRef.current.naturalHeight);
       }
 
-      const containerRect = containerRef.current.getBoundingClientRect();
-      const imgRect = imgRef.current.getBoundingClientRect();
-
-      const offsetX = imgRect.left - containerRect.left;
-      const offsetY = imgRect.top - containerRect.top;
-      const width = imgRect.width;
-      const height = imgRect.height;
-
-      setImageInfo({
-        width,
-        height,
-        offsetX,
-        offsetY,
-      });
+      measureImage();
     }
   };
 

--- a/frontend/src/components/annotation/FullImageSequence.tsx
+++ b/frontend/src/components/annotation/FullImageSequence.tsx
@@ -189,28 +189,50 @@ export default function FullImageSequence({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [seekRequest?.nonce]);
 
+  // The frame list is read through a ref by the interval below. Listing
+  // `images` in that effect's dependencies tore the 200ms timer down and
+  // recreated it on every single image load, so during the initial load burst
+  // the timer kept resetting and playback lurched.
+  const imagesRef = useRef(images);
+  useEffect(() => {
+    imagesRef.current = images;
+  });
+
+  // The old start condition as one boolean. It flips false -> true once, early
+  // in the load, and stays true — so the effect below re-runs on that single
+  // transition rather than once per loaded image.
+  const canPlay = images.length > 1 && images.filter(img => img.loaded && !img.error).length > 1;
+
   // Auto-play animation with 200ms interval - only when images are loaded
   // and no seek-hold is pinning the current frame.
   useEffect(() => {
-    const loadedImagesCount = images.filter(img => img.loaded && !img.error).length;
+    if (!canPlay || isLoading || isHolding) return;
 
-    if (images.length > 1 && loadedImagesCount > 1 && !isLoading && !isHolding) {
-      intervalRef.current = setInterval(() => {
-        setCurrentIndex(prev => (prev + 1) % images.length);
-      }, 200);
-    } else {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-    }
+    intervalRef.current = setInterval(() => {
+      setCurrentIndex(prev => {
+        // Advance only onto frames the browser has decoded. An <img> whose
+        // src has nothing decoded has no intrinsic height, so landing on one
+        // used to collapse the container entirely; with the box now reserved
+        // it still blanks the player for a tick. Errored frames stay in the
+        // rotation on purpose: "not decoded yet" is transient and the frame
+        // rejoins the loop when it arrives, but an error is permanent, and
+        // skipping it would silently shorten the loop and hide the failure.
+        const frames = imagesRef.current;
+        for (let step = 1; step <= frames.length; step++) {
+          const next = (prev + step) % frames.length;
+          if (frames[next]?.loaded || frames[next]?.error) return next;
+        }
+        return prev;
+      });
+    }, 200);
 
     return () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
     };
-  }, [images.length, images, isLoading, isHolding]);
+  }, [canPlay, isLoading, isHolding]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/frontend/src/components/annotation/FullImageSequence.tsx
+++ b/frontend/src/components/annotation/FullImageSequence.tsx
@@ -67,6 +67,10 @@ export default function FullImageSequence({
     offsetX: number;
     offsetY: number;
   } | null>(null);
+  // Locked aspect ratio for the reserved box, measured once from the first
+  // frame that decodes so a non-16:9 camera is never letterboxed. Null until
+  // then — the box holds 16:9 in the meantime.
+  const [aspect, setAspect] = useState<number | null>(null);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
@@ -98,6 +102,7 @@ export default function FullImageSequence({
     setIsLoading(true);
     setError(null);
     setImageInfo(null); // Clear image positioning info
+    setAspect(null); // A new frame list measures its own box.
     // A pending seek-hold belongs to the old frame list.
     setIsHolding(false);
     if (holdTimeoutRef.current) clearTimeout(holdTimeoutRef.current);
@@ -222,6 +227,14 @@ export default function FullImageSequence({
   // Handle image load to get dimensions for bbox positioning
   const handleImageLoad = () => {
     if (imgRef.current && containerRef.current) {
+      // Lock the reserved box to the first decoded frame's own ratio. The
+      // measurement below is one frame stale at the instant this locks (the
+      // image's rect moves as the box resizes) — onLoad fires on every frame
+      // swap, so that self-heals within one 200ms tick.
+      if (aspect === null && imgRef.current.naturalWidth > 0 && imgRef.current.naturalHeight > 0) {
+        setAspect(imgRef.current.naturalWidth / imgRef.current.naturalHeight);
+      }
+
       const containerRect = containerRef.current.getBoundingClientRect();
       const imgRect = imgRef.current.getBoundingClientRect();
 
@@ -345,11 +358,16 @@ export default function FullImageSequence({
       {/* Full Image Container */}
       <div
         ref={containerRef}
-        className="relative border border-gray-300 rounded shadow-sm mx-auto overflow-hidden"
+        data-testid="full-image-viewport"
+        className="relative mx-auto flex items-center justify-center overflow-hidden rounded border border-gray-300 bg-char shadow-sm"
         style={{
           width: '1280px',
           maxWidth: '100%',
-          height: 'auto',
+          // Reserve the height. Deriving it from the image (the old
+          // `height: 'auto'` here plus `w-full h-auto` on the <img>) collapsed
+          // this box to nothing on every frame the browser had not decoded
+          // yet, which resized the whole cockpit 5x a second.
+          aspectRatio: aspect ?? 16 / 9,
         }}
       >
         {/* Loading State */}
@@ -380,7 +398,7 @@ export default function FullImageSequence({
               src={currentImage.url}
               alt={`Detection ${currentIndex + 1}`}
               onLoad={handleImageLoad}
-              className="w-full h-auto"
+              className="max-w-full max-h-full object-contain"
             />
 
             {/* Bounding Box Overlay */}

--- a/frontend/tests/components/annotation/FullImageSequence.stability.test.tsx
+++ b/frontend/tests/components/annotation/FullImageSequence.stability.test.tsx
@@ -25,6 +25,18 @@ class ImmediateImage {
 }
 vi.stubGlobal('Image', ImmediateImage as unknown as typeof Image);
 
+// A second stub for the loop tests below: decides per URL whether the preload
+// resolves, so one frame can be held permanently undecoded.
+const stalled = new Set<string>();
+class ControlledImage {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  set src(value: string) {
+    if (stalled.has(value)) return;
+    queueMicrotask(() => this.onload?.());
+  }
+}
+
 const frames = [1, 2].map(id => ({ detection_id: id, xyxyn: [0, 0, 1, 1] }));
 
 const viewport = () => screen.getByTestId('full-image-viewport');
@@ -90,5 +102,43 @@ describe('FullImageSequence reserved box', () => {
     });
 
     expect(parseFloat(viewport().style.aspectRatio)).toBeCloseTo(16 / 9, 4);
+  });
+});
+
+const fourFrames = [1, 2, 3, 4].map(id => ({ detection_id: id, xyxyn: [0, 0, 1, 1] }));
+const shownSrc = () => screen.getByRole('img').getAttribute('src');
+
+describe('FullImageSequence undecoded frames', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stalled.clear();
+    vi.stubGlobal('Image', ControlledImage as unknown as typeof Image);
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.stubGlobal('Image', ImmediateImage as unknown as typeof Image);
+  });
+
+  it('steps over a frame whose image has not decoded yet', async () => {
+    stalled.add('https://example.com/3.png');
+
+    render(<FullImageSequence bboxes={fourFrames} sequenceId={101} />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(shownSrc()).toBe('https://example.com/1.png');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(shownSrc()).toBe('https://example.com/2.png');
+
+    // Frame 3 never decoded: showing it would blank the player for a tick, so
+    // the loop steps over it to frame 4 and picks it up if it ever arrives.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(shownSrc()).toBe('https://example.com/4.png');
   });
 });

--- a/frontend/tests/components/annotation/FullImageSequence.stability.test.tsx
+++ b/frontend/tests/components/annotation/FullImageSequence.stability.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Layout stability: the player's box must reserve its own height instead of
+ * inheriting it from whatever the <img> happens to have decoded. Deriving the
+ * height from the image collapsed the container to nothing on every
+ * not-yet-decoded frame, which resized the whole classify cockpit 5x a second.
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+vi.mock('@/services/api', () => ({
+  apiClient: {
+    getDetectionImageUrl: vi.fn(async (id: number) => ({ url: `https://example.com/${id}.png` })),
+  },
+}));
+
+import FullImageSequence from '@/components/annotation/FullImageSequence';
+
+// jsdom never actually loads images; make `new Image()` resolve synchronously
+// so FullImageSequence's own preloading effects settle without real network.
+class ImmediateImage {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  set src(_value: string) {
+    queueMicrotask(() => this.onload?.());
+  }
+}
+vi.stubGlobal('Image', ImmediateImage as unknown as typeof Image);
+
+const frames = [1, 2].map(id => ({ detection_id: id, xyxyn: [0, 0, 1, 1] }));
+
+const viewport = () => screen.getByTestId('full-image-viewport');
+
+async function renderPlayer() {
+  const view = render(<FullImageSequence bboxes={frames} sequenceId={101} />);
+  // Flush URL fetches + Image preloads (microtasks) under fake timers.
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+  return view;
+}
+
+describe('FullImageSequence reserved box', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reserves a 16:9 box before any frame has decoded', async () => {
+    await renderPlayer();
+    // jsdom fires no load event on the rendered <img>, so nothing has been
+    // measured yet — the box must already hold a height regardless.
+    expect(parseFloat(viewport().style.aspectRatio)).toBeCloseTo(16 / 9, 4);
+  });
+
+  it("locks the box to the first decoded frame's own ratio", async () => {
+    await renderPlayer();
+
+    const img = screen.getByRole('img');
+    Object.defineProperty(img, 'naturalWidth', { value: 800, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 600, configurable: true });
+    await act(async () => {
+      fireEvent.load(img);
+    });
+
+    expect(parseFloat(viewport().style.aspectRatio)).toBeCloseTo(800 / 600, 4);
+  });
+
+  it('re-measures when the frame list changes', async () => {
+    const { rerender } = await renderPlayer();
+
+    const img = screen.getByRole('img');
+    Object.defineProperty(img, 'naturalWidth', { value: 800, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 600, configurable: true });
+    await act(async () => {
+      fireEvent.load(img);
+    });
+    expect(parseFloat(viewport().style.aspectRatio)).toBeCloseTo(800 / 600, 4);
+
+    // Next alert: a different frame list must not inherit the old ratio.
+    rerender(
+      <FullImageSequence
+        bboxes={[3, 4].map(id => ({ detection_id: id, xyxyn: [0, 0, 1, 1] }))}
+        sequenceId={301}
+      />
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(parseFloat(viewport().style.aspectRatio)).toBeCloseTo(16 / 9, 4);
+  });
+});

--- a/frontend/tests/components/annotation/FullImageSequence.stability.test.tsx
+++ b/frontend/tests/components/annotation/FullImageSequence.stability.test.tsx
@@ -79,6 +79,27 @@ describe('FullImageSequence reserved box', () => {
     expect(parseFloat(viewport().style.aspectRatio)).toBeCloseTo(800 / 600, 4);
   });
 
+  // Regression: the lock resizes the box, which moves the image inside it, so
+  // the geometry the load handler measured describes the *old* box. A
+  // single-frame alert never fires a second onLoad (the loop needs two decoded
+  // frames to start), so without a re-measure its overlays stay misplaced.
+  it('re-measures the overlay geometry after the box locks', async () => {
+    await renderPlayer();
+
+    const img = screen.getByRole('img');
+    Object.defineProperty(img, 'naturalWidth', { value: 800, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 600, configurable: true });
+
+    const measured = vi.spyOn(img, 'getBoundingClientRect');
+    await act(async () => {
+      fireEvent.load(img);
+    });
+
+    // Once inside the load handler against the 16:9 default, then again once
+    // the 4:3 lock has been applied to the box.
+    expect(measured.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
   it('re-measures when the frame list changes', async () => {
     const { rerender } = await renderPlayer();
 


### PR DESCRIPTION
## Problem

On `/classify/:id`, the object section of the media column moved continuously while the frame loop played. The column changed height, which changed the page height, which toggled the window scrollbar and reflowed the whole cockpit. The missed-smoke section of the same page never did this.

## Root cause

Both symptoms lived in `FullImageSequence.tsx`.

1. **Nothing reserved the height.** The container was `width: 1280px; height: auto` with a `w-full h-auto` `<img>` inside it, so the container's height was whatever the image decoded to. An `<img>` with nothing decoded has zero intrinsic height.
2. **The loop landed on frames that had not decoded yet.** The interval started as soon as *two* images reported `loaded`, then advanced `(prev + 1) % images.length` across the whole list — so for the first several seconds it stepped onto entries still in flight.

Together, every uncached frame collapsed the container for ~200ms and the next cached frame restored it. The "Loading image…" overlay is `absolute inset-0`, so inside a collapsed box it was invisible: you saw the jump, not a spinner.

`SequencePlayer` (the missed-smoke player) was immune for exactly the reasons this one was not — a fixed `aspect-video` container, an `object-contain` image that cannot resize it, and windowed preloading.

## Changes

**Reserve the box.** The container declares `aspectRatio` and the image becomes `max-w-full max-h-full object-contain`, so it can no longer influence the container's size. The ratio is locked once from the first frame that decodes (defaulting to 16:9 until then) and reset with the frame list, so a non-16:9 camera is never letterboxed.

**Advance only onto decoded frames.** The interval scans forward with wraparound for the next entry with `loaded === true`, holding position if none is ready. Errored frames stay in the rotation deliberately: "not decoded yet" is transient, but an error is permanent, and skipping it would silently shorten the loop and hide a broken frame.

Alongside that, the `images` array moves behind a ref so the 200ms timer is no longer torn down and recreated on *every* individual image load — during the initial burst that kept resetting the timer and made playback lurch.

**Re-measure the overlays after the box locks.** Locking the aspect resizes the box, which moves the image inside it, so the geometry measured synchronously in the load handler describes the pre-lock box — for a 4:3 frame in the 16:9 default, 25% too narrow and offset. A multi-frame alert would paper over this on the next frame's `onLoad`, but a single-frame alert never fires one (the loop needs two decoded frames to start), so its overlays would stay misplaced. Measurement moved into a shared callback invoked both from the load handler and from a `useLayoutEffect` keyed on the locked ratio.

`sequence-annotation/ObjectCard` is the other consumer and gets the fix unchanged.

## Deliberately out of scope

- The `isLoading` branch still returns a bare text row, so the player still snaps once on first load.
- `CroppedImageSequence` still blanks on object switch.

Both are transitions rather than the continuous motion this targets.

## Testing

New `FullImageSequence.stability.test.tsx` (5 tests): the box reserves 16:9 before any decode, locks to the first decoded frame's ratio, re-measures on frame-list change, re-measures the overlay geometry after the lock, and the loop steps over an undecoded frame. Each was confirmed to fail against the pre-change behaviour before being made to pass.

Full frontend suite green (103 files / 1317 tests), plus `type-check`, `lint --max-warnings 0`, and `format:check`.

Verified by hand against a freshly imported local dataset — with a cold cache and images downloading for real, which is the condition that used to make it strobe.

Spec: `docs/specs/2026-08-11-classify-media-stability-design.md`.
