### PR TITLE
feat(groups): temporal model score column on the recurring-objects list

### DIFF
--- a/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
+++ b/annotation_api/src/app/api/api_v1/endpoints/sequence_groups.py
@@ -45,6 +45,7 @@ class SequenceGroupOrderByField(str, Enum):
     camera_name = "camera_name"
     azimuth = "azimuth"
     created_at = "created_at"
+    temporal_model_score = "temporal_model_score"
 
 
 class OrderDirection(str, Enum):
@@ -201,6 +202,10 @@ async def list_sequence_groups(
             # All members share one camera; min() just picks that value.
             func.min(Sequence.camera_name).label("camera_name"),
             func.min(Sequence.organisation_name).label("organisation_name"),
+            # Only the alert's primary lane carries a score; siblings are
+            # NULL. MAX skips NULLs, so this is the max over the object's
+            # scored sightings without needing to join to find the primary.
+            func.max(Sequence.temporal_model_score).label("temporal_model_score"),
         )
         .where(Sequence.sequence_group_id.is_not(None))
         .group_by(Sequence.sequence_group_id)
@@ -212,9 +217,16 @@ async def list_sequence_groups(
         SequenceGroupOrderByField.camera_name: member_count_subq.c.camera_name,
         SequenceGroupOrderByField.azimuth: SequenceGroup.azimuth,
         SequenceGroupOrderByField.created_at: SequenceGroup.created_at,
+        SequenceGroupOrderByField.temporal_model_score: (
+            member_count_subq.c.temporal_model_score
+        ),
     }
     primary = order_columns[order_by]
     primary = desc(primary) if order_direction == OrderDirection.desc else asc(primary)
+    # Postgres orders NULLs FIRST on DESC. Unscored groups must sink to the
+    # bottom either way, or a "most likely fires first" sort opens with the
+    # objects nothing ever scored.
+    primary = primary.nullslast()
     query = (
         select(
             SequenceGroup.id,
@@ -232,6 +244,7 @@ async def list_sequence_groups(
             member_count_subq.c.member_count,
             member_count_subq.c.camera_name,
             member_count_subq.c.organisation_name,
+            member_count_subq.c.temporal_model_score,
         )
         # Inner-join so small groups (no row in the subquery) drop out.
         .join(member_count_subq, member_count_subq.c.group_id == SequenceGroup.id)

--- a/annotation_api/src/app/schemas/sequence_group.py
+++ b/annotation_api/src/app/schemas/sequence_group.py
@@ -108,6 +108,12 @@ class SequenceGroupListItem(BaseModel):
     labeled_at: Optional[datetime]
     created_at: datetime
     member_count: int
+    # Highest temporal-model score among the group's members. Only the
+    # primary lane of an alert carries a score (siblings are NULL by
+    # construction), so MAX ignoring NULLs is exact, not a heuristic — it is
+    # the max over the sightings where this object was the alert's scored
+    # object. None when no member was ever scored.
+    temporal_model_score: Optional[float] = None
     # Distinct humans who contributed to any member sequence's annotation,
     # ordered by first contribution. Hydrated after pagination, not in SQL.
     annotators: List[str] = []

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -1514,8 +1514,13 @@ async def test_list_groups_orderable_by_temporal_score_nulls_last(
     async_session: AsyncSession,
 ):
     """Sorting by score ranks high scores first and parks unscored groups at
-    the end in BOTH directions — Postgres would otherwise put NULLs first on
-    DESC and fill the top of the list with objects nothing ever scored."""
+    the end in BOTH directions.
+
+    The DESC half is the real guard: without nullslast Postgres puts NULLs
+    FIRST there, filling the top of the list with objects nothing ever
+    scored. The ASC half only pins Postgres's own default (NULLS LAST on
+    ASC) — it passes with or without nullslast, so it would not catch a
+    DESC-only implementation."""
     high = await _seed_group_with_members(
         async_session,
         n_members=3,

--- a/annotation_api/src/tests/endpoints/test_sequence_groups.py
+++ b/annotation_api/src/tests/endpoints/test_sequence_groups.py
@@ -106,9 +106,12 @@ async def _seed_group_with_members(
     organisation_name: str = "org",
     azimuth: int = 0,
     smoke_type: str | None = None,
+    scores: list[float | None] | None = None,
 ) -> int:
     """Insert a SequenceGroup with `n_members` member sequences (each with a
-    distinct alert_api_id) and return its id."""
+    distinct alert_api_id) and return its id. `scores` sets each member's
+    temporal_model_score positionally; None (or a shorter list) leaves the
+    remaining members unscored, mirroring sibling object-lanes."""
     group_id = (
         await session.exec(
             text(
@@ -149,6 +152,9 @@ async def _seed_group_with_members(
                 lon=0.0,
                 organisation_id=1,
                 sequence_group_id=group_id,
+                temporal_model_score=(
+                    scores[i] if scores is not None and i < len(scores) else None
+                ),
             )
         )
     await session.commit()
@@ -1451,3 +1457,99 @@ def test_crop_bbox_none_when_no_valid_boxes():
         )
         is None
     )
+
+
+@pytest.mark.asyncio
+async def test_list_groups_report_max_temporal_score_ignoring_nulls(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """A group's score is the max over its scored members. Unscored sibling
+    lanes are skipped, not treated as zero; an all-unscored group is null."""
+    mixed = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        alert_api_id_start=700,
+        scores=[0.48, None, 0.0],
+    )
+    unscored = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 2, 2, tzinfo=timezone.utc),
+        alert_api_id_start=800,
+        scores=None,
+    )
+
+    resp = await authenticated_client.get("/sequence_groups/")
+    assert resp.status_code == 200, resp.text
+    by_id = {i["id"]: i for i in resp.json()["items"]}
+    assert by_id[mixed]["temporal_model_score"] == pytest.approx(0.48)
+    assert by_id[unscored]["temporal_model_score"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_groups_zero_score_is_not_null(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """A group whose only scored member scored exactly 0.0 reports 0.0."""
+    zeroed = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 2, 3, tzinfo=timezone.utc),
+        alert_api_id_start=900,
+        scores=[0.0, None, None],
+    )
+
+    resp = await authenticated_client.get("/sequence_groups/")
+    assert resp.status_code == 200, resp.text
+    by_id = {i["id"]: i for i in resp.json()["items"]}
+    assert by_id[zeroed]["temporal_model_score"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_list_groups_orderable_by_temporal_score_nulls_last(
+    authenticated_client: AsyncClient,
+    async_session: AsyncSession,
+):
+    """Sorting by score ranks high scores first and parks unscored groups at
+    the end in BOTH directions — Postgres would otherwise put NULLs first on
+    DESC and fill the top of the list with objects nothing ever scored."""
+    high = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        alert_api_id_start=1000,
+        scores=[0.58, None, None],
+    )
+    low = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 3, 2, tzinfo=timezone.utc),
+        alert_api_id_start=1100,
+        scores=[0.05, None, None],
+    )
+    unscored = await _seed_group_with_members(
+        async_session,
+        n_members=3,
+        created_at=datetime(2026, 3, 3, tzinfo=timezone.utc),
+        alert_api_id_start=1200,
+        scores=None,
+    )
+
+    async def ids(params: str) -> list[int]:
+        resp = await authenticated_client.get(f"/sequence_groups/{params}")
+        assert resp.status_code == 200, resp.text
+        return [i["id"] for i in resp.json()["items"]]
+
+    assert await ids("?order_by=temporal_model_score&order_direction=desc") == [
+        high,
+        low,
+        unscored,
+    ]
+    assert await ids("?order_by=temporal_model_score&order_direction=asc") == [
+        low,
+        high,
+        unscored,
+    ]

--- a/docs/specs/2026-08-12-groups-temporal-score-design.md
+++ b/docs/specs/2026-08-12-groups-temporal-score-design.md
@@ -80,8 +80,12 @@ Groups whose every member is unscored yield NULL and sort last.
   `'desc'` (first click shows the highest scores, like `member_count`).
 - New `ColumnHeader label="Score"` between **Azimuth** and **Sightings**,
   mirroring the classify queue's azimuth → score → count order. Tip: "Highest
-  Alert API temporal-model score across this object's sightings. — means none
-  of its sightings were scored."
+  Alert API temporal-model score across this object's sightings. The platform
+  scores one object per alert, so — means this object was never the one it
+  scored." The tip must not say "none of its sightings were scored": an object
+  that is never its alert's primary lane shows — even though every one of
+  those alerts *was* scored, just for a different object. Wording it the
+  loose way would push annotators to deprioritize exactly those objects.
 - Cell renders the existing `<TemporalScoreCell score={g.temporal_model_score} />`
   unchanged, in a `${CELL_CLASSES} ${DATA_CELL_TEXT}` cell. Left-aligned like
   this table's other numeric cells — the queues right-align theirs, but
@@ -108,8 +112,11 @@ Backend (`src/tests/endpoints/test_sequence_groups.py`):
   directions. Assert row order, not the compiled clause: with distinct scores
   the ordering is fully determined by the column, and Postgres's NULL default
   is specified (FIRST on DESC), so dropping `nullslast` fails the DESC case
-  deterministically rather than by luck. Asserting ASC too is what catches a
-  `nullslast` applied to only one branch.
+  deterministically rather than by luck. **Only the DESC half has teeth** —
+  Postgres already defaults ASC to NULLS LAST, so that assertion passes with
+  or without `.nullslast()`. It is kept as a regression pin on the default,
+  not as a guard against a `nullslast` applied to only one branch; a
+  DESC-only implementation would still pass it.
 
 Frontend (`tests/pages/SequenceGroupsListPage.test.tsx`):
 

--- a/docs/specs/2026-08-12-groups-temporal-score-design.md
+++ b/docs/specs/2026-08-12-groups-temporal-score-design.md
@@ -1,0 +1,126 @@
+# Temporal model score on the recurring-objects list
+
+**Date:** 2026-08-12
+**Status:** Approved
+**Page:** `/classify/groups` (`SequenceGroupsListPage`)
+
+## Problem
+
+The recurring-objects list shows camera, organisation, azimuth, sighting count,
+label and annotators, but nothing about how likely the object is to be real
+smoke. The alert platform's temporal-model score already rides on every
+imported sequence and is surfaced in all four alert queues; the groups list is
+the one work list that ignores it. Annotators triaging which recurring object
+to label next have no way to float the likely fires to the top.
+
+## Decision
+
+Add a single sortable **Score** column showing the **maximum**
+`temporal_model_score` across the group's member sequences.
+
+### Why max, and why one number
+
+The column's job is triage order — a ranking key, like the classify queue's
+score column. That argues for one number per row, not a range or a
+distribution.
+
+Max is also the only aggregate that is exact given how the score is stored.
+Only the primary lane of an alert carries a score; sibling object-lanes are
+NULL by construction (see `docs/specs/2026-08-10-import-temporal-model-score-design.md`).
+`MAX` ignores NULLs, so an unscored sibling never drags a group down, and no
+join is needed to find the scored lane. A mean or median over the same column
+would silently average over a denominator that depends on how many of the
+object's sightings happened to be the alert's primary object — not a
+meaningful quantity.
+
+### What the number means, honestly
+
+The group max is the highest score among the sightings **where this object was
+the alert's scored object**. We deliberately do not borrow an alert's score for
+a sibling lane: the temporal model builds its ROI from one object's box only,
+so a sibling would inherit a score computed while deliberately excluding it.
+That misattribution is exactly what the import design prevents.
+
+Within-group spread is large in real data — every group in the local dataset
+has a min of 0.00 while maxes reach 0.48–0.58 — so a row reading 58% may come
+from one sighting out of three. The header tip says so; the cell does not try
+to.
+
+## Backend
+
+`GET /api/v1/sequence_groups/` (`list_sequence_groups`).
+
+- Add `func.max(Sequence.temporal_model_score).label("temporal_model_score")`
+  to the existing `member_count_subq`. It groups by `sequence_group_id`
+  already, so this is a new aggregate on an existing scan — no extra join, no
+  extra query, and it stays inside the `HAVING count(*) >= 3` population.
+- Select `member_count_subq.c.temporal_model_score` in the outer query. It
+  flows into `SequenceGroupListItem` through the existing
+  `**dict(r._mapping)` splat in `_hydrate`.
+- Add `temporal_model_score: Optional[float]` to `SequenceGroupListItem`.
+- Add `temporal_model_score` to `SequenceGroupOrderByField` and to the
+  `order_columns` map, pointing at `member_count_subq.c.temporal_model_score`.
+
+### NULL ordering
+
+The chosen sort column must be wrapped in `.nullslast()` in **both**
+directions. Postgres orders NULLs first on DESC, which would fill the top of a
+"most likely fires first" sort with objects nothing ever scored. The existing
+`created_at desc, id desc` tie-breakers stay so paginated offsets remain
+stable.
+
+Groups whose every member is unscored yield NULL and sort last.
+
+## Frontend
+
+`SequenceGroupsListPage` and `types/api.ts`.
+
+- `SequenceGroupListItem` gains `temporal_model_score: number | null`.
+- `OrderBy` gains `'temporal_model_score'`; `DEFAULT_DIRECTION` maps it to
+  `'desc'` (first click shows the highest scores, like `member_count`).
+- New `ColumnHeader label="Score"` between **Azimuth** and **Sightings**,
+  mirroring the classify queue's azimuth → score → count order. Tip: "Highest
+  Alert API temporal-model score across this object's sightings. — means none
+  of its sightings were scored."
+- Cell renders the existing `<TemporalScoreCell score={g.temporal_model_score} />`
+  unchanged, in a `${CELL_CLASSES} ${DATA_CELL_TEXT}` cell. Left-aligned like
+  this table's other numeric cells — the queues right-align theirs, but
+  internal consistency within this table wins.
+
+`TemporalScoreCell` already handles the three cases: a percentage, `0%` for a
+real zero (it tests `score == null`, never truthiness), and `—` for null.
+
+### Default sort unchanged
+
+The page keeps defaulting to `member_count desc` — "label the object that
+unlocks the most sightings first" is this page's stated pitch, and the score
+column is one click away. No auto-advance or continuous-flow code reads this
+page's ordering, so nothing else has to change.
+
+## Testing
+
+Backend (`src/tests/endpoints/test_sequence_groups.py`):
+
+- A group whose members mix real scores and NULLs reports the max of the
+  non-NULL ones.
+- A group whose members are all unscored reports `null`.
+- Sorting by `temporal_model_score` desc places all-NULL groups last.
+  Assert white-box on the compiled ORDER BY containing `NULLS LAST`, not only
+  on row order: without `nullslast` the order is *undefined*, not reliably
+  wrong, so a behavioural test can pass by luck.
+
+Frontend (`tests/pages/SequenceGroupsListPage.test.tsx`):
+
+- The row renders the percentage for a scored group.
+- The row renders `—` for a null score.
+- A score of `0` renders `0%`, not `—`.
+- Clicking the Score header issues `order_by=temporal_model_score` with
+  `order_direction=desc` on first click.
+
+## Out of scope
+
+- The group detail page `/classify/groups/:id` renders member *cards*, not a
+  table, and the "no per-object score badge" decision from 2026-08-10 stands.
+- Backfilling scores onto sequences imported before the score capture landed.
+  Until that happens, groups whose members all predate it show `—`.
+- Any filter or threshold on the score. Sorting only.

--- a/docs/specs/2026-08-12-groups-temporal-score-design.md
+++ b/docs/specs/2026-08-12-groups-temporal-score-design.md
@@ -104,10 +104,12 @@ Backend (`src/tests/endpoints/test_sequence_groups.py`):
 - A group whose members mix real scores and NULLs reports the max of the
   non-NULL ones.
 - A group whose members are all unscored reports `null`.
-- Sorting by `temporal_model_score` desc places all-NULL groups last.
-  Assert white-box on the compiled ORDER BY containing `NULLS LAST`, not only
-  on row order: without `nullslast` the order is *undefined*, not reliably
-  wrong, so a behavioural test can pass by luck.
+- Sorting by `temporal_model_score` places all-NULL groups last in **both**
+  directions. Assert row order, not the compiled clause: with distinct scores
+  the ordering is fully determined by the column, and Postgres's NULL default
+  is specified (FIRST on DESC), so dropping `nullslast` fails the DESC case
+  deterministically rather than by luck. Asserting ASC too is what catches a
+  `nullslast` applied to only one branch.
 
 Frontend (`tests/pages/SequenceGroupsListPage.test.tsx`):
 

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -9,6 +9,7 @@ import { SequenceGroupStats } from '@/types/api';
 import { classifyGroup, classifyGroups, ROUTES, SequenceGroupsFilter } from '@/utils/routes';
 import { ColumnHeader } from '@/components/sequences/ColumnHeader';
 import { TablePagination } from '@/components/sequences/TablePagination';
+import { TemporalScoreCell } from '@/components/sequences/TemporalScoreCell';
 import {
   CELL_CLASSES,
   CELL_TEXT,
@@ -22,7 +23,7 @@ import {
   THEAD_CLASSES,
 } from '@/components/sequences/tableStyles';
 import { formatDateTime } from '@/utils/datetime';
-type OrderBy = 'member_count' | 'camera_name' | 'azimuth' | 'created_at';
+type OrderBy = 'member_count' | 'camera_name' | 'azimuth' | 'created_at' | 'temporal_model_score';
 type OrderDirection = 'asc' | 'desc';
 
 // First click on a column uses its natural direction: text asc, numbers/dates desc.
@@ -31,6 +32,7 @@ const DEFAULT_DIRECTION: Record<OrderBy, OrderDirection> = {
   camera_name: 'asc',
   azimuth: 'asc',
   created_at: 'desc',
+  temporal_model_score: 'desc',
 };
 
 const FILTERS: {
@@ -302,6 +304,15 @@ export default function SequenceGroupsListPage({
                     }}
                   />
                   <ColumnHeader
+                    label="Score"
+                    tip="Highest Alert API temporal-model score across this object's sightings. — means none of its sightings were scored."
+                    sort={{
+                      active: orderBy === 'temporal_model_score',
+                      direction: orderDirection,
+                      onSort: () => handleSort('temporal_model_score'),
+                    }}
+                  />
+                  <ColumnHeader
                     label="Sightings"
                     tip="Times this object was seen"
                     sort={{
@@ -367,6 +378,9 @@ export default function SequenceGroupsListPage({
                       {formatDateTime(g.created_at)}
                     </td>
                     <td className={`${CELL_CLASSES} ${DATA_CELL_TEXT}`}>{g.azimuth}°</td>
+                    <td className={`${CELL_CLASSES} ${DATA_CELL_TEXT}`}>
+                      <TemporalScoreCell score={g.temporal_model_score} />
+                    </td>
                     <td className={`${CELL_CLASSES} ${DATA_CELL_TEXT}`}>{g.member_count}</td>
                     <td className={`${CELL_CLASSES} ${CELL_TEXT}`}>
                       {g.smoke_type ? (

--- a/frontend/src/pages/SequenceGroupsListPage.tsx
+++ b/frontend/src/pages/SequenceGroupsListPage.tsx
@@ -305,7 +305,7 @@ export default function SequenceGroupsListPage({
                   />
                   <ColumnHeader
                     label="Score"
-                    tip="Highest Alert API temporal-model score across this object's sightings. — means none of its sightings were scored."
+                    tip="Highest Alert API temporal-model score across this object's sightings. The platform scores one object per alert, so — means this object was never the one it scored."
                     sort={{
                       active: orderBy === 'temporal_model_score',
                       direction: orderDirection,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -461,7 +461,7 @@ class ApiClient {
       labeled?: boolean;
       page?: number;
       size?: number;
-      order_by?: 'member_count' | 'camera_name' | 'azimuth' | 'created_at';
+      order_by?: 'member_count' | 'camera_name' | 'azimuth' | 'created_at' | 'temporal_model_score';
       order_direction?: 'asc' | 'desc';
     } = {}
   ): Promise<PaginatedResponse<SequenceGroupListItem>> {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -350,6 +350,9 @@ export interface SequenceGroupListItem {
   labeled_at: string | null;
   created_at: string;
   member_count: number;
+  // Highest Alert API temporal-model score among the object's sightings.
+  // null when none of them was scored — 0 is a real score, not "unscored".
+  temporal_model_score: number | null;
   // Distinct humans who annotated any of the object's sightings, ordered by
   // first contribution. The worker's machine writes never appear.
   annotators: string[];

--- a/frontend/tests/pages/SequenceGroupsListPage.test.tsx
+++ b/frontend/tests/pages/SequenceGroupsListPage.test.tsx
@@ -42,6 +42,7 @@ const group = {
   organisation_name: 'SDIS 07',
   azimuth: 120,
   member_count: 5,
+  temporal_model_score: 0.48,
   smoke_type: null,
   false_positive_type: null,
   is_validated: false,
@@ -153,6 +154,7 @@ describe('SequenceGroupsListPage', () => {
       'Organisation',
       'Created',
       'Azimuth',
+      'Score',
       'Sightings',
       'Label',
       'Annotators',
@@ -186,6 +188,69 @@ describe('SequenceGroupsListPage', () => {
     await waitFor(() =>
       expect(apiClient.getSequenceGroups).toHaveBeenCalledWith(
         expect.objectContaining({ order_by: 'camera_name', order_direction: 'asc' })
+      )
+    );
+  });
+
+  it('renders the max temporal score as a percentage', async () => {
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
+      items: [group],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 1,
+    });
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
+    expect(screen.getByText('48%')).toBeTruthy();
+  });
+
+  it('renders a dash for a group no sighting of which was ever scored', async () => {
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
+      items: [{ ...group, temporal_model_score: null }],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 1,
+    });
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
+    expect(screen.getByText('—')).toBeTruthy();
+    expect(screen.queryByText('0%')).toBeNull();
+  });
+
+  it('renders a zero score as 0%, not as unscored', async () => {
+    // 0 is falsy in JS and is a real verdict in production data.
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
+      items: [{ ...group, temporal_model_score: 0 }],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 1,
+    });
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
+    expect(screen.getByText('0%')).toBeTruthy();
+  });
+
+  it('clicking the Score header sorts by score descending', async () => {
+    vi.mocked(apiClient.getSequenceGroups).mockResolvedValue({
+      items: [group],
+      page: 1,
+      pages: 1,
+      size: 50,
+      total: 1,
+    });
+    renderAt('/classify/groups');
+    await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: /score/i }));
+    await waitFor(() =>
+      expect(apiClient.getSequenceGroups).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order_by: 'temporal_model_score',
+          order_direction: 'desc',
+        })
       )
     );
   });
@@ -228,10 +293,11 @@ describe('SequenceGroupsListPage', () => {
     renderAt('/classify/groups');
     await waitFor(() => expect(screen.getByText('CAM_07')).toBeTruthy());
     // One tooltip per labeled column (Preview, Camera, Organisation, Created,
-    // Azimuth, Sightings, Label, Annotators) plus one on the row's "to label"
-    // badge.
-    expect(within(screen.getByRole('table')).getAllByRole('tooltip')).toHaveLength(9);
+    // Azimuth, Score, Sightings, Label, Annotators) plus one on the row's
+    // "to label" badge.
+    expect(within(screen.getByRole('table')).getAllByRole('tooltip')).toHaveLength(10);
     expect(screen.getByText('Times this object was seen')).toBeTruthy();
+    expect(screen.getByText(/Highest Alert API temporal-model score/)).toBeTruthy();
     expect(screen.getByText(/propagates to every sighting/)).toBeTruthy();
     expect(screen.getByText('Camera viewing direction, in degrees')).toBeTruthy();
     expect(screen.getByText('Organisation operating the camera')).toBeTruthy();
@@ -254,8 +320,9 @@ describe('SequenceGroupsListPage', () => {
     // headers while every getByText still passes.
     const row = screen.getByText('CAM_07').closest('tr')!;
     expect(row.cells[2].textContent).toBe('SDIS 07');
-    expect(row.cells[5].textContent).toBe('5');
-    expect(row.cells[7].textContent).toBe('alice, bob');
+    expect(row.cells[5].textContent).toBe('48%');
+    expect(row.cells[6].textContent).toBe('5');
+    expect(row.cells[8].textContent).toBe('alice, bob');
     // Nobody has annotated the second object yet.
     const untouched = screen.getByText('CAM_08').closest('tr')!;
     expect(within(untouched).getByText('—')).toBeTruthy();


### PR DESCRIPTION
Adds the Alert API temporal-model score to `/classify/groups`, the one work list that didn't surface it. Annotators triaging which recurring object to label next can now sort the likely fires to the top.

Design: `docs/specs/2026-08-12-groups-temporal-score-design.md`

## What changes

**Backend** — `GET /api/v1/sequence_groups/`
- `SequenceGroupListItem` gains `temporal_model_score: float | null` = `MAX(temporal_model_score)` over the group's member sequences.
- The aggregate rides the existing `member_count_subq`, which already groups by `sequence_group_id`. No new join, no extra query, no migration.
- `temporal_model_score` added to `SequenceGroupOrderByField`, so the column is sortable.

**Frontend** — `SequenceGroupsListPage`
- New sortable **Score** column between Azimuth and Sightings, mirroring the classify queue's azimuth → score → count order.
- Renders the existing `TemporalScoreCell` unchanged: `48%`, `0%` for a real zero, `—` when nothing in the group was scored.
- Default sort stays `member_count desc` — "label the object that unlocks the most sightings first" is still this page's pitch. Score is one click away.

## Why MAX is exact, not a heuristic

Only the primary lane of an alert carries a score; sibling object-lanes are NULL by construction (#364). `MAX` ignores NULLs, so no join is needed to find the scored lane — the same property the queue score column relies on.

It also means the group max is the max over the sightings **where this object was the alert's scored object**. We deliberately do not borrow an alert's score for a sibling lane: the temporal model builds its ROI from one object's box only, so a sibling would inherit a score computed while deliberately excluding it. That's the misattribution #364 exists to prevent.

## Two traps this had to avoid

- **NULLs must sort last explicitly.** Postgres orders them FIRST on DESC, which would open a "most likely fires first" sort with the objects nothing ever scored. The chosen sort column is wrapped in `.nullslast()` in both directions.
- **`0` is falsy in JS and is a real verdict.** `TemporalScoreCell` already tests `score == null` rather than truthiness; a test pins `0 → 0%`, not `—`.

## Considered and rejected

Showing a range or a mean instead of a single number. Within-group spread is large in real data — every group in the local dataset has a min of `0.00` while maxes reach `0.48`–`0.58` — so a range is genuinely more informative. But the column's job here is ranking, and a mean over this column would average across a denominator that depends on how many of the object's sightings happened to be their alert's primary object. The header tip carries the caveat instead.

## Tests

Backend (`test_sequence_groups.py`, 3 new): max over mixed scored/NULL members; all-NULL group reports `null`; `0.0` survives as `0.0`; sorting parks unscored groups last in **both** directions (asserting ASC too is what catches a `nullslast` applied to only one branch).

Frontend (`SequenceGroupsListPage.test.tsx`, 4 new): percentage renders; `—` for null; `0%` for zero; clicking Score refetches with `order_by=temporal_model_score&order_direction=desc`. Two existing guards were updated for the new column — the tooltip count (9→10) and the cell-index assertion, which is the test written to catch a header added without its matching `<td>`.

Full suites green locally: backend 808 passed, frontend 1449 passed.
