### PR TITLE
Unsure recurring objects are a third label state, not a to-do

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
@@ -10,7 +10,7 @@ from typing import Optional
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
 from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.sqlalchemy import apaginate
-from sqlalchemy import asc, desc, func, select
+from sqlalchemy import and_, asc, desc, func, not_, or_, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.api.dependencies import get_current_user, get_sequence_group_crud
@@ -45,6 +45,34 @@ class SequenceGroupOrderByField(str, Enum):
     camera_name = "camera_name"
     azimuth = "azimuth"
     created_at = "created_at"
+
+
+class GroupLabelState(str, Enum):
+    """A group's label state. The three values are mutually exclusive and
+    together cover every group.
+
+    `unsure` is a recorded annotator decision — the object was judged
+    undecidable and the verdict fanned across the group without a label
+    (`_propagate_to_group_if_validated`) — so it partitions *out* of
+    `unlabeled` rather than sitting inside it as phantom to-do work."""
+
+    labeled = "labeled"
+    unlabeled = "unlabeled"
+    unsure = "unsure"
+
+
+def _label_state_clause(state: GroupLabelState):
+    """SQL predicate for one label state. A group carrying both a label and
+    is_unsure counts as labeled: the label is the stronger statement."""
+    has_label = or_(
+        SequenceGroup.smoke_type.is_not(None),
+        SequenceGroup.false_positive_type.is_not(None),
+    )
+    if state is GroupLabelState.labeled:
+        return has_label
+    if state is GroupLabelState.unsure:
+        return and_(not_(has_label), SequenceGroup.is_unsure.is_(True))
+    return and_(not_(has_label), SequenceGroup.is_unsure.is_(False))
 
 
 class OrderDirection(str, Enum):
@@ -175,11 +203,12 @@ async def _thumbnails_for_groups(
     summary="List sequence groups (paginated, with member counts)",
 )
 async def list_sequence_groups(
-    labeled: Optional[bool] = Query(
+    label_state: Optional[GroupLabelState] = Query(
         None,
         description=(
-            "Filter by label presence: true = only labeled groups, "
-            "false = only unlabeled, omit for both."
+            "Filter by label state: 'labeled' (smoke or false-positive type "
+            "set), 'unsure' (no label, marked undecidable), or 'unlabeled' "
+            "(no label and not unsure). Omit for all three."
         ),
     ),
     order_by: SequenceGroupOrderByField = Query(
@@ -246,16 +275,8 @@ async def list_sequence_groups(
             desc(SequenceGroup.id),
         )
     )
-    if labeled is True:
-        query = query.where(
-            (SequenceGroup.smoke_type.is_not(None))
-            | (SequenceGroup.false_positive_type.is_not(None))
-        )
-    elif labeled is False:
-        query = query.where(
-            SequenceGroup.smoke_type.is_(None)
-            & SequenceGroup.false_positive_type.is_(None)
-        )
+    if label_state is not None:
+        query = query.where(_label_state_clause(label_state))
 
     async def _hydrate(rows: list) -> list[SequenceGroupListItem]:
         group_ids = [r.id for r in rows]
@@ -316,22 +337,23 @@ async def get_sequence_group_stats(
             .filter(SequenceGroup.is_validated.is_(True))
             .label("validated"),
             func.count(SequenceGroup.id)
-            .filter(
-                (SequenceGroup.smoke_type.is_not(None))
-                | (SequenceGroup.false_positive_type.is_not(None))
-            )
+            .filter(_label_state_clause(GroupLabelState.labeled))
             .label("labeled"),
+            func.count(SequenceGroup.id)
+            .filter(_label_state_clause(GroupLabelState.unsure))
+            .label("unsure"),
         )
         .select_from(SequenceGroup)
         .join(member_count_subq, member_count_subq.c.group_id == SequenceGroup.id)
     )
-    total, validated, labeled = (await session.exec(query)).one()
+    total, validated, labeled, unsure = (await session.exec(query)).one()
     return SequenceGroupStats(
         total=total,
         validated=validated,
         unvalidated=total - validated,
         labeled=labeled,
-        unlabeled=total - labeled,
+        unsure=unsure,
+        unlabeled=total - labeled - unsure,
     )
 
 

--- a/annotation_api/src/app/schemas/sequence_group.py
+++ b/annotation_api/src/app/schemas/sequence_group.py
@@ -119,13 +119,17 @@ class SequenceGroupListItem(BaseModel):
 class SequenceGroupStats(BaseModel):
     """Aggregate counts over groups with 3 or more members — the same
     population the list endpoint returns, so UI counts match the list.
-    A group is "labeled" when smoke_type or false_positive_type is set —
-    the same predicate as the list endpoint's `labeled` filter."""
+
+    `labeled`, `unsure` and `unlabeled` partition `total`: a group is
+    labeled when smoke_type or false_positive_type is set, unsure when it
+    carries no label but is_unsure, and unlabeled otherwise. Same
+    predicates as the list endpoint's `label_state` filter."""
 
     total: int
     validated: int
     unvalidated: int
     labeled: int
+    unsure: int
     unlabeled: int
 
 

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -106,6 +106,7 @@ async def _seed_group_with_members(
     organisation_name: str = "org",
     azimuth: int = 0,
     smoke_type: str | None = None,
+    is_unsure: bool = False,
 ) -> int:
     """Insert a SequenceGroup with `n_members` member sequences (each with a
     distinct alert_api_id) and return its id."""
@@ -115,10 +116,10 @@ async def _seed_group_with_members(
                 """
                 INSERT INTO sequence_groups
                     (camera_id, azimuth, representative_bbox, is_validated,
-                     created_at, smoke_type, labeled_at)
+                     created_at, smoke_type, labeled_at, is_unsure)
                 VALUES
                     (1, :azimuth, CAST(:bbox AS jsonb), false, :created_at,
-                     :smoke_type, :labeled_at)
+                     :smoke_type, :labeled_at, :is_unsure)
                 RETURNING id
                 """
             ).bindparams(
@@ -129,6 +130,7 @@ async def _seed_group_with_members(
                 # ck_sequence_group_labeled_at_consistency: a labeled group
                 # must carry a labeled_at timestamp.
                 labeled_at=created_at if smoke_type else None,
+                is_unsure=is_unsure,
             )
         )
     ).scalar_one()
@@ -1062,6 +1064,7 @@ async def test_stats_empty(authenticated_client: AsyncClient):
         "validated": 0,
         "unvalidated": 0,
         "labeled": 0,
+        "unsure": 0,
         "unlabeled": 0,
     }
 
@@ -1104,6 +1107,7 @@ async def test_stats_counts_only_groups_with_three_plus_members(
         "validated": 1,
         "unvalidated": 1,
         "labeled": 0,
+        "unsure": 0,
         "unlabeled": 2,
     }
 
@@ -1451,3 +1455,81 @@ def test_crop_bbox_none_when_no_valid_boxes():
         )
         is None
     )
+
+
+async def _seed_one_group_of_each_label_state(session: AsyncSession) -> dict[str, int]:
+    """One labeled, one unsure, one plain-unlabeled group, all with 3 members
+    so they clear the list/stats population floor."""
+    labeled = await _seed_group_with_members(
+        session,
+        n_members=3,
+        created_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        alert_api_id_start=1700,
+        smoke_type="wildfire",
+    )
+    unsure = await _seed_group_with_members(
+        session,
+        n_members=3,
+        created_at=datetime(2026, 2, 2, tzinfo=timezone.utc),
+        alert_api_id_start=1800,
+        is_unsure=True,
+    )
+    unlabeled = await _seed_group_with_members(
+        session,
+        n_members=3,
+        created_at=datetime(2026, 2, 3, tzinfo=timezone.utc),
+        alert_api_id_start=1900,
+    )
+    return {"labeled": labeled, "unsure": unsure, "unlabeled": unlabeled}
+
+
+@pytest.mark.asyncio
+async def test_list_label_state_returns_each_partition(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """The three label states are mutually exclusive: an unsure group is in
+    neither `unlabeled` nor `labeled`."""
+    ids = await _seed_one_group_of_each_label_state(async_session)
+
+    for state, expected_id in ids.items():
+        resp = await authenticated_client.get(f"/sequence_groups/?label_state={state}")
+        assert resp.status_code == 200, resp.text
+        returned = [g["id"] for g in resp.json()["items"]]
+        assert returned == [expected_id], f"label_state={state}"
+
+
+@pytest.mark.asyncio
+async def test_list_without_label_state_returns_every_state(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """Omitting the filter is 'all three', not 'labeled + unlabeled'."""
+    ids = await _seed_one_group_of_each_label_state(async_session)
+
+    resp = await authenticated_client.get("/sequence_groups/")
+    assert resp.status_code == 200, resp.text
+    assert set(g["id"] for g in resp.json()["items"]) == set(ids.values())
+
+    # An unknown state is a client error, not a silent "all".
+    bad = await authenticated_client.get("/sequence_groups/?label_state=bogus")
+    assert bad.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_stats_partition_total_across_the_three_label_states(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """labeled + unsure + unlabeled == total, with the unsure group counted
+    once, under `unsure` only."""
+    await _seed_one_group_of_each_label_state(async_session)
+
+    resp = await authenticated_client.get("/sequence_groups/stats")
+    assert resp.status_code == 200, resp.text
+    stats = resp.json()
+    assert stats["total"] == 3
+    assert stats["labeled"] == 1
+    assert stats["unsure"] == 1
+    assert stats["unlabeled"] == 1
+    assert stats["labeled"] + stats["unsure"] + stats["unlabeled"] == stats["total"]

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -1533,3 +1533,42 @@ async def test_stats_partition_total_across_the_three_label_states(
     assert stats["unsure"] == 1
     assert stats["unlabeled"] == 1
     assert stats["labeled"] + stats["unsure"] + stats["unlabeled"] == stats["total"]
+
+
+@pytest.mark.asyncio
+async def test_label_outranks_is_unsure_in_the_partition(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """A group can carry a label *and* is_unsure, so the two states must be
+    ordered rather than treated as disjoint inputs.
+
+    `_propagate_to_group_if_validated` assigns `group.is_unsure` from the
+    source annotation alongside whatever label it derived, so an unsure
+    classification whose clusters still carry a smoke type produces exactly
+    this combination. It counts as labeled — the label is the stronger
+    statement — and must land in that one partition only."""
+    both = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 2, 4, tzinfo=timezone.utc),
+        alert_api_id_start=2000,
+        smoke_type="wildfire",
+        is_unsure=True,
+    )
+
+    for state, expected in (
+        ("labeled", [both]),
+        ("unsure", []),
+        ("unlabeled", []),
+    ):
+        resp = await authenticated_client.get(f"/sequence_groups/?label_state={state}")
+        assert resp.status_code == 200, resp.text
+        assert [
+            g["id"] for g in resp.json()["items"]
+        ] == expected, f"label_state={state}"
+
+    resp = await authenticated_client.get("/sequence_groups/stats")
+    assert resp.status_code == 200, resp.text
+    stats = resp.json()
+    assert (stats["labeled"], stats["unsure"], stats["unlabeled"]) == (1, 0, 0)

--- a/docs/specs/2026-08-12-unsure-group-label-state-design.md
+++ b/docs/specs/2026-08-12-unsure-group-label-state-design.md
@@ -1,0 +1,152 @@
+# An unsure recurring object is a third label state, not a to-do
+
+**Date**: 2026-08-12
+**Status**: Approved
+**Base**: `main` at `5af0c53d`.
+
+## Problem
+
+Four validated recurring objects (groups `368`, `599`, `2928`, `3489`, 63 member
+sequences between them) sit in the "To label" tab of `/classify/groups`
+permanently, even though every one of their sightings is annotated. They read
+exactly like objects nobody has touched.
+
+All four share one shape:
+
+```
+ id  | is_unsure | is_validated | smoke_type | false_positive_type | labeled_at
+3489 |     t     |      t       |    NULL    |        NULL         |   NULL
+ 368 |     t     |      t       |    NULL    |        NULL         |   NULL
+ 599 |     t     |      t       |    NULL    |        NULL         |   NULL
+2928 |     t     |      t       |    NULL    |        NULL         |   NULL
+```
+
+Every member is at `SEQ_ANNOTATION_DONE` with `is_unsure = true`,
+`has_smoke = false` and no false-positive types — all written within ~300 ms of
+each other, i.e. one fan-out.
+
+### How they got there
+
+An annotator validated the group, opened one member, and classified it *unsure
+with no label*. `_propagate_to_group_if_validated`
+(`annotation_api/src/app/api/api_v1/endpoints/sequence_annotations.py:1055-1077`)
+takes its unsure branch: it sets `group.is_unsure = True`, leaves both label
+columns `NULL` — they *must* stay `NULL`, the
+`ck_sequence_group_labeled_at_consistency` check constraint forbids a
+`labeled_at` without a label — and fans that unsure state onto every sibling.
+
+That branch is deliberate ("spread the uncertainty across the group instead of
+dropping it", commit `864110bb`, 2026-06-18). The commit is backend-only; the UI
+was never taught that a group can be unsure.
+
+### Why it looks like a to-do
+
+Four places decide what a group's label state is, and all four key on
+`smoke_type OR false_positive_type` alone:
+
+| Site | Effect |
+| --- | --- |
+| `SequenceGroupsListPage.tsx:371-389` | falls through to the ember "to label" chip |
+| `SequenceGroupAnnotatePage.tsx:296-308` | same chip in the detail header |
+| `sequence_groups.py:249-257` (`labeled` filter) | group is returned by the "To label" tab |
+| `sequence_groups.py:318-323` (stats) | counted in `unlabeled` |
+
+`is_unsure` is already selected by the list query, already present on
+`SequenceGroupListItem` and on the frontend's `SequenceGroupListItem` type. It is
+simply never rendered and never counted.
+
+`unlabeled` also drives the sidebar badge (`useAnnotationCounts.ts:39`) and the
+dashboard's "objects to label" figure (`usePipelineStats.ts:20`), so the four
+groups inflate those too.
+
+### Not #253
+
+The known gap #253 (group `PATCH` validate never re-derives a label from members
+already at a done stage) is a different failure. No validated group in the
+2026-08-12 dump has a labelled member and no group label. 314 such groups exist,
+but all are unvalidated, so they are simply awaiting validation.
+
+## Scope
+
+**In:** making the unsure state legible — a fourth branch in the two label
+displays, a third value in the list filter, a third count in the stats, and a
+new tab/route. Tests for all of it.
+
+**Out:** the 63 fanned-out member annotations. They stay as they are, including
+their hold on those alerts' entry into the localize queue (they are "unsettled
+unsure", so `unsettled_unsure_clause` withholds their alerts). Also out: any
+change to whether unsure *should* fan out across a validated group at all, any
+direct group-label action, and any link from the new tab into the resolution
+flow.
+
+## Design
+
+### The partition
+
+Three mutually exclusive states covering every group:
+
+| State | Predicate |
+| --- | --- |
+| `labeled` | `smoke_type IS NOT NULL OR false_positive_type IS NOT NULL` |
+| `unsure` | no label **and** `is_unsure` |
+| `unlabeled` | no label **and not** `is_unsure` |
+
+A group carrying both a label and `is_unsure` counts as `labeled` — the label is
+the stronger statement, and propagation cannot produce that combination anyway
+(it refuses to overwrite a labelled group with an unsure write, and a labelled
+propagation resets `is_unsure` from the source annotation).
+
+### Backend
+
+`GET /api/v1/sequence_groups/` — replace the boolean `labeled` query parameter
+with an enum, because the states are no longer a yes/no:
+
+```
+label_state: Optional[GroupLabelState]   # "labeled" | "unlabeled" | "unsure"
+                                         # omitted = all
+```
+
+The only caller is this repo's frontend, so the parameter is replaced outright
+rather than kept alongside a new one.
+
+`GET /api/v1/sequence_groups/stats` — `SequenceGroupStats` gains `unsure: int`,
+and `unlabeled` becomes `total - labeled - unsure`. The three now partition
+`total` over the same 3+-member population the list endpoint uses. The sidebar
+badge and dashboard figure shed the four groups as a consequence, which is
+correct: they are not actionable labelling work.
+
+### Frontend
+
+- `SequenceGroupsFilter` (`utils/routes.ts:46`) gains `'unsure'`;
+  `classifyGroups('unsure')` yields `/classify/groups/unsure`. The bare path
+  remains "To label". New route in `App.tsx` beside the `labeled` and `all` ones.
+- Tabs become **To label · Unsure · Labeled · All**, each with its count from
+  stats.
+- `apiClient.getSequenceGroups` takes `label_state?: GroupLabelState` in place of
+  `labeled?: boolean`.
+- The label cell and the detail header gain a fourth branch: no label and
+  `is_unsure` renders an **"unsure"** chip in neutral tokens (`bg-ash` /
+  `text-haze`), deliberately not the ember "to label" chip — an unsure object is
+  a recorded decision, not an outstanding task. Its hover tip states that the
+  object was marked undecidable and that unsure sightings are settled from
+  `/classify/done` under the "Only Unsure" filter. Text only; no link.
+- An empty state for the Unsure tab in the same idiom as the existing two.
+
+## Testing
+
+**Backend** (`src/tests/endpoints/test_sequence_groups.py`)
+
+- Each `label_state` value returns exactly its partition; an unsure group is
+  absent from `unlabeled` and from `labeled`.
+- Omitting `label_state` returns all three kinds.
+- `stats`: `labeled + unsure + unlabeled == total`, with an unsure group counted
+  under `unsure` only.
+
+**Frontend** (`tests/pages/SequenceGroupsListPage.test.tsx`)
+
+- A group with `is_unsure` and no label renders the "unsure" chip, not "to
+  label".
+- The Unsure tab requests `label_state=unsure`. Assert on the serialized request
+  URL — the axios serializer in `services/api.ts` silently drops any filter whose
+  value is `null`.
+- The four tabs render their counts from `SequenceGroupStats`.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -94,6 +94,10 @@ function App() {
                     element={<SequenceGroupsListPage filter="labeled" />}
                   />
                   <Route
+                    path="/classify/groups/unsure"
+                    element={<SequenceGroupsListPage filter="unsure" />}
+                  />
+                  <Route
                     path="/classify/groups/all"
                     element={<SequenceGroupsListPage filter="all" />}
                   />

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -301,6 +301,10 @@ export default function SequenceGroupAnnotatePage() {
               <span className="flex-none rounded-full border border-line bg-paper px-2.5 py-0.5 font-body text-xs font-semibold text-char">
                 false positive · {group.false_positive_type.replace(/_/g, ' ')}
               </span>
+            ) : group.is_unsure ? (
+              <span className="flex-none rounded-full bg-ash px-2.5 py-0.5 font-body text-xs font-semibold text-haze">
+                unsure
+              </span>
             ) : (
               <span className="flex-none rounded-full bg-ember-soft px-2.5 py-0.5 font-body text-xs font-semibold text-ember">
                 to label

--- a/frontend/src/pages/SequenceGroupAnnotatePage.tsx
+++ b/frontend/src/pages/SequenceGroupAnnotatePage.tsx
@@ -19,6 +19,7 @@ import { usePersistedTabState } from '@/hooks/usePersistedTabState';
 import { useState } from 'react';
 import { AlgoPrediction, SequenceGroup, SequenceGroupMember } from '@/types/api';
 import { ROUTES, classifyDetail, classifyGroup } from '@/utils/routes';
+import { UNSURE_GROUP_TIP } from '@/utils/groupLabels';
 import { formatDateTime } from '@/utils/datetime';
 
 // Minimum card width per size step; the auto-fill grid derives the column
@@ -302,8 +303,19 @@ export default function SequenceGroupAnnotatePage() {
                 false positive · {group.false_positive_type.replace(/_/g, ' ')}
               </span>
             ) : group.is_unsure ? (
-              <span className="flex-none rounded-full bg-ash px-2.5 py-0.5 font-body text-xs font-semibold text-haze">
-                unsure
+              // The only header chip whose state isn't self-evident, and the
+              // landing point from the Unsure tab — so unlike its siblings it
+              // carries its own explanation, in the page's tooltip idiom.
+              <span tabIndex={0} className="group relative flex-none">
+                <span className="rounded-full bg-ash px-2.5 py-0.5 font-body text-xs font-semibold text-haze">
+                  unsure
+                </span>
+                <span
+                  role="tooltip"
+                  className="pointer-events-none absolute left-0 top-full z-40 mt-1 hidden w-max max-w-[20rem] whitespace-normal rounded bg-char px-2.5 py-2 font-body text-xs font-normal text-white group-hover:block group-focus-within:block"
+                >
+                  {UNSURE_GROUP_TIP}
+                </span>
               </span>
             ) : (
               <span className="flex-none rounded-full bg-ember-soft px-2.5 py-0.5 font-body text-xs font-semibold text-ember">

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -7,6 +7,7 @@ import { apiClient } from '@/services/api';
 import { BboxCrop } from '@/components/annotation/BboxCrop';
 import { SequenceGroupStats } from '@/types/api';
 import { classifyGroup, classifyGroups, ROUTES, SequenceGroupsFilter } from '@/utils/routes';
+import { UNSURE_GROUP_TIP } from '@/utils/groupLabels';
 import { ColumnHeader } from '@/components/sequences/ColumnHeader';
 import { TablePagination } from '@/components/sequences/TablePagination';
 import {
@@ -138,6 +139,7 @@ export default function SequenceGroupsListPage({
 
   const items = data?.items ?? [];
   const totalPages = data?.pages ?? 1;
+  const unsureCount = stats?.unsure ?? 0;
 
   return (
     <div className="space-y-6">
@@ -205,7 +207,10 @@ export default function SequenceGroupsListPage({
         <div className="flex items-center justify-center min-h-96">
           <div className="text-center max-w-md">
             {filter === 'unlabeled' ? (
-              // Every group labeled - success
+              // Nothing left on this tab. Unsure objects carry no label
+              // either, so "every object is labeled" is only true when there
+              // are none of them — otherwise the success copy is a lie about
+              // the very objects the next tab is holding.
               <>
                 <span
                   aria-hidden="true"
@@ -214,11 +219,20 @@ export default function SequenceGroupsListPage({
                   <Check className="h-7 w-7 text-pine" />
                 </span>
                 <h2 className="mt-4 font-display text-base font-semibold text-char">
-                  All objects labeled
+                  {unsureCount > 0 ? 'Nothing left to label' : 'All objects labeled'}
                 </h2>
                 <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
-                  Nice work — every object is labeled. New objects appear automatically a few
-                  minutes after each import.
+                  {unsureCount > 0 ? (
+                    <>
+                      {`${unsureCount} object${unsureCount === 1 ? ' is' : 's are'} marked unsure — an annotator judged them undecidable, so they carry no label.`}{' '}
+                      <Link to={classifyGroups('unsure')} className="text-ember underline">
+                        Review them
+                      </Link>
+                      .
+                    </>
+                  ) : (
+                    'Nice work — every object is labeled. New objects appear automatically a few minutes after each import.'
+                  )}
                 </p>
                 <Link
                   to={ROUTES.CLASSIFY}
@@ -404,11 +418,7 @@ export default function SequenceGroupsListPage({
                           <span className="inline-flex rounded-full bg-ash px-2 py-1 font-body text-xs font-semibold text-haze">
                             unsure
                           </span>
-                          {headerTip(
-                            'An annotator marked this object undecidable, so no label ' +
-                              'could be derived from its sightings. Settle them under ' +
-                              'Classify → Done, with the "Only Unsure" filter.'
-                          )}
+                          {headerTip(UNSURE_GROUP_TIP)}
                         </span>
                       ) : (
                         <span className="group relative inline-block">

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -395,6 +395,21 @@ export default function SequenceGroupsListPage({
                         <span>smoke · {g.smoke_type}</span>
                       ) : g.false_positive_type ? (
                         <span>false positive · {g.false_positive_type.replace(/_/g, ' ')}</span>
+                      ) : g.is_unsure ? (
+                        // A verdict, not a to-do — hence neutral tones and no
+                        // ember chip. The label columns stay null by design:
+                        // the check constraint forbids a labeled_at without a
+                        // label, so an undecidable object cannot be "labeled".
+                        <span className="group relative inline-block">
+                          <span className="inline-flex rounded-full bg-ash px-2 py-1 font-body text-xs font-semibold text-haze">
+                            unsure
+                          </span>
+                          {headerTip(
+                            'An annotator marked this object undecidable, so no label ' +
+                              'could be derived from its sightings. Settle them under ' +
+                              'Classify → Done, with the "Only Unsure" filter.'
+                          )}
+                        </span>
                       ) : (
                         <span className="group relative inline-block">
                           <span className="inline-flex rounded-full bg-ember-soft px-2 py-1 font-body text-xs font-semibold text-ember">

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { Popover } from '@headlessui/react';
-import { Loader2, AlertCircle, Check, Info, Layers, ChevronRight } from 'lucide-react';
+import { Loader2, AlertCircle, Check, HelpCircle, Info, Layers, ChevronRight } from 'lucide-react';
 import { apiClient } from '@/services/api';
 import { BboxCrop } from '@/components/annotation/BboxCrop';
 import { SequenceGroupStats } from '@/types/api';
@@ -44,6 +44,12 @@ const FILTERS: {
     label: 'To label',
     countOf: 'unlabeled',
     tip: "Objects that don't have a label yet",
+  },
+  {
+    value: 'unsure',
+    label: 'Unsure',
+    countOf: 'unsure',
+    tip: 'Objects an annotator marked undecidable',
   },
   {
     value: 'labeled',
@@ -90,7 +96,7 @@ export default function SequenceGroupsListPage({
     queryKey: ['sequenceGroupsList', filter, page, size, orderBy, orderDirection],
     queryFn: () =>
       apiClient.getSequenceGroups({
-        labeled: filter === 'all' ? undefined : filter === 'labeled',
+        label_state: filter === 'all' ? undefined : filter,
         page,
         size,
         order_by: orderBy,
@@ -220,6 +226,22 @@ export default function SequenceGroupsListPage({
                 >
                   Start classifying
                 </Link>
+              </>
+            ) : filter === 'unsure' ? (
+              // Not a to-do: these carry a verdict, they just carry no label.
+              <>
+                <span
+                  aria-hidden="true"
+                  className="inline-flex h-14 w-14 items-center justify-center rounded-full border border-line bg-ash"
+                >
+                  <HelpCircle className="h-6 w-6 text-haze" />
+                </span>
+                <h2 className="mt-4 font-display text-base font-semibold text-char">
+                  No unsure objects
+                </h2>
+                <p className="mt-1.5 font-body text-sm leading-relaxed text-haze">
+                  Objects whose sightings an annotator marked undecidable land here.
+                </p>
               </>
             ) : filter === 'labeled' ? (
               // Nothing labeled yet - work to do

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -458,7 +458,7 @@ class ApiClient {
 
   async getSequenceGroups(
     filters: {
-      labeled?: boolean;
+      label_state?: 'labeled' | 'unlabeled' | 'unsure';
       page?: number;
       size?: number;
       order_by?: 'member_count' | 'camera_name' | 'azimuth' | 'created_at';

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -362,6 +362,7 @@ export interface SequenceGroupStats {
   validated: number;
   unvalidated: number;
   labeled: number;
+  unsure: number;
   unlabeled: number;
 }
 

--- a/frontend/src/utils/groupLabels.ts
+++ b/frontend/src/utils/groupLabels.ts
@@ -1,0 +1,6 @@
+// Copy shared by the two places that render a recurring object's label
+// state — the list row's Label cell and the group page's header chip. One
+// string so the two explanations can't drift apart.
+export const UNSURE_GROUP_TIP =
+  'An annotator marked this object undecidable, so no label could be derived ' +
+  'from its sightings. Settle them under Classify → Done, with the "Only Unsure" filter.';

--- a/frontend/src/utils/routes.ts
+++ b/frontend/src/utils/routes.ts
@@ -43,7 +43,7 @@ export function classifyGroup(id: number | string): string {
   return `${ROUTES.CLASSIFY_GROUPS}/${id}`;
 }
 
-export type SequenceGroupsFilter = 'unlabeled' | 'labeled' | 'all';
+export type SequenceGroupsFilter = 'unlabeled' | 'unsure' | 'labeled' | 'all';
 
 // Bare path is the To-label default; other filters are path segments.
 export function classifyGroups(filter: SequenceGroupsFilter): string {

--- a/frontend/tests/hooks/useAnnotationCounts.test.tsx
+++ b/frontend/tests/hooks/useAnnotationCounts.test.tsx
@@ -32,6 +32,7 @@ describe('useAnnotationCounts', () => {
       validated: 20,
       unvalidated: 15,
       labeled: 28,
+      unsure: 0,
       unlabeled: 12,
     });
   });

--- a/frontend/tests/hooks/usePipelineStats.test.tsx
+++ b/frontend/tests/hooks/usePipelineStats.test.tsx
@@ -39,6 +39,7 @@ describe('usePipelineStats', () => {
       validated: 20,
       unvalidated: 20,
       labeled: 28,
+      unsure: 0,
       unlabeled: 12,
     });
     vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue(page(9));

--- a/frontend/tests/hooks/useQueueTotals.test.tsx
+++ b/frontend/tests/hooks/useQueueTotals.test.tsx
@@ -41,6 +41,7 @@ describe('queue totals shared by the sidebar badges and the dashboard', () => {
       validated: 20,
       unvalidated: 15,
       labeled: 28,
+      unsure: 0,
       unlabeled: 12,
     });
   });

--- a/frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx
@@ -106,6 +106,14 @@ describe('SequenceGroupAnnotatePage', () => {
     expect(screen.queryByText('to label')).toBeNull();
   });
 
+  it('the "unsure" badge explains itself — the only header chip whose state is not self-evident', async () => {
+    // Arriving from the Unsure tab, this chip is the whole explanation of
+    // why the object sits outside both backlogs.
+    await renderGroup({ is_unsure: true });
+    expect(screen.getByText(/marked this object undecidable/)).toBeTruthy();
+    expect(screen.getByText(/Settle them under Classify/)).toBeTruthy();
+  });
+
   it('Validate group is the ember primary button', async () => {
     await renderGroup();
     const btn = screen.getByRole('button', { name: /Validate group/ });

--- a/frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupAnnotatePage.test.tsx
@@ -100,6 +100,12 @@ describe('SequenceGroupAnnotatePage', () => {
     expect(screen.getByText('to label')).toHaveClass('bg-ember-soft', 'text-ember');
   });
 
+  it('renders the "unsure" badge with neutral tones', async () => {
+    await renderGroup({ is_unsure: true });
+    expect(screen.getByText('unsure')).toHaveClass('bg-ash', 'text-haze');
+    expect(screen.queryByText('to label')).toBeNull();
+  });
+
   it('Validate group is the ember primary button', async () => {
     await renderGroup();
     const btn = screen.getByRole('button', { name: /Validate group/ });

--- a/frontend/tests/pages/SequenceGroupsListPage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupsListPage.test.tsx
@@ -257,6 +257,39 @@ describe('SequenceGroupsListPage', () => {
     expect(screen.getByText('to label')).toHaveClass('bg-ember-soft', 'text-ember');
   });
 
+  it('an unsure group renders the neutral "unsure" chip, not "to label"', async () => {
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
+      items: [{ ...group, is_unsure: true }],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 1,
+    });
+    renderAt('/classify/groups/unsure');
+    await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
+
+    // Neutral tokens, deliberately not the ember to-do chip: an unsure
+    // object is a recorded decision, not outstanding work.
+    expect(screen.getByText('unsure')).toHaveClass('bg-ash', 'text-haze');
+    expect(screen.queryByText('to label')).toBeNull();
+    expect(screen.getByText(/Settle them under Classify/)).toBeTruthy();
+  });
+
+  it('a label outranks is_unsure in the label cell', async () => {
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
+      items: [{ ...group, is_unsure: true, smoke_type: 'wildfire' }],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 1,
+    });
+    renderAt('/classify/groups/all');
+    await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
+
+    expect(screen.getByText('smoke · wildfire')).toBeTruthy();
+    expect(screen.queryByText('unsure')).toBeNull();
+  });
+
   it('filter tabs carry explanatory tooltips', async () => {
     renderAt('/classify/groups');
     await waitFor(() => expect(screen.getByRole('link', { name: /To label/ })).toBeTruthy());

--- a/frontend/tests/pages/SequenceGroupsListPage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupsListPage.test.tsx
@@ -27,6 +27,10 @@ function renderAt(path: string) {
             path="/classify/groups/labeled"
             element={<SequenceGroupsListPage filter="labeled" />}
           />
+          <Route
+            path="/classify/groups/unsure"
+            element={<SequenceGroupsListPage filter="unsure" />}
+          />
           <Route path="/classify/groups/all" element={<SequenceGroupsListPage filter="all" />} />
         </Routes>
       </MemoryRouter>
@@ -45,6 +49,7 @@ const group = {
   smoke_type: null,
   false_positive_type: null,
   is_validated: false,
+  is_unsure: false,
   created_at: '2026-08-01T10:00:00Z',
   annotators: ['alice', 'bob'],
   representative_bbox: { xyxyn: [0.1, 0.1, 0.4, 0.4], confidence: 0.9 },
@@ -57,23 +62,71 @@ describe('SequenceGroupsListPage', () => {
     vi.mocked(apiClient.getSequenceGroupStats).mockResolvedValue({
       total: 0,
       labeled: 0,
+      unsure: 0,
       unlabeled: 0,
     });
   });
 
-  it('selector tabs are links to the three filter routes with aria-current on the active one', async () => {
-    renderAt('/classify/groups/labeled');
+  it('selector tabs are links to the four filter routes with aria-current on the active one', async () => {
+    renderAt('/classify/groups/unsure');
     await waitFor(() => expect(screen.getByRole('link', { name: /To label/ })).toBeTruthy());
     expect(screen.getByRole('link', { name: /To label/ }).getAttribute('href')).toBe(
       '/classify/groups'
     );
-    const labeled = screen.getByRole('link', { name: /Labeled/ });
-    expect(labeled.getAttribute('href')).toBe('/classify/groups/labeled');
-    expect(labeled.getAttribute('aria-current')).toBe('page');
+    const unsure = screen.getByRole('link', { name: /Unsure/ });
+    expect(unsure.getAttribute('href')).toBe('/classify/groups/unsure');
+    expect(unsure.getAttribute('aria-current')).toBe('page');
+    expect(screen.getByRole('link', { name: /Labeled/ }).getAttribute('href')).toBe(
+      '/classify/groups/labeled'
+    );
     expect(screen.getByRole('link', { name: /All/ }).getAttribute('href')).toBe(
       '/classify/groups/all'
     );
     expect(screen.getByRole('link', { name: /To label/ }).getAttribute('aria-current')).toBeNull();
+  });
+
+  it('each tab requests its own label_state partition', async () => {
+    renderAt('/classify/groups');
+    await waitFor(() =>
+      expect(apiClient.getSequenceGroups).toHaveBeenCalledWith(
+        expect.objectContaining({ label_state: 'unlabeled' })
+      )
+    );
+
+    vi.mocked(apiClient.getSequenceGroups).mockClear();
+    renderAt('/classify/groups/unsure');
+    await waitFor(() =>
+      expect(apiClient.getSequenceGroups).toHaveBeenCalledWith(
+        expect.objectContaining({ label_state: 'unsure' })
+      )
+    );
+
+    vi.mocked(apiClient.getSequenceGroups).mockClear();
+    renderAt('/classify/groups/labeled');
+    await waitFor(() =>
+      expect(apiClient.getSequenceGroups).toHaveBeenCalledWith(
+        expect.objectContaining({ label_state: 'labeled' })
+      )
+    );
+
+    // 'All' must send no filter at all. `undefined` is dropped by the
+    // serializer; `null` would be dropped too but silently, so assert the
+    // key is absent rather than that it is falsy.
+    vi.mocked(apiClient.getSequenceGroups).mockClear();
+    renderAt('/classify/groups/all');
+    await waitFor(() => expect(apiClient.getSequenceGroups).toHaveBeenCalled());
+    const allCall = vi.mocked(apiClient.getSequenceGroups).mock.calls[0][0]!;
+    expect(allCall.label_state).toBeUndefined();
+  });
+
+  it('Unsure empty shows the no-unsure-objects state with no action', async () => {
+    renderAt('/classify/groups/unsure');
+    await waitFor(() => expect(screen.getByText('No unsure objects')).toBeTruthy());
+    // Not just /marked undecidable/: the Unsure tab's own tooltip matches
+    // that too, so anchor on the empty state's sentence.
+    expect(screen.getByText(/whose sightings an annotator marked undecidable/)).toBeTruthy();
+    expect(screen.queryByRole('link', { name: 'Start classifying' })).toBeNull();
+    expect(screen.queryByRole('table')).toBeNull();
   });
 
   it('To label empty shows all-groups-labeled state, CTA to classify, and no table', async () => {
@@ -208,11 +261,13 @@ describe('SequenceGroupsListPage', () => {
     renderAt('/classify/groups');
     await waitFor(() => expect(screen.getByRole('link', { name: /To label/ })).toBeTruthy());
     expect(screen.getByText("Objects that don't have a label yet")).toBeTruthy();
+    expect(screen.getByText('Objects an annotator marked undecidable')).toBeTruthy();
     expect(screen.getByText('Objects that already have a label')).toBeTruthy();
     expect(screen.getByText('Every object, labeled or not')).toBeTruthy();
     // Tooltip text must not leak into the tab links' accessible names
     // (exact names: label + mocked zero count).
     expect(screen.getByRole('link', { name: 'To label 0' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Unsure 0' })).toBeTruthy();
     expect(screen.getByRole('link', { name: 'Labeled 0' })).toBeTruthy();
     expect(screen.getByRole('link', { name: 'All 0' })).toBeTruthy();
   });

--- a/frontend/tests/pages/SequenceGroupsListPage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupsListPage.test.tsx
@@ -139,6 +139,40 @@ describe('SequenceGroupsListPage', () => {
     expect(screen.queryByRole('table')).toBeNull();
   });
 
+  it('To label empty does not claim everything is labeled while unsure objects exist', async () => {
+    // Unsure objects carry no label either, so the success copy would be a
+    // lie — they just aren't work that lives on this tab.
+    vi.mocked(apiClient.getSequenceGroupStats).mockResolvedValue({
+      total: 4,
+      validated: 4,
+      unvalidated: 0,
+      labeled: 0,
+      unsure: 4,
+      unlabeled: 0,
+    });
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getByText('Nothing left to label')).toBeTruthy());
+    expect(screen.queryByText('All objects labeled')).toBeNull();
+    expect(screen.getByText(/4 objects are marked unsure/)).toBeTruthy();
+    expect(screen.getByRole('link', { name: /Review them/ }).getAttribute('href')).toBe(
+      '/classify/groups/unsure'
+    );
+  });
+
+  it('To label empty keeps the success copy when nothing is unsure', async () => {
+    vi.mocked(apiClient.getSequenceGroupStats).mockResolvedValue({
+      total: 4,
+      validated: 4,
+      unvalidated: 0,
+      labeled: 4,
+      unsure: 0,
+      unlabeled: 0,
+    });
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getByText('All objects labeled')).toBeTruthy());
+    expect(screen.getByText(/every object is labeled/)).toBeTruthy();
+  });
+
   it('Labeled empty shows no-labeled-groups state with CTA to the To label tab', async () => {
     renderAt('/classify/groups/labeled');
     await waitFor(() => expect(screen.getByText('No labeled objects yet')).toBeTruthy());


### PR DESCRIPTION
## Problem

Four validated recurring objects (groups `368`, `599`, `2928`, `3489` — 63 member sequences between them) sit in the **To label** tab of `/classify/groups` permanently, even though every one of their sightings is annotated. They read exactly like objects nobody has touched.

All four share one shape: `is_validated`, `is_unsure`, both label columns `NULL`.

**How they got there.** An annotator validated the group, opened one member, and classified it *unsure with no label*. `_propagate_to_group_if_validated` takes its unsure branch (`sequence_annotations.py:1055-1077`): it sets `group.is_unsure = True`, leaves both label columns `NULL` — they *must* stay `NULL`, `ck_sequence_group_labeled_at_consistency` forbids a `labeled_at` without a label — and fans that unsure verdict onto every sibling.

That branch is deliberate (commit `864110bb`, 2026-06-18, "propagate unsure flag across validated group"). The commit is backend-only; the UI was never taught that a group can be unsure.

**Why it looks like a to-do.** Four places decide a group's label state, and all four key on `smoke_type OR false_positive_type` alone: the list row's Label cell, the detail header, the `labeled` list filter, and the stats counter. `is_unsure` was already selected by the list query and already present on `SequenceGroupListItem` in both layers — it was simply never rendered or counted. `unlabeled` also drives the sidebar badge and the dashboard "objects to label" figure, so the four groups inflated those too.

This is **not** #253: no validated group in the reference dump has a labelled member and no group label.

## Change

Three mutually exclusive states now partition every group:

| State | Predicate |
| --- | --- |
| `labeled` | `smoke_type IS NOT NULL OR false_positive_type IS NOT NULL` |
| `unsure` | no label **and** `is_unsure` |
| `unlabeled` | no label **and not** `is_unsure` |

A group carrying both a label and `is_unsure` counts as `labeled` — the label is the stronger statement, and propagation cannot produce that combination anyway.

**Backend.** One predicate helper, `_label_state_clause`, drives both the list filter and the stats counters. `GET /sequence_groups/` takes `label_state=labeled|unlabeled|unsure` in place of the boolean `labeled` (this repo's frontend is its only caller). `SequenceGroupStats` gains `unsure`, and `unlabeled` becomes `total - labeled - unsure`.

**Frontend.** New `/classify/groups/unsure` route and a fourth tab — **To label · Unsure · Labeled · All**. Both label displays gain an "unsure" branch rendering a neutral `bg-ash`/`text-haze` chip, deliberately not the ember "to label" chip: an unsure object is a recorded decision, not outstanding work. Its tooltip points at `/classify/done` → "Only Unsure", which is where such a lane is actually settled.

The sidebar badge and dashboard figure shed the four groups as a consequence, which is correct — they are not actionable labelling work.

No migration. No change to member annotations, to the unsure fan-out itself, or to any group's stored data.

## Verification

- Backend: 808 passed. Frontend: 1450 passed. `type-check`, `eslint --max-warnings 0`, `prettier --check`, and per-file `ruff format`/`ruff check` all clean.
- New backend tests cover each `label_state` partition, the unfiltered case, `422` on an unknown state, and `labeled + unsure + unlabeled == total`.
- New frontend tests cover the four tab routes, the `label_state` each tab requests (asserting `all` sends no key — the axios serializer drops `null` silently), the unsure chip's neutral tokens, label-outranks-unsure, and the new empty state.
- Replayed against the 2026-08-12 production dump: 77 labeled + 278 to-label + 4 unsure = 359, with the unsure bucket exactly `{368, 599, 2928, 3489}`. "To label" drops from 282 to 278.

## Deliberately out of scope

The 63 fanned-out member annotations are untouched, including their hold on those alerts' entry into the localize queue — they are "unsettled unsure", so `unsettled_unsure_clause` withholds their alerts. Also out: whether unsure *should* fan out across a validated group at all, any direct group-label action, and any link from the new tab into the resolution flow.

### Known consequence: a stale `group.is_unsure` now moves a group out of the backlog

`group.is_unsure` is only ever refreshed by `_propagate_to_group_if_validated` and bulk-apply, and that function returns early (`sequence_annotations.py:1054`) when no label can be derived *and* the new annotation isn't unsure — a member settled as smoke with no `smoke_type`, say. It also never runs at all once a group is unvalidated. Either way the group keeps `is_unsure` with no label.

Before this PR such a group sat in **To label**. After it, it sits in **Unsure** — still listed, still openable, but out of the To-label backlog and out of the sidebar badge and dashboard "objects to label" counts, under copy that frames it as settled.

Repairing stale `is_unsure` means touching propagation, which this PR deliberately doesn't. Flagging it as the one behavioural regression in the change; worth its own issue if it turns out to bite.

Spec: `docs/specs/2026-08-12-unsure-group-label-state-design.md`
