### PR TITLE
fix(localize): keep the cropped loop's zoom pill under page popovers

### DIFF
--- a/frontend/src/components/annotation/CroppedImageSequence.tsx
+++ b/frontend/src/components/annotation/CroppedImageSequence.tsx
@@ -356,10 +356,19 @@ export default function CroppedImageSequence({
     <div className={`w-full ${className}`}>
       {/* Fixed square viewport — the element never resizes; zoom changes the
           drawn source rect instead (see squareCropUtils). */}
+      {/* `isolate` is load-bearing: `relative` alone leaves `z-index: auto`, so
+          the overlays below (the zoom pill at z-20) compete in the ROOT
+          stacking context against whatever the host page positions. On the
+          Localize alert page the accept-boxes popover is also z-20 and drops
+          from the action bar above the loop — equal z-index, so tree order
+          wins and the pill, being later in the DOM, painted on top of the
+          popover. Isolating confines these z-indices to the square, which is
+          all they were ever meant to order (the viewport is `overflow-hidden`,
+          so nothing inside escapes anyway). */}
       <div
         ref={setViewportEl}
         data-testid="cropped-viewport"
-        className={`relative mx-auto w-full aspect-square overflow-hidden bg-gray-900 ${
+        className={`relative isolate mx-auto w-full aspect-square overflow-hidden bg-gray-900 ${
           accentColor ? 'border-2' : ''
         }`}
         style={{

--- a/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
+++ b/frontend/tests/components/annotation/CroppedImageSequence.test.tsx
@@ -66,6 +66,17 @@ describe('CroppedImageSequence', () => {
     expect(screen.queryByRole('slider')).not.toBeInTheDocument();
   });
 
+  it('isolates the viewport so its overlays cannot outrank the host page', async () => {
+    // jsdom computes no stacking order, so the class is as far as this can go
+    // — but the class IS the whole fix. Without `isolate` the viewport keeps
+    // `z-index: auto`, the zoom pill's z-20 lands in the root stacking
+    // context, and on the Localize alert page it tied with (and, being later
+    // in the DOM, painted over) the accept-boxes popover dropping onto the
+    // loop from the action bar above it.
+    await renderLoaded();
+    expect(screen.getByTestId('cropped-viewport').className).toContain('isolate');
+  });
+
   it('wheel-zooms over the viewport even though it mounts after loading', async () => {
     // The viewport div does not exist during the loading state — the wheel
     // listener must bind when it appears (callback-ref state), not on mount.


### PR DESCRIPTION
## Problem

On `/localize/:sequenceId/object/:laneId`, with the cropped loop open (`P`), opening the **Accept boxes** popover left the loop's zoom control painted on top of the popover.

## Root cause

`CroppedImageSequence`'s viewport is `position: relative` with `z-index: auto` — which is **not** a stacking context. Its zoom pill's `z-20` therefore landed in the *root* stacking context, where it tied with `AcceptRemainingPopover`'s own `z-20`. Equal z-index means tree order decides the winner, and the loop renders after the action bar the popover drops from — so the pill won.

Not actually tied to play/pause: `P` toggles `cropExpanded`, i.e. whether the loop is on screen at all, so this happened whenever the loop was showing.

## Fix

One class — `isolate` on the crop viewport. That confines the component's internal z-indices to the square, which is all they were ever meant to order: the viewport is `overflow-hidden`, so nothing inside escapes it anyway. The popover's `z-20` then wins on the ordinary rules.

The other four consumers (`ObjectCard`, `ClassifyMediaPanel`, `AcceptRemainingPopover`'s own nested preview, `LocalizeAlertPage`) all render the loop in normal flow; isolating it only removes leakage.

## Verification

- Reproduced the stacking behavior in headless Chromium with a minimal two-column repro — pill over popover before, behind after. Painted pixels, not the DOM.
- Regression test added; confirmed it fails without the class and passes with it. jsdom computes no stacking order, so the class assertion is as far as a unit test can reach — but the class *is* the whole fix.
- Full frontend suite green (1472 tests / 108 files), plus `type-check`, eslint `--max-warnings 0`, prettier.
- User-verified in the browser on the real page.