### PR TITLE
feat(localize): auto-advance to the next queue alert after submit

### DIFF
--- a/docs/specs/2026-08-12-localize-auto-advance-design.md
+++ b/docs/specs/2026-08-12-localize-auto-advance-design.md
@@ -1,0 +1,164 @@
+# Auto-advance to the next queue alert after a Localize submit
+
+**Date**: 2026-08-12
+**Status**: Approved
+**Base**: `main` (classify's own post-submit auto-advance #264, the alert-skip
+escape hatch #297, and the collocated localize cockpit #274/#278 all merged).
+**Scope**: frontend only. No API or schema change.
+
+## Problem
+
+`/classify/:id` flows continuously: submit an alert and the page pulls the next
+one straight from the classify queue, so an annotator works a session without
+ever returning to the table (`ClassifyAlertPage.tsx:857-917`).
+
+`/localize/:sequenceId` does not. Both of its queue-mode exits dump the
+annotator back on the list:
+
+- Submit — `setTimeout(() => navigate(listPath), 1000)` (`LocalizeAlertPage.tsx:1216`)
+- Skip alert — `navigate(listPath)` (`:1256`)
+
+Every alert therefore costs a round trip through `/localize`: find your place
+in the table again, click the next row. Localize is the slower of the two
+passes, so the tax is paid on the more expensive work.
+
+A second, smaller problem rides along: that `setTimeout` has no cleanup. Leave
+the page inside its 1 s window and the timer still fires, navigating a user who
+already went somewhere else.
+
+## Decision
+
+After a successful Submit (and after a Skip) in **queue mode**, fetch the
+localize queue fresh and open the next alert, exactly as classify does.
+"Next" is read from the queue listing the annotator was actually working — the
+queue view travels from `/localize` into the detail URL as query params.
+
+Done mode (`/localize/done/:sequenceId`) and the revert action are untouched:
+they keep returning to their list.
+
+## Design
+
+### 1. The URL carries the queue view you came from
+
+`DetectionAnnotatePage` holds its sort in component-local state
+(`DetectionAnnotatePage.tsx:25-26`, default `temporal_model_score` / `desc`)
+and its Skipped toggle likewise (`:21`). None of it survives the navigation
+into the detail page today.
+
+`handleAlertClick` appends that view to the target URL:
+
+```
+/localize/1234?order_by=recorded_at&order_direction=asc
+/localize/1234?order_by=temporal_model_score&order_direction=desc&skipped=1
+```
+
+- `order_by` / `order_direction` are always emitted, even at the defaults: one
+  code path, and the URL says what it is doing.
+- `skipped=1` only in the Skipped backlog view.
+- `page` is deliberately **not** carried — see §3.
+
+`LocalizeAlertPage` already threads `location.search` through every internal
+navigation (object selection `:1474`, editor `:1567`, back-out `:651`,
+add-object `:636`), so the params survive object and editor navigation without
+new plumbing.
+
+Reading them back: parse against the `QueueOrderBy` union, and treat anything
+missing or unrecognised as the queue page's own defaults
+(`temporal_model_score` / `desc`, `skipped=false`). A deep link, a dashboard
+link, or a hand-edited URL therefore behaves like a default-sorted queue entry
+rather than sending a junk `order_by` to the API.
+
+Framing: the params describe *which listing you were working*, and the advance
+re-runs that same listing. Working the Skipped backlog keeps you in the
+backlog.
+
+### 2. The advance
+
+One helper on `LocalizeAlertPage`, shared by both exits. Queue mode only —
+`mode === 'done'` returns to `listPath` as today.
+
+1. `apiClient.getLocalizationQueue({ page: 1, size: 5, skipped, order_by, order_direction })`
+   — a direct call, not a cache read, so it reflects what other annotators have
+   finished in the meantime.
+2. Take the first item that is **not** the current alert and that yields a
+   lane. Identity is `(source_api, platform_alert_id)`: `LocalizationQueueItem`
+   has no `primary_sequence_id` (`types/api.ts:58-68`), unlike the classify
+   queue item. The lane comes from `pickNextLocalizeLane(item.lanes, -1)`,
+   the same picker the table's own row click uses
+   (`DetectionAnnotatePage.tsx:83`).
+3. `navigate(localizeDetail(laneSequenceId) + <queue params>)`. Only the queue
+   params are carried; alert-scoped ones — `frame` (`LocalizeAlertPage.tsx:501`)
+   above all — are dropped, since they mean nothing in the next alert.
+4. No usable item, or the fetch throws → `navigate(listPath)`, exactly today's
+   behaviour. The list's branded "Localization queue is clear" empty state is
+   the end-of-queue message, so no extra toast is invented for it.
+
+`size: 5` rather than classify's `2`: the exclusion is by alert identity, and
+an item could in principle yield no workable lane, so the page gives itself a
+few candidates instead of one.
+
+**Submit** keeps the existing `Objects submitted` success toast and the 1 s
+delay before navigating (the delay exists because navigating unmounts the page
+and with it the `NotificationSystem` that owns the toast — see the comment at
+`:1285-1287`), then advances with a `Moving to the next alert in the queue`
+info toast, matching classify's wording (`ClassifyAlertPage.tsx:900`).
+
+**Skip** advances immediately, no delay and no extra toast — matching
+classify's skip path (`ClassifyAlertPage.tsx:949-969`).
+
+### 3. What is deliberately not preserved
+
+The advance always reads page 1 of the fresh listing. An annotator on page 4 of
+the queue lands on the current top alert of their sort, not on row 5 of page 4.
+Under the default score ordering that is the most valuable next alert anyway,
+and pinning a page number would hand out stale rows as the queue drains. The
+sort is the part of the view worth preserving; the offset is not.
+
+### 4. Guards
+
+Mirror classify's bookkeeping (`ClassifyAlertPage.tsx:206-218, 276-278`):
+
+- `advanceTimerRef` — the pending submit timer, cleared on unmount and on
+  `sequenceIdNum` change. This is the latent-bug fix: today's bare `setTimeout`
+  at `:1216` and `:1288` has no cleanup at all.
+- `advancingRef` — set when the advance starts, re-checked after the async
+  queue fetch resolves, so a user who navigated away mid-flight is not yanked
+  into an unrelated alert.
+
+Classify additionally guards `advancingRef` against a second Enter re-submitting
+inside the window (`ClassifyAlertPage.tsx:982`). Localize needs no such guard:
+submit has no keyboard shortcut here — the only call sites are the rail button
+(`LocalizeAlertPage.tsx:2091`) and the soft-confirm dialog's two buttons — and
+`handleSubmitClick` already returns early while the mutation is pending
+(`:1306`).
+
+## Testing
+
+New `tests/pages/LocalizeAlertPage.autoAdvance.test.tsx`, modelled on
+`ClassifyAlertPage.autoAdvance.test.tsx` (real timers, real routes and an
+unmocked `useNavigate`, as that suite does):
+
+1. Successful submit navigates to the next queue alert's object route.
+2. The queue call receives the URL's `order_by` / `order_direction` / `skipped`
+   — asserted on the mocked `getLocalizationQueue` arguments, not inferred from
+   the destination.
+3. Missing or invalid params fall back to `temporal_model_score` / `desc`.
+4. Empty queue (and a rejected queue fetch) → `/localize`.
+5. Skip advances immediately.
+6. Unmounting inside the 1 s window navigates nowhere.
+
+Changed existing tests:
+
+- `tests/pages/LocalizeAlertPage.test.tsx:1303` ("navigates back to the queue"
+  after submit) gets an empty-queue mock so it keeps asserting the fallback
+  rather than accidentally testing the advance.
+- `tests/components/dashboard/DetectionAnnotatePage.test.tsx` gains a case that
+  a row click carries the active sort (and the Skipped flag) into the URL.
+
+## Out of scope
+
+- Done mode and the revert action — both keep returning to their list.
+- Any table-position "workflow" store for localize (classify's
+  `annotationWorkflow`). The fresh fetch replaces it.
+- Backend changes: `GET /sequences/localization-queue` already takes
+  `order_by` / `order_direction` / `skipped`.

--- a/docs/specs/2026-08-12-localize-auto-advance-design.md
+++ b/docs/specs/2026-08-12-localize-auto-advance-design.md
@@ -38,24 +38,29 @@ they keep returning to their list.
 
 ## Design
 
-### 1. The URL carries the queue view you came from
+### 1. The URL carries the queue ordering you came from
 
 `DetectionAnnotatePage` holds its sort in component-local state
-(`DetectionAnnotatePage.tsx:25-26`, default `temporal_model_score` / `desc`)
-and its Skipped toggle likewise (`:21`). None of it survives the navigation
-into the detail page today.
+(`DetectionAnnotatePage.tsx:25-26`, default `temporal_model_score` / `desc`).
+It does not survive the navigation into the detail page today.
 
-`handleAlertClick` appends that view to the target URL:
+`handleAlertClick` appends it to the target URL:
 
 ```
 /localize/1234?order_by=recorded_at&order_direction=asc
-/localize/1234?order_by=temporal_model_score&order_direction=desc&skipped=1
+/localize/1234?order_by=temporal_model_score&order_direction=desc
 ```
 
-- `order_by` / `order_direction` are always emitted, even at the defaults: one
-  code path, and the URL says what it is doing.
-- `skipped=1` only in the Skipped backlog view.
-- `page` is deliberately **not** carried — see §3.
+Always emitted, even at the defaults: one code path, and the URL says what it
+is doing. `page` is deliberately **not** carried — see §3.
+
+**The Skipped backlog is not part of this** (amended during implementation).
+The original design also carried `skipped=1` so that working the backlog kept
+you in the backlog — but backlog rows are not clickable in the first place
+(`LocalizeQueueTable.tsx:144`, `onClick={skippedView ? undefined : …}`): an
+alert is unskipped before it can be opened. No entry path, so the flag would
+have been dead weight in the URL, the helpers and the advance. Making the
+backlog directly workable is a separate feature.
 
 `LocalizeAlertPage` already threads `location.search` through every internal
 navigation (object selection `:1474`, editor `:1567`, back-out `:651`,
@@ -64,20 +69,16 @@ new plumbing.
 
 Reading them back: parse against the `QueueOrderBy` union, and treat anything
 missing or unrecognised as the queue page's own defaults
-(`temporal_model_score` / `desc`, `skipped=false`). A deep link, a dashboard
-link, or a hand-edited URL therefore behaves like a default-sorted queue entry
-rather than sending a junk `order_by` to the API.
-
-Framing: the params describe *which listing you were working*, and the advance
-re-runs that same listing. Working the Skipped backlog keeps you in the
-backlog.
+(`temporal_model_score` / `desc`). A deep link, a dashboard link, or a
+hand-edited URL therefore behaves like a default-sorted queue entry rather
+than sending a junk `order_by` to the API.
 
 ### 2. The advance
 
 One helper on `LocalizeAlertPage`, shared by both exits. Queue mode only —
 `mode === 'done'` returns to `listPath` as today.
 
-1. `apiClient.getLocalizationQueue({ page: 1, size: 5, skipped, order_by, order_direction })`
+1. `apiClient.getLocalizationQueue({ page: 1, size: 5, order_by, order_direction })`
    — a direct call, not a cache read, so it reflects what other annotators have
    finished in the meantime.
 2. Take the first item that is **not** the current alert and that yields a
@@ -142,25 +143,27 @@ unmocked `useNavigate` and real landing routes (`:212-262`), and owns the
 fixtures a submit test needs (`mockAllFramesAccepted`, `renderAndSettle`).
 Cases:
 
-1. Successful submit navigates to the next queue alert's object route.
-2. The queue call receives the URL's `order_by` / `order_direction` / `skipped`
-   — asserted on the mocked `getLocalizationQueue` arguments, not inferred from
-   the destination.
+1. Successful submit navigates to the next queue alert, carrying the ordering.
+2. The queue call receives the URL's `order_by` / `order_direction` — asserted
+   on the mocked `getLocalizationQueue` arguments, not inferred from the
+   destination.
 3. Missing or invalid params fall back to `temporal_model_score` / `desc`.
-4. Empty queue (and a rejected queue fetch) → `/localize`.
-5. Skip advances immediately.
-6. Unmounting inside the 1 s window navigates nowhere.
+4. A queue still listing the just-submitted alert (stale read) is stepped over.
+5. Empty queue, and a rejected queue fetch → `/localize`.
+6. Done mode never advances and never calls the queue.
+7. Skip advances immediately, with no advance toast; an empty queue after a
+   skip still lands on `/localize`.
+8. Unmounting inside the 1 s window navigates nowhere.
 
 Changed existing tests:
 
 - `tests/pages/LocalizeAlertPage.test.tsx` mocks `getLocalizationQueue` with an
   empty page in its top-level `beforeEach`, so every pre-existing submit and
-  skip test — `:1303` ("navigates back to the queue"), `:1524` (Done list),
-  `:3549` (skip confirm) — keeps asserting the fallback rather than
-  accidentally exercising the advance.
+  skip test — "navigates back to the queue", the Done-list submit, the skip
+  confirm — keeps asserting the fallback rather than accidentally exercising
+  the advance.
 - `tests/components/dashboard/DetectionAnnotatePage.test.tsx:165` (row click)
-  now expects the queue params on the URL, and gains cases for a re-sorted
-  queue and for the Skipped backlog.
+  now expects the ordering params on the URL, and gains a re-sorted-queue case.
 
 ## Out of scope
 
@@ -168,4 +171,5 @@ Changed existing tests:
 - Any table-position "workflow" store for localize (classify's
   `annotationWorkflow`). The fresh fetch replaces it.
 - Backend changes: `GET /sequences/localization-queue` already takes
-  `order_by` / `order_direction` / `skipped`.
+  `order_by` / `order_direction`.
+- Making the Skipped backlog directly workable (see §1).

--- a/docs/specs/2026-08-12-localize-auto-advance-design.md
+++ b/docs/specs/2026-08-12-localize-auto-advance-design.md
@@ -134,9 +134,13 @@ submit has no keyboard shortcut here — the only call sites are the rail button
 
 ## Testing
 
-New `tests/pages/LocalizeAlertPage.autoAdvance.test.tsx`, modelled on
-`ClassifyAlertPage.autoAdvance.test.tsx` (real timers, real routes and an
-unmocked `useNavigate`, as that suite does):
+A new `post-submit auto-advance` describe inside the existing
+`tests/pages/LocalizeAlertPage.test.tsx`, not a separate file. Classify needed
+its own `ClassifyAlertPage.autoAdvance.test.tsx` because its main suite mocks
+`useNavigate`; this one already renders through a real `MemoryRouter` with an
+unmocked `useNavigate` and real landing routes (`:212-262`), and owns the
+fixtures a submit test needs (`mockAllFramesAccepted`, `renderAndSettle`).
+Cases:
 
 1. Successful submit navigates to the next queue alert's object route.
 2. The queue call receives the URL's `order_by` / `order_direction` / `skipped`
@@ -149,11 +153,14 @@ unmocked `useNavigate`, as that suite does):
 
 Changed existing tests:
 
-- `tests/pages/LocalizeAlertPage.test.tsx:1303` ("navigates back to the queue"
-  after submit) gets an empty-queue mock so it keeps asserting the fallback
-  rather than accidentally testing the advance.
-- `tests/components/dashboard/DetectionAnnotatePage.test.tsx` gains a case that
-  a row click carries the active sort (and the Skipped flag) into the URL.
+- `tests/pages/LocalizeAlertPage.test.tsx` mocks `getLocalizationQueue` with an
+  empty page in its top-level `beforeEach`, so every pre-existing submit and
+  skip test — `:1303` ("navigates back to the queue"), `:1524` (Done list),
+  `:3549` (skip confirm) — keeps asserting the fallback rather than
+  accidentally exercising the advance.
+- `tests/components/dashboard/DetectionAnnotatePage.test.tsx:165` (row click)
+  now expects the queue params on the URL, and gains cases for a re-sorted
+  queue and for the Skipped backlog.
 
 ## Out of scope
 

--- a/frontend/src/pages/DetectionAnnotatePage.tsx
+++ b/frontend/src/pages/DetectionAnnotatePage.tsx
@@ -7,7 +7,7 @@ import { LocalizationQueueItem } from '@/types/api';
 import { LocalizeQueueTable, TablePagination } from '@/components/sequences';
 import { Tooltip } from '@/components/ui/Tooltip';
 import { TABLE_CARD_CLASSES } from '@/components/sequences/tableStyles';
-import { pickNextLocalizeLane } from '@/utils/annotation/localizeUtils';
+import { localizeQueueViewSearch, pickNextLocalizeLane } from '@/utils/annotation/localizeUtils';
 import { localizeDetail, ROUTES } from '@/utils/routes';
 import { QUEUE_COUNTS_KEY } from '@/hooks/useQueueTotals';
 import type { QueueOrderBy } from '@/types/api';
@@ -82,7 +82,10 @@ export default function DetectionAnnotatePage() {
     // -1 never matches a sequence id: picks the alert's first unfinished lane.
     const first = pickNextLocalizeLane(item.lanes, -1);
     if (first !== null) {
-      navigate(localizeDetail(first));
+      // The ordering travels with the click. Without it the detail page's
+      // post-submit advance would walk score order while the annotator is
+      // working recency order.
+      navigate(`${localizeDetail(first)}${localizeQueueViewSearch({ orderBy, orderDirection })}`);
     }
   };
 

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -134,7 +134,12 @@ import {
 } from '@/utils/annotation/alertLocalizeUtils';
 import { buildFilmstripEntries } from '@/utils/annotation/objectFilmstrip';
 import { materializeGapFrame } from '@/utils/annotation/gapFrameMaterialize';
-import { laneNeedsLocalization } from '@/utils/annotation/localizeUtils';
+import {
+  laneNeedsLocalization,
+  localizeQueueViewSearch,
+  parseLocalizeQueueView,
+  pickNextLocalizeLane,
+} from '@/utils/annotation/localizeUtils';
 import {
   buildQuickSubmitPlan,
   collectLaneBoxes,
@@ -168,6 +173,7 @@ import { Tooltip } from '@/components/ui/Tooltip';
 import {
   ROUTES,
   classifyDetailWithReturn,
+  localizeDetail,
   localizeObject,
   localizeObjectRoute,
   localizeObjectSelect,
@@ -216,6 +222,30 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
   // the first cell click would silently move you onto the queue route.
   const listPath = mode === 'done' ? ROUTES.LOCALIZE_DONE : ROUTES.LOCALIZE;
   const basePath = `${listPath}/${sequenceIdNum}`;
+
+  // The queue ordering this alert was opened under — /localize hangs it off
+  // the row click. Absent on a deep link, and then it is the queue page's own
+  // default view.
+  const queueView = useMemo(() => parseLocalizeQueueView(location.search), [location.search]);
+
+  // Post-submit auto-advance bookkeeping: the deferred navigation must not
+  // fire after unmount, and the queue lookup behind it must not yank someone
+  // who moved on while it was in flight.
+  const advanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const advancingRef = useRef(false);
+  useEffect(
+    () => () => {
+      if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current);
+      advancingRef.current = false;
+    },
+    []
+  );
+  // A pending advance belongs to the alert it was started from.
+  useEffect(() => {
+    if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current);
+    advanceTimerRef.current = null;
+    advancingRef.current = false;
+  }, [sequenceIdNum]);
 
   // The active object IS the URL: the selection child route names it
   // directly, and while the editor is open the editor's own route carries
@@ -1202,6 +1232,54 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       } in Classify first.`
     : 'Spotted a mistake? This alert returns to the Localize queue with all its boxes intact, and stops being exported until it is submitted again.';
 
+  // Continuous flow: pull the next alert of the listing this one was opened
+  // under and open its first workable object. Falls back to the list when the
+  // queue is empty or the lookup fails — the list's "queue is clear" state is
+  // the end-of-queue message, so nothing extra is announced there.
+  const advanceToNextAlert = useCallback(
+    async (announce: boolean) => {
+      if (mode === 'done') {
+        navigate(listPath);
+        return;
+      }
+      try {
+        const queue = await apiClient.getLocalizationQueue({
+          page: 1,
+          size: 5,
+          order_by: queueView.orderBy,
+          order_direction: queueView.orderDirection,
+        });
+        // Navigated away while the lookup was in flight (unmount / alert
+        // switch clears the flag) — don't yank them into another alert.
+        if (!advancingRef.current) return;
+        for (const item of queue.items) {
+          // Alert identity, not sequence id: a queue row is a whole alert and
+          // carries no primary sequence id of its own.
+          if (
+            item.source_api === sequence?.source_api &&
+            item.platform_alert_id === sequence?.platform_alert_id
+          ) {
+            continue;
+          }
+          const lane = pickNextLocalizeLane(item.lanes, -1);
+          if (lane === null) continue;
+          if (announce) {
+            showToastNotification('Moving to the next alert in the queue', 'info');
+          }
+          // Only the ordering travels on; alert-scoped params (`frame`) mean
+          // nothing in the next alert.
+          navigate(`${localizeDetail(lane)}${localizeQueueViewSearch(queueView)}`);
+          return;
+        }
+      } catch {
+        // Queue lookup failed — fall through to the list.
+      }
+      if (!advancingRef.current) return;
+      navigate(listPath);
+    },
+    [mode, listPath, queueView, sequence, navigate, showToastNotification]
+  );
+
   // Submit: atomically ships the whole alert. No accept step of its own —
   // `allObjectsAccepted` gates the button, so every frame already carries a
   // committed box by the time this can fire.
@@ -1213,7 +1291,14 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       queryClient.invalidateQueries({ queryKey: ['pipeline-stats'] });
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.SEQUENCE_ANNOTATIONS });
       showToastNotification('Objects submitted', 'success');
-      setTimeout(() => navigate(listPath), 1000);
+      // Delayed: navigating unmounts this page and with it the
+      // NotificationSystem that owns the toast, so an immediate navigate
+      // would swallow the confirmation entirely.
+      advancingRef.current = true;
+      advanceTimerRef.current = setTimeout(() => {
+        advanceTimerRef.current = null;
+        void advanceToNextAlert(true);
+      }, 1000);
     },
     onError: err => {
       const detail = (err as { detail?: string })?.detail || (err as Error)?.message || '';

--- a/frontend/src/pages/LocalizeAlertPage.tsx
+++ b/frontend/src/pages/LocalizeAlertPage.tsx
@@ -1329,7 +1329,7 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
         skipNote.trim() || undefined
       );
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       setSkipConfirmOpen(false);
       setSkipNote('');
       queryClient.invalidateQueries({ queryKey: ['localization-queue'] });
@@ -1338,7 +1338,10 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       queryClient.invalidateQueries({ queryKey: ['pipeline-stats'] });
       queryClient.invalidateQueries({ queryKey: alertDetailQueryKey });
       showToastNotification('Alert skipped', 'success');
-      navigate(listPath);
+      // Same continuous flow as the post-submit advance, but immediate: there
+      // is no success toast to protect from the unmount here.
+      advancingRef.current = true;
+      await advanceToNextAlert(false);
     },
     onError: err => {
       const detail = (err as { detail?: string })?.detail || (err as Error)?.message || '';
@@ -1369,8 +1372,13 @@ export default function LocalizeAlertPage({ mode }: LocalizeAlertPageProps = {})
       showToastNotification('Alert sent back to the queue', 'success');
       // Delayed like the submit path: navigating unmounts this page and with
       // it the NotificationSystem that owns the toast, so an immediate
-      // navigate would swallow the confirmation entirely.
-      setTimeout(() => navigate(listPath), 1000);
+      // navigate would swallow the confirmation entirely. Held in the shared
+      // ref so unmount cancels it. Done mode only, so it never advances.
+      advancingRef.current = true;
+      advanceTimerRef.current = setTimeout(() => {
+        advanceTimerRef.current = null;
+        navigate(listPath);
+      }, 1000);
     },
     onError: err => {
       const detail = (err as { detail?: string })?.detail || (err as Error)?.message || '';

--- a/frontend/src/utils/annotation/localizeUtils.ts
+++ b/frontend/src/utils/annotation/localizeUtils.ts
@@ -68,23 +68,23 @@ export function pickNextLocalizeLane(
 }
 
 /**
- * The queue listing an alert was opened from. It rides in the detail URL
- * (`?order_by=…&order_direction=…[&skipped=1]`) so the post-submit advance
- * re-runs the same listing the annotator is working, rather than silently
- * walking score order while they work by recency — or pulling them out of the
- * skipped backlog after one alert.
+ * The queue ordering an alert was opened under. It rides in the detail URL
+ * (`?order_by=…&order_direction=…`) so the post-submit advance re-runs the
+ * same listing the annotator is working, rather than silently walking score
+ * order while they work by recency.
+ *
+ * The skipped backlog is deliberately absent: its rows are not clickable
+ * (`LocalizeQueueTable.tsx`), so no alert is ever opened from it.
  */
 export interface LocalizeQueueView {
   orderBy: QueueOrderBy;
   orderDirection: 'asc' | 'desc';
-  skipped: boolean;
 }
 
-/** What /localize itself shows on arrival (DetectionAnnotatePage.tsx:21-26). */
+/** What /localize itself shows on arrival (DetectionAnnotatePage.tsx:25-26). */
 export const DEFAULT_LOCALIZE_QUEUE_VIEW: LocalizeQueueView = {
   orderBy: 'temporal_model_score',
   orderDirection: 'desc',
-  skipped: false,
 };
 
 const QUEUE_ORDER_BY_VALUES: QueueOrderBy[] = ['recorded_at', 'temporal_model_score'];
@@ -107,16 +107,13 @@ export function parseLocalizeQueueView(search: string): LocalizeQueueView {
       orderDirection === 'asc' || orderDirection === 'desc'
         ? orderDirection
         : DEFAULT_LOCALIZE_QUEUE_VIEW.orderDirection,
-    skipped: params.get('skipped') === '1',
   };
 }
 
 /** The search string to hang off a `/localize/:sequenceId` URL. */
 export function localizeQueueViewSearch(view: LocalizeQueueView): string {
-  const params = new URLSearchParams({
+  return `?${new URLSearchParams({
     order_by: view.orderBy,
     order_direction: view.orderDirection,
-  });
-  if (view.skipped) params.set('skipped', '1');
-  return `?${params.toString()}`;
+  }).toString()}`;
 }

--- a/frontend/src/utils/annotation/localizeUtils.ts
+++ b/frontend/src/utils/annotation/localizeUtils.ts
@@ -1,4 +1,4 @@
-import { LocalizationQueueLane } from '@/types/api';
+import { LocalizationQueueLane, QueueOrderBy } from '@/types/api';
 
 /**
  * Stage to write at classify submit (spec: smoke-localization entry point;
@@ -65,4 +65,58 @@ export function pickNextLocalizeLane(
       l.processing_stage === 'seq_annotation_done'
   );
   return next ? next.sequence_id : null;
+}
+
+/**
+ * The queue listing an alert was opened from. It rides in the detail URL
+ * (`?order_by=…&order_direction=…[&skipped=1]`) so the post-submit advance
+ * re-runs the same listing the annotator is working, rather than silently
+ * walking score order while they work by recency — or pulling them out of the
+ * skipped backlog after one alert.
+ */
+export interface LocalizeQueueView {
+  orderBy: QueueOrderBy;
+  orderDirection: 'asc' | 'desc';
+  skipped: boolean;
+}
+
+/** What /localize itself shows on arrival (DetectionAnnotatePage.tsx:21-26). */
+export const DEFAULT_LOCALIZE_QUEUE_VIEW: LocalizeQueueView = {
+  orderBy: 'temporal_model_score',
+  orderDirection: 'desc',
+  skipped: false,
+};
+
+const QUEUE_ORDER_BY_VALUES: QueueOrderBy[] = ['recorded_at', 'temporal_model_score'];
+
+/**
+ * Reads the view out of a location search string. Anything missing or
+ * unrecognised falls back to the defaults, so a deep link, a dashboard link or
+ * a hand-edited URL behaves like a plain queue entry instead of forwarding an
+ * order_by the API would reject.
+ */
+export function parseLocalizeQueueView(search: string): LocalizeQueueView {
+  const params = new URLSearchParams(search);
+  const orderBy = params.get('order_by');
+  const orderDirection = params.get('order_direction');
+  return {
+    orderBy: QUEUE_ORDER_BY_VALUES.includes(orderBy as QueueOrderBy)
+      ? (orderBy as QueueOrderBy)
+      : DEFAULT_LOCALIZE_QUEUE_VIEW.orderBy,
+    orderDirection:
+      orderDirection === 'asc' || orderDirection === 'desc'
+        ? orderDirection
+        : DEFAULT_LOCALIZE_QUEUE_VIEW.orderDirection,
+    skipped: params.get('skipped') === '1',
+  };
+}
+
+/** The search string to hang off a `/localize/:sequenceId` URL. */
+export function localizeQueueViewSearch(view: LocalizeQueueView): string {
+  const params = new URLSearchParams({
+    order_by: view.orderBy,
+    order_direction: view.orderDirection,
+  });
+  if (view.skipped) params.set('skipped', '1');
+  return `?${params.toString()}`;
 }

--- a/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
+++ b/frontend/tests/components/dashboard/DetectionAnnotatePage.test.tsx
@@ -162,7 +162,29 @@ describe('DetectionAnnotatePage (Localize queue)', () => {
     render(<DetectionAnnotatePage />, { wrapper });
     await waitFor(() => expect(screen.getByText('CAM_01')).toBeTruthy());
     fireEvent.click(screen.getByText('CAM_01'));
-    expect(navigateMock).toHaveBeenCalledWith('/localize/11');
+    expect(navigateMock).toHaveBeenCalledWith(
+      '/localize/11?order_by=temporal_model_score&order_direction=desc'
+    );
+  });
+
+  it('carries the active sort into the alert URL so the detail page advances in the same order', async () => {
+    render(<DetectionAnnotatePage />, { wrapper });
+    await waitFor(() => expect(screen.getByText('CAM_01')).toBeTruthy());
+
+    // Re-sort by recorded time, the way an annotator working chronologically would.
+    fireEvent.click(screen.getByRole('button', { name: /Recorded/ }));
+    await waitFor(() =>
+      expect(apiClient.getLocalizationQueue).toHaveBeenCalledWith(
+        expect.objectContaining({ order_by: 'recorded_at', order_direction: 'desc' })
+      )
+    );
+
+    // Re-sorting swaps the query key, so the table reloads before the row is
+    // clickable again.
+    fireEvent.click(await screen.findByText('CAM_01'));
+    expect(navigateMock).toHaveBeenCalledWith(
+      '/localize/11?order_by=recorded_at&order_direction=desc'
+    );
   });
 
   it('shows an all-caught-up empty state linking to the classify queue', async () => {

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -30,6 +30,8 @@ import type {
   SequenceAnnotation,
   Detection,
   DetectionAnnotation,
+  LocalizationQueueItem,
+  PaginatedResponse,
 } from '@/types/api';
 
 vi.mock('@/services/api', () => ({
@@ -45,6 +47,7 @@ vi.mock('@/services/api', () => ({
     updateSequenceAnnotation: vi.fn(),
     localizeSubmit: vi.fn(),
     localizeRevert: vi.fn(),
+    getLocalizationQueue: vi.fn(),
     deleteSequence: vi.fn(),
     addObject: vi.fn(),
     skipAlert: vi.fn(),
@@ -422,6 +425,16 @@ describe('LocalizeAlertPage', () => {
     Element.prototype.scrollIntoView = vi.fn();
     vi.mocked(apiClient.getSequence).mockResolvedValue(makeSequence());
     vi.mocked(apiClient.getAlertDetail).mockResolvedValue(makeTwoLaneAlertDetail());
+    // Default: the queue is empty, so every test that submits or skips keeps
+    // asserting the fall-back-to-the-list behaviour it was written for. The
+    // auto-advance block below opts in by returning a next alert.
+    vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue({
+      items: [],
+      page: 1,
+      pages: 0,
+      size: 5,
+      total: 0,
+    });
     vi.mocked(apiClient.getDetectionAnnotations).mockResolvedValue(emptyAnnotationsPage);
     vi.mocked(apiClient.getSequenceDetections).mockImplementation(async (id: number) => {
       if (id === 101) return [makeDetection(1001, T1)];
@@ -3840,5 +3853,170 @@ describe('LocalizeAlertPage', () => {
     expect(within(legend).getByText('committed')).toBeInTheDocument();
     expect(within(legend).getByText('model box to accept')).toBeInTheDocument();
     expect(within(legend).getByText('no box')).toBeInTheDocument();
+  });
+
+  /**
+   * Continuous flow (spec: 2026-08-12-localize-auto-advance): submitting the
+   * alert pulls the next one out of the queue listing this alert was opened
+   * under, instead of dropping the annotator back on the table.
+   */
+  describe('post-submit auto-advance', () => {
+    // A queue alert that is NOT the one under test (sequence 101, platform
+    // alert 500). Its first workable lane is 303.
+    const nextQueueItem: LocalizationQueueItem = {
+      source_api: 'pyronear_french',
+      platform_alert_id: 777,
+      camera_name: 'CAM-9',
+      organisation_name: 'Org',
+      azimuth: 12,
+      recorded_at: '2026-01-02T10:00:00Z',
+      temporal_model_score: 0.9,
+      lanes: [
+        {
+          sequence_id: 303,
+          alert_api_id: 9777,
+          has_smoke: true,
+          has_missed_smoke: false,
+          is_unsure: false,
+          processing_stage: 'seq_annotation_done',
+          smoke_types: ['wildfire'],
+          total_detections: 3,
+          annotated_detections: 0,
+          auto_annotated_at: '2026-01-02T11:00:00Z',
+        },
+      ],
+    };
+
+    const queuePage = (
+      items: LocalizationQueueItem[]
+    ): PaginatedResponse<LocalizationQueueItem> => ({
+      items,
+      page: 1,
+      pages: items.length ? 1 : 0,
+      size: 5,
+      total: items.length,
+    });
+
+    const submitAndSettle = async () => {
+      await waitFor(() => expect(screen.getByRole('button', { name: /Submit/ })).toBeEnabled());
+      fireEvent.click(screen.getByRole('button', { name: /Submit/ }));
+      await waitFor(() => expect(apiClient.localizeSubmit).toHaveBeenCalled());
+    };
+
+    beforeEach(() => {
+      mockAllFramesAccepted();
+    });
+
+    it('opens the next queue alert, carrying the queue ordering forward', async () => {
+      vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue(queuePage([nextQueueItem]));
+
+      await renderAndSettle(<LocalizeAlertPage />, {
+        wrapper: makeWrapper('/localize/101?order_by=recorded_at&order_direction=asc'),
+      });
+      await submitAndSettle();
+
+      await waitFor(
+        () =>
+          expect(screen.getByTestId('location')).toHaveTextContent(
+            '/localize/303?order_by=recorded_at&order_direction=asc'
+          ),
+        { timeout: 3000 }
+      );
+      // The lookup runs the annotator's own listing, not the default one.
+      expect(apiClient.getLocalizationQueue).toHaveBeenCalledWith({
+        page: 1,
+        size: 5,
+        order_by: 'recorded_at',
+        order_direction: 'asc',
+      });
+    });
+
+    it('defaults to score order when the URL carries no ordering (deep link)', async () => {
+      vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue(queuePage([nextQueueItem]));
+
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      await submitAndSettle();
+
+      await waitFor(
+        () =>
+          expect(apiClient.getLocalizationQueue).toHaveBeenCalledWith(
+            expect.objectContaining({
+              order_by: 'temporal_model_score',
+              order_direction: 'desc',
+            })
+          ),
+        { timeout: 3000 }
+      );
+    });
+
+    it('never re-opens the alert just submitted', async () => {
+      // The queue still lists this very alert (a stale read); the next usable
+      // one has to win.
+      const staleSelf: LocalizationQueueItem = {
+        ...nextQueueItem,
+        platform_alert_id: 500,
+        lanes: [{ ...nextQueueItem.lanes[0], sequence_id: 101 }],
+      };
+      vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue(
+        queuePage([staleSelf, nextQueueItem])
+      );
+
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      await submitAndSettle();
+
+      await waitFor(
+        () => expect(screen.getByTestId('location')).toHaveTextContent('/localize/303'),
+        { timeout: 3000 }
+      );
+    });
+
+    it('falls back to the queue list when nothing is left', async () => {
+      vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue(queuePage([]));
+
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      await submitAndSettle();
+
+      await waitFor(() => expect(screen.getByTestId('localize-queue-landing')).toBeInTheDocument(), {
+        timeout: 3000,
+      });
+    });
+
+    it('falls back to the queue list when the lookup fails', async () => {
+      vi.mocked(apiClient.getLocalizationQueue).mockRejectedValue(new Error('network'));
+
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      await submitAndSettle();
+
+      await waitFor(() => expect(screen.getByTestId('localize-queue-landing')).toBeInTheDocument(), {
+        timeout: 3000,
+      });
+    });
+
+    it('does not advance from the Done list', async () => {
+      vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue(queuePage([nextQueueItem]));
+
+      await renderAndSettle(<LocalizeAlertPage mode="done" />, { wrapper: doneWrapper });
+      await submitAndSettle();
+
+      await waitFor(() => expect(screen.getByTestId('localize-done-landing')).toBeInTheDocument(), {
+        timeout: 3000,
+      });
+      expect(apiClient.getLocalizationQueue).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate after the page unmounts inside the delay window', async () => {
+      vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue(queuePage([nextQueueItem]));
+
+      const view = render(<LocalizeAlertPage />, { wrapper });
+      await waitFor(() =>
+        expect(screen.getAllByTestId(/^frame-segment-/).length).toBeGreaterThan(0)
+      );
+      await submitAndSettle();
+      view.unmount();
+
+      // Past the 1 s window: the cleared timer means no queue lookup ever ran.
+      await new Promise(resolve => setTimeout(resolve, 1500));
+      expect(apiClient.getLocalizationQueue).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/tests/pages/LocalizeAlertPage.test.tsx
+++ b/frontend/tests/pages/LocalizeAlertPage.test.tsx
@@ -4004,6 +4004,44 @@ describe('LocalizeAlertPage', () => {
       expect(apiClient.getLocalizationQueue).not.toHaveBeenCalled();
     });
 
+    const skipAndConfirm = () => {
+      fireEvent.click(screen.getByRole('button', { name: /Skip alert/ }));
+      fireEvent.click(
+        within(screen.getByTestId('skip-alert-confirm')).getByRole('button', {
+          name: /Skip alert/,
+        })
+      );
+    };
+
+    const skipResponse = {
+      skipped_at: '2026-08-05T10:00:00Z',
+      skipped_by: 'annotator',
+      note: null,
+    };
+
+    it('advances immediately after a skip, with no delay of its own', async () => {
+      vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue(queuePage([nextQueueItem]));
+      vi.mocked(apiClient.skipAlert).mockResolvedValue(skipResponse);
+
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      skipAndConfirm();
+
+      await waitFor(() => expect(apiClient.skipAlert).toHaveBeenCalled());
+      await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('/localize/303'));
+      // Skip says nothing extra on the way out — 'Alert skipped' is the message.
+      expect(screen.queryByText('Moving to the next alert in the queue')).toBeNull();
+    });
+
+    it('falls back to the queue list when a skip empties the queue', async () => {
+      vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue(queuePage([]));
+      vi.mocked(apiClient.skipAlert).mockResolvedValue(skipResponse);
+
+      await renderAndSettle(<LocalizeAlertPage />, { wrapper });
+      skipAndConfirm();
+
+      await waitFor(() => expect(screen.getByTestId('localize-queue-landing')).toBeInTheDocument());
+    });
+
     it('does not navigate after the page unmounts inside the delay window', async () => {
       vi.mocked(apiClient.getLocalizationQueue).mockResolvedValue(queuePage([nextQueueItem]));
 

--- a/frontend/tests/utils/localizeUtils.test.ts
+++ b/frontend/tests/utils/localizeUtils.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  DEFAULT_LOCALIZE_QUEUE_VIEW,
+  LocalizeQueueView,
   determineClassifySubmitStage,
+  localizeQueueViewSearch,
+  parseLocalizeQueueView,
   pickNextLocalizeLane,
 } from '@/utils/annotation/localizeUtils';
 import { LocalizationQueueLane } from '@/types/api';
@@ -209,4 +213,42 @@ describe('pickNextLocalizeLane', () => {
     expect(
       pickNextLocalizeLane([lane(1), lane(2, { has_smoke: true, is_unsure: true }), lane(3)], 1)
     ).toBe(3));
+});
+
+describe('localize queue view (the listing an alert was opened from)', () => {
+  it('reads the queue listing out of a detail URL', () => {
+    expect(parseLocalizeQueueView('?order_by=recorded_at&order_direction=asc&skipped=1')).toEqual({
+      orderBy: 'recorded_at',
+      orderDirection: 'asc',
+      skipped: true,
+    });
+  });
+
+  it('falls back to the queue page defaults when the params are absent, junk or unrelated', () => {
+    expect(parseLocalizeQueueView('')).toEqual(DEFAULT_LOCALIZE_QUEUE_VIEW);
+    // A hand-edited or stale URL must never reach the API as an order_by it rejects.
+    expect(parseLocalizeQueueView('?order_by=drop_table&order_direction=sideways')).toEqual(
+      DEFAULT_LOCALIZE_QUEUE_VIEW
+    );
+    // Alert-scoped params (the editor's deep-link frame) are not view state.
+    expect(parseLocalizeQueueView('?frame=3')).toEqual(DEFAULT_LOCALIZE_QUEUE_VIEW);
+  });
+
+  it('round-trips through the search string it builds', () => {
+    const view: LocalizeQueueView = {
+      orderBy: 'recorded_at',
+      orderDirection: 'asc',
+      skipped: true,
+    };
+    expect(localizeQueueViewSearch(view)).toBe(
+      '?order_by=recorded_at&order_direction=asc&skipped=1'
+    );
+    expect(parseLocalizeQueueView(localizeQueueViewSearch(view))).toEqual(view);
+  });
+
+  it('omits the skipped flag for the main queue', () => {
+    expect(localizeQueueViewSearch(DEFAULT_LOCALIZE_QUEUE_VIEW)).toBe(
+      '?order_by=temporal_model_score&order_direction=desc'
+    );
+  });
 });

--- a/frontend/tests/utils/localizeUtils.test.ts
+++ b/frontend/tests/utils/localizeUtils.test.ts
@@ -217,10 +217,9 @@ describe('pickNextLocalizeLane', () => {
 
 describe('localize queue view (the listing an alert was opened from)', () => {
   it('reads the queue listing out of a detail URL', () => {
-    expect(parseLocalizeQueueView('?order_by=recorded_at&order_direction=asc&skipped=1')).toEqual({
+    expect(parseLocalizeQueueView('?order_by=recorded_at&order_direction=asc')).toEqual({
       orderBy: 'recorded_at',
       orderDirection: 'asc',
-      skipped: true,
     });
   });
 
@@ -238,15 +237,12 @@ describe('localize queue view (the listing an alert was opened from)', () => {
     const view: LocalizeQueueView = {
       orderBy: 'recorded_at',
       orderDirection: 'asc',
-      skipped: true,
     };
-    expect(localizeQueueViewSearch(view)).toBe(
-      '?order_by=recorded_at&order_direction=asc&skipped=1'
-    );
+    expect(localizeQueueViewSearch(view)).toBe('?order_by=recorded_at&order_direction=asc');
     expect(parseLocalizeQueueView(localizeQueueViewSearch(view))).toEqual(view);
   });
 
-  it('omits the skipped flag for the main queue', () => {
+  it('spells out the default view rather than emitting an empty search', () => {
     expect(localizeQueueViewSearch(DEFAULT_LOCALIZE_QUEUE_VIEW)).toBe(
       '?order_by=temporal_model_score&order_direction=desc'
     );


### PR DESCRIPTION
Submitting an alert from `/localize/:sequenceId` dropped the annotator back on the queue table, so every alert cost a round trip: find your place in the list again, click the next row. Classify has flowed continuously since #264; localize now does the same.

Spec: `docs/specs/2026-08-12-localize-auto-advance-design.md`.

## What changes

**The queue ordering rides in the URL.** `/localize` holds its sort in component state, so the detail page had no way to know it. Row clicks now carry it: `/localize/1234?order_by=recorded_at&order_direction=asc`. Parsed back against the `QueueOrderBy` union — a deep link, a dashboard link or a hand-edited URL falls back to the queue page's own defaults (`temporal_model_score` / `desc`) rather than forwarding a junk `order_by` to the API.

**Submit advances.** After the existing 1 s toast window, the page fetches page 1 of that same listing (a direct call, not a cache read, so it reflects what other annotators just finished), steps over the alert it submitted — identity is `(source_api, platform_alert_id)`; a localize queue row is a whole alert with no primary sequence id — and opens the next one's first workable object via `pickNextLocalizeLane`. Toast: *Moving to the next alert in the queue*, same wording classify uses. Empty queue or a failed lookup falls back to `navigate(listPath)`, exactly as before; the list's "Localization queue is clear" state is the end-of-queue message.

**Skip advances too**, immediately — no delay, no extra toast.

**Done mode and revert are untouched**: both still return to their list.

**Page offset is deliberately not preserved.** Advance always takes page 1 of the fresh listing, so from page 4 you land on the current top alert of your sort. Under score ordering that is the most valuable next alert, and a pinned page number would hand out stale rows as the queue drains.

**Latent bug fixed on the way:** the post-submit and post-revert `setTimeout`s had no cleanup, so leaving the page inside the 1 s window still navigated. Both now live in `advanceTimerRef`, cleared on unmount and on alert switch, with an `advancingRef` re-checked after the async queue lookup so someone who moved on mid-flight isn't yanked into another alert (mirrors `ClassifyAlertPage`).

## Amended during implementation

The approved design also carried `skipped=1`, so that working the Skipped backlog kept you in the backlog. Backlog rows are not clickable in the first place (`LocalizeQueueTable.tsx:144`, `onClick={skippedView ? undefined : …}`) — an alert is unskipped before it can be opened — so the flag had no entry path to describe and would have been dead weight in the URL, the helpers and the advance. Making the backlog directly workable is a separate feature; the spec records the reasoning.

## Tests

`npm test`: 108 files, 1459 passing (baseline 1445). `npm run type-check` and `npm run lint` clean.

New `post-submit auto-advance` block in `LocalizeAlertPage.test.tsx` (not a separate file — that suite already renders through a real router with an unmocked `useNavigate` and owns the fixtures a submit test needs): advance carries the ordering forward; the queue call receives the URL's params; deep links default to score order; a stale queue still listing the submitted alert is stepped over; empty queue and rejected fetch both fall back; done mode never calls the queue; skip advances silently; unmounting inside the window navigates nowhere. Plus queue-view helper unit tests and a re-sorted-queue case on the queue table.

`getLocalizationQueue` is mocked empty in the page suite's top-level `beforeEach`, so every pre-existing submit/skip test keeps asserting the fallback it was written for.

## Not verified here

The browser flow — the tests only ever see the queue lookup mocked. Worth one pass through: sort by Recorded, submit, confirm the next alert opens with the sort intact and that submitting to an empty queue lands on `/localize`.
