### PR TITLE
docs: record pyro-dataset as a downstream consumer of the alert export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,8 @@ Writes `manifest.jsonl` (one line per alert) plus `images/{source_api}/{platform
 
 Each alert also carries `temporal_model_score` (plus `temporal_model_version` / `temporal_api_version`) for score-based mining: rank objects by their alert's score and filter on `record_kind` to surface hard negatives. The score is alert-level because the platform's temporal model scores an alert, not an object — the verdict rides the primary lane and object-split siblings hold NULL. `null` means **no verdict is attributed**: either never scored (alerts imported before 2026-08-10, fail-opens, risk-gated sequences) or scored but not attributable to a lane during the object split. It never means "scored low", so drop nulls when ranking rather than coalescing them to `0.0`; `0.0` itself is a real verdict. Note a score refresh does not move `last_annotated_at`, so a backfill only shows up in a full pull, not an `annotation_updated_gte` one.
 
+**Downstream consumer**: pyro-dataset imports this export into its sequential dataset for the temporal model — see `docs/specs/2026-08-13-annotator-export-sequential-import-design.md` in `pyronear/pyro-dataset` (branch `feat/annotator-export-import` until merged), and the "Downstream consumers" section of `docs/specs/2026-08-06-export-alerts-endpoint-design.md` for the fields it depends on. Check there before reshaping the payload.
+
 ### Export QA overlays
 
 ```bash

--- a/docs/specs/2026-08-06-export-alerts-endpoint-design.md
+++ b/docs/specs/2026-08-06-export-alerts-endpoint-design.md
@@ -298,3 +298,25 @@ Rewrite `src/tests/endpoints/test_export.py` against the new endpoint:
   replaces the deleted `export_dataset.py`.
 - Trainer-format conversion (YOLO/COCO) — downstream of the script.
 - API keys / scoped service accounts.
+
+## Downstream consumers
+
+**pyro-dataset's sequential-dataset import** (`pyronear/pyro-dataset`,
+`docs/specs/2026-08-13-annotator-export-sequential-import-design.md`, branch
+`feat/annotator-export-import` until merged) builds training sequences for the temporal
+model from this export. Recorded here so a change to the payload is known to have a
+consumer — it depends on:
+
+| field | what it is used for |
+|-------|---------------------|
+| `record_kind` | decides whether a sequence is a positive (`wildfire/`) or a negative (`fp/`) |
+| `false_positive_types` | stratifies the false-positive sample across failure modes |
+| `temporal_model_score` | ranks hard negatives — the false positives the deployed model still believes |
+| box `origin`, `smoke_type`, `false_positive_types` | selects which boxes become YOLO labels and which are kept as provenance only |
+| `xyxyn` | converted to YOLO `xywhn` |
+| `image_path` (pull script) + `bucket_key` | materialised frames, and the stable frame identity |
+| `platform_alert_id`, `camera_name`, `azimuth`, `recorded_at` | the sequence folder name, which is also its identity across re-imports |
+
+Two properties it relies on beyond the field list: sibling lanes of one alert share
+identical frame images, and an alert's lanes never mix `record_kind` in practice (the
+importer handles the mixed case, but its box-selection rule assumes it is rare).


### PR DESCRIPTION
## What

Documentation only — no code changes.

pyro-dataset now imports `/export/alerts` into its **sequential dataset**, which trains the temporal model. This records that dependency in two places:

- `docs/specs/2026-08-06-export-alerts-endpoint-design.md` gains a **Downstream consumers** section listing the exact fields the importer relies on.
- The Alert Export section of `CLAUDE.md` points at the consumer's design doc.

## Why

The export payload now has a consumer outside this repo. Without a note here, the next person reshaping `AlertExportItem` or `ObjectExport` has no way to know something downstream depends on `record_kind`, `false_positive_types`, `temporal_model_score`, box `origin` or `image_path`.

Deliberately a **pointer, not a copy**. The design itself is 400 lines and lives with the code that implements it, in `pyronear/pyro-dataset` (`docs/specs/2026-08-13-annotator-export-sequential-import-design.md`, branch `feat/annotator-export-import` until merged). Duplicating it here would guarantee the two copies diverge.

## Fields the importer depends on

| field | used for |
|-------|----------|
| `record_kind` | positive (`wildfire/`) vs negative (`fp/`) sequence |
| `false_positive_types` | stratifying the FP sample across failure modes |
| `temporal_model_score` | ranking hard negatives — FPs the deployed model still believes |
| box `origin`, `smoke_type`, `false_positive_types` | which boxes become YOLO labels vs provenance only |
| `xyxyn` | converted to YOLO `xywhn` |
| `image_path`, `bucket_key` | materialised frames and stable frame identity |
| `platform_alert_id`, `camera_name`, `azimuth`, `recorded_at` | sequence folder name, which is its identity across re-imports |

Plus two structural properties: sibling lanes of one alert share identical frame images, and lanes of one alert never mix `record_kind` in practice (737 pure-FP and 58 pure-smoke alerts in the 2026-08-13 export, zero mixed).