### PR TITLE
fix(localize): draw bbox strokes as paint, so thin actually means thin

### DIFF
--- a/frontend/src/components/annotation/ImageOverlays.tsx
+++ b/frontend/src/components/annotation/ImageOverlays.tsx
@@ -17,6 +17,7 @@ import {
   validateBoundingBox,
   ImageInfo,
 } from '@/utils/annotation/coordinateUtils';
+import { hairlineStroke } from '@/utils/annotation/hairlineStroke';
 
 // Where each resize handle sits relative to the selected box, for a handle of
 // `size` px. Computed rather than fixed because the size varies with the
@@ -168,9 +169,19 @@ export interface ObjectOverlayItem {
 interface ObjectIdentityOverlayProps {
   objects: ObjectOverlayItem[];
   imageInfo: ImageInfo;
+  /**
+   * The zoom this overlay is rendered inside, as for `DrawingOverlay`. These
+   * boxes are context, not the thing being edited, so they stay hairline at
+   * every zoom instead of growing into the frame you are working on.
+   */
+  strokeScale?: number;
 }
 
-export function ObjectIdentityOverlay({ objects, imageInfo }: ObjectIdentityOverlayProps) {
+export function ObjectIdentityOverlay({
+  objects,
+  imageInfo,
+  strokeScale = 1,
+}: ObjectIdentityOverlayProps) {
   if (!objects || objects.length === 0) return null;
 
   return (
@@ -185,13 +196,14 @@ export function ObjectIdentityOverlay({ objects, imageInfo }: ObjectIdentityOver
             return (
               <div
                 key={`object-overlay-${objectIndex}-${boxIndex}`}
-                className="absolute border-2 border-dashed pointer-events-none opacity-90"
+                data-testid="object-overlay-box"
+                className="absolute pointer-events-none opacity-90"
                 style={{
                   left: `${left}px`,
                   top: `${top}px`,
                   width: `${width}px`,
                   height: `${height}px`,
-                  borderColor: object.color,
+                  ...hairlineStroke({ color: object.color, width: 1, scale: strokeScale }),
                 }}
               >
                 <div
@@ -364,14 +376,12 @@ interface DrawingOverlayProps {
    * so smoke type says nothing that varies here, while the source does.
    */
   boxColor?: string;
-  /** Border width in px, when `boxColor` is driving the stroke. */
+  /** Stroke width in screen px, when `boxColor` is driving the stroke. */
   boxWidth?: number;
-  /** Dark ring hugging the stroke so it survives a bright background. */
-  boxShadow?: string;
   /**
    * The zoom this overlay is rendered inside. Stroke widths and handle sizes
    * are divided by it, so they stay the same thickness on screen however far
-   * the image is zoomed — otherwise a 4px border is drawn at 12px at 3x.
+   * the image is zoomed — otherwise a 4px stroke is drawn at 12px at 3x.
    */
   strokeScale?: number;
 }
@@ -390,7 +400,6 @@ export function DrawingOverlay({
   onHandlePointerDown,
   boxColor,
   boxWidth,
-  boxShadow,
   strokeScale = 1,
 }: DrawingOverlayProps) {
   // Handles are squares in screen pixels; at 3x an unscaled 10px handle would
@@ -461,14 +470,18 @@ export function DrawingOverlay({
               width: `${width}px`,
               height: `${height}px`,
               ...(boxColor
-                ? {
-                    borderColor: boxColor,
-                    borderStyle: 'solid',
+                ? // Painted, not laid out — a CSS border cannot go below
+                  // `strokeScale` device px. See `hairlineStroke`.
+                  hairlineStroke({
+                    color: boxColor,
                     // Selection thickens the stroke rather than recolouring
                     // it: the colour is carrying the box's source already.
-                    borderWidth: `${((boxWidth ?? 2) + (isSelected ? 2 : 0)) / strokeScale}px`,
-                    boxShadow,
-                  }
+                    // One px, not two — the resize handles are the loud part
+                    // of the selected state, and on a small box a heavier
+                    // bump swallows the thing being annotated.
+                    width: (boxWidth ?? 2) + (isSelected ? 1 : 0),
+                    scale: strokeScale,
+                  })
                 : {}),
             }}
           >
@@ -498,8 +511,14 @@ export function DrawingOverlay({
           const { left, top, width, height } = renderRectangle(currentDrawing, 'drawing');
           return (
             <div
-              className="absolute border-2 border-dashed border-blue-400 pointer-events-none"
+              data-testid="drawing-rubber-band"
+              className="absolute pointer-events-none"
               style={{
+                // Divided by the zoom like every other stroke in this layer.
+                // It was authored in flat CSS pixels, so it drew at 8px at 4x
+                // — thickest exactly when you are zoomed in to trace a small
+                // smoke, and covering the pixels you are aiming at.
+                ...hairlineStroke({ color: '#60A5FA', width: 1, scale: strokeScale }),
                 left: `${left}px`,
                 top: `${top}px`,
                 width: `${width}px`,

--- a/frontend/src/components/detection-annotation/DetectionAnnotationCanvas.tsx
+++ b/frontend/src/components/detection-annotation/DetectionAnnotationCanvas.tsx
@@ -4,7 +4,7 @@
  *
  * An object has AT MOST ONE box per frame, so this renders exactly one
  * committed box — always draggable and resizable — plus the candidates that
- * are NOT committed, as read-only dashed ghosts. The per-model-box review
+ * are NOT committed, as read-only dimmed ghosts. The per-model-box review
  * vocabulary this component used to carry (reject / adjust / select over an
  * unbounded rectangle array) has nothing left to express: clearing the box
  * is "reject", editing it in place is "adjust". See
@@ -26,11 +26,8 @@ import {
   ObjectIdentityOverlay,
   type ObjectOverlayItem,
 } from '@/components/annotation/ImageOverlays';
-import {
-  haloShadow,
-  SOURCE_COLOR,
-  SOURCE_WEIGHT,
-} from '@/components/localize/editor/sourceIdentity';
+import { SOURCE_COLOR, SOURCE_WEIGHT } from '@/components/localize/editor/sourceIdentity';
+import { hairlineStroke } from '@/utils/annotation/hairlineStroke';
 
 interface ImageInfo {
   width: number;
@@ -46,7 +43,7 @@ interface DetectionAnnotationCanvasProps {
   detection: Detection;
   /** The single committed box, or null on a frame with none. */
   committed: BoxCandidate | null;
-  /** Candidates that are NOT committed, drawn dimmed and dashed. */
+  /** Candidates that are NOT committed, drawn dimmed. */
   ghosts: BoxCandidate[];
   showGhosts: boolean;
   /** Whether the committed box is selected — only then does it show handles. */
@@ -175,7 +172,11 @@ export function DetectionAnnotationCanvas({
           <SiblingBoundingBoxOverlay detection={detection} imageInfo={imageInfo} />
         )}
         {objectOverlays !== undefined && imageInfo && (
-          <ObjectIdentityOverlay objects={objectOverlays} imageInfo={imageInfo} />
+          <ObjectIdentityOverlay
+            objects={objectOverlays}
+            imageInfo={imageInfo}
+            strokeScale={zoomLevel}
+          />
         )}
       </div>
 
@@ -183,8 +184,8 @@ export function DetectionAnnotationCanvas({
           Read-only — committing one is the rail's job, so they never take
           pointer events away from drawing or from the committed box.
           Unlabeled: the rail beside the image is a permanent legend naming
-          every source next to its swatch, and colour, stroke weight and the
-          dashed style already say which is which. Other OBJECTS' boxes do
+          every source next to its swatch, and colour and stroke weight
+          already say which is which. Other OBJECTS' boxes do
           keep their labels — nothing else on screen names them. */}
       {showGhosts && imageInfo && (
         <div
@@ -203,13 +204,17 @@ export function DetectionAnnotationCanvas({
               <div
                 key={`${ghost.source}-${ghost.index}`}
                 data-testid={`ghost-box-${ghost.source}-${ghost.index}`}
-                className="absolute border-dashed opacity-90"
+                className="absolute opacity-90"
                 style={{
-                  borderColor: SOURCE_COLOR[ghost.source],
                   // Divided by the zoom so the stroke keeps its on-screen
-                  // weight however far the image is scaled.
-                  borderWidth: `${SOURCE_WEIGHT[ghost.source] / zoomLevel}px`,
-                  boxShadow: haloShadow(zoomLevel),
+                  // weight however far the image is scaled — and painted
+                  // rather than laid out, so that division is not clamped
+                  // away. See `hairlineStroke`.
+                  ...hairlineStroke({
+                    color: SOURCE_COLOR[ghost.source],
+                    width: SOURCE_WEIGHT[ghost.source],
+                    scale: zoomLevel,
+                  }),
                   left: `${box.left}px`,
                   top: `${box.top}px`,
                   width: `${box.width}px`,
@@ -240,7 +245,6 @@ export function DetectionAnnotationCanvas({
             normalizedToImage={normalizedToImage}
             boxColor={committed ? SOURCE_COLOR[committed.source] : undefined}
             boxWidth={committed ? SOURCE_WEIGHT[committed.source] : undefined}
-            boxShadow={haloShadow(zoomLevel)}
             strokeScale={zoomLevel}
             onBoxPointerDown={(_id, e) => onBoxPointerDown(e)}
             onHandlePointerDown={

--- a/frontend/src/components/localize/editor/BoxSourceRail.tsx
+++ b/frontend/src/components/localize/editor/BoxSourceRail.tsx
@@ -90,8 +90,11 @@ function CandidateCrop({
       const y = toY(candidate.xyxyn[1]);
       const w = toX(candidate.xyxyn[2]) - x;
       const h = toY(candidate.xyxyn[3]) - y;
-      // Dark halo first, colour over it — the same trick the stage uses, so a
-      // bright stroke stays visible against a bright sky.
+      // Dark halo first, colour over it, so a bright stroke stays visible
+      // against a bright sky. The stage dropped its own halo once its strokes
+      // went hairline — a ring on both sides then outweighed the stroke it
+      // backed. These thumbnails keep theirs: at CROP_STROKE the ring is a
+      // fraction of the stroke, not a multiple of it.
       ctx.strokeStyle = 'rgba(0,0,0,0.65)';
       ctx.lineWidth = CROP_STROKE + 3;
       ctx.strokeRect(x, y, w, h);

--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -515,7 +515,7 @@ export function LocalizeObjectEditor({
 
   // --- Coordinates --------------------------------------------------------
 
-  const handleImageLoad = () => {
+  const handleImageLoad = useCallback(() => {
     const img = imgRef.current;
     if (!img || !containerRef.current) return;
     // LAYOUT metrics, not getBoundingClientRect(): the rect is already scaled
@@ -530,7 +530,24 @@ export function LocalizeObjectEditor({
       offsetX: img.offsetLeft,
       offsetY: img.offsetTop,
     });
-  };
+  }, []);
+
+  // Re-measure when the image's rendered size changes without a reload —
+  // browser zoom (ctrl +/-) and window resizes both do that, and `load` does
+  // not fire again. Every overlay is positioned from `imageInfo`, so a stale
+  // measurement leaves the boxes drawn away from the smoke they mark. Same
+  // reasoning, same pattern as `DetectionImageCard`.
+  useEffect(() => {
+    const img = imgRef.current;
+    if (!img || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(() => {
+      if (imgRef.current?.complete) handleImageLoad();
+    });
+    observer.observe(img);
+    return () => observer.disconnect();
+    // The canvas renders the <img> only once the URL resolves, so on a cold
+    // open the ref is still null on the first pass — re-run to attach then.
+  }, [handleImageLoad, imageData?.url]);
 
   const getImageInfo = (): {
     containerOffset: Point;

--- a/frontend/src/components/localize/editor/sourceIdentity.ts
+++ b/frontend/src/components/localize/editor/sourceIdentity.ts
@@ -46,7 +46,7 @@ export const SOURCE_STROKE: Record<BoxSource, string> = {
 export const SOURCE_COLOR = SOURCE_STROKE;
 
 /**
- * Border width in px, descending with the source's claim.
+ * Stroke width in px, descending with the source's claim.
  *
  * Kept deliberately hairline. A wildfire at the start of an alert can be a
  * dozen pixels across, and a stroke authored for comfort at alert scale sits

--- a/frontend/src/components/localize/editor/sourceIdentity.ts
+++ b/frontend/src/components/localize/editor/sourceIdentity.ts
@@ -8,17 +8,18 @@
  * anything neutral disappears into one of them — an earlier ordinal ramp in
  * the app's own neutrals (char / pine / haze) was unreadable for exactly that
  * reason: char vanished into terrain, haze into smoke. These are high-chroma
- * hues chosen because they do NOT occur in the scene, and every box is drawn
- * with `HALO_SHADOW` so the stroke survives even against bright sky.
+ * hues chosen because they do NOT occur in the scene, which is what lets them
+ * carry a hairline stroke unaided — an earlier dark halo behind every box was
+ * dropped once the strokes got thin enough for it to outweigh them.
  *
  * Deliberately outside DESIGN.md's semantic tokens, on the same reasoning
  * `objectColors.ts` gives: ember/pine/signal mark action, positive state and
  * error, and a box's provenance is none of those. Legibility over a
  * photograph is a different problem from chrome, and it wins here.
  *
- * The manual > auto > engine hierarchy is carried by STROKE WEIGHT AND STYLE
- * rather than by colour — see `SOURCE_WEIGHT`. Weight reads on any
- * background; a lightness ramp does not.
+ * The manual > auto > engine hierarchy is carried by STROKE WEIGHT rather
+ * than by colour — see `SOURCE_WEIGHT`. Weight reads on any background; a
+ * lightness ramp does not.
  */
 
 import type { BoxSource } from '@/utils/annotation/objectBoxCandidates';
@@ -44,24 +45,28 @@ export const SOURCE_STROKE: Record<BoxSource, string> = {
  */
 export const SOURCE_COLOR = SOURCE_STROKE;
 
-/** Border width in px, descending with the source's claim. */
-export const SOURCE_WEIGHT: Record<BoxSource, number> = {
-  manual: 4,
-  auto: 3,
-  engine: 2,
-};
-
 /**
- * A dark ring hugging the stroke on both sides, so a bright box stays visible
- * against a bright sky without dimming the hue itself.
+ * Border width in px, descending with the source's claim.
  *
- * Divided by the zoom, like every other stroke on the stage: these marks live
- * inside the scaled layer, so a ring authored in CSS pixels would be drawn
- * three times as thick at 3x.
+ * Kept deliberately hairline. A wildfire at the start of an alert can be a
+ * dozen pixels across, and a stroke authored for comfort at alert scale sits
+ * ON the smoke rather than around it — you end up drawing against your own
+ * box. The ladder still reads because colour separates the three sources
+ * anyway; weight only has to break the tie.
+ *
+ * These are drawn as PAINT, not as CSS borders — a border cannot render below
+ * one device pixel per unit of zoom, which silently flattened this whole
+ * ladder to a single width whenever the annotator zoomed in. See
+ * `utils/annotation/hairlineStroke`.
+ *
+ * Because the paint path is honest, these numbers are now literal device
+ * pixels on screen, and the floor is 1: below that a stroke is anti-aliased
+ * to partial alpha and reads as missing rather than as thin.
  */
-export const haloShadow = (scale = 1): string => {
-  const ring = 1 / scale;
-  return `0 0 0 ${ring}px rgba(0,0,0,0.65), inset 0 0 0 ${ring}px rgba(0,0,0,0.65)`;
+export const SOURCE_WEIGHT: Record<BoxSource, number> = {
+  manual: 2,
+  auto: 1.5,
+  engine: 1,
 };
 
 /**

--- a/frontend/src/utils/annotation/hairlineStroke.ts
+++ b/frontend/src/utils/annotation/hairlineStroke.ts
@@ -1,0 +1,64 @@
+/**
+ * Box outlines thinner than a CSS border can draw.
+ *
+ * The annotation stage puts every overlay inside a `scale(zoomLevel)`
+ * transform, so a stroke has to be authored at `width / zoom` to keep a
+ * constant weight on screen. That is where CSS borders fail us: Blink floors
+ * `border-width` to whole pixels and clamps any nonzero value under 1px back
+ * up to 1px, so `0.25px` and `1.33px` both resolve to `1px` and the transform
+ * then paints them at `zoom` device pixels. Measured in headless Chrome at
+ * zoom 3, every authored width from 0.167px to 1.33px painted the same 3px —
+ * which silently flattened the whole `SOURCE_WEIGHT` ladder to one width
+ * whenever the annotator zoomed in. `outline` is clamped identically.
+ *
+ * `box-shadow` spread is a PAINT property — no layout rounding, no clamp — and
+ * renders a true sub-pixel ring, verified complete and crisp at zoom 1 to 4.
+ *
+ * This matters because a wildfire at the start of an alert can be a dozen
+ * pixels across, and the annotator zooms in precisely because it is small —
+ * the moment a border-drawn stroke is at its fattest and sitting on the smoke
+ * being traced.
+ *
+ * Two things were tried and rejected, both of which LOOK right in the DOM and
+ * fail only when painted:
+ *
+ * - Dashed strokes as four `background` gradient bands. Chrome will not
+ *   reliably rasterize a band a fraction of a pixel tall; it drops whole
+ *   edges rather than anti-aliasing them, so boxes lost their top or right
+ *   side as the zoom rose. Sources are distinguished by colour and weight
+ *   instead, and every stroke here is solid.
+ * - A dark halo behind the stroke. Around a 2-4px border it bought legibility
+ *   over bright sky, but at these widths its inner half is thicker than the
+ *   stroke it backs and lands ON the smoke. The source colours are high-chroma
+ *   hues absent from wildfire scenes, so they carry themselves.
+ */
+
+import type { CSSProperties } from 'react';
+
+export interface HairlineStrokeOptions {
+  color: string;
+  /**
+   * Stroke width in screen px, before the zoom division. Values below 1 are
+   * anti-aliased to partial alpha and read as missing rather than as thin, so
+   * 1 is the practical floor.
+   */
+  width: number;
+  /** The zoom this stroke is rendered inside. */
+  scale?: number;
+}
+
+/**
+ * CSS for one box outline. Returns paint properties only — the caller still
+ * owns the box's position and size.
+ *
+ * The ring is INSET, i.e. painted just inside the box's own rect. An outset
+ * ring reads better — it leaves the smoke completely unobscured — but it is
+ * painted outside the element, and the stage clips to `overflow-hidden`, so
+ * any box reaching the frame edge lost the stroke on that side. Engine boxes
+ * are the loosest of the three and hit the edge most often. A CSS border
+ * never had this problem because it is part of the element's own box; that is
+ * the one thing borders were doing for us here.
+ */
+export function hairlineStroke({ color, width, scale = 1 }: HairlineStrokeOptions): CSSProperties {
+  return { boxShadow: `inset 0 0 0 ${width / scale}px ${color}` };
+}

--- a/frontend/tests/components/annotation/DrawingOverlay.strokes.test.tsx
+++ b/frontend/tests/components/annotation/DrawingOverlay.strokes.test.tsx
@@ -89,9 +89,17 @@ describe('DrawingOverlay stroke weights', () => {
   it('never lays the strokes out as CSS borders, at any zoom', () => {
     // A border would floor to 1 layout px and paint at `zoom` device px,
     // silently discarding every width above.
+    //
+    // Checked as class AND inline style, because the two strokes regressed
+    // differently: the committed box set `borderWidth` inline, while the
+    // rubber band carried `border-2 border-dashed` as a Tailwind class and
+    // no inline border at all. Asserting on the style alone would let the
+    // band's old markup sail through this guard.
     for (const scale of [1, 2, 3, 4]) {
-      expect(renderBox(scale, true).style.borderWidth).toBe('');
-      expect(renderBand(scale).style.borderWidth).toBe('');
+      for (const el of [renderBox(scale, true), renderBand(scale)]) {
+        expect(el.className).not.toMatch(/\bborder(-|\b)/);
+        expect(el.style.borderWidth).toBe('');
+      }
     }
   });
 });

--- a/frontend/tests/components/annotation/DrawingOverlay.strokes.test.tsx
+++ b/frontend/tests/components/annotation/DrawingOverlay.strokes.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Stroke weights on the localize editor's drawing layer.
+ *
+ * Everything DrawingOverlay renders sits inside a `scale(zoomLevel)` transform,
+ * so a width authored in flat CSS pixels is multiplied on screen. That matters
+ * here more than anywhere: an annotator zooms in precisely because the smoke is
+ * a few pixels across, and a stroke that grows with the zoom covers the pixels
+ * being aimed at.
+ *
+ * The strokes are therefore PAINTED (box-shadow spread / background bands) and
+ * never laid out as CSS borders, which Blink clamps to a minimum of one device
+ * pixel per unit of zoom. See `utils/annotation/hairlineStroke`.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DrawingOverlay } from '@/components/annotation/ImageOverlays';
+import { ImageInfo } from '@/utils/annotation/coordinateUtils';
+
+const imageInfo: ImageInfo = { width: 100, height: 100, offsetX: 0, offsetY: 0 };
+
+const baseProps = {
+  imageInfo,
+  panOffset: { x: 0, y: 0 },
+  transformOrigin: { x: 50, y: 50 },
+  isDragging: false,
+  normalizedToImage: (x: number, y: number) => ({ x: x * 100, y: y * 100 }),
+};
+
+/**
+ * Spread radius of the box-shadow ring, i.e. the coloured stroke width. It is
+ * the last length in `0 0 0 <spread>px <color>`; the leading zeros may or may
+ * not carry a unit depending on who serialised the value.
+ */
+const spreadOf = (boxShadow: string) => {
+  const lengths = boxShadow.match(/[\d.]+px/g) ?? [];
+  return parseFloat(lengths[lengths.length - 1]);
+};
+
+const renderBand = (strokeScale: number) =>
+  render(
+    <DrawingOverlay
+      {...baseProps}
+      drawnRectangles={[]}
+      currentDrawing={{ startX: 10, startY: 10, currentX: 30, currentY: 30 }}
+      selectedRectangleId={null}
+      zoomLevel={strokeScale}
+      strokeScale={strokeScale}
+    />
+  ).container.querySelector('[data-testid="drawing-rubber-band"]') as HTMLElement;
+
+const renderBox = (strokeScale: number, selected: boolean) =>
+  render(
+    <DrawingOverlay
+      {...baseProps}
+      drawnRectangles={[{ id: 'box-1', xyxyn: [0.1, 0.1, 0.2, 0.2] }]}
+      currentDrawing={null}
+      selectedRectangleId={selected ? 'box-1' : null}
+      zoomLevel={strokeScale}
+      strokeScale={strokeScale}
+      boxColor="#FF2D95"
+      boxWidth={2}
+    />
+  ).container.querySelector('[data-testid="drawn-box-box-1"]') as HTMLElement;
+
+describe('DrawingOverlay stroke weights', () => {
+  it('divides the in-progress rubber band by the zoom', () => {
+    const widthAt = (scale: number) => spreadOf(renderBand(scale).style.boxShadow);
+
+    const at1x = widthAt(1);
+    expect(at1x).toBeGreaterThan(0);
+    expect(widthAt(4)).toBeCloseTo(at1x / 4);
+  });
+
+  it('divides the committed box stroke by the zoom', () => {
+    const at1x = spreadOf(renderBox(1, false).style.boxShadow);
+    expect(at1x).toBeCloseTo(2);
+    expect(spreadOf(renderBox(4, false).style.boxShadow)).toBeCloseTo(0.5);
+  });
+
+  it('keeps a selected box only marginally heavier than an unselected one', () => {
+    // Selection is signalled mostly by the resize handles; the stroke bump is
+    // a hint, not a second box drawn on top of the first.
+    const bump =
+      spreadOf(renderBox(1, true).style.boxShadow) - spreadOf(renderBox(1, false).style.boxShadow);
+    expect(bump).toBeCloseTo(1);
+  });
+
+  it('never lays the strokes out as CSS borders, at any zoom', () => {
+    // A border would floor to 1 layout px and paint at `zoom` device px,
+    // silently discarding every width above.
+    for (const scale of [1, 2, 3, 4]) {
+      expect(renderBox(scale, true).style.borderWidth).toBe('');
+      expect(renderBand(scale).style.borderWidth).toBe('');
+    }
+  });
+});

--- a/frontend/tests/components/annotation/ObjectIdentityOverlay.test.tsx
+++ b/frontend/tests/components/annotation/ObjectIdentityOverlay.test.tsx
@@ -36,8 +36,10 @@ describe('ObjectIdentityOverlay', () => {
       />
     );
 
-    const box = container.querySelector('.border-2') as HTMLElement;
-    expect(box.style.borderColor).toBe('rgb(22, 106, 93)'); // #166A5D
+    const box = container.querySelector('[data-testid="object-overlay-box"]') as HTMLElement;
+    // The stroke is painted as a box-shadow ring rather than laid out as a
+    // CSS border, so the colour lands there. See hairlineStroke.
+    expect(box.style.boxShadow).toContain('#166A5D');
     const label = screen.getByText('Object 2');
     expect(label.style.backgroundColor).toBe('rgb(22, 106, 93)');
   });
@@ -49,7 +51,7 @@ describe('ObjectIdentityOverlay', () => {
         objects={[{ color: '#166A5D', label: 'Object 2', boxes: [{ xyxyn: [0.1, 0.1, 0.2, 0.2] }] }]}
       />
     );
-    expect(container.querySelector('.border-2')?.className).toContain('pointer-events-none');
+    expect(container.querySelector('[data-testid="object-overlay-box"]')?.className).toContain('pointer-events-none');
   });
 
   it('renders multiple boxes for the same object', () => {
@@ -68,12 +70,12 @@ describe('ObjectIdentityOverlay', () => {
         ]}
       />
     );
-    expect(container.querySelectorAll('.border-2')).toHaveLength(2);
+    expect(container.querySelectorAll('[data-testid="object-overlay-box"]')).toHaveLength(2);
   });
 
   it('renders nothing when there are no objects', () => {
     const { container } = render(<ObjectIdentityOverlay imageInfo={imageInfo} objects={[]} />);
-    expect(container.querySelectorAll('.border-2')).toHaveLength(0);
+    expect(container.querySelectorAll('[data-testid="object-overlay-box"]')).toHaveLength(0);
   });
 
   it('skips an invalid box without crashing', () => {
@@ -85,6 +87,46 @@ describe('ObjectIdentityOverlay', () => {
         ]}
       />
     );
-    expect(container.querySelectorAll('.border-2')).toHaveLength(0);
+    expect(container.querySelectorAll('[data-testid="object-overlay-box"]')).toHaveLength(0);
+  });
+
+  // These boxes live inside the canvas's scaled layer, so a stroke authored in
+  // flat CSS pixels is drawn `zoomLevel` times as thick — worst exactly when
+  // the annotator has zoomed in on a small smoke.
+  it('divides the stroke by the zoom so it keeps its on-screen weight', () => {
+    const strokeAt = (strokeScale: number) => {
+      const { container } = render(
+        <ObjectIdentityOverlay
+          imageInfo={imageInfo}
+          strokeScale={strokeScale}
+          objects={[
+            { color: '#166A5D', label: 'Object 2', boxes: [{ xyxyn: [0.1, 0.1, 0.2, 0.2] }] },
+          ]}
+        />
+      );
+      const box = container.querySelector('[data-testid="object-overlay-box"]') as HTMLElement;
+      // The ring's spread radius is the stroke width: `0 0 0 <spread>px <color>`.
+      const lengths = box.style.boxShadow.match(/[\d.]+px/g) ?? [];
+      return parseFloat(lengths[lengths.length - 1]);
+    };
+
+    const at1x = strokeAt(1);
+    expect(at1x).toBeGreaterThan(0);
+    expect(strokeAt(4)).toBeCloseTo(at1x / 4);
+  });
+
+  // The regression this whole approach exists for: a CSS border cannot paint
+  // below one device pixel per unit of zoom, so it must not come back.
+  it('paints the stroke rather than laying it out as a border', () => {
+    const { container } = render(
+      <ObjectIdentityOverlay
+        imageInfo={imageInfo}
+        strokeScale={3}
+        objects={[{ color: '#166A5D', label: 'Object 2', boxes: [{ xyxyn: [0.1, 0.1, 0.2, 0.2] }] }]}
+      />
+    );
+    const box = container.querySelector('[data-testid="object-overlay-box"]') as HTMLElement;
+    expect(box.style.borderWidth).toBe('');
+    expect(box.style.boxShadow).not.toBe('');
   });
 });

--- a/frontend/tests/components/annotation/ObjectIdentityOverlay.test.tsx
+++ b/frontend/tests/components/annotation/ObjectIdentityOverlay.test.tsx
@@ -126,6 +126,10 @@ describe('ObjectIdentityOverlay', () => {
       />
     );
     const box = container.querySelector('[data-testid="object-overlay-box"]') as HTMLElement;
+    // Both spellings: this box carried its border as a Tailwind class
+    // (`border-2 border-dashed`), so asserting on the inline style alone
+    // would pass against the very code this guards against.
+    expect(box.className).not.toMatch(/\bborder(-|\b)/);
     expect(box.style.borderWidth).toBe('');
     expect(box.style.boxShadow).not.toBe('');
   });

--- a/frontend/tests/components/detection-annotation/DetectionAnnotationCanvas.test.tsx
+++ b/frontend/tests/components/detection-annotation/DetectionAnnotationCanvas.test.tsx
@@ -156,7 +156,13 @@ describe('DetectionAnnotationCanvas single-box model', () => {
     const { rerender } = render(
       <DetectionAnnotationCanvas {...defaultProps} committed={auto} ghosts={[engine]} />
     );
-    const at1x = screen.getByTestId('ghost-box-engine-0').style.borderWidth;
+    // Painted as a box-shadow ring, not laid out as a CSS border: the spread
+    // radius in `0 0 0 <spread>px <color>` is the stroke width.
+    const strokeWidth = (el: HTMLElement) => {
+      const lengths = el.style.boxShadow.match(/[\d.]+px/g) ?? [];
+      return lengths[lengths.length - 1];
+    };
+    const at1x = strokeWidth(screen.getByTestId('ghost-box-engine-0'));
 
     rerender(
       <DetectionAnnotationCanvas
@@ -166,7 +172,7 @@ describe('DetectionAnnotationCanvas single-box model', () => {
         zoomLevel={3}
       />
     );
-    const at3x = screen.getByTestId('ghost-box-engine-0').style.borderWidth;
+    const at3x = strokeWidth(screen.getByTestId('ghost-box-engine-0'));
 
     expect(parseFloat(at3x)).toBeCloseTo(parseFloat(at1x) / 3);
   });

--- a/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
+++ b/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
@@ -14,8 +14,19 @@ beforeAll(() => {
   })) as unknown as HTMLCanvasElement['getContext'];
 });
 
+const IMAGE_URL = 'https://img.example/1.jpg';
+
+/**
+ * Mutable so a test can render the editor BEFORE the image URL resolves,
+ * which is what a cold open really does — the canvas renders no <img> until
+ * then, so anything reaching for `imgRef` on the first pass finds null.
+ */
+const imageState = vi.hoisted(() => ({
+  data: { url: 'https://img.example/1.jpg' } as { url: string } | undefined,
+}));
+
 vi.mock('@/hooks/useDetectionImage', () => ({
-  useDetectionImage: () => ({ data: { url: 'https://img.example/1.jpg' } }),
+  useDetectionImage: () => ({ data: imageState.data }),
 }));
 
 const LANE = 27;
@@ -124,7 +135,10 @@ const renderLoadedEditor = (over: Partial<Props> = {}) => {
   return result;
 };
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  imageState.data = { url: IMAGE_URL };
+});
 
 describe('LocalizeObjectEditor', () => {
   it('commits the clicked candidate with its own origin', () => {
@@ -425,6 +439,49 @@ const drag = (from: [number, number], to: [number, number], init: object = {}) =
 };
 
 describe('LocalizeObjectEditor canvas', () => {
+  // Browser zoom (ctrl +/-) and window resizes change the image's rendered
+  // size without firing `load`. Every overlay is positioned from the measured
+  // geometry, so without this the boxes stay drawn where the image used to be.
+  it('observes the image for resizes, to re-measure overlay geometry', () => {
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    vi.stubGlobal(
+      'ResizeObserver',
+      vi.fn(() => ({ observe, disconnect, unobserve: vi.fn() }))
+    );
+
+    const { unmount } = renderLoadedEditor();
+    expect(observe).toHaveBeenCalledTimes(1);
+    expect(observe.mock.calls[0][0]).toBe(document.querySelector('img'));
+    unmount();
+    expect(disconnect).toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  // A cold open has no image URL on the first render, so the canvas renders no
+  // <img> at all and the ref is null. Attaching only once on mount would leave
+  // the observer permanently unattached — passing only because test fixtures
+  // hand over the URL synchronously.
+  it('still attaches the observer when the image URL arrives late', () => {
+    const observe = vi.fn();
+    vi.stubGlobal(
+      'ResizeObserver',
+      vi.fn(() => ({ observe, disconnect: vi.fn(), unobserve: vi.fn() }))
+    );
+
+    imageState.data = undefined;
+    const { rerender } = renderEditor();
+    expect(document.querySelector('img')).toBeNull();
+    expect(observe).not.toHaveBeenCalled();
+
+    imageState.data = { url: IMAGE_URL };
+    rerender(editorWith());
+
+    expect(observe).toHaveBeenCalledTimes(1);
+    expect(observe.mock.calls[0][0]).toBe(document.querySelector('img'));
+    vi.unstubAllGlobals();
+  });
+
   it('draws on a plain drag, with nothing to arm first', () => {
     const onCommit = vi.fn();
     renderLoadedEditor({ onCommit });


### PR DESCRIPTION
## Why

The bbox borders in the localize object editor were too thick to annotate small fires against — you end up drawing over your own box.

Lowering the numbers did nothing, and the reason turned out to be a real bug rather than a taste question.

## The bug

The strokes are authored at `width / zoomLevel` so they keep a constant weight on screen. Blink throws that away: it floors `border-width` to whole pixels and clamps any nonzero value below 1px back up to 1px. The stage's `scale(zoomLevel)` transform then multiplies the clamped value back up.

Measured in headless Chrome at zoom 3 — every authored width paints identically:

| authored | used | painted |
| --- | --- | --- |
| 1.33px (manual, old) | `1px` | 3 device px |
| 1.00px (auto, old) | `1px` | 3 device px |
| 0.67px (engine, old) | `1px` | 3 device px |
| 0.33px | `1px` | 3 device px |
| 0.167px | `1px` | 3 device px |

So **no CSS border on that canvas could be thinner than `zoomLevel` device pixels**, and the `SOURCE_WEIGHT` ladder silently collapsed to a single width whenever the annotator zoomed in — precisely when it matters, since you zoom in *because* the smoke is small. `outline` is clamped identically.

## The fix

Strokes are painted as an inset `box-shadow` ring (`hairlineStroke`) instead of laid out as a border. `box-shadow` spread is a paint property: no layout rounding, no clamp, true sub-pixel rendering.

The ladder drops from **4 / 3 / 2px** to **2 / 1.5 / 1px**, and is now honest at every zoom.

Two things went with it, both reported as regressions during review and then diagnosed:

- **Dashes.** Drawing them as four background gradient bands looked correct in the DOM but Chrome will not rasterize a sub-pixel-tall background band — it drops whole edges rather than anti-aliasing them, so boxes lost their top or right side as zoom rose. Sources are now told apart by colour and weight alone.
- **The dark halo.** Around a 2–4px border it bought legibility over bright sky. At hairline widths its inner half was thicker than the stroke it backed and sat on the smoke.

The ring is **inset**, not outset. An outset ring reads better — it leaves the smoke unobscured — but it paints outside the element, and the stage clips to `overflow-hidden`, so boxes reaching the frame edge lost the stroke on that side. Being part of the element's own box is the one thing a border was doing for us.

`1px` is the practical floor: below it a stroke anti-aliases to partial alpha and reads as *missing* rather than as thin.

## Also fixed

A pre-existing bug found while verifying: `imageInfo` — the geometry every overlay positions itself from — was written only by the image's `onLoad`. Browser zoom (ctrl +/-) and window resizes change the image's rendered size without re-firing `load`, leaving every box drawn against stale geometry. A `ResizeObserver` re-measures, matching what `DetectionImageCard` already does for the same reason.

## Verification

Findings are from painted-pixel measurements in headless Chrome, not from reading the DOM — the DOM was misleading in all three cases above.

- Painted-pixel screenshots confirm complete, crisp rectangles for all three sources at zoom 1×–4×, including boxes flush against the frame edge.
- Both new `ResizeObserver` tests were confired non-vacuous by reverting the fix and watching them fail.
- 1325 tests pass; `type-check`, `lint`, `format:check` clean.

## Notes for the reviewer

- Non-localize consumers of `DrawingOverlay` are untouched: the Tailwind `border-2` fallback path (when `boxColor` is absent) still applies, as does `SiblingBoundingBoxOverlay`.
- The resize handles (10px squares, 2px outline) are unchanged and still dominate a small box — deliberately left out of scope.
