### PR TITLE
fix(ui): reserve the scrollbar gutter so the classify player stops juddering

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,6 +5,17 @@
 @layer base {
   html {
     font-family: 'IBM Plex Sans', system-ui, sans-serif;
+
+    /* Reserve the scrollbar's space whether or not it is showing. Without
+       this, a page whose height lands near the viewport's can oscillate
+       forever: the scrollbar appears, which narrows the viewport, which
+       narrows the classify cockpit's media column, whose height is its width
+       divided by the frame's aspect ratio — so the page gets shorter, the
+       scrollbar goes away, the column widens, and it starts over. On
+       /classify/:id that reads as the player juddering several times a
+       second. Browser zoom "fixed" it only by pushing the page clear of the
+       threshold so the scrollbar stayed put. */
+    scrollbar-gutter: stable;
   }
 
   body {


### PR DESCRIPTION
## Problem

On the test server, `/classify/:id` juddered several times a second — the media column visibly shaking. It looked identical to the layout instability fixed in #368, but that fix was already deployed and the column genuinely no longer resizes from image decoding.

The tell was that **zooming the browser to 125% stopped it**, and the missed-smoke section of the same alert was always smooth.

## Root cause

A scrollbar feedback loop. Nothing reserved space for the vertical scrollbar, so when the page's height landed near the viewport's:

1. the scrollbar appears, which narrows the viewport
2. which narrows the classify cockpit's media column
3. whose height is `width ÷ aspect ratio`, so the page gets **shorter**
4. so the scrollbar disappears, the viewport widens, and it starts over

It oscillates for as long as the page sits at that threshold.

This explains the observations that ruled out every other candidate:

- **125% zoom "fixes" it** — the smaller CSS viewport makes the page definitely overflow, so the scrollbar stays pinned and the loop cannot start. Zoom changes neither the data nor the network, which is what rules out latency and content-based explanations.
- **The missed-smoke section is smooth on the same alert** — that section is taller (player + control strip + CTA bar), so the page always overflows there. It was a height coincidence, not a component difference.
- **It never reproduces locally** — a different window size and content height means you are simply not at the threshold.

This is **not** a regression from #368. The previous `h-auto` had the same width→height dependency; that PR changed what sets the height, not the fact that height derives from width.

## Fix

`scrollbar-gutter: stable` on `html`. The gutter is reserved whether or not the scrollbar is showing, so its appearance can no longer change the layout width and the loop has nothing to feed on.

## Testing

Full frontend suite green (103 files / 1317 tests), plus `type-check`, `lint --max-warnings 0` and `format:check`.

**No automated test.** The failure mode is a layout feedback loop between viewport width and content height, which jsdom does not model — a test asserting the stylesheet contains the string would be tautological. Verified instead by:

1. applying the rule via DevTools on the affected page, which stopped the juddering immediately at 100% zoom;
2. deploying this branch to the test server and confirming the page is stable there.

## Compatibility

`scrollbar-gutter` requires Chrome 94+, Firefox 97+, Safari 18.2+. Older browsers simply keep today's behaviour — the rule is ignored, nothing breaks. If pre-18.2 Safari needs covering, the blunt alternative is `overflow-y: scroll` on `html`, which always paints a scrollbar track even on short pages.
