### PR TITLE
fix(localize): one box per object per frame, drawn and committed alike

### DIFF
--- a/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
+++ b/frontend/src/components/localize/editor/LocalizeObjectEditor.tsx
@@ -290,8 +290,16 @@ export function LocalizeObjectEditor({
   const shownCommitted: BoxCandidate | null = boxEdit
     ? { source: 'manual', index: 0, xyxyn: boxEdit.next }
     : committed;
+  // Matched on GEOMETRY, not on source+index: `committedBox` reports
+  // `index: 0` for whatever it read out of the annotation, while the auto
+  // layer is ordered anchored-first (`boxCandidates`), so the committed box
+  // is frequently candidate index 1. Comparing the pair would then mark the
+  // wrong candidate as committed — drawing a ghost on top of the committed
+  // box and hiding the only real loser, which is the comparison `G` exists
+  // to offer. Two candidates sharing a geometry are the same box, so
+  // dropping both is right.
   const losers = candidates.filter(
-    c => !(shownCommitted && c.source === shownCommitted.source && c.index === shownCommitted.index)
+    c => !(shownCommitted && c.xyxyn.every((v, i) => v === shownCommitted.xyxyn[i]))
   );
 
   /**
@@ -435,7 +443,12 @@ export function LocalizeObjectEditor({
       resetStageZoom();
       return;
     }
-    const boxes = committed ? [committed] : candidates;
+    // The box that speaks for the object — committed, else the one Enter
+    // would commit. NOT every candidate: a layer holding a stray box
+    // elsewhere in the scene made the window span both, which
+    // `computeCellCrop` clamps to scale 1, so the framing did nothing on
+    // precisely the frames that needed it.
+    const boxes = committed ? [committed] : pick ? [pick] : [];
     if (boxes.length === 0) return;
     applyStageView(computeCellCrop(boxes, OBJECT_FRAMING));
     // Re-frames on frame change too, since the object moves between frames.

--- a/frontend/src/utils/annotation/alertLocalizeUtils.ts
+++ b/frontend/src/utils/annotation/alertLocalizeUtils.ts
@@ -55,6 +55,12 @@ export interface AlertFrameCell {
   cellState: CellState;
   /** The lane's object color — tints markers that don't ride on a box (the cleared chip). */
   color: string;
+  /**
+   * The object's box on this frame. At most one — see the cap in
+   * `buildAlertFrameModel`. Kept as a list because the crop helpers take
+   * one, and because an empty cell is a real state (cleared, or no model
+   * evidence yet).
+   */
   boxes: AlertFrameBox[];
   /** Read-only false-positive context (opt-in) — visible, never openable in the editor. */
   isFalsePositive?: boolean;
@@ -174,15 +180,36 @@ export function buildAlertFrameModel(
       // with nothing to draw — no mini-boxes, no crop-mode zoom, and a
       // timeline row stuck at 'empty'. Its engine track is what the
       // read-only context view is for.
-      const rawBoxes = falsePositive
-        ? falsePositiveContextBoxes(detection)
-        : cellState === 'done'
-          ? (annotation?.annotation?.annotation ?? [])
-              .filter(item => item.false_positive_type == null)
-              .map(item => ({ xyxyn: item.xyxyn }))
-          : cellState === 'auto'
-            ? getWinningBoxes(detection).boxes.map(b => ({ xyxyn: b.xyxyn }))
-            : [];
+      //
+      // Capped at ONE box: an object has at most one box per frame — the
+      // invariant the editor's box model states
+      // (`objectBoxCandidates.ts`) and the only thing this lane can ever
+      // commit. Nothing upstream enforces it. The worker keeps every
+      // sensitive-model prediction overlapping the lane's engine anchor
+      // (`worker.py`), and that model runs at a 0.01 confidence floor, so a
+      // pending frame's auto layer regularly holds two or three boxes — the
+      // extras being noise the annotator is not being asked about. Drawing
+      // the whole layer stacked them all in one cell and read as "this
+      // object is in three places at once", while the editor, three clicks
+      // away, drew one.
+      //
+      // So both surfaces have to choose, and they have to choose alike. The
+      // editor draws `priorityPick` / `committedBox`, each the FIRST of its
+      // list; the cap here is the same rule, which is why it is applied
+      // BEFORE `focusOnMainObject` below — that filter has no counterpart in
+      // the editor, and letting it run first could leave the grid showing a
+      // different box from the one Enter would commit.
+      const rawBoxes = (
+        falsePositive
+          ? falsePositiveContextBoxes(detection)
+          : cellState === 'done'
+            ? (annotation?.annotation?.annotation ?? [])
+                .filter(item => item.false_positive_type == null)
+                .map(item => ({ xyxyn: item.xyxyn }))
+            : cellState === 'auto'
+              ? getWinningBoxes(detection).boxes.map(b => ({ xyxyn: b.xyxyn }))
+              : []
+      ).slice(0, 1);
 
       // All three cell states stay distinct on the strip. Collapsing 'auto'
       // and 'no-box' into one "pending" fill made a frame with nothing on it

--- a/frontend/src/utils/annotation/alertLocalizeUtils.ts
+++ b/frontend/src/utils/annotation/alertLocalizeUtils.ts
@@ -56,10 +56,9 @@ export interface AlertFrameCell {
   /** The lane's object color — tints markers that don't ride on a box (the cleared chip). */
   color: string;
   /**
-   * The object's box on this frame. At most one — see the cap in
-   * `buildAlertFrameModel`. Kept as a list because the crop helpers take
-   * one, and because an empty cell is a real state (cleared, or no model
-   * evidence yet).
+   * The object's boxes on this frame. One on a pending frame (the model
+   * layer is capped at its winning box); whatever is committed on a settled
+   * one; empty is a real state (cleared, or no model evidence yet).
    */
   boxes: AlertFrameBox[];
   /** Read-only false-positive context (opt-in) — visible, never openable in the editor. */
@@ -181,27 +180,23 @@ export function buildAlertFrameModel(
       // timeline row stuck at 'empty'. Its engine track is what the
       // read-only context view is for.
       //
-      // Capped at ONE box, because an object has at most one box per frame
-      // (`objectBoxCandidates.ts`) and nothing upstream enforces it. The
-      // model layers are capped at source in `getWinningBoxes`; this cap
-      // covers the two paths that don't go through it — a committed
-      // annotation, which no constraint stops from holding several items,
-      // and an FP lane's engine track.
-      //
-      // Applied BEFORE `focusOnMainObject` below: that filter has no
-      // counterpart in the editor, so letting it choose could leave the grid
-      // showing a different box from the one the editor would commit.
-      const rawBoxes = (
-        falsePositive
-          ? falsePositiveContextBoxes(detection)
-          : cellState === 'done'
-            ? (annotation?.annotation?.annotation ?? [])
-                .filter(item => item.false_positive_type == null)
-                .map(item => ({ xyxyn: item.xyxyn }))
-            : cellState === 'auto'
-              ? getWinningBoxes(detection).boxes.map(b => ({ xyxyn: b.xyxyn }))
-              : []
-      ).slice(0, 1);
+      // A pending frame draws ONE box, because `getWinningBoxes` caps the
+      // model layer at the box it would also commit — the model regularly
+      // proposes two or three and the extras are noise nobody is being asked
+      // about. The committed and false-positive paths are deliberately NOT
+      // capped: those boxes are already in the database and the export ships
+      // every one of them, so a surface that quietly drew fewer would
+      // under-report what is stored — the same class of mismatch, pointed
+      // the other way.
+      const rawBoxes = falsePositive
+        ? falsePositiveContextBoxes(detection)
+        : cellState === 'done'
+          ? (annotation?.annotation?.annotation ?? [])
+              .filter(item => item.false_positive_type == null)
+              .map(item => ({ xyxyn: item.xyxyn }))
+          : cellState === 'auto'
+            ? getWinningBoxes(detection).boxes.map(b => ({ xyxyn: b.xyxyn }))
+            : [];
 
       // All three cell states stay distinct on the strip. Collapsing 'auto'
       // and 'no-box' into one "pending" fill made a frame with nothing on it

--- a/frontend/src/utils/annotation/alertLocalizeUtils.ts
+++ b/frontend/src/utils/annotation/alertLocalizeUtils.ts
@@ -181,24 +181,16 @@ export function buildAlertFrameModel(
       // timeline row stuck at 'empty'. Its engine track is what the
       // read-only context view is for.
       //
-      // Capped at ONE box: an object has at most one box per frame — the
-      // invariant the editor's box model states
-      // (`objectBoxCandidates.ts`) and the only thing this lane can ever
-      // commit. Nothing upstream enforces it. The worker keeps every
-      // sensitive-model prediction overlapping the lane's engine anchor
-      // (`worker.py`), and that model runs at a 0.01 confidence floor, so a
-      // pending frame's auto layer regularly holds two or three boxes — the
-      // extras being noise the annotator is not being asked about. Drawing
-      // the whole layer stacked them all in one cell and read as "this
-      // object is in three places at once", while the editor, three clicks
-      // away, drew one.
+      // Capped at ONE box, because an object has at most one box per frame
+      // (`objectBoxCandidates.ts`) and nothing upstream enforces it. The
+      // model layers are capped at source in `getWinningBoxes`; this cap
+      // covers the two paths that don't go through it — a committed
+      // annotation, which no constraint stops from holding several items,
+      // and an FP lane's engine track.
       //
-      // So both surfaces have to choose, and they have to choose alike. The
-      // editor draws `priorityPick` / `committedBox`, each the FIRST of its
-      // list; the cap here is the same rule, which is why it is applied
-      // BEFORE `focusOnMainObject` below — that filter has no counterpart in
-      // the editor, and letting it run first could leave the grid showing a
-      // different box from the one Enter would commit.
+      // Applied BEFORE `focusOnMainObject` below: that filter has no
+      // counterpart in the editor, so letting it choose could leave the grid
+      // showing a different box from the one the editor would commit.
       const rawBoxes = (
         falsePositive
           ? falsePositiveContextBoxes(detection)

--- a/frontend/src/utils/annotation/objectBoxCandidates.ts
+++ b/frontend/src/utils/annotation/objectBoxCandidates.ts
@@ -14,8 +14,8 @@
  * rather than reach an unhandled branch. It is not hypothetical: 255 of 6,807
  * auto-annotated detections (3.7%) carried more than one auto box as of
  * 2026-08-12, the extras being sub-0.1-confidence noise from a detector run
- * at a 0.01 floor. Only the FIRST is ever drawn or committed (`priorityPick`,
- * `committedBox`, and the grid's own cap in `alertLocalizeUtils.ts`).
+ * at a 0.01 floor. Only ONE is ever drawn or committed by default — the one
+ * anchored to the frame, see `boxCandidates` and `getWinningBoxes`.
  */
 
 import type {
@@ -26,6 +26,7 @@ import type {
   DetectionAnnotationBbox,
   SmokeType,
 } from '@/types/api';
+import { focusOnMainObject } from './gridCropUtils';
 
 export type BoxSource = 'manual' | 'auto' | 'engine';
 
@@ -107,6 +108,14 @@ export function isCleared(annotation: DetectionAnnotation | null | undefined): b
  * (manual, then auto, then engine). A manual candidate exists only once one
  * has been drawn and saved — drawing commits immediately, so the committed
  * annotation IS where a manual box lives.
+ *
+ * Within the auto layer, the boxes anchored to THIS frame come first, so the
+ * head of the list — what `priorityPick` returns and Enter commits — is the
+ * same box `getWinningBoxes` draws in the grid and writes on accept-remaining.
+ * The model orders its output by confidence, but the worker's anchor is
+ * sequence-wide, so the most confident box is not always the one on this
+ * frame's plume. The runners-up are kept, in their original order: the rail
+ * exists so a deliberate choice is still possible.
  */
 export function boxCandidates(
   detection: Detection,
@@ -115,9 +124,13 @@ export function boxCandidates(
   const committed = committedBox(annotation);
   const manual: BoxCandidate[] = committed && committed.source === 'manual' ? [committed] : [];
 
+  const auto = fromPredictions('auto', detection.auto_predictions?.predictions ?? []);
+  const anchored = new Set(focusOnMainObject(detection, auto));
+
   return [
     ...manual,
-    ...fromPredictions('auto', detection.auto_predictions?.predictions ?? []),
+    ...auto.filter(c => anchored.has(c)),
+    ...auto.filter(c => !anchored.has(c)),
     ...fromPredictions('engine', detection.algo_predictions?.predictions ?? []),
   ];
 }

--- a/frontend/src/utils/annotation/objectBoxCandidates.ts
+++ b/frontend/src/utils/annotation/objectBoxCandidates.ts
@@ -11,8 +11,11 @@
  * Nothing in the pipeline guarantees a model layer returns a single box —
  * object_split.py:208 writes a list, worker.py:109 keeps every box overlapping
  * the lane's anchor — so a layer holding two boxes must render as two rows
- * rather than reach an unhandled branch. It does not happen in today's data
- * (0 occurrences in 10,047 detections); this keeps it from ever mattering.
+ * rather than reach an unhandled branch. It is not hypothetical: 255 of 6,807
+ * auto-annotated detections (3.7%) carried more than one auto box as of
+ * 2026-08-12, the extras being sub-0.1-confidence noise from a detector run
+ * at a 0.01 floor. Only the FIRST is ever drawn or committed (`priorityPick`,
+ * `committedBox`, and the grid's own cap in `alertLocalizeUtils.ts`).
  */
 
 import type {

--- a/frontend/src/utils/annotation/objectBoxCandidates.ts
+++ b/frontend/src/utils/annotation/objectBoxCandidates.ts
@@ -114,8 +114,16 @@ export function isCleared(annotation: DetectionAnnotation | null | undefined): b
  * same box `getWinningBoxes` draws in the grid and writes on accept-remaining.
  * The model orders its output by confidence, but the worker's anchor is
  * sequence-wide, so the most confident box is not always the one on this
- * frame's plume. The runners-up are kept, in their original order: the rail
- * exists so a deliberate choice is still possible.
+ * frame's plume.
+ *
+ * The runners-up are kept, in their original order, but note what that does
+ * and does not buy: `BoxSourceRail` renders one row per SOURCE, so only the
+ * head of each layer is clickable, and `G` ghosts the rest for comparison
+ * without offering them. On a frame whose engine anchor is stale, the more
+ * confident box is therefore visible but not selectable — the annotator has
+ * to draw it. Acceptable because the anchored box is the better default on
+ * the 30% of multi-box frames where the two differ, but it is a real
+ * trade, not a free one.
  */
 export function boxCandidates(
   detection: Detection,

--- a/frontend/src/utils/annotation/quickSubmitUtils.ts
+++ b/frontend/src/utils/annotation/quickSubmitUtils.ts
@@ -1,8 +1,9 @@
 /**
  * Localize quick submit: per-frame cell state for the grid glance-check and
- * the batch payloads for one-click lane submit. Reuses the modal's exact
- * submit semantics (getWinningModelLayer + materializeReviewAnnotation with
- * every box accepted) so what the grid shows is what submit records.
+ * the batch payloads for one-click lane submit. Both read the frame's box
+ * through `getWinningBoxes`, so what the grid shows is what submit records —
+ * the property this module exists to hold, and the reason that function caps
+ * the layer rather than each caller doing it.
  */
 
 import {

--- a/frontend/src/utils/annotation/quickSubmitUtils.ts
+++ b/frontend/src/utils/annotation/quickSubmitUtils.ts
@@ -39,14 +39,36 @@ export function getIsAnnotated(
   return annotation?.processing_stage === 'annotated';
 }
 
-/** The winning model layer's boxes for a detection (auto if ≥1 box, else engine). */
+/**
+ * The winning model layer's box for a detection (auto if ≥1 box, else
+ * engine), as a list of AT MOST ONE.
+ *
+ * The layer itself can hold several: the sensitive model runs at a 0.01
+ * confidence floor and the worker keeps every prediction overlapping the
+ * lane's engine anchor, so a frame's auto layer routinely carries two or
+ * three boxes, the runners-up being sub-0.1-confidence noise. But an object
+ * has at most one box per frame (`objectBoxCandidates.ts`), and everything
+ * downstream of here either DRAWS this box (the grid cell, the preview loop)
+ * or COMMITS it (`buildQuickSubmitPlan`). Returning the whole layer meant
+ * accept-remaining wrote boxes to the database that no surface had ever
+ * shown, and that the export would then ship.
+ *
+ * The first is the winner: the model emits its predictions in descending
+ * confidence, and the editor's `priorityPick` takes the first of the same
+ * list — so capping here is what keeps accept-remaining agreeing with the
+ * per-frame accept the annotator would otherwise have pressed.
+ *
+ * `boxCandidates` deliberately does NOT go through this function: the
+ * editor's rail offers every candidate, which is where a runner-up can still
+ * be chosen deliberately.
+ */
 export function getWinningBoxes(detection: Detection) {
   const layer = getWinningModelLayer(detection);
   const boxes =
     layer === 'auto'
       ? (detection.auto_predictions?.predictions ?? [])
       : (detection.algo_predictions?.predictions ?? []);
-  return { layer, boxes };
+  return { layer, boxes: boxes.slice(0, 1) };
 }
 
 /**

--- a/frontend/src/utils/annotation/quickSubmitUtils.ts
+++ b/frontend/src/utils/annotation/quickSubmitUtils.ts
@@ -57,9 +57,15 @@ export function getIsAnnotated(
  * accept-remaining wrote boxes to the database that no surface had ever
  * shown, and that the export would then ship.
  *
- * The winner is the most confident box ANCHORED TO THIS FRAME, not simply
- * the most confident. The model emits predictions in descending confidence,
- * so the head of the list looks like the obvious pick — but the worker's
+ * The winner is the first box ANCHORED TO THIS FRAME — which for the auto
+ * layer means the most confident such box, since the model emits its
+ * predictions in descending confidence. (The engine layer carries no
+ * ordering guarantee: it arrives from the alert API. No detection in the
+ * data has ever had more than one engine box, so which one "first" means
+ * there has never mattered; if that changes, sort before slicing.)
+ *
+ * Anchoring is the point. The head of the list looks like the obvious pick
+ * on confidence alone — but the worker's
  * anchor is sequence-wide (`engine_seed_boxes` aggregates the engine boxes
  * of every detection in the lane), so a box survives by matching where the
  * object was on some OTHER frame. On 77 of the 255 multi-box detections in

--- a/frontend/src/utils/annotation/quickSubmitUtils.ts
+++ b/frontend/src/utils/annotation/quickSubmitUtils.ts
@@ -1,9 +1,12 @@
 /**
  * Localize quick submit: per-frame cell state for the grid glance-check and
- * the batch payloads for one-click lane submit. Both read the frame's box
- * through `getWinningBoxes`, so what the grid shows is what submit records —
- * the property this module exists to hold, and the reason that function caps
- * the layer rather than each caller doing it.
+ * the batch payloads for one-click lane submit. Every model-layer read in
+ * here and in the grid goes through `getWinningBoxes`, so what the grid
+ * shows is what submit records — the property this module exists to hold,
+ * and the reason that function picks the frame's box itself rather than
+ * leaving each caller to choose. Committed boxes are a different matter:
+ * those are read straight from the annotation, all of them, because they are
+ * already stored and already exported.
  */
 
 import {
@@ -54,14 +57,22 @@ export function getIsAnnotated(
  * accept-remaining wrote boxes to the database that no surface had ever
  * shown, and that the export would then ship.
  *
- * The first is the winner: the model emits its predictions in descending
- * confidence, and the editor's `priorityPick` takes the first of the same
- * list — so capping here is what keeps accept-remaining agreeing with the
- * per-frame accept the annotator would otherwise have pressed.
+ * The winner is the most confident box ANCHORED TO THIS FRAME, not simply
+ * the most confident. The model emits predictions in descending confidence,
+ * so the head of the list looks like the obvious pick — but the worker's
+ * anchor is sequence-wide (`engine_seed_boxes` aggregates the engine boxes
+ * of every detection in the lane), so a box survives by matching where the
+ * object was on some OTHER frame. On 77 of the 255 multi-box detections in
+ * the 2026-08-12 data, the top-confidence box does not overlap its own
+ * frame's engine box while a runner-up does; taking the head there would
+ * draw and commit a box sitting where the plume isn't. `focusOnMainObject`
+ * falls back to the whole list when nothing is anchored, so a frame the
+ * engine never boxed still gets its most confident candidate.
  *
- * `boxCandidates` deliberately does NOT go through this function: the
+ * `boxCandidates` deliberately does NOT go through this function — the
  * editor's rail offers every candidate, which is where a runner-up can still
- * be chosen deliberately.
+ * be chosen deliberately — but it orders its own auto candidates the same
+ * way, so `priorityPick` and this agree on the default.
  */
 export function getWinningBoxes(detection: Detection) {
   const layer = getWinningModelLayer(detection);
@@ -69,7 +80,7 @@ export function getWinningBoxes(detection: Detection) {
     layer === 'auto'
       ? (detection.auto_predictions?.predictions ?? [])
       : (detection.algo_predictions?.predictions ?? []);
-  return { layer, boxes: boxes.slice(0, 1) };
+  return { layer, boxes: focusOnMainObject(detection, boxes).slice(0, 1) };
 }
 
 /**

--- a/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
+++ b/frontend/tests/components/localize/editor/LocalizeObjectEditor.test.tsx
@@ -233,6 +233,40 @@ describe('LocalizeObjectEditor', () => {
     expect(screen.queryByTestId('ghost-box-engine-0')).not.toBeInTheDocument();
   });
 
+  it('ghosts the box that lost, not the one that was committed, when the pick was a runner-up', () => {
+    // The anchored box can be the layer's SECOND prediction, and
+    // `committedBox` reports `index: 0` for whatever was committed, so
+    // identifying the committed candidate by source+index matched the wrong
+    // one: `G` drew a ghost on top of the committed box and hid the real
+    // loser — the one comparison `G` exists to offer.
+    const stray = { xyxyn: [0.7, 0.7, 0.8, 0.8], confidence: 0.52, class_name: 'smoke' };
+    const anchored = { xyxyn: [0.15, 0.15, 0.35, 0.35], confidence: 0.15, class_name: 'smoke' };
+    const detection = {
+      ...makeDetection('t001'),
+      auto_predictions: { predictions: [stray, anchored] },
+      algo_predictions: {
+        predictions: [{ xyxyn: [0.1, 0.1, 0.4, 0.4], confidence: 0.5, class_name: 'smoke' }],
+      },
+    } as unknown as Detection;
+    const committed = {
+      id: 7,
+      detection_id: detection.id,
+      annotation: {
+        annotation: [
+          { xyxyn: anchored.xyxyn, class_name: 'smoke', smoke_type: 'wildfire', origin: 'auto' },
+        ],
+      },
+    } as unknown as DetectionAnnotation;
+
+    renderLoadedEditor({ detection, existingAnnotation: committed });
+    fireEvent.keyDown(window, { key: 'g' });
+
+    // The stray is what the annotator did not take, so it is what `G` shows.
+    expect(screen.getByTestId('ghost-box-auto-0')).toBeInTheDocument();
+    // The committed box must not also be drawn as its own ghost.
+    expect(screen.queryByTestId('ghost-box-auto-1')).not.toBeInTheDocument();
+  });
+
   it('G cycles the stage through pick, every candidate, none, and back', () => {
     renderLoadedEditor();
 
@@ -980,6 +1014,30 @@ describe('LocalizeObjectEditor chrome', () => {
     fireEvent.keyDown(window, { key: 'z' });
     expect(screen.getByAltText(/^Detection /)).toHaveStyle({
       transform: 'scale(3) translate(0px, 0px)',
+    });
+  });
+
+  it('frames the box it would commit, not the union with a stray candidate', () => {
+    // Framing every candidate meant that on exactly the multi-box frames
+    // this branch is about, the window spanned the pick AND a stray sitting
+    // elsewhere in the scene — `computeCellCrop` clamps that to scale 1, so
+    // the object framing silently did nothing on the frames that needed it.
+    const stray = { xyxyn: [0.7, 0.7, 0.8, 0.8], confidence: 0.52, class_name: 'smoke' };
+    const anchored = { xyxyn: [0.15, 0.15, 0.35, 0.35], confidence: 0.15, class_name: 'smoke' };
+    const detection = {
+      ...makeDetection('t001'),
+      auto_predictions: { predictions: [stray, anchored] },
+      algo_predictions: {
+        predictions: [{ xyxyn: [0.1, 0.1, 0.4, 0.4], confidence: 0.5, class_name: 'smoke' }],
+      },
+    } as unknown as Detection;
+
+    renderLoadedEditor({ detection });
+
+    // 0.32 target fill over the pick's 0.2 span = 1.6. The union of all
+    // three candidates spans 0.7, which clamps to 1 — no zoom at all.
+    expect(screen.getByAltText(/^Detection /)).toHaveStyle({
+      transform: 'scale(1.6) translate(0px, 0px)',
     });
   });
 

--- a/frontend/tests/utils/annotation/alertLocalizeUtils.test.ts
+++ b/frontend/tests/utils/annotation/alertLocalizeUtils.test.ts
@@ -180,12 +180,14 @@ describe('buildAlertFrameModel', () => {
     expect(cell.boxes.map(b => b.xyxyn)).toEqual([best.xyxyn]);
   });
 
-  it('draws only the first committed box when an annotation holds several', () => {
-    // Same invariant on the committed side: nothing validates one box per
-    // object per frame in the database, and the editor's `committedBox`
-    // reads the first smoke item, so the grid must agree with it.
+  it('draws every committed box, so a settled frame never under-reports what is stored', () => {
+    // The cap belongs on the MODEL layer, where the extras are noise nobody
+    // was asked about. A committed box is already in the database and the
+    // export ships it, so drawing fewer than are stored would hide real data
+    // from the surface whose job is to review it.
     const t1 = '2026-01-01T10:00:00Z';
     const first: [number, number, number, number] = [0.2, 0.2, 0.4, 0.4];
+    const second: [number, number, number, number] = [0.15, 0.15, 0.25, 0.25];
 
     const { frames } = buildAlertFrameModel(
       [makeLane(1)],
@@ -194,9 +196,7 @@ describe('buildAlertFrameModel', () => {
         1: [
           makeDetAnnotation(1, 'annotated', [
             { xyxyn: first, class_name: 'smoke', smoke_type: 'wildfire' },
-            // Inside the engine anchor, so `focusOnMainObject` keeps it and
-            // the cap is what has to drop it.
-            { xyxyn: [0.15, 0.15, 0.25, 0.25], class_name: 'smoke', smoke_type: 'wildfire' },
+            { xyxyn: second, class_name: 'smoke', smoke_type: 'wildfire' },
           ]),
         ],
       }
@@ -204,7 +204,7 @@ describe('buildAlertFrameModel', () => {
 
     const cell = frames[0].cells[0];
     expect(cell.cellState).toBe('done');
-    expect(cell.boxes.map(b => b.xyxyn)).toEqual([first]);
+    expect(cell.boxes.map(b => b.xyxyn)).toEqual([first, second]);
   });
 
   it('maps a committed annotation with zero smoke boxes to cleared, not confirmed', () => {

--- a/frontend/tests/utils/annotation/alertLocalizeUtils.test.ts
+++ b/frontend/tests/utils/annotation/alertLocalizeUtils.test.ts
@@ -155,6 +155,58 @@ describe('buildAlertFrameModel', () => {
     expect(noBoxCell.boxes).toHaveLength(0);
   });
 
+  it('draws only the priority pick when the winning layer holds several boxes', () => {
+    // The sensitive model runs at a 0.01 confidence floor and the worker
+    // keeps EVERY prediction overlapping the lane's engine anchor
+    // (worker.py:107), so a pending frame's auto layer routinely carries two
+    // or three boxes — 3.7% of auto-annotated detections at the time of
+    // writing. The object still has at most one box (see
+    // objectBoxCandidates.ts), and the editor draws exactly the one Enter
+    // would commit, so the grid must not stack the runners-up on top of it.
+    const t1 = '2026-01-01T10:00:00Z';
+    const best = box(0.4, 0.3, 0.49, 0.4);
+    const runnerUp = box(0.43, 0.38, 0.45, 0.4);
+
+    const { frames } = buildAlertFrameModel(
+      [makeLane(1)],
+      // Engine box spans both, so `focusOnMainObject` keeps both — the
+      // overlap filter is not what limits the cell to one box.
+      { 1: [makeDetection(1, t1, { engine: [box(0.37, 0.29, 0.49, 0.41)], auto: [best, runnerUp] })] },
+      { 1: [] }
+    );
+
+    const cell = frames[0].cells[0];
+    expect(cell.cellState).toBe('auto');
+    expect(cell.boxes.map(b => b.xyxyn)).toEqual([best.xyxyn]);
+  });
+
+  it('draws only the first committed box when an annotation holds several', () => {
+    // Same invariant on the committed side: nothing validates one box per
+    // object per frame in the database, and the editor's `committedBox`
+    // reads the first smoke item, so the grid must agree with it.
+    const t1 = '2026-01-01T10:00:00Z';
+    const first: [number, number, number, number] = [0.2, 0.2, 0.4, 0.4];
+
+    const { frames } = buildAlertFrameModel(
+      [makeLane(1)],
+      { 1: [makeDetection(1, t1, { engine: [box()] })] },
+      {
+        1: [
+          makeDetAnnotation(1, 'annotated', [
+            { xyxyn: first, class_name: 'smoke', smoke_type: 'wildfire' },
+            // Inside the engine anchor, so `focusOnMainObject` keeps it and
+            // the cap is what has to drop it.
+            { xyxyn: [0.15, 0.15, 0.25, 0.25], class_name: 'smoke', smoke_type: 'wildfire' },
+          ]),
+        ],
+      }
+    );
+
+    const cell = frames[0].cells[0];
+    expect(cell.cellState).toBe('done');
+    expect(cell.boxes.map(b => b.xyxyn)).toEqual([first]);
+  });
+
   it('maps a committed annotation with zero smoke boxes to cleared, not confirmed', () => {
     const t1 = '2026-01-01T10:00:00Z';
     // Evidence-bearing frame (engine box) cleared by the annotator: the

--- a/frontend/tests/utils/annotation/quickSubmitUtils.test.ts
+++ b/frontend/tests/utils/annotation/quickSubmitUtils.test.ts
@@ -245,6 +245,40 @@ describe('buildQuickSubmitPlan', () => {
     expect(plan.noBoxCount).toBe(0);
   });
 
+  it('commits only the box that was shown when the winning layer holds several', () => {
+    // Accept-remaining must write what the annotator was looking at. The
+    // auto layer regularly carries two or three boxes on one frame (the
+    // sensitive model runs at a 0.01 confidence floor), and the runners-up
+    // are noise nobody was asked about — committing them would put boxes in
+    // the database that no surface ever displayed, and ship them in the
+    // export.
+    const best = box(0.4, 0.3, 0.49, 0.4, 0.52);
+    const runnerUp = box(0.43, 0.38, 0.45, 0.4, 0.15);
+    const detection = makeDetection(1, {
+      engine: [box(0.37, 0.29, 0.49, 0.41)],
+      auto: [best, runnerUp],
+    });
+
+    const plan = buildQuickSubmitPlan([detection], new Map(), 'wildfire');
+
+    expect(plan.payloads[0].body.annotation.annotation).toEqual([
+      { xyxyn: best.xyxyn, class_name: 'smoke', smoke_type: 'wildfire', origin: 'auto' },
+    ]);
+  });
+
+  it('shows one box per frame in the preview loop when the layer holds several', () => {
+    const best = box(0.4, 0.3, 0.49, 0.4, 0.52);
+    const runnerUp = box(0.43, 0.38, 0.45, 0.4, 0.15);
+    const detection = makeDetection(1, {
+      engine: [box(0.37, 0.29, 0.49, 0.41)],
+      auto: [best, runnerUp],
+    });
+
+    expect(collectLaneBoxes([detection], new Map())).toEqual([
+      { detection_id: 1, xyxyn: best.xyxyn },
+    ]);
+  });
+
   it('routes to update when an annotation exists, create when missing', () => {
     const dExisting = makeDetection(1, { auto: [box()] });
     const dMissing = makeDetection(2, { auto: [box()] });
@@ -291,10 +325,15 @@ describe('buildQuickSubmitPlan', () => {
     expect(items[0].smoke_type).toBe('industrial');
   });
 
-  it('keeps multiple boxes on one frame', () => {
+  it('commits one box on a frame whose layer holds several, whatever their geometry', () => {
+    // Replaces a `keeps multiple boxes on one frame` assertion from the
+    // util's first commit (2026-07-28), which predated the object editor's
+    // one-box-per-object model. A lane is a single object, so two boxes on
+    // its frame are the model's runners-up, not two things to record.
+    // Disjoint geometry here, so no overlap filter can be what drops one.
     const d = makeDetection(1, { auto: [box(), box(0.5, 0.5, 0.7, 0.7)] });
     const plan = buildQuickSubmitPlan([d], new Map(), 'wildfire');
-    expect(plan.payloads[0].body.annotation.annotation).toHaveLength(2);
+    expect(plan.payloads[0].body.annotation.annotation).toHaveLength(1);
   });
 
   it('includes no-box frames with empty items and counts them', () => {

--- a/frontend/tests/utils/annotation/quickSubmitUtils.test.ts
+++ b/frontend/tests/utils/annotation/quickSubmitUtils.test.ts
@@ -266,6 +266,41 @@ describe('buildQuickSubmitPlan', () => {
     ]);
   });
 
+  it('prefers the box anchored to this frame over a higher-confidence stray', () => {
+    // The worker anchors sequence-wide: `engine_seed_boxes` aggregates the
+    // engine boxes of EVERY detection in the lane, so an auto box survives
+    // by matching where the object was on some OTHER frame. On 77 of the 255
+    // multi-box detections in the 2026-08-12 data, the top-confidence box
+    // does not overlap its own frame's engine box while a runner-up does.
+    // Picking by confidence alone would commit a box sitting where the plume
+    // isn't.
+    const anchor = box(0.37, 0.29, 0.49, 0.41);
+    const stray = box(0.05, 0.05, 0.12, 0.12, 0.52);
+    const anchored = box(0.4, 0.3, 0.47, 0.4, 0.15);
+    const detection = makeDetection(1, { engine: [anchor], auto: [stray, anchored] });
+
+    const plan = buildQuickSubmitPlan([detection], new Map(), 'wildfire');
+
+    expect(plan.payloads[0].body.annotation.annotation).toEqual([
+      { xyxyn: anchored.xyxyn, class_name: 'smoke', smoke_type: 'wildfire', origin: 'auto' },
+    ]);
+  });
+
+  it('falls back to the top-confidence box when none is anchored to this frame', () => {
+    const top = box(0.05, 0.05, 0.12, 0.12, 0.52);
+    const other = box(0.6, 0.6, 0.7, 0.7, 0.15);
+    const detection = makeDetection(1, {
+      engine: [box(0.37, 0.29, 0.49, 0.41)],
+      auto: [top, other],
+    });
+
+    const plan = buildQuickSubmitPlan([detection], new Map(), 'wildfire');
+
+    expect(plan.payloads[0].body.annotation.annotation).toEqual([
+      { xyxyn: top.xyxyn, class_name: 'smoke', smoke_type: 'wildfire', origin: 'auto' },
+    ]);
+  });
+
   it('shows one box per frame in the preview loop when the layer holds several', () => {
     const best = box(0.4, 0.3, 0.49, 0.4, 0.52);
     const runnerUp = box(0.43, 0.38, 0.45, 0.4, 0.15);

--- a/frontend/tests/utils/objectBoxCandidates.test.ts
+++ b/frontend/tests/utils/objectBoxCandidates.test.ts
@@ -50,6 +50,32 @@ describe('boxCandidates', () => {
     expect(result.map(c => c.source)).toEqual(['manual', 'auto', 'engine']);
   });
 
+  it('offers the auto box anchored to this frame first, keeping the rest', () => {
+    // What Enter commits must be the box the grid drew and accept-remaining
+    // would write (`getWinningBoxes`), and that is the most confident box
+    // overlapping THIS frame's engine box — the worker's anchor is
+    // sequence-wide, so the top-confidence box can sit where the object was
+    // on another frame. The runners-up stay on the rail: the annotator can
+    // still pick one deliberately.
+    const stray = { xyxyn: [0.05, 0.05, 0.12, 0.12], confidence: 0.52, class_name: 'smoke' };
+    const anchored = { xyxyn: [0.4, 0.3, 0.47, 0.4], confidence: 0.15, class_name: 'smoke' };
+
+    const result = boxCandidates(
+      detection({
+        auto_predictions: { predictions: [stray, anchored] },
+        algo_predictions: {
+          predictions: [{ xyxyn: [0.37, 0.29, 0.49, 0.41], confidence: 0.5, class_name: 'smoke' }],
+        },
+      }),
+      null
+    );
+
+    expect(priorityPick(result)?.xyxyn).toEqual(anchored.xyxyn);
+    // Original positions travel with the candidates — `index` is identity,
+    // not display order.
+    expect(result.filter(c => c.source === 'auto').map(c => c.index)).toEqual([1, 0]);
+  });
+
   it('omits sources with no box', () => {
     const result = boxCandidates(
       detection({


### PR DESCRIPTION
Reported from `/localize/971/object/971` on the test server: one object showed two or three boxes on a frame in the media grid, while the editor canvas showed one.

## What was happening

Not bad data — the lane's `sequences_bbox` holds exactly one box per frame. The grid was rendering the raw model layer. The sensitive model runs at `AUTOANNOTATE_CONF=0.01` and `keep_boxes_overlapping` keeps every prediction with IoU > 0 against any engine anchor in the lane, so **255 of 6,807 auto-annotated detections (3.7%)** carry more than one auto box. The 2nd averages 0.118 confidence, the 3rd 0.042 — noise the annotator is not being asked about. The grid drew all of them; the editor, three clicks away, drew one.

## The worse half

Chasing the rendering fix surfaced a second, unreported problem on the **submit** path. `buildQuickSubmitPlan` ran the whole winning layer through `materializeReviewAnnotation` with nothing rejected, so **"accept remaining" committed every box** — including the 0.038-confidence one. The editor's per-frame accept never had this problem: it writes `priorityPick`, a single candidate. So the two accept paths recorded different things for the same frame, and the extras would have shipped in the export.

Fixing only the grid would have hidden this: the cell would show one box while submit still wrote three.

## The fix

**One box per frame, chosen once.** `getWinningBoxes` now returns the most confident model box *anchored to that frame*, and the grid cell, the preview loop and the submit payload all read through it. `boxCandidates` orders its auto candidates the same way, so the editor's default pick agrees rather than forming a third opinion. The runners-up stay on the editor's rail — a deliberate choice is still available with `G`.

**Anchored, not just most confident.** This is the part a review pass caught, and it is not a corner case. The worker's anchor is sequence-wide (`engine_seed_boxes` aggregates the engine boxes of *every* detection in the lane), so a box survives by matching where the object was on some **other** frame. On **77 of the 255 multi-box detections (30%)** the top-confidence box does not overlap its own frame's engine box while a runner-up does. Picking by confidence alone would draw and commit a box sitting where the plume isn't — and would have silently disabled `focusOnMainObject`, which used to filter exactly this (a one-element list always hits its fallback). Anchor first, then cap, keeping the fallback for frames the engine never boxed.

**Committed boxes are not capped.** Only the model layer is. Committed boxes are already in the database and the export already ships them, so a surface drawing fewer than are stored would under-report real data — the same mismatch this branch set out to fix, pointed the other way. This also lines the grid up with `collectLaneBoxes` branch for branch, so the cell and the preview loop cannot disagree.

## Notes

- **No data cleanup needed.** Zero detection annotations in the database hold more than one box — the bulk path had not yet been run on a multi-box frame. Caught before it wrote anything.
- **Status derivation is untouched.** `confirmed` / `cleared` / `empty` only ever tested list non-emptiness, so nothing moves between states.
- **One test reversed.** `keeps multiple boxes on one frame` dates to this util's first commit (4a4e0590, 2026-07-28), predating the object editor's one-box-per-object model. Unlike its neighbours it carried no rationale — it characterized the pass-through rather than defending it. Replaced with the inverted rule plus a note, rather than quietly deleted.
- **A stale comment corrected.** `objectBoxCandidates.ts` claimed "0 occurrences in 10,047 detections", which is what made this look impossible. It is 3.7% now.
- `BoxCandidate.index` still carries each candidate's original position, so it stays identity rather than display order — the one place it is consumed compares it for equality.
- `DetectionImageCard` consumes `getWinningBoxes` but is exported and never mounted. Left alone — flagging it as dead code, not removing it here.

## Follow-up, not in this PR

Trimming at the source in `worker.py`. Deliberately deferred: of the 174 committed smoke boxes in the database, **zero** land on a multi-box frame, so there is no evidence yet whether an annotator would ever want the runner-up — and trimming would remove a candidate the editor legitimately offers. The anchor finding above sharpens what the rule should be: not "highest confidence" but "highest confidence overlapping this frame's engine box". Worth re-running the query after the next batch of localize work. With this PR the extras never reach the database anyway.

## Verification

Every test written before its fix and watched fail. One initially passed by accident — `focusOnMainObject` happened to drop the second box because I had placed it outside the engine anchor — so it was moved inside, where the cap is what has to drop it.

Full suite 1440/1440, `type-check`, `lint`, `format:check` all clean. Verified visually against the live test-server data on the four affected frames of alert 971 (13:34:56, 13:35:26, 13:35:55, 13:36:26).