### PR TITLE
feat(localize): accept an object in one atomic request

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/detection_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/detection_annotations.py
@@ -11,6 +11,7 @@ from fastapi_pagination import Page, Params, create_page
 from fastapi_pagination.ext.sqlalchemy import apaginate
 from pydantic import ValidationError
 from sqlalchemy import asc, desc, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.dependencies import get_current_user, get_detection_annotation_crud
@@ -118,7 +119,8 @@ async def bulk_upsert_detection_annotations(
     its own commit: a failure partway left the object half-annotated, and
     the retry collided with uq_detection_annotation_detection_id. Every
     check below runs before the first write, so a rejection leaves the
-    database untouched.
+    database untouched, and the writes themselves upsert on that constraint
+    rather than racing against it.
     """
     detection_ids = [item.detection_id for item in payload.items]
 
@@ -151,55 +153,50 @@ async def bulk_upsert_detection_annotations(
             ),
         )
 
-    existing = {
-        row.detection_id: row
-        for row in (
-            await session.execute(
-                select(DetectionAnnotation).where(
-                    DetectionAnnotation.detection_id.in_(detection_ids)
-                )
-            )
-        )
-        .scalars()
-        .all()
-    }
-
-    written = []
-    for item in payload.items:
-        row = existing.get(item.detection_id)
-        # Contribution rule mirrors CRUD.update: attribute the write when the
-        # row lands at ANNOTATED, or when it already was.
-        was_annotated = (
-            row is not None
-            and row.processing_stage == DetectionAnnotationProcessingStage.ANNOTATED
-        )
-        if row is None:
-            row = DetectionAnnotation(
-                detection_id=item.detection_id,
-                annotation=item.annotation.model_dump(),
-                processing_stage=item.processing_stage,
-                created_at=datetime.now(UTC),
-            )
-        else:
-            row.annotation = item.annotation.model_dump()
-            row.processing_stage = item.processing_stage
-        session.add(row)
-        written.append((row, item, was_annotated))
-
-    await session.flush()  # assign ids for the contribution rows
-
+    now = datetime.now(UTC)
     results = []
-    for row, item, was_annotated in written:
-        if (
-            item.processing_stage == DetectionAnnotationProcessingStage.ANNOTATED
-            or was_annotated
-        ):
-            await annotations.record_contribution(row.id, current_user.id, commit=False)
+    for item in payload.items:
+        annotation_json = item.annotation.model_dump()
+        # INSERT ... ON CONFLICT rather than read-then-write: two accepts of
+        # the same lane racing (a double-fired mutation, or two annotators on
+        # one alert) would otherwise both see no row, both insert, and the
+        # loser would trip uq_detection_annotation_detection_id for a 500.
+        # updated_at is stamped here because the column's `onupdate` only
+        # fires for ORM-emitted UPDATEs, and stays NULL on the insert branch
+        # so a freshly created row is still distinguishable (#216).
+        statement = (
+            pg_insert(DetectionAnnotation)
+            .values(
+                detection_id=item.detection_id,
+                annotation=annotation_json,
+                processing_stage=item.processing_stage,
+                created_at=now,
+            )
+            .on_conflict_do_update(
+                index_elements=[DetectionAnnotation.detection_id],
+                set_={
+                    "annotation": annotation_json,
+                    "processing_stage": item.processing_stage,
+                    "updated_at": now,
+                },
+            )
+            .returning(DetectionAnnotation.id)
+        )
+        annotation_id = (await session.execute(statement)).scalar_one()
+
+        # Attribute only writes that LAND at ANNOTATED — the same rule as
+        # CRUD.update, which tests the post-update stage (it applies the
+        # payload before the check, making its second operand redundant).
+        if item.processing_stage == DetectionAnnotationProcessingStage.ANNOTATED:
+            await annotations.record_contribution(
+                annotation_id, current_user.id, commit=False
+            )
+
         results.append(
             DetectionAnnotationBulkResult(
-                annotation_id=row.id,
-                detection_id=row.detection_id,
-                processing_stage=row.processing_stage,
+                annotation_id=annotation_id,
+                detection_id=item.detection_id,
+                processing_stage=item.processing_stage,
             )
         )
 

--- a/annotation_api/src/app/api/api_v1/endpoints/detection_annotations.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/detection_annotations.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Optional
 
@@ -26,6 +26,9 @@ from app.models import (
     Sequence,
 )
 from app.schemas.detection_annotations import (
+    DetectionAnnotationBulkRequest,
+    DetectionAnnotationBulkResponse,
+    DetectionAnnotationBulkResult,
     DetectionAnnotationCreate,
     DetectionAnnotationRead,
     DetectionAnnotationUpdate,
@@ -100,6 +103,108 @@ async def create_detection_annotation(
     ]
 
     return DetectionAnnotationRead(**annotation_dict)
+
+
+@router.post("/bulk")
+async def bulk_upsert_detection_annotations(
+    payload: DetectionAnnotationBulkRequest = Body(...),
+    session: AsyncSession = Depends(get_session),
+    annotations: DetectionAnnotationCRUD = Depends(get_detection_annotation_crud),
+    current_user: User = Depends(get_current_localizer),
+) -> DetectionAnnotationBulkResponse:
+    """Upsert every frame of one object atomically.
+
+    Replaces a client-side loop that issued one POST/PATCH per frame, each
+    its own commit: a failure partway left the object half-annotated, and
+    the retry collided with uq_detection_annotation_detection_id. Every
+    check below runs before the first write, so a rejection leaves the
+    database untouched.
+    """
+    detection_ids = [item.detection_id for item in payload.items]
+
+    seen: set[int] = set()
+    duplicates = sorted({d for d in detection_ids if d in seen or seen.add(d)})
+    if duplicates:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Duplicate detection_id in items: {duplicates}",
+        )
+
+    owned = set(
+        (
+            await session.execute(
+                select(Detection.id).where(
+                    Detection.sequence_id == payload.sequence_id,
+                    Detection.id.in_(detection_ids),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    foreign = sorted(set(detection_ids) - owned)
+    if foreign:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Detections do not belong to sequence {payload.sequence_id}: {foreign}"
+            ),
+        )
+
+    existing = {
+        row.detection_id: row
+        for row in (
+            await session.execute(
+                select(DetectionAnnotation).where(
+                    DetectionAnnotation.detection_id.in_(detection_ids)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    }
+
+    written = []
+    for item in payload.items:
+        row = existing.get(item.detection_id)
+        # Contribution rule mirrors CRUD.update: attribute the write when the
+        # row lands at ANNOTATED, or when it already was.
+        was_annotated = (
+            row is not None
+            and row.processing_stage == DetectionAnnotationProcessingStage.ANNOTATED
+        )
+        if row is None:
+            row = DetectionAnnotation(
+                detection_id=item.detection_id,
+                annotation=item.annotation.model_dump(),
+                processing_stage=item.processing_stage,
+                created_at=datetime.now(UTC),
+            )
+        else:
+            row.annotation = item.annotation.model_dump()
+            row.processing_stage = item.processing_stage
+        session.add(row)
+        written.append((row, item, was_annotated))
+
+    await session.flush()  # assign ids for the contribution rows
+
+    results = []
+    for row, item, was_annotated in written:
+        if (
+            item.processing_stage == DetectionAnnotationProcessingStage.ANNOTATED
+            or was_annotated
+        ):
+            await annotations.record_contribution(row.id, current_user.id, commit=False)
+        results.append(
+            DetectionAnnotationBulkResult(
+                annotation_id=row.id,
+                detection_id=row.detection_id,
+                processing_stage=row.processing_stage,
+            )
+        )
+
+    await session.commit()
+    return DetectionAnnotationBulkResponse(results=results)
 
 
 @router.get("/")

--- a/annotation_api/src/app/schemas/detection_annotations.py
+++ b/annotation_api/src/app/schemas/detection_annotations.py
@@ -97,6 +97,12 @@ class DetectionAnnotationBulkRequest(BaseModel):
     Accepting an object used to be one request per frame, each its own
     commit, so a failure partway left it half-annotated with nothing to
     reconcile it.
+
+    The 500-item ceiling is a server guard, not a chunk size: a lane holds
+    one frame per detection (~30 at the import window's widest), so it is
+    unreachable in practice. Splitting an oversized object across requests
+    would reintroduce exactly the partial write this endpoint exists to
+    remove, so raise the ceiling before reaching for chunking.
     """
 
     sequence_id: int

--- a/annotation_api/src/app/schemas/detection_annotations.py
+++ b/annotation_api/src/app/schemas/detection_annotations.py
@@ -14,6 +14,10 @@ from app.schemas.annotation_validation import DetectionAnnotationData
 from app.schemas.user import ContributorRead
 
 __all__ = [
+    "DetectionAnnotationBulkItem",
+    "DetectionAnnotationBulkRequest",
+    "DetectionAnnotationBulkResponse",
+    "DetectionAnnotationBulkResult",
     "DetectionAnnotationCreate",
     "DetectionAnnotationRead",
     "DetectionAnnotationUpdate",
@@ -79,3 +83,31 @@ class DetectionAnnotationUpdate(BaseModel):
         description="Updated processing stage in the detection annotation workflow. Use to advance or modify the current stage.",
         examples=["visual_check", "bbox_annotation", "annotated"],
     )
+
+
+class DetectionAnnotationBulkItem(BaseModel):
+    detection_id: int
+    annotation: DetectionAnnotationData
+    processing_stage: DetectionAnnotationProcessingStage
+
+
+class DetectionAnnotationBulkRequest(BaseModel):
+    """One object's frames, written in a single transaction.
+
+    Accepting an object used to be one request per frame, each its own
+    commit, so a failure partway left it half-annotated with nothing to
+    reconcile it.
+    """
+
+    sequence_id: int
+    items: List[DetectionAnnotationBulkItem] = Field(..., min_length=1, max_length=500)
+
+
+class DetectionAnnotationBulkResult(BaseModel):
+    annotation_id: int
+    detection_id: int
+    processing_stage: DetectionAnnotationProcessingStage
+
+
+class DetectionAnnotationBulkResponse(BaseModel):
+    results: List[DetectionAnnotationBulkResult]

--- a/annotation_api/src/tests/endpoints/test_detection_annotations_bulk.py
+++ b/annotation_api/src/tests/endpoints/test_detection_annotations_bulk.py
@@ -230,3 +230,192 @@ async def test_resending_the_same_batch_is_a_clean_update(
     assert [r["annotation_id"] for r in first.json()["results"]] == [
         r["annotation_id"] for r in second.json()["results"]
     ]
+
+
+@pytest.mark.asyncio
+async def test_a_detection_from_another_sequence_is_rejected_before_any_write(
+    authenticated_client: AsyncClient, async_session
+):
+    seq, dets = await _lane(async_session, alert_api_id=920, frames=2)
+    other_seq, other_dets = await _lane(async_session, alert_api_id=921, frames=1)
+    # Read every id up front: the rollback below expires these instances, and
+    # touching an expired attribute afterwards is lazy IO in a sync context.
+    detection_ids = [det.id for det in dets]
+    foreign_id = other_dets[0].id
+
+    response = await authenticated_client.post(
+        "/annotations/detections/bulk",
+        json={
+            "sequence_id": seq.id,
+            "items": [
+                {
+                    "detection_id": det.id,
+                    "annotation": annotation(BOX),
+                    "processing_stage": "annotated",
+                }
+                for det in [*dets, other_dets[0]]
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+    assert str(foreign_id) in response.json()["detail"]
+    # Nothing was written — not even the two valid frames. The rollback is
+    # load-bearing: conftest hands the endpoint THIS session, so any row the
+    # handler staged but never committed would be autoflushed by the SELECT
+    # below and the assertion would silently pass against a dirty session.
+    await async_session.rollback()
+    rows = (
+        (
+            await async_session.execute(
+                select(DetectionAnnotation).where(
+                    DetectionAnnotation.detection_id.in_(detection_ids)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_detection_id_is_rejected(
+    authenticated_client: AsyncClient, async_session
+):
+    seq, dets = await _lane(async_session, alert_api_id=922, frames=1)
+
+    response = await authenticated_client.post(
+        "/annotations/detections/bulk",
+        json={
+            "sequence_id": seq.id,
+            "items": [
+                {
+                    "detection_id": 99_999_999,
+                    "annotation": annotation(BOX),
+                    "processing_stage": "annotated",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+    assert "99999999" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_detection_ids_are_rejected(
+    authenticated_client: AsyncClient, async_session
+):
+    seq, dets = await _lane(async_session, alert_api_id=923, frames=1)
+    detection_id = dets[0].id  # read before the rollback expires the instance
+    item = {
+        "detection_id": detection_id,
+        "annotation": annotation(BOX),
+        "processing_stage": "annotated",
+    }
+
+    response = await authenticated_client.post(
+        "/annotations/detections/bulk",
+        json={"sequence_id": seq.id, "items": [item, item]},
+    )
+
+    assert response.status_code == 422
+    assert str(detection_id) in response.json()["detail"]
+    await async_session.rollback()  # see the note in the foreign-detection test
+    rows = (
+        (
+            await async_session.execute(
+                select(DetectionAnnotation).where(
+                    DetectionAnnotation.detection_id == detection_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_an_invalid_box_writes_nothing_at_all(
+    authenticated_client: AsyncClient, async_session
+):
+    """The regression test for the reported bug: a batch that fails on its
+    LAST item must not leave the earlier frames annotated."""
+    seq, dets = await _lane(async_session, alert_api_id=924, frames=3)
+    detection_ids = [det.id for det in dets]  # read before the rollback
+
+    response = await authenticated_client.post(
+        "/annotations/detections/bulk",
+        json={
+            "sequence_id": seq.id,
+            "items": [
+                {
+                    "detection_id": dets[0].id,
+                    "annotation": annotation(BOX),
+                    "processing_stage": "annotated",
+                },
+                {
+                    "detection_id": dets[1].id,
+                    "annotation": annotation(BOX),
+                    "processing_stage": "annotated",
+                },
+                {
+                    "detection_id": dets[2].id,
+                    # x1 > x2: rejected by DetectionAnnotationData
+                    "annotation": annotation({**BOX, "xyxyn": [0.9, 0.1, 0.2, 0.2]}),
+                    "processing_stage": "annotated",
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+    await async_session.rollback()  # see the note in the foreign-detection test
+    rows = (
+        (
+            await async_session.execute(
+                select(DetectionAnnotation).where(
+                    DetectionAnnotation.detection_id.in_(detection_ids)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_an_empty_batch_is_rejected(
+    authenticated_client: AsyncClient, async_session
+):
+    seq, _ = await _lane(async_session, alert_api_id=925, frames=1)
+    response = await authenticated_client.post(
+        "/annotations/detections/bulk",
+        json={"sequence_id": seq.id, "items": []},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_a_classify_only_user_may_not_bulk_write(
+    async_client: AsyncClient, regular_user_token: str
+):
+    response = await async_client.post(
+        "/annotations/detections/bulk",
+        json={
+            "sequence_id": 1,
+            "items": [
+                {
+                    "detection_id": 1,
+                    "annotation": annotation(BOX),
+                    "processing_stage": "annotated",
+                }
+            ],
+        },
+        headers={"Authorization": f"Bearer {regular_user_token}"},
+    )
+    assert response.status_code == 403
+    assert "Not enough permissions" in response.json()["detail"]

--- a/annotation_api/src/tests/endpoints/test_detection_annotations_bulk.py
+++ b/annotation_api/src/tests/endpoints/test_detection_annotations_bulk.py
@@ -233,6 +233,88 @@ async def test_resending_the_same_batch_is_a_clean_update(
 
 
 @pytest.mark.asyncio
+async def test_updated_at_is_null_on_create_and_stamped_on_upsert(
+    authenticated_client: AsyncClient, async_session
+):
+    """The column's `onupdate` only fires for ORM-emitted UPDATEs, so the
+    ON CONFLICT branch has to stamp updated_at itself (#216)."""
+    seq, dets = await _lane(async_session, alert_api_id=914, frames=1)
+    body = {
+        "sequence_id": seq.id,
+        "items": [
+            {
+                "detection_id": dets[0].id,
+                "annotation": annotation(BOX),
+                "processing_stage": "annotated",
+            }
+        ],
+    }
+
+    first = await authenticated_client.post("/annotations/detections/bulk", json=body)
+    assert first.status_code == 200
+    annotation_id = first.json()["results"][0]["annotation_id"]
+
+    created = await authenticated_client.get(f"/annotations/detections/{annotation_id}")
+    assert created.json()["updated_at"] is None
+
+    second = await authenticated_client.post("/annotations/detections/bulk", json=body)
+    assert second.status_code == 200
+
+    upserted = await authenticated_client.get(
+        f"/annotations/detections/{annotation_id}"
+    )
+    assert upserted.json()["updated_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_a_demotion_is_not_attributed_to_the_caller(
+    authenticated_client: AsyncClient, async_session, test_user
+):
+    """Only writes that LAND at annotated are contributions. Attributing a
+    demotion would list the caller as a contributor to work they removed."""
+    seq, dets = await _lane(async_session, alert_api_id=915, frames=1)
+    annotated = DetectionAnnotation(
+        detection_id=dets[0].id,
+        annotation=annotation(BOX),
+        processing_stage=DetectionAnnotationProcessingStage.ANNOTATED,
+        created_at=NOW,
+    )
+    async_session.add(annotated)
+    await async_session.commit()
+    await async_session.refresh(annotated)
+    annotation_id = annotated.id
+
+    response = await authenticated_client.post(
+        "/annotations/detections/bulk",
+        json={
+            "sequence_id": seq.id,
+            "items": [
+                {
+                    "detection_id": dets[0].id,
+                    "annotation": annotation(BOX),
+                    "processing_stage": "bbox_annotation",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    contributions = (
+        (
+            await async_session.execute(
+                select(DetectionAnnotationContribution).where(
+                    DetectionAnnotationContribution.detection_annotation_id
+                    == annotation_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert contributions == []
+
+
+@pytest.mark.asyncio
 async def test_a_detection_from_another_sequence_is_rejected_before_any_write(
     authenticated_client: AsyncClient, async_session
 ):

--- a/annotation_api/src/tests/endpoints/test_detection_annotations_bulk.py
+++ b/annotation_api/src/tests/endpoints/test_detection_annotations_bulk.py
@@ -1,0 +1,232 @@
+"""Bulk detection-annotation upsert: accept a whole object in one atomic
+write. See docs/specs/2026-08-12-bulk-detection-annotation-accept-design.md."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.models import (
+    Detection,
+    DetectionAnnotation,
+    DetectionAnnotationContribution,
+    DetectionAnnotationProcessingStage,
+    Sequence,
+    SourceApi,
+)
+
+NOW = datetime(2026, 8, 12, 12, 0, tzinfo=UTC)
+
+BOX = {
+    "xyxyn": [0.1, 0.1, 0.2, 0.2],
+    "class_name": "smoke",
+    "smoke_type": "wildfire",
+    "origin": "auto",
+}
+
+
+def annotation(*boxes):
+    return {"annotation": list(boxes)}
+
+
+async def _lane(session, *, alert_api_id, frames=3):
+    """A lane sequence with `frames` detections, no annotations yet."""
+    seq = Sequence(
+        source_api=SourceApi.PYRONEAR_FRENCH_API,
+        alert_api_id=alert_api_id,
+        platform_alert_id=900,
+        created_at=NOW,
+        recorded_at=NOW,
+        last_seen_at=NOW,
+        camera_name="cam",
+        camera_id=1,
+        lat=1.0,
+        lon=2.0,
+        organisation_name="org",
+        organisation_id=1,
+    )
+    session.add(seq)
+    await session.flush()
+    dets = []
+    for i in range(frames):
+        det = Detection(
+            alert_api_id=alert_api_id * 1000 + i,
+            sequence_id=seq.id,
+            recorded_at=NOW + timedelta(minutes=i),
+            bucket_key=f"{alert_api_id}-{i}.jpg",
+            created_at=NOW,
+            algo_predictions={"predictions": []},
+        )
+        session.add(det)
+        dets.append(det)
+    await session.commit()
+    await session.refresh(seq)
+    for det in dets:
+        await session.refresh(det)
+    return seq, dets
+
+
+@pytest.mark.asyncio
+async def test_bulk_creates_an_annotation_for_every_frame(
+    authenticated_client: AsyncClient, async_session
+):
+    seq, dets = await _lane(async_session, alert_api_id=910)
+
+    response = await authenticated_client.post(
+        "/annotations/detections/bulk",
+        json={
+            "sequence_id": seq.id,
+            "items": [
+                {
+                    "detection_id": det.id,
+                    "annotation": annotation(BOX),
+                    "processing_stage": "annotated",
+                }
+                for det in dets
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert [r["detection_id"] for r in results] == [d.id for d in dets]
+    assert all(r["processing_stage"] == "annotated" for r in results)
+    assert all(isinstance(r["annotation_id"], int) for r in results)
+
+    rows = (
+        (
+            await async_session.execute(
+                select(DetectionAnnotation).where(
+                    DetectionAnnotation.detection_id.in_([d.id for d in dets])
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == len(dets)
+    assert all(
+        row.processing_stage == DetectionAnnotationProcessingStage.ANNOTATED
+        for row in rows
+    )
+    assert all(row.annotation["annotation"][0]["xyxyn"] == BOX["xyxyn"] for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_bulk_updates_existing_rows_and_mixes_with_creates(
+    authenticated_client: AsyncClient, async_session
+):
+    seq, dets = await _lane(async_session, alert_api_id=911)
+    stale = DetectionAnnotation(
+        detection_id=dets[0].id,
+        annotation=annotation({**BOX, "xyxyn": [0.5, 0.5, 0.6, 0.6]}),
+        processing_stage=DetectionAnnotationProcessingStage.BBOX_ANNOTATION,
+        created_at=NOW,
+    )
+    async_session.add(stale)
+    await async_session.commit()
+    await async_session.refresh(stale)
+
+    response = await authenticated_client.post(
+        "/annotations/detections/bulk",
+        json={
+            "sequence_id": seq.id,
+            "items": [
+                {
+                    "detection_id": det.id,
+                    "annotation": annotation(BOX),
+                    "processing_stage": "annotated",
+                }
+                for det in dets
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    # The pre-existing row is UPDATED in place, not duplicated.
+    by_detection = {r["detection_id"]: r for r in response.json()["results"]}
+    assert by_detection[dets[0].id]["annotation_id"] == stale.id
+    await async_session.refresh(stale)
+    assert stale.processing_stage == DetectionAnnotationProcessingStage.ANNOTATED
+    assert stale.annotation["annotation"][0]["xyxyn"] == BOX["xyxyn"]
+
+    count = len(
+        (
+            await async_session.execute(
+                select(DetectionAnnotation).where(
+                    DetectionAnnotation.detection_id.in_([d.id for d in dets])
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert count == len(dets)
+
+
+@pytest.mark.asyncio
+async def test_bulk_records_one_contribution_per_annotated_row(
+    authenticated_client: AsyncClient, async_session, test_user
+):
+    seq, dets = await _lane(async_session, alert_api_id=912, frames=2)
+
+    response = await authenticated_client.post(
+        "/annotations/detections/bulk",
+        json={
+            "sequence_id": seq.id,
+            "items": [
+                {
+                    "detection_id": det.id,
+                    "annotation": annotation(BOX),
+                    "processing_stage": "annotated",
+                }
+                for det in dets
+            ],
+        },
+    )
+    assert response.status_code == 200
+
+    ids = [r["annotation_id"] for r in response.json()["results"]]
+    contributions = (
+        (
+            await async_session.execute(
+                select(DetectionAnnotationContribution).where(
+                    DetectionAnnotationContribution.detection_annotation_id.in_(ids)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(contributions) == len(dets)
+    assert {c.user_id for c in contributions} == {test_user.id}
+
+
+@pytest.mark.asyncio
+async def test_resending_the_same_batch_is_a_clean_update(
+    authenticated_client: AsyncClient, async_session
+):
+    """The old loop's retry hit uq_detection_annotation_detection_id; the
+    upsert must not."""
+    seq, dets = await _lane(async_session, alert_api_id=913, frames=2)
+    body = {
+        "sequence_id": seq.id,
+        "items": [
+            {
+                "detection_id": det.id,
+                "annotation": annotation(BOX),
+                "processing_stage": "annotated",
+            }
+            for det in dets
+        ],
+    }
+
+    first = await authenticated_client.post("/annotations/detections/bulk", json=body)
+    second = await authenticated_client.post("/annotations/detections/bulk", json=body)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert [r["annotation_id"] for r in first.json()["results"]] == [
+        r["annotation_id"] for r in second.json()["results"]
+    ]

--- a/docs/specs/2026-08-12-bulk-detection-annotation-accept-design.md
+++ b/docs/specs/2026-08-12-bulk-detection-annotation-accept-design.md
@@ -49,9 +49,10 @@ modal's **Accept boxes** (`LocalizeObjectEditor.tsx:740` →
 `LocalizeAlertPage.tsx:2189`), and Enter to confirm the popover
 (`LocalizeAlertPage.tsx:1709`). All three are fixed by fixing the loop.
 
-`runLaneQuickAccept` is additionally what **Accept all & submit alert** runs
-per workable lane, so that path drops from N×M requests to N without any
-extra work.
+`runLaneQuickAccept` has exactly one caller, the `quickAcceptLane` mutation
+those three affordances share. (Its comment claimed a second caller, "Accept
+all & submit alert", running it per workable lane — that control no longer
+exists outside Guide copy, so there is no N×M path to fix.)
 
 Out of scope: the editor's per-frame saves (`saveDetection` /
 `acceptAndNext`, `LocalizeObjectEditor.tsx:412`). Those are already one
@@ -100,11 +101,15 @@ Pydantic rejects a malformed box with 422 before the handler body runs.
 
 ### Semantics
 
-**Upsert by `detection_id`.** The handler loads existing `DetectionAnnotation`
-rows for the requested detections in one query and, per item, updates the
-existing row or inserts a new one. The client no longer routes between POST
-and PATCH, and a retry after a failure updates rather than colliding with the
-unique constraint.
+**Upsert by `detection_id`.** Each item is written with
+`INSERT ... ON CONFLICT (detection_id) DO UPDATE`, so the client no longer
+routes between POST and PATCH, and a retry after a failure updates rather
+than colliding with the unique constraint. A read-then-write would leave that
+collision reachable whenever two accepts of the same lane overlap — a
+double-fired mutation, or two annotators on one alert — with the loser
+raising an uncaught `IntegrityError` (500). `updated_at` is stamped in the
+`DO UPDATE` branch, since the column's `onupdate` only fires for ORM-emitted
+UPDATEs; it stays NULL on insert, matching the single-item path (#216).
 
 **Validate everything before writing anything:**
 
@@ -119,16 +124,18 @@ rolls back. This mirrors `localize-submit`
 multi-lane write atomically.
 
 Contributions follow the same rule as `CRUD.update`
-(`crud_detection_annotation.py:70-80`): record a contribution when the row
-lands at `ANNOTATED`, or when it was already `ANNOTATED`. They are staged with
-the existing `record_contribution(..., commit=False)`
+(`crud_detection_annotation.py:70-80`): record a contribution when the write
+**lands** at `ANNOTATED`. (`CRUD.update` reads as "lands at ANNOTATED, or was
+already" only on the surface — it applies the payload before the check, so
+both operands describe the post-update stage and the second is redundant.
+Testing the pre-update stage here instead would attribute a demotion to the
+caller, listing them as a contributor to work they removed.) Contributions
+are staged with the existing `record_contribution(..., commit=False)`
 (`crud_detection_annotation.py:88`), whose docstring was written for exactly
 this case — a partial commit would leave `ANNOTATED` rows unattributed, and
 nothing backfills them.
 
 `created_at` is set explicitly on inserts, matching the single-item CRUD.
-`updated_at` is left alone — it is server-owned, stamped by the column's
-`onupdate` (`models.py:446-449`).
 
 ### Response
 

--- a/docs/specs/2026-08-12-bulk-detection-annotation-accept-design.md
+++ b/docs/specs/2026-08-12-bulk-detection-annotation-accept-design.md
@@ -1,0 +1,174 @@
+# Bulk detection-annotation accept
+
+**Date:** 2026-08-12
+**Status:** Approved
+
+## Problem
+
+On `/localize/{alertId}/object/{laneId}`, pressing **Accept boxes** writes the
+object's boxes one frame at a time. `runLaneQuickAccept`
+(`frontend/src/pages/LocalizeAlertPage.tsx:878-903`) builds a plan with
+`buildQuickSubmitPlan` and then loops:
+
+```ts
+for (const payload of plan.payloads) {
+  if (payload.existingAnnotationId !== null) {
+    await apiClient.updateDetectionAnnotation(payload.existingAnnotationId, payload.body);
+  } else {
+    await apiClient.createDetectionAnnotation({ detection_id: payload.detection.id, ...payload.body });
+  }
+}
+```
+
+One `POST /api/v1/annotations/detections/` (multipart) or
+`PATCH /api/v1/annotations/detections/{id}` per pending frame, strictly
+sequential, no retry, fail-fast. A 20–40 frame object is 20–40 serialised
+round-trips, each its own transaction (`crud_detection_annotation.py:53`,
+`:86`).
+
+The observed failure is a **partial accept**: the loop throws partway, the
+generic toast appears, and the object is left half-annotated — some frames
+`annotated`, some not. `onError` does not invalidate the lane cache
+(`LocalizeAlertPage.tsx:919-921`), so the UI keeps showing the pre-accept
+state until something else refetches. Pressing Accept again before a refetch
+re-POSTs frames whose annotation already landed, hitting
+`uq_detection_annotation_detection_id` (`models.py:427`) — an IntegrityError
+rather than a clean recovery.
+
+The root defect is that "accept this object" is not atomic. Latency is a
+secondary symptom of the same shape.
+
+## Solution
+
+One bulk endpoint, one transaction, one request.
+
+Three UI affordances funnel into `quickAcceptLane` and therefore into this
+loop — the rail/CTA-bar **Accept boxes**
+(`LocalizeObjectActions.tsx:89` → `LocalizeAlertPage.tsx:1872`), the editor
+modal's **Accept boxes** (`LocalizeObjectEditor.tsx:740` →
+`LocalizeAlertPage.tsx:2189`), and Enter to confirm the popover
+(`LocalizeAlertPage.tsx:1709`). All three are fixed by fixing the loop.
+
+`runLaneQuickAccept` is additionally what **Accept all & submit alert** runs
+per workable lane, so that path drops from N×M requests to N without any
+extra work.
+
+Out of scope: the editor's per-frame saves (`saveDetection` /
+`acceptAndNext`, `LocalizeObjectEditor.tsx:412`). Those are already one
+request per user action, with nothing to batch. The existing single-item
+POST/PATCH endpoints stay exactly as they are to serve them.
+
+## Backend
+
+### Endpoint
+
+`POST /api/v1/annotations/detections/bulk`, auth `get_current_localizer`,
+JSON body (not multipart — the existing form-encoded POST does not extend to
+a list).
+
+```json
+{
+  "sequence_id": 1449,
+  "items": [
+    {
+      "detection_id": 8801,
+      "annotation": {
+        "annotation": [
+          {"xyxyn": [0.1, 0.2, 0.3, 0.4], "class_name": "smoke", "smoke_type": "wildfire", "origin": "auto"}
+        ]
+      },
+      "processing_stage": "annotated"
+    }
+  ]
+}
+```
+
+New schemas in `app/schemas/detection_annotations.py`:
+
+- `DetectionAnnotationBulkItem`: `detection_id: int`,
+  `annotation: DetectionAnnotationData`,
+  `processing_stage: DetectionAnnotationProcessingStage`.
+- `DetectionAnnotationBulkRequest`: `sequence_id: int`,
+  `items: List[DetectionAnnotationBulkItem] = Field(min_length=1, max_length=500)`.
+- `DetectionAnnotationBulkResult`: `annotation_id: int`, `detection_id: int`,
+  `processing_stage: DetectionAnnotationProcessingStage`.
+- `DetectionAnnotationBulkResponse`: `results: List[DetectionAnnotationBulkResult]`.
+
+Per-item box validation is unchanged — `DetectionAnnotationData`
+(`schemas/annotation_validation.py:180-250`) is reused as the field type, so
+Pydantic rejects a malformed box with 422 before the handler body runs.
+
+### Semantics
+
+**Upsert by `detection_id`.** The handler loads existing `DetectionAnnotation`
+rows for the requested detections in one query and, per item, updates the
+existing row or inserts a new one. The client no longer routes between POST
+and PATCH, and a retry after a failure updates rather than colliding with the
+unique constraint.
+
+**Validate everything before writing anything:**
+
+- duplicate `detection_id` within `items` → 422 listing the duplicates;
+- any `detection_id` not belonging to `sequence_id` (including ids that do not
+  exist) → 422 listing the offending ids.
+
+**One transaction.** All annotation rows plus one contribution row each are
+staged, then a single `await session.commit()`; any raised `HTTPException`
+rolls back. This mirrors `localize-submit`
+(`endpoints/sequence_annotations.py:1363-1494`), which already commits a
+multi-lane write atomically.
+
+Contributions follow the same rule as `CRUD.update`
+(`crud_detection_annotation.py:70-80`): record a contribution when the row
+lands at `ANNOTATED`, or when it was already `ANNOTATED`. They are staged with
+the existing `record_contribution(..., commit=False)`
+(`crud_detection_annotation.py:88`), whose docstring was written for exactly
+this case — a partial commit would leave `ANNOTATED` rows unattributed, and
+nothing backfills them.
+
+`created_at` is set explicitly on inserts and `updated_at` on updates, matching
+the single-item CRUD.
+
+### Response
+
+`200 {"results": [{"annotation_id", "detection_id", "processing_stage"}]}` —
+the same shape as the `localize-submit` bulk response. Deliberately not
+`DetectionAnnotationRead`: contributors would cost a query per row and the
+client does not read them (it invalidates and refetches).
+
+## Frontend
+
+- `services/api.ts`: add `bulkUpsertDetectionAnnotations(sequenceId, items)`,
+  a plain JSON POST to `/annotations/detections/bulk`.
+- `buildQuickSubmitPlan` (`utils/annotation/quickSubmitUtils.ts:169`) is
+  unchanged, including the rule that frames already at `annotated` are skipped
+  and that false-positive items on the existing annotation are preserved
+  (`:193-201`).
+- `runLaneQuickAccept` maps `plan.payloads` to
+  `{detection_id, annotation, processing_stage}` and issues one call, returning
+  early when the plan is empty. `existingAnnotationId` is no longer read by
+  this path; it stays on the shared plan type, and is removed only if no other
+  caller reads it.
+- Unchanged: the popover, the Enter binding, `isAccepting`, both cache
+  invalidations, and the error toast. The difference is that on error there is
+  now nothing half-written to reconcile.
+
+## Testing
+
+Backend (pytest, isolated compose stack with a unique project name):
+
+- create-only, update-only, and mixed create+update batches land correctly;
+- **atomicity** — a batch whose last item is invalid writes nothing (the
+  regression test for the reported bug);
+- a `detection_id` belonging to another sequence → 422, before any write;
+- duplicate `detection_id` in one batch → 422, before any write;
+- one contribution row per annotated row, attributed to the caller;
+- re-sending an identical batch is a clean update, not an IntegrityError;
+- a non-localizer caller → 403.
+
+Frontend (vitest):
+
+- accepting an object issues exactly one request whose items cover every
+  pending frame and omit frames already `annotated`;
+- false-positive items survive in the sent payload;
+- a rejected call shows the error toast and does not invalidate the cache.

--- a/docs/specs/2026-08-12-bulk-detection-annotation-accept-design.md
+++ b/docs/specs/2026-08-12-bulk-detection-annotation-accept-design.md
@@ -126,8 +126,9 @@ the existing `record_contribution(..., commit=False)`
 this case — a partial commit would leave `ANNOTATED` rows unattributed, and
 nothing backfills them.
 
-`created_at` is set explicitly on inserts and `updated_at` on updates, matching
-the single-item CRUD.
+`created_at` is set explicitly on inserts, matching the single-item CRUD.
+`updated_at` is left alone — it is server-owned, stamped by the column's
+`onupdate` (`models.py:446-449`).
 
 ### Response
 

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -871,10 +871,12 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   };
 
   // Shared step: accept the winning model boxes for every pending frame of
-  // one lane (create-or-update, sequential — fail-fast on the first
-  // rejection). Does not submit the lane. Used both by the per-object
-  // quick-accept button and by "Accept all & submit alert", which runs this
-  // for every workable lane before the atomic localize-submit call.
+  // one lane, in ONE request the server upserts atomically — this used to be
+  // a POST/PATCH per frame, each its own commit, so a failure partway left
+  // the object half-annotated with nothing to reconcile it. Does not submit
+  // the lane. Used both by the per-object quick-accept button and by "Accept
+  // all & submit alert", which runs this for every workable lane before the
+  // atomic localize-submit call.
   const runLaneQuickAccept = useCallback(
     async (laneSequenceId: number) => {
       const lane = alertDetail?.lanes.find(l => l.sequence.id === laneSequenceId);
@@ -888,16 +890,12 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
         annotations,
         sequenceSmokeType(lane.annotation)
       );
-      for (const payload of plan.payloads) {
-        if (payload.existingAnnotationId !== null) {
-          await apiClient.updateDetectionAnnotation(payload.existingAnnotationId, payload.body);
-        } else {
-          await apiClient.createDetectionAnnotation({
-            detection_id: payload.detection.id,
-            ...payload.body,
-          });
-        }
-      }
+      const items = plan.payloads.map(payload => ({
+        detection_id: payload.detection.id,
+        ...payload.body,
+      }));
+      if (items.length === 0) return;
+      await apiClient.bulkUpsertDetectionAnnotations(laneSequenceId, items);
     },
     [alertDetail, detectionsByLaneId, annotationsByLaneId]
   );

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -870,13 +870,11 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
     });
   };
 
-  // Shared step: accept the winning model boxes for every pending frame of
-  // one lane, in ONE request the server upserts atomically — this used to be
-  // a POST/PATCH per frame, each its own commit, so a failure partway left
-  // the object half-annotated with nothing to reconcile it. Does not submit
-  // the lane. Used both by the per-object quick-accept button and by "Accept
-  // all & submit alert", which runs this for every workable lane before the
-  // atomic localize-submit call.
+  // Accept the winning model boxes for every pending frame of one lane, in
+  // ONE request the server upserts atomically — this used to be a POST/PATCH
+  // per frame, each its own commit, so a failure partway left the object
+  // half-annotated with nothing to reconcile it. Does not submit the lane:
+  // that stays with the alert-wide localize-submit call.
   const runLaneQuickAccept = useCallback(
     async (laneSequenceId: number) => {
       const lane = alertDetail?.lanes.find(l => l.sequence.id === laneSequenceId);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -4,6 +4,8 @@ import {
   Sequence,
   SequenceAnnotation,
   DetectionAnnotation,
+  DetectionAnnotationBulkItem,
+  DetectionAnnotationBulkResult,
   Detection,
   Camera,
   Contributor,
@@ -576,6 +578,23 @@ class ApiClient {
 
   async deleteDetectionAnnotation(id: number): Promise<void> {
     await this.client.delete(`/annotations/detections/${id}`);
+  }
+
+  /**
+   * Accept a whole object in one transaction. The per-frame loop this
+   * replaced could fail partway and leave the object half-annotated; the
+   * server upserts by detection_id, so a retry updates instead of colliding.
+   */
+  async bulkUpsertDetectionAnnotations(
+    sequenceId: number,
+    items: DetectionAnnotationBulkItem[]
+  ): Promise<DetectionAnnotationBulkResult[]> {
+    const response: AxiosResponse<{ results: DetectionAnnotationBulkResult[] }> =
+      await this.client.post(`${API_ENDPOINTS.DETECTION_ANNOTATIONS}bulk`, {
+        sequence_id: sequenceId,
+        items,
+      });
+    return response.data.results;
   }
 
   // Authentication

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -290,6 +290,21 @@ export interface DetectionAnnotationData {
   bbox_xyxyn?: [number, number, number, number];
 }
 
+// One frame of a bulk accept. The whole object goes up in a single request,
+// upserted by detection_id — the per-frame loop this replaced could fail
+// partway and leave the object half-annotated.
+export interface DetectionAnnotationBulkItem {
+  detection_id: number;
+  annotation: { annotation: DetectionAnnotationBbox[] };
+  processing_stage: DetectionProcessingStage;
+}
+
+export interface DetectionAnnotationBulkResult {
+  annotation_id: number;
+  detection_id: number;
+  processing_stage: DetectionProcessingStage;
+}
+
 export interface SequenceGroupRepresentativeBbox {
   xyxyn: [number, number, number, number];
   confidence: number;

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -41,6 +41,7 @@ vi.mock('@/services/api', () => ({
     getDetectionImageUrl: vi.fn(),
     createDetectionAnnotation: vi.fn(),
     updateDetectionAnnotation: vi.fn(),
+    bulkUpsertDetectionAnnotations: vi.fn(),
     updateSequenceAnnotation: vi.fn(),
     localizeSubmit: vi.fn(),
     localizeRevert: vi.fn(),
@@ -438,6 +439,14 @@ describe('LocalizeAlertPage', () => {
       created_at: '2026-01-01T00:00:00Z',
       updated_at: null,
     }));
+    vi.mocked(apiClient.bulkUpsertDetectionAnnotations).mockImplementation(
+      async (_sequenceId, items) =>
+        items.map(item => ({
+          annotation_id: 9100 + item.detection_id,
+          detection_id: item.detection_id,
+          processing_stage: item.processing_stage,
+        }))
+    );
     vi.mocked(apiClient.localizeSubmit).mockResolvedValue({
       results: [
         { annotation_id: 201, sequence_id: 101, processing_stage: 'annotated' },
@@ -1307,6 +1316,7 @@ describe('LocalizeAlertPage', () => {
       });
       expect(apiClient.localizeSubmit).toHaveBeenCalledTimes(1);
       expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
+      expect(apiClient.bulkUpsertDetectionAnnotations).not.toHaveBeenCalled();
 
       expect(screen.getByText('Objects submitted')).toBeInTheDocument();
       await waitFor(
@@ -2233,14 +2243,6 @@ describe('LocalizeAlertPage', () => {
     });
 
     it("accepts the active object's boxes from the header, then reports nothing left and drops the action", async () => {
-      vi.mocked(apiClient.createDetectionAnnotation).mockImplementation(async payload => ({
-        id: 9100 + payload.detection_id,
-        detection_id: payload.detection_id,
-        annotation: payload.annotation,
-        processing_stage: payload.processing_stage,
-        created_at: '2026-01-01T00:00:00Z',
-        updated_at: null,
-      }));
       await renderAndSettle(<LocalizeAlertPage />, { wrapper });
 
       fireEvent.click(screen.getByRole('button', { name: 'Object 1' }));
@@ -2256,18 +2258,107 @@ describe('LocalizeAlertPage', () => {
       // object, not on the alert. Object 2's frames (1002, 1003) must never
       // be touched by Object 1's quick-accept.
       await waitFor(() => {
-        expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
-          expect.objectContaining({ detection_id: 1001 })
+        expect(apiClient.bulkUpsertDetectionAnnotations).toHaveBeenCalledWith(
+          101,
+          [expect.objectContaining({ detection_id: 1001 })]
         );
       });
-      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalledWith(
-        expect.objectContaining({ detection_id: 1002 })
-      );
-      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalledWith(
-        expect.objectContaining({ detection_id: 1003 })
-      );
 
+      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
       expect(apiClient.updateDetectionAnnotation).not.toHaveBeenCalled();
+    });
+
+    it("sends the active object's pending frames as ONE bulk request, not one per frame", async () => {
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Object 2' }));
+      fireEvent.click(
+        within(screen.getByTestId('localize-active-object-actions')).getByRole('button', {
+          name: "Accept Object 2's boxes",
+        })
+      );
+      fireEvent.click(await screen.findByTestId('accept-remaining-confirm'));
+
+      // Object 2's two frames land in a single call — the half-accepted
+      // object was only reachable because this used to be one request each.
+      await waitFor(() => {
+        expect(apiClient.bulkUpsertDetectionAnnotations).toHaveBeenCalledTimes(1);
+      });
+      const [sequenceId, items] = vi.mocked(apiClient.bulkUpsertDetectionAnnotations).mock
+        .calls[0];
+      expect(sequenceId).toBe(102);
+      expect(items.map(i => i.detection_id).sort()).toEqual([1002, 1003]);
+      expect(items.every(i => i.processing_stage === 'annotated')).toBe(true);
+      // Object 1's frame belongs to another object and is never touched.
+      expect(items.map(i => i.detection_id)).not.toContain(1001);
+      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
+      expect(apiClient.updateDetectionAnnotation).not.toHaveBeenCalled();
+    });
+
+    it('carries existing false-positive items through into the bulk payload', async () => {
+      // An FP item is not an editable rectangle: accepting the model's boxes
+      // must not silently drop it (the rule buildQuickSubmitPlan encodes).
+      vi.mocked(apiClient.getDetectionAnnotations).mockImplementation(async filters => {
+        if (filters?.sequence_id !== 102) return emptyAnnotationsPage;
+        const items = [
+          {
+            ...makeDetectionAnnotation(1002),
+            processing_stage: 'bbox_annotation' as const,
+            annotation: {
+              annotation: [
+                {
+                  xyxyn: [0.4, 0.4, 0.5, 0.5] as [number, number, number, number],
+                  class_name: 'smoke',
+                  false_positive_type: 'antenna' as const,
+                },
+              ],
+            },
+          },
+        ];
+        return { ...emptyAnnotationsPage, items, total: items.length };
+      });
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Object 2' }));
+      fireEvent.click(
+        within(screen.getByTestId('localize-active-object-actions')).getByRole('button', {
+          name: "Accept Object 2's boxes",
+        })
+      );
+      fireEvent.click(await screen.findByTestId('accept-remaining-confirm'));
+
+      await waitFor(() => {
+        expect(apiClient.bulkUpsertDetectionAnnotations).toHaveBeenCalledTimes(1);
+      });
+      const [, items] = vi.mocked(apiClient.bulkUpsertDetectionAnnotations).mock.calls[0];
+      const frame = items.find(i => i.detection_id === 1002)!;
+      expect(frame.annotation.annotation).toContainEqual(
+        expect.objectContaining({ false_positive_type: 'antenna' })
+      );
+    });
+
+    it('toasts and leaves the Accept action in place when the bulk write fails', async () => {
+      vi.mocked(apiClient.bulkUpsertDetectionAnnotations).mockRejectedValue(
+        new Error('boom')
+      );
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Object 2' }));
+      fireEvent.click(
+        within(screen.getByTestId('localize-active-object-actions')).getByRole('button', {
+          name: "Accept Object 2's boxes",
+        })
+      );
+      fireEvent.click(await screen.findByTestId('accept-remaining-confirm'));
+
+      expect(await screen.findByText(/failed to accept boxes/i)).toBeInTheDocument();
+      // Nothing landed server-side, so there is nothing to reconcile: the
+      // object is still fully acceptable.
+      expect(
+        within(screen.getByTestId('localize-active-object-actions')).getByRole('button', {
+          name: "Accept Object 2's boxes",
+        })
+      ).toBeInTheDocument();
     });
 
     it('drops Accept once the object has every box, keeping Reclassify', async () => {
@@ -2306,6 +2397,7 @@ describe('LocalizeAlertPage', () => {
       expect(loop).toHaveAttribute('data-sequence-id', '101');
       expect(loop).toHaveAttribute('data-show-boxes', 'true');
       // Nothing was written by the click.
+      expect(apiClient.bulkUpsertDetectionAnnotations).not.toHaveBeenCalled();
       expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
       expect(apiClient.updateDetectionAnnotation).not.toHaveBeenCalled();
     });
@@ -2319,13 +2411,10 @@ describe('LocalizeAlertPage', () => {
       // Object 1's lane is detection 1001 only — the popover acts on the
       // active object, never on Object 2's frames.
       await waitFor(() => {
-        expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
-          expect.objectContaining({ detection_id: 1001 })
-        );
+        expect(apiClient.bulkUpsertDetectionAnnotations).toHaveBeenCalledWith(101, [
+          expect.objectContaining({ detection_id: 1001 }),
+        ]);
       });
-      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalledWith(
-        expect.objectContaining({ detection_id: 1002 })
-      );
       await waitFor(() => {
         expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
       });
@@ -2342,7 +2431,7 @@ describe('LocalizeAlertPage', () => {
       fireEvent.mouseDown(document.body);
       expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
 
-      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
+      expect(apiClient.bulkUpsertDetectionAnnotations).not.toHaveBeenCalled();
     });
 
     it('offers no Accept button when the lane has nothing acceptable, even though it is not localized', async () => {
@@ -2409,13 +2498,13 @@ describe('LocalizeAlertPage', () => {
 
       fireEvent.keyDown(window, { key: 'Enter' });
       expect(await screen.findByTestId('accept-remaining-popover')).toBeInTheDocument();
-      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
+      expect(apiClient.bulkUpsertDetectionAnnotations).not.toHaveBeenCalled();
 
       fireEvent.keyDown(window, { key: 'Enter' });
       await waitFor(() => {
-        expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
-          expect.objectContaining({ detection_id: 1001 })
-        );
+        expect(apiClient.bulkUpsertDetectionAnnotations).toHaveBeenCalledWith(101, [
+          expect.objectContaining({ detection_id: 1001 }),
+        ]);
       });
       await waitFor(() => {
         expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
@@ -2431,7 +2520,7 @@ describe('LocalizeAlertPage', () => {
       fireEvent.keyDown(window, { key: 'Escape' });
 
       expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
-      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
+      expect(apiClient.bulkUpsertDetectionAnnotations).not.toHaveBeenCalled();
     });
 
     it('Enter on a focused control is left to the control — a rail row keeps its own Enter', async () => {
@@ -2459,9 +2548,9 @@ describe('LocalizeAlertPage', () => {
       fireEvent.keyDown(trigger, { key: 'Enter' });
 
       await waitFor(() => {
-        expect(apiClient.createDetectionAnnotation).toHaveBeenCalledWith(
-          expect.objectContaining({ detection_id: 1001 })
-        );
+        expect(apiClient.bulkUpsertDetectionAnnotations).toHaveBeenCalledWith(101, [
+          expect.objectContaining({ detection_id: 1001 }),
+        ]);
       });
       await waitFor(() => {
         expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
@@ -2477,7 +2566,7 @@ describe('LocalizeAlertPage', () => {
       await waitFor(() => {
         expect(screen.queryByTestId('accept-remaining-popover')).not.toBeInTheDocument();
       });
-      expect(apiClient.createDetectionAnnotation).not.toHaveBeenCalled();
+      expect(apiClient.bulkUpsertDetectionAnnotations).not.toHaveBeenCalled();
     });
 
     it('Enter is inert while the shortcuts sheet is up', async () => {


### PR DESCRIPTION
## Problem

Accepting an object on `/localize/{alertId}/object/{laneId}` wrote **one request per frame**. `runLaneQuickAccept` looped over the lane's pending frames and awaited a `POST /annotations/detections/` or `PATCH /annotations/detections/{id}` for each, serially, with no retry — and each one was its own commit server-side.

So a failure partway left the object **half-annotated**: some frames at `annotated`, some not. The error toast deliberately does not invalidate the lane cache, so the UI kept showing the pre-accept state, and pressing Accept again re-POSTed frames whose annotation had already landed — colliding with `uq_detection_annotation_detection_id` instead of recovering cleanly.

A 20–40 frame object meant 20–40 serialised round-trips, which is also where the latency came from.

## Change

**New `POST /api/v1/annotations/detections/bulk`** (`get_current_localizer`, JSON):

```json
{"sequence_id": 14, "items": [{"detection_id": 8801, "annotation": {"annotation": [...]}, "processing_stage": "annotated"}]}
```

- **Validates the whole batch before writing anything** — duplicate `detection_id`s, and detections that do not belong to `sequence_id` (unknown ids included), both 422 naming the offenders. Per-item box invariants come from the existing `DetectionAnnotationData`, so a malformed box is rejected at parse time.
- **Upserts by `detection_id`** via `INSERT ... ON CONFLICT DO UPDATE`, so the client no longer routes between POST and PATCH and a retry updates rather than colliding with the unique constraint. Writing on the constraint rather than read-then-write also keeps two overlapping accepts of the same lane (a double-fired mutation, or two annotators on one alert) from both inserting and handing the loser a 500. `updated_at` is stamped in the `DO UPDATE` branch, since the column's `onupdate` only fires for ORM-emitted UPDATEs, and stays NULL on insert (#216).
- **One transaction**: every annotation row plus one contribution row each, staged via the existing `record_contribution(commit=False)`, then a single `session.commit()`. Contributions attribute only writes that **land** at ANNOTATED — keying off the pre-update stage would credit a demotion to the caller, listing them as a contributor to work they removed.
- Response mirrors the `localize-submit` bulk shape: `{"results": [{"annotation_id", "detection_id", "processing_stage"}]}` — no per-row contributors query the client doesn't read.

**Frontend**: `runLaneQuickAccept` maps its existing `buildQuickSubmitPlan` output to items and issues one call. All three accept affordances go through it — the rail/CTA **Accept boxes**, the editor modal's **Accept boxes**, and Enter-to-confirm on the popover.

The single-item POST/PATCH endpoints are unchanged — the editor's per-frame saves still use them, and those are one request per user action with nothing to batch.

Spec: `docs/specs/2026-08-12-bulk-detection-annotation-accept-design.md`

## Tests

Backend (12 new, `test_detection_annotations_bulk.py`): create-only, update-in-place, mixed batches; one contribution per annotated row attributed to the caller, and none for a demotion; `updated_at` NULL on create, stamped on upsert; re-sending an identical batch is a clean update rather than an IntegrityError; a foreign `detection_id` / unknown id / duplicate id / invalid box each 422s with **zero rows written**; empty batch 422; classify-only user 403.

Frontend (3 new): accepting an object issues exactly one bulk call carrying every pending frame and no already-annotated frame; existing false-positive items survive into the payload; a rejected write toasts and leaves the Accept action in place. The accept tests' negative assertions moved to the bulk spy — watching `createDetectionAnnotation` there would now pass vacuously.

Full suites: **805 backend passed**, **1436 frontend passed** (baseline 1433), plus `type-check` / `lint` / `format:check` clean.

## Verification

Checked in the browser against the real dev database on a 16-frame object: one `POST /annotations/detections/bulk`, object fully accepted.
